### PR TITLE
 unify strlen usage in types.h

### DIFF
--- a/include/assimp/types.h
+++ b/include/assimp/types.h
@@ -314,7 +314,7 @@ struct aiString
 
 	/** Append a string to the string */
 	void Append (const char* app)	{
-		const size_t len = strlen(app);
+		const size_t len = ::strlen(app);
 		if (!len) {
 			return;
 		}


### PR DESCRIPTION
this fixes a compile error with mingw32/crosscompile.
