### PR TITLE
fix typo

### DIFF
--- a/code/Win32DebugLogStream.h
+++ b/code/Win32DebugLogStream.h
@@ -4,7 +4,7 @@
 #ifdef WIN32
 
 #include "../include/LogStream.h"
-#include "Windows.h"
+#include "windows.h"
 
 namespace Assimp	{
 


### PR DESCRIPTION
just fix a typo... include filenames are lowercase on linux
