### PR TITLE
Fix error message to contain the correct solution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ ELSE ( ASSIMP_ENABLE_BOOST_WORKAROUND )
 		MESSAGE( FATAL_ERROR
 			"Boost libraries (http://www.boost.org/) not found. "
 			"You can build a non-boost version of Assimp with slightly reduced "
-			"functionality by specifying -DENABLE_BOOST_WORKAROUND=ON."
+			"functionality by specifying -DASSIMP_ENABLE_BOOST_WORKAROUND=ON."
 		)
 	ENDIF ( NOT Boost_FOUND )
 


### PR DESCRIPTION
```
$ cmake -G "Unix Makefiles" -DENABLE_BOOST_WORKAROUND=ON .. 
-- Could NOT find Boost
Unable to find the Boost header files. Please set BOOST_ROOT to the root directory containing Boost or    BOOST_INCLUDEDIR to the directory containing Boost's headers.
CMake Error at CMakeLists.txt:82 (MESSAGE):
Boost libraries (http://www.boost.org/) not found.  You can build a
non-boost version of Assimp with slightly reduced functionality by
specifying -DENABLE_BOOST_WORKAROUND=ON.
```

In the CMakeList ENABLE_BOOST_WORKAROUND is actually ASSIMP_ENABLE_BOOST_WORKAROUND, patch provided change the error message to the correct define.
