### PR TITLE
Please apply spelling fixes

### DIFF
--- a/code/IFCCurve.cpp
+++ b/code/IFCCurve.cpp
@@ -568,7 +568,7 @@ size_t Curve :: EstimateSampleCount(float a, float b) const
 }
 
 // ------------------------------------------------------------------------------------------------
-float RecursiveSearch(const Curve* cv, const aiVector3D& val, float a, float b, unsigned int samples, float treshold, unsigned int recurse = 0, unsigned int max_recurse = 15)
+float RecursiveSearch(const Curve* cv, const aiVector3D& val, float a, float b, unsigned int samples, float threshold, unsigned int recurse = 0, unsigned int max_recurse = 15)
 {
 	ai_assert(samples>1);
 
@@ -592,7 +592,7 @@ float RecursiveSearch(const Curve* cv, const aiVector3D& val, float a, float b, 
 	}
 
 	ai_assert(min_diff[0] != inf && min_diff[1] != inf);
-	if ( fabs(a-min_point[0]) < treshold || recurse >= max_recurse) {
+	if ( fabs(a-min_point[0]) < threshold || recurse >= max_recurse) {
 		return min_point[0];
 	}
 
@@ -608,7 +608,7 @@ float RecursiveSearch(const Curve* cv, const aiVector3D& val, float a, float b, 
 		}
 	}
 
-	return RecursiveSearch(cv,val,min_point[0],min_point[1],samples,treshold,recurse+1,max_recurse);
+	return RecursiveSearch(cv,val,min_point[0],min_point[1],samples,threshold,recurse+1,max_recurse);
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -618,12 +618,12 @@ bool Curve :: ReverseEval(const aiVector3D& val, float& paramOut) const
 	// in all possible cases, but it will always return at least some value so this function
 	// will never fail in the default implementation.
 
-	// XXX derive treshold from curve topology
-	const float treshold = 1e-4f;
+	// XXX derive threshold from curve topology
+	const float threshold = 1e-4f;
 	const unsigned int samples = 16;
 
 	const ParamRange& range = GetParametricRange();
-	paramOut = RecursiveSearch(this,val,range.first,range.second,samples,treshold);
+	paramOut = RecursiveSearch(this,val,range.first,range.second,samples,threshold);
 
 	return true;
 }

--- a/code/IFCGeometry.cpp
+++ b/code/IFCGeometry.cpp
@@ -305,12 +305,12 @@ void MergePolygonBoundaries(TempMesh& result, const TempMesh& inmesh, size_t mas
 	// skip over extremely small boundaries - this is a workaround to fix cases
 	// in which the number of holes is so extremely large that the
 	// triangulation code fails.
-#define IFC_VERTICAL_HOLE_SIZE_TRESHOLD 0.000001f
+#define IFC_VERTICAL_HOLE_SIZE_THRESHOLD 0.000001f
 	size_t vidx = 0, removed = 0, index = 0;
-	const float treshold = area_outer_polygon * IFC_VERTICAL_HOLE_SIZE_TRESHOLD;
+	const float threshold = area_outer_polygon * IFC_VERTICAL_HOLE_SIZE_THRESHOLD;
 	for(iit = begin; iit != end ;++index) {
 		const float sqlen = normals[index].SquareLength();
-		if (sqlen < treshold) {
+		if (sqlen < threshold) {
 			std::vector<aiVector3D>::iterator inbase = in.begin()+vidx;
 			in.erase(inbase,inbase+*iit);
 			
@@ -318,7 +318,7 @@ void MergePolygonBoundaries(TempMesh& result, const TempMesh& inmesh, size_t mas
 			*iit++ = 0;
 			++removed;
 
-			IFCImporter::LogDebug("skip small hole below treshold");
+			IFCImporter::LogDebug("skip small hole below threshold");
 		}
 		else {
 			normals[index] /= sqrt(sqlen);

--- a/code/Subdivision.cpp
+++ b/code/Subdivision.cpp
@@ -246,7 +246,7 @@ void CatmullClarkSubdivider::InternSubdivide (
 	SpatialSort spatial;
 
 	// ---------------------------------------------------------------------
-	// 0. Offset table to index all meshes continously , generate a spatially
+	// 0. Offset table to index all meshes continuously , generate a spatially
 	// sorted representation of all vertices in all meshes.
 	// ---------------------------------------------------------------------
 	typedef std::pair<unsigned int,unsigned int> IntPair;

--- a/doc/dox_cmd.h
+++ b/doc/dox_cmd.h
@@ -413,7 +413,7 @@ more information can be found in the <tt>aiPostProcess.h</tt> header.
   <tr>
     <td><tt>-slm</tt></td>
     <td><tt>--split-large-meshes</tt></td>
-	<td>Split large meshes over a specific treshold in smaller sub meshes. The default vertex & face limit is 1000000</td>
+	<td>Split large meshes over a specific threshold in smaller sub meshes. The default vertex & face limit is 1000000</td>
   </tr>
   <tr>
     <td><tt>-lbw</tt></td>

--- a/workspaces/xcode3/info.txt
+++ b/workspaces/xcode3/info.txt
@@ -1,4 +1,4 @@
-The xcode project files in this directory are contributed by Andy Maloney and are not continously updated. 
+The xcode project files in this directory are contributed by Andy Maloney and are not continuously updated. 
 Currently, it's for Assimp r352. If you're using a newer revision, watch out for missing files/includes/...
 
 See Andy's description at


### PR DESCRIPTION
The patch set fixes two spelling errors throughout the assimp codebase.

It replaces continously with continuously and treshold with threshold.
