### PR TITLE
fixed scaling bug appeared in multi-mesh models

### DIFF
--- a/samples/SimpleTexturedOpenGL/SimpleTexturedOpenGL/src/model_loading.cpp
+++ b/samples/SimpleTexturedOpenGL/SimpleTexturedOpenGL/src/model_loading.cpp
@@ -409,8 +409,9 @@ void recursive_render (const struct aiScene *sc, const struct aiNode* nd, float 
 	unsigned int i;
 	unsigned int n=0, t;
 	aiMatrix4x4 m = nd->mTransformation;
-
-	m.Scaling(aiVector3D(scale, scale, scale), m);
+	aiMatrix4x4 m2;
+	aiMatrix4x4::Scaling(aiVector3D(scale, scale, scale), m2);
+	m = m * m2;
 
 	// update transform
 	m.Transpose();


### PR DESCRIPTION
when loading models with multi-meshes, all the meshes appears in (0,0,0) 
that's because m.Scaling returns a Scaling matrix, Not scales a matrix !
so when the scale is 1, we always have identity Matrix 
