### PR TITLE
Q3BSP Loader bug

### DIFF
--- a/code/Q3BSPFileImporter.cpp
+++ b/code/Q3BSPFileImporter.cpp
@@ -640,6 +640,7 @@ bool Q3BSPFileImporter::importTextureFromArchive( const Q3BSP::Q3BSPModel *pMode
 	std::vector<std::string> supportedExtensions;
 	supportedExtensions.push_back( ".jpg" );
 	supportedExtensions.push_back( ".png" );
+	supportedExtensions.push_back( ".tga" );
 	if ( NULL == pArchive || NULL == pArchive || NULL == pMatHelper )
 	{
 		return false;


### PR DESCRIPTION
There is a small bug in how the Q3BSP loader populates the achFormatHint. It also ignores embedded TGA textures which I've found to be popular in this file type. The attached commits fix these issues.
