### PR TITLE
[workspaces/xcode] Make all targets build + iOS target (OSX 10.8.3 + Xcode 4.6.1)

### DIFF
--- a/code/BoostWorkaround/boost/tuple/tuple.hpp
+++ b/code/BoostWorkaround/boost/tuple/tuple.hpp
@@ -181,7 +181,7 @@ namespace boost	{
 		// ... and the const version
 		template <unsigned N>
 		const typename detail::type_getter<T0,0,typename very_long::next_type, N>::type& get () const	{
-			return m.get<N>();
+			return m.template get<N>();
 		}
 
 
@@ -208,14 +208,14 @@ namespace boost	{
 	template <unsigned N,typename T0,typename T1,typename T2,typename T3,typename T4>
 	inline typename tuple<T0,T1,T2,T3,T4>::very_long::template type_getter<N>::type& get (
 			tuple<T0,T1,T2,T3,T4>& m)	{
-			return m.get<N>();
+			return m.template get<N>();
 		}
 
 	// ... and the const version
 	template <unsigned N,typename T0,typename T1,typename T2,typename T3,typename T4>
 	inline const typename tuple<T0,T1,T2,T3,T4>::very_long::template type_getter<N>::type& get (
 			const tuple<T0,T1,T2,T3,T4>& m)	{
-			return m.get<N>();
+			return m.template get<N>();
 		}
 
 	// Constructs a tuple with 5 elements
@@ -224,11 +224,11 @@ namespace boost	{
 		const T1& t1,const T2& t2,const T3& t3,const T4& t4) {
 
 		tuple <T0,T1,T2,T3,T4> t;
-		t.get<0>() = t0;
-		t.get<1>() = t1;
-		t.get<2>() = t2;
-		t.get<3>() = t3;
-		t.get<4>() = t4;
+		t.template get<0>() = t0;
+		t.template get<1>() = t1;
+		t.template get<2>() = t2;
+		t.template get<3>() = t3;
+		t.template get<4>() = t4;
 		return t;
 	}
 
@@ -237,10 +237,10 @@ namespace boost	{
 	inline tuple <T0,T1,T2,T3> make_tuple (const T0& t0,
 		const T1& t1,const T2& t2,const T3& t3) {
 		tuple <T0,T1,T2,T3> t;
-		t.get<0>() = t0;
-		t.get<1>() = t1;
-		t.get<2>() = t2;
-		t.get<3>() = t3;
+		t.template get<0>() = t0;
+		t.template get<1>() = t1;
+		t.template get<2>() = t2;
+		t.template get<3>() = t3;
 		return t;
 	}
 
@@ -249,9 +249,9 @@ namespace boost	{
 	inline tuple <T0,T1,T2> make_tuple (const T0& t0,
 		const T1& t1,const T2& t2) {
 		tuple <T0,T1,T2> t;
-		t.get<0>() = t0;
-		t.get<1>() = t1;
-		t.get<2>() = t2;
+		t.template get<0>() = t0;
+		t.template get<1>() = t1;
+		t.template get<2>() = t2;
 		return t;
 	}
 
@@ -260,8 +260,8 @@ namespace boost	{
 	inline tuple <T0,T1> make_tuple (const T0& t0,
 		const T1& t1) {
 		tuple <T0,T1> t;
-		t.get<0>() = t0;
-		t.get<1>() = t1;
+		t.template get<0>() = t0;
+		t.template get<1>() = t1;
 		return t;
 	}
 
@@ -269,7 +269,7 @@ namespace boost	{
 	template <typename T0>
 	inline tuple <T0> make_tuple (const T0& t0) {
 		tuple <T0> t;
-		t.get<0>() = t0;
+		t.template get<0>() = t0;
 		return t;
 	}
 

--- a/workspaces/xcode3/assimp.xcodeproj/project.pbxproj
+++ b/workspaces/xcode3/assimp.xcodeproj/project.pbxproj
@@ -3,23 +3,1003 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 44;
+	objectVersion = 46;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2B7F46DD1708365200A106A9 /* assbin_chunks.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F456D1708365100A106A9 /* assbin_chunks.h */; };
+		2B7F46DE1708365200A106A9 /* assbin_chunks.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F456D1708365100A106A9 /* assbin_chunks.h */; };
+		2B7F46DF1708365200A106A9 /* assbin_chunks.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F456D1708365100A106A9 /* assbin_chunks.h */; };
+		2B7F46E01708365200A106A9 /* assbin_chunks.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F456D1708365100A106A9 /* assbin_chunks.h */; };
+		2B7F46E11708365200A106A9 /* assbin_chunks.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F456D1708365100A106A9 /* assbin_chunks.h */; };
+		2B7F46E21708365200A106A9 /* Assimp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F456E1708365100A106A9 /* Assimp.cpp */; };
+		2B7F46E31708365200A106A9 /* Assimp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F456E1708365100A106A9 /* Assimp.cpp */; };
+		2B7F46E41708365200A106A9 /* Assimp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F456E1708365100A106A9 /* Assimp.cpp */; };
+		2B7F46E51708365200A106A9 /* Assimp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F456E1708365100A106A9 /* Assimp.cpp */; };
+		2B7F46E61708365200A106A9 /* Assimp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F456E1708365100A106A9 /* Assimp.cpp */; };
+		2B7F46E71708365200A106A9 /* AssimpCExport.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F456F1708365100A106A9 /* AssimpCExport.cpp */; };
+		2B7F46E81708365200A106A9 /* AssimpCExport.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F456F1708365100A106A9 /* AssimpCExport.cpp */; };
+		2B7F46E91708365200A106A9 /* AssimpCExport.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F456F1708365100A106A9 /* AssimpCExport.cpp */; };
+		2B7F46EA1708365200A106A9 /* AssimpCExport.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F456F1708365100A106A9 /* AssimpCExport.cpp */; };
+		2B7F46EB1708365200A106A9 /* AssimpCExport.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F456F1708365100A106A9 /* AssimpCExport.cpp */; };
+		2B7F47001708365200A106A9 /* BaseImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45741708365100A106A9 /* BaseImporter.cpp */; };
+		2B7F47011708365200A106A9 /* BaseImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45741708365100A106A9 /* BaseImporter.cpp */; };
+		2B7F47021708365200A106A9 /* BaseImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45741708365100A106A9 /* BaseImporter.cpp */; };
+		2B7F47031708365200A106A9 /* BaseImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45741708365100A106A9 /* BaseImporter.cpp */; };
+		2B7F47041708365200A106A9 /* BaseImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45741708365100A106A9 /* BaseImporter.cpp */; };
+		2B7F47051708365200A106A9 /* BaseImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45751708365100A106A9 /* BaseImporter.h */; };
+		2B7F47061708365200A106A9 /* BaseImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45751708365100A106A9 /* BaseImporter.h */; };
+		2B7F47071708365200A106A9 /* BaseImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45751708365100A106A9 /* BaseImporter.h */; };
+		2B7F47081708365200A106A9 /* BaseImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45751708365100A106A9 /* BaseImporter.h */; };
+		2B7F47091708365200A106A9 /* BaseImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45751708365100A106A9 /* BaseImporter.h */; };
+		2B7F470A1708365200A106A9 /* BaseProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45761708365100A106A9 /* BaseProcess.cpp */; };
+		2B7F470B1708365200A106A9 /* BaseProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45761708365100A106A9 /* BaseProcess.cpp */; };
+		2B7F470C1708365200A106A9 /* BaseProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45761708365100A106A9 /* BaseProcess.cpp */; };
+		2B7F470D1708365200A106A9 /* BaseProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45761708365100A106A9 /* BaseProcess.cpp */; };
+		2B7F470E1708365200A106A9 /* BaseProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45761708365100A106A9 /* BaseProcess.cpp */; };
+		2B7F470F1708365200A106A9 /* BaseProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45771708365100A106A9 /* BaseProcess.h */; };
+		2B7F47101708365200A106A9 /* BaseProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45771708365100A106A9 /* BaseProcess.h */; };
+		2B7F47111708365200A106A9 /* BaseProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45771708365100A106A9 /* BaseProcess.h */; };
+		2B7F47121708365200A106A9 /* BaseProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45771708365100A106A9 /* BaseProcess.h */; };
+		2B7F47131708365200A106A9 /* BaseProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45771708365100A106A9 /* BaseProcess.h */; };
+		2B7F47461708365200A106A9 /* BlobIOSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45831708365100A106A9 /* BlobIOSystem.h */; };
+		2B7F47471708365200A106A9 /* BlobIOSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45831708365100A106A9 /* BlobIOSystem.h */; };
+		2B7F47481708365200A106A9 /* BlobIOSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45831708365100A106A9 /* BlobIOSystem.h */; };
+		2B7F47491708365200A106A9 /* BlobIOSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45831708365100A106A9 /* BlobIOSystem.h */; };
+		2B7F474A1708365200A106A9 /* BlobIOSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45831708365100A106A9 /* BlobIOSystem.h */; };
+		2B7F474B1708365200A106A9 /* foreach.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45861708365100A106A9 /* foreach.hpp */; };
+		2B7F474C1708365200A106A9 /* foreach.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45861708365100A106A9 /* foreach.hpp */; };
+		2B7F474D1708365200A106A9 /* foreach.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45861708365100A106A9 /* foreach.hpp */; };
+		2B7F474E1708365200A106A9 /* foreach.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45861708365100A106A9 /* foreach.hpp */; };
+		2B7F474F1708365200A106A9 /* foreach.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45861708365100A106A9 /* foreach.hpp */; };
+		2B7F47501708365200A106A9 /* format.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45871708365100A106A9 /* format.hpp */; };
+		2B7F47511708365200A106A9 /* format.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45871708365100A106A9 /* format.hpp */; };
+		2B7F47521708365200A106A9 /* format.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45871708365100A106A9 /* format.hpp */; };
+		2B7F47531708365200A106A9 /* format.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45871708365100A106A9 /* format.hpp */; };
+		2B7F47541708365200A106A9 /* format.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45871708365100A106A9 /* format.hpp */; };
+		2B7F47551708365200A106A9 /* lexical_cast.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45881708365100A106A9 /* lexical_cast.hpp */; };
+		2B7F47561708365200A106A9 /* lexical_cast.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45881708365100A106A9 /* lexical_cast.hpp */; };
+		2B7F47571708365200A106A9 /* lexical_cast.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45881708365100A106A9 /* lexical_cast.hpp */; };
+		2B7F47581708365200A106A9 /* lexical_cast.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45881708365100A106A9 /* lexical_cast.hpp */; };
+		2B7F47591708365200A106A9 /* lexical_cast.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45881708365100A106A9 /* lexical_cast.hpp */; };
+		2B7F475A1708365200A106A9 /* make_shared.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F458A1708365100A106A9 /* make_shared.hpp */; };
+		2B7F475B1708365200A106A9 /* make_shared.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F458A1708365100A106A9 /* make_shared.hpp */; };
+		2B7F475C1708365200A106A9 /* make_shared.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F458A1708365100A106A9 /* make_shared.hpp */; };
+		2B7F475D1708365200A106A9 /* make_shared.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F458A1708365100A106A9 /* make_shared.hpp */; };
+		2B7F475E1708365200A106A9 /* make_shared.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F458A1708365100A106A9 /* make_shared.hpp */; };
+		2B7F475F1708365200A106A9 /* common_factor_rt.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F458C1708365100A106A9 /* common_factor_rt.hpp */; };
+		2B7F47601708365200A106A9 /* common_factor_rt.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F458C1708365100A106A9 /* common_factor_rt.hpp */; };
+		2B7F47611708365200A106A9 /* common_factor_rt.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F458C1708365100A106A9 /* common_factor_rt.hpp */; };
+		2B7F47621708365200A106A9 /* common_factor_rt.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F458C1708365100A106A9 /* common_factor_rt.hpp */; };
+		2B7F47631708365200A106A9 /* common_factor_rt.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F458C1708365100A106A9 /* common_factor_rt.hpp */; };
+		2B7F47641708365200A106A9 /* noncopyable.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F458D1708365100A106A9 /* noncopyable.hpp */; };
+		2B7F47651708365200A106A9 /* noncopyable.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F458D1708365100A106A9 /* noncopyable.hpp */; };
+		2B7F47661708365200A106A9 /* noncopyable.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F458D1708365100A106A9 /* noncopyable.hpp */; };
+		2B7F47671708365200A106A9 /* noncopyable.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F458D1708365100A106A9 /* noncopyable.hpp */; };
+		2B7F47681708365200A106A9 /* noncopyable.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F458D1708365100A106A9 /* noncopyable.hpp */; };
+		2B7F47691708365200A106A9 /* pointer_cast.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F458E1708365100A106A9 /* pointer_cast.hpp */; };
+		2B7F476A1708365200A106A9 /* pointer_cast.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F458E1708365100A106A9 /* pointer_cast.hpp */; };
+		2B7F476B1708365200A106A9 /* pointer_cast.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F458E1708365100A106A9 /* pointer_cast.hpp */; };
+		2B7F476C1708365200A106A9 /* pointer_cast.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F458E1708365100A106A9 /* pointer_cast.hpp */; };
+		2B7F476D1708365200A106A9 /* pointer_cast.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F458E1708365100A106A9 /* pointer_cast.hpp */; };
+		2B7F476E1708365200A106A9 /* scoped_array.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F458F1708365100A106A9 /* scoped_array.hpp */; };
+		2B7F476F1708365200A106A9 /* scoped_array.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F458F1708365100A106A9 /* scoped_array.hpp */; };
+		2B7F47701708365200A106A9 /* scoped_array.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F458F1708365100A106A9 /* scoped_array.hpp */; };
+		2B7F47711708365200A106A9 /* scoped_array.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F458F1708365100A106A9 /* scoped_array.hpp */; };
+		2B7F47721708365200A106A9 /* scoped_array.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F458F1708365100A106A9 /* scoped_array.hpp */; };
+		2B7F47731708365200A106A9 /* scoped_ptr.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45901708365100A106A9 /* scoped_ptr.hpp */; };
+		2B7F47741708365200A106A9 /* scoped_ptr.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45901708365100A106A9 /* scoped_ptr.hpp */; };
+		2B7F47751708365200A106A9 /* scoped_ptr.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45901708365100A106A9 /* scoped_ptr.hpp */; };
+		2B7F47761708365200A106A9 /* scoped_ptr.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45901708365100A106A9 /* scoped_ptr.hpp */; };
+		2B7F47771708365200A106A9 /* scoped_ptr.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45901708365100A106A9 /* scoped_ptr.hpp */; };
+		2B7F47781708365200A106A9 /* shared_array.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45911708365100A106A9 /* shared_array.hpp */; };
+		2B7F47791708365200A106A9 /* shared_array.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45911708365100A106A9 /* shared_array.hpp */; };
+		2B7F477A1708365200A106A9 /* shared_array.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45911708365100A106A9 /* shared_array.hpp */; };
+		2B7F477B1708365200A106A9 /* shared_array.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45911708365100A106A9 /* shared_array.hpp */; };
+		2B7F477C1708365200A106A9 /* shared_array.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45911708365100A106A9 /* shared_array.hpp */; };
+		2B7F477D1708365200A106A9 /* shared_ptr.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45921708365100A106A9 /* shared_ptr.hpp */; };
+		2B7F477E1708365200A106A9 /* shared_ptr.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45921708365100A106A9 /* shared_ptr.hpp */; };
+		2B7F477F1708365200A106A9 /* shared_ptr.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45921708365100A106A9 /* shared_ptr.hpp */; };
+		2B7F47801708365200A106A9 /* shared_ptr.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45921708365100A106A9 /* shared_ptr.hpp */; };
+		2B7F47811708365200A106A9 /* shared_ptr.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45921708365100A106A9 /* shared_ptr.hpp */; };
+		2B7F47821708365200A106A9 /* static_assert.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45931708365100A106A9 /* static_assert.hpp */; };
+		2B7F47831708365200A106A9 /* static_assert.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45931708365100A106A9 /* static_assert.hpp */; };
+		2B7F47841708365200A106A9 /* static_assert.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45931708365100A106A9 /* static_assert.hpp */; };
+		2B7F47851708365200A106A9 /* static_assert.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45931708365100A106A9 /* static_assert.hpp */; };
+		2B7F47861708365200A106A9 /* static_assert.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45931708365100A106A9 /* static_assert.hpp */; };
+		2B7F47871708365200A106A9 /* timer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45941708365100A106A9 /* timer.hpp */; };
+		2B7F47881708365200A106A9 /* timer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45941708365100A106A9 /* timer.hpp */; };
+		2B7F47891708365200A106A9 /* timer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45941708365100A106A9 /* timer.hpp */; };
+		2B7F478A1708365200A106A9 /* timer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45941708365100A106A9 /* timer.hpp */; };
+		2B7F478B1708365200A106A9 /* timer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45941708365100A106A9 /* timer.hpp */; };
+		2B7F478C1708365200A106A9 /* tuple.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45961708365100A106A9 /* tuple.hpp */; };
+		2B7F478D1708365200A106A9 /* tuple.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45961708365100A106A9 /* tuple.hpp */; };
+		2B7F478E1708365200A106A9 /* tuple.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45961708365100A106A9 /* tuple.hpp */; };
+		2B7F478F1708365200A106A9 /* tuple.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45961708365100A106A9 /* tuple.hpp */; };
+		2B7F47901708365200A106A9 /* tuple.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45961708365100A106A9 /* tuple.hpp */; };
+		2B7F479B1708365200A106A9 /* ByteSwap.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45991708365100A106A9 /* ByteSwap.h */; };
+		2B7F479C1708365200A106A9 /* ByteSwap.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45991708365100A106A9 /* ByteSwap.h */; };
+		2B7F479D1708365200A106A9 /* ByteSwap.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45991708365100A106A9 /* ByteSwap.h */; };
+		2B7F479E1708365200A106A9 /* ByteSwap.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45991708365100A106A9 /* ByteSwap.h */; };
+		2B7F479F1708365200A106A9 /* ByteSwap.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45991708365100A106A9 /* ByteSwap.h */; };
+		2B7F47A01708365200A106A9 /* CalcTangentsProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F459A1708365100A106A9 /* CalcTangentsProcess.cpp */; };
+		2B7F47A11708365200A106A9 /* CalcTangentsProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F459A1708365100A106A9 /* CalcTangentsProcess.cpp */; };
+		2B7F47A21708365200A106A9 /* CalcTangentsProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F459A1708365100A106A9 /* CalcTangentsProcess.cpp */; };
+		2B7F47A31708365200A106A9 /* CalcTangentsProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F459A1708365100A106A9 /* CalcTangentsProcess.cpp */; };
+		2B7F47A41708365200A106A9 /* CalcTangentsProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F459A1708365100A106A9 /* CalcTangentsProcess.cpp */; };
+		2B7F47A51708365200A106A9 /* CalcTangentsProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F459B1708365100A106A9 /* CalcTangentsProcess.h */; };
+		2B7F47A61708365200A106A9 /* CalcTangentsProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F459B1708365100A106A9 /* CalcTangentsProcess.h */; };
+		2B7F47A71708365200A106A9 /* CalcTangentsProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F459B1708365100A106A9 /* CalcTangentsProcess.h */; };
+		2B7F47A81708365200A106A9 /* CalcTangentsProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F459B1708365100A106A9 /* CalcTangentsProcess.h */; };
+		2B7F47A91708365200A106A9 /* CalcTangentsProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F459B1708365100A106A9 /* CalcTangentsProcess.h */; };
+		2B7F47AA1708365200A106A9 /* CInterfaceIOWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F459C1708365100A106A9 /* CInterfaceIOWrapper.h */; };
+		2B7F47AB1708365200A106A9 /* CInterfaceIOWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F459C1708365100A106A9 /* CInterfaceIOWrapper.h */; };
+		2B7F47AC1708365200A106A9 /* CInterfaceIOWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F459C1708365100A106A9 /* CInterfaceIOWrapper.h */; };
+		2B7F47AD1708365200A106A9 /* CInterfaceIOWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F459C1708365100A106A9 /* CInterfaceIOWrapper.h */; };
+		2B7F47AE1708365200A106A9 /* CInterfaceIOWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F459C1708365100A106A9 /* CInterfaceIOWrapper.h */; };
+		2B7F47BE1708365200A106A9 /* ColladaExporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45A11708365100A106A9 /* ColladaExporter.cpp */; };
+		2B7F47BF1708365200A106A9 /* ColladaExporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45A11708365100A106A9 /* ColladaExporter.cpp */; };
+		2B7F47C01708365200A106A9 /* ColladaExporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45A11708365100A106A9 /* ColladaExporter.cpp */; };
+		2B7F47C11708365200A106A9 /* ColladaExporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45A11708365100A106A9 /* ColladaExporter.cpp */; };
+		2B7F47C21708365200A106A9 /* ColladaExporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45A11708365100A106A9 /* ColladaExporter.cpp */; };
+		2B7F47C31708365200A106A9 /* ColladaExporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45A21708365100A106A9 /* ColladaExporter.h */; };
+		2B7F47C41708365200A106A9 /* ColladaExporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45A21708365100A106A9 /* ColladaExporter.h */; };
+		2B7F47C51708365200A106A9 /* ColladaExporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45A21708365100A106A9 /* ColladaExporter.h */; };
+		2B7F47C61708365200A106A9 /* ColladaExporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45A21708365100A106A9 /* ColladaExporter.h */; };
+		2B7F47C71708365200A106A9 /* ColladaExporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45A21708365100A106A9 /* ColladaExporter.h */; };
+		2B7F47C81708365200A106A9 /* ColladaHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45A31708365100A106A9 /* ColladaHelper.h */; };
+		2B7F47C91708365200A106A9 /* ColladaHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45A31708365100A106A9 /* ColladaHelper.h */; };
+		2B7F47CA1708365200A106A9 /* ColladaHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45A31708365100A106A9 /* ColladaHelper.h */; };
+		2B7F47CB1708365200A106A9 /* ColladaHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45A31708365100A106A9 /* ColladaHelper.h */; };
+		2B7F47CC1708365200A106A9 /* ColladaHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45A31708365100A106A9 /* ColladaHelper.h */; };
+		2B7F47CD1708365200A106A9 /* ColladaLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45A41708365100A106A9 /* ColladaLoader.cpp */; };
+		2B7F47CE1708365200A106A9 /* ColladaLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45A41708365100A106A9 /* ColladaLoader.cpp */; };
+		2B7F47CF1708365200A106A9 /* ColladaLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45A41708365100A106A9 /* ColladaLoader.cpp */; };
+		2B7F47D01708365200A106A9 /* ColladaLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45A41708365100A106A9 /* ColladaLoader.cpp */; };
+		2B7F47D11708365200A106A9 /* ColladaLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45A41708365100A106A9 /* ColladaLoader.cpp */; };
+		2B7F47D21708365200A106A9 /* ColladaLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45A51708365100A106A9 /* ColladaLoader.h */; };
+		2B7F47D31708365200A106A9 /* ColladaLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45A51708365100A106A9 /* ColladaLoader.h */; };
+		2B7F47D41708365200A106A9 /* ColladaLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45A51708365100A106A9 /* ColladaLoader.h */; };
+		2B7F47D51708365200A106A9 /* ColladaLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45A51708365100A106A9 /* ColladaLoader.h */; };
+		2B7F47D61708365200A106A9 /* ColladaLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45A51708365100A106A9 /* ColladaLoader.h */; };
+		2B7F47D71708365200A106A9 /* ColladaParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45A61708365100A106A9 /* ColladaParser.cpp */; };
+		2B7F47D81708365200A106A9 /* ColladaParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45A61708365100A106A9 /* ColladaParser.cpp */; };
+		2B7F47D91708365200A106A9 /* ColladaParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45A61708365100A106A9 /* ColladaParser.cpp */; };
+		2B7F47DA1708365200A106A9 /* ColladaParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45A61708365100A106A9 /* ColladaParser.cpp */; };
+		2B7F47DB1708365200A106A9 /* ColladaParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45A61708365100A106A9 /* ColladaParser.cpp */; };
+		2B7F47DC1708365200A106A9 /* ColladaParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45A71708365100A106A9 /* ColladaParser.h */; };
+		2B7F47DD1708365200A106A9 /* ColladaParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45A71708365100A106A9 /* ColladaParser.h */; };
+		2B7F47DE1708365200A106A9 /* ColladaParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45A71708365100A106A9 /* ColladaParser.h */; };
+		2B7F47DF1708365200A106A9 /* ColladaParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45A71708365100A106A9 /* ColladaParser.h */; };
+		2B7F47E01708365200A106A9 /* ColladaParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45A71708365100A106A9 /* ColladaParser.h */; };
+		2B7F47E11708365200A106A9 /* ComputeUVMappingProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45A81708365100A106A9 /* ComputeUVMappingProcess.cpp */; };
+		2B7F47E21708365200A106A9 /* ComputeUVMappingProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45A81708365100A106A9 /* ComputeUVMappingProcess.cpp */; };
+		2B7F47E31708365200A106A9 /* ComputeUVMappingProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45A81708365100A106A9 /* ComputeUVMappingProcess.cpp */; };
+		2B7F47E41708365200A106A9 /* ComputeUVMappingProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45A81708365100A106A9 /* ComputeUVMappingProcess.cpp */; };
+		2B7F47E51708365200A106A9 /* ComputeUVMappingProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45A81708365100A106A9 /* ComputeUVMappingProcess.cpp */; };
+		2B7F47E61708365200A106A9 /* ComputeUVMappingProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45A91708365100A106A9 /* ComputeUVMappingProcess.h */; };
+		2B7F47E71708365200A106A9 /* ComputeUVMappingProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45A91708365100A106A9 /* ComputeUVMappingProcess.h */; };
+		2B7F47E81708365200A106A9 /* ComputeUVMappingProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45A91708365100A106A9 /* ComputeUVMappingProcess.h */; };
+		2B7F47E91708365200A106A9 /* ComputeUVMappingProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45A91708365100A106A9 /* ComputeUVMappingProcess.h */; };
+		2B7F47EA1708365200A106A9 /* ComputeUVMappingProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45A91708365100A106A9 /* ComputeUVMappingProcess.h */; };
+		2B7F47EB1708365200A106A9 /* ConvertToLHProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45AA1708365100A106A9 /* ConvertToLHProcess.cpp */; };
+		2B7F47EC1708365200A106A9 /* ConvertToLHProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45AA1708365100A106A9 /* ConvertToLHProcess.cpp */; };
+		2B7F47ED1708365200A106A9 /* ConvertToLHProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45AA1708365100A106A9 /* ConvertToLHProcess.cpp */; };
+		2B7F47EE1708365200A106A9 /* ConvertToLHProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45AA1708365100A106A9 /* ConvertToLHProcess.cpp */; };
+		2B7F47EF1708365200A106A9 /* ConvertToLHProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45AA1708365100A106A9 /* ConvertToLHProcess.cpp */; };
+		2B7F47F01708365200A106A9 /* ConvertToLHProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45AB1708365100A106A9 /* ConvertToLHProcess.h */; };
+		2B7F47F11708365200A106A9 /* ConvertToLHProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45AB1708365100A106A9 /* ConvertToLHProcess.h */; };
+		2B7F47F21708365200A106A9 /* ConvertToLHProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45AB1708365100A106A9 /* ConvertToLHProcess.h */; };
+		2B7F47F31708365200A106A9 /* ConvertToLHProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45AB1708365100A106A9 /* ConvertToLHProcess.h */; };
+		2B7F47F41708365200A106A9 /* ConvertToLHProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45AB1708365100A106A9 /* ConvertToLHProcess.h */; };
+		2B7F47FF1708365200A106A9 /* DeboneProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45AE1708365100A106A9 /* DeboneProcess.cpp */; };
+		2B7F48001708365200A106A9 /* DeboneProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45AE1708365100A106A9 /* DeboneProcess.cpp */; };
+		2B7F48011708365200A106A9 /* DeboneProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45AE1708365100A106A9 /* DeboneProcess.cpp */; };
+		2B7F48021708365200A106A9 /* DeboneProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45AE1708365100A106A9 /* DeboneProcess.cpp */; };
+		2B7F48031708365200A106A9 /* DeboneProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45AE1708365100A106A9 /* DeboneProcess.cpp */; };
+		2B7F48041708365200A106A9 /* DeboneProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45AF1708365100A106A9 /* DeboneProcess.h */; };
+		2B7F48051708365200A106A9 /* DeboneProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45AF1708365100A106A9 /* DeboneProcess.h */; };
+		2B7F48061708365200A106A9 /* DeboneProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45AF1708365100A106A9 /* DeboneProcess.h */; };
+		2B7F48071708365200A106A9 /* DeboneProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45AF1708365100A106A9 /* DeboneProcess.h */; };
+		2B7F48081708365200A106A9 /* DeboneProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45AF1708365100A106A9 /* DeboneProcess.h */; };
+		2B7F48091708365200A106A9 /* DefaultIOStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45B01708365100A106A9 /* DefaultIOStream.cpp */; };
+		2B7F480A1708365200A106A9 /* DefaultIOStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45B01708365100A106A9 /* DefaultIOStream.cpp */; };
+		2B7F480B1708365200A106A9 /* DefaultIOStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45B01708365100A106A9 /* DefaultIOStream.cpp */; };
+		2B7F480C1708365200A106A9 /* DefaultIOStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45B01708365100A106A9 /* DefaultIOStream.cpp */; };
+		2B7F480D1708365200A106A9 /* DefaultIOStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45B01708365100A106A9 /* DefaultIOStream.cpp */; };
+		2B7F480E1708365200A106A9 /* DefaultIOStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45B11708365100A106A9 /* DefaultIOStream.h */; };
+		2B7F480F1708365200A106A9 /* DefaultIOStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45B11708365100A106A9 /* DefaultIOStream.h */; };
+		2B7F48101708365200A106A9 /* DefaultIOStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45B11708365100A106A9 /* DefaultIOStream.h */; };
+		2B7F48111708365200A106A9 /* DefaultIOStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45B11708365100A106A9 /* DefaultIOStream.h */; };
+		2B7F48121708365200A106A9 /* DefaultIOStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45B11708365100A106A9 /* DefaultIOStream.h */; };
+		2B7F48131708365200A106A9 /* DefaultIOSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45B21708365100A106A9 /* DefaultIOSystem.cpp */; };
+		2B7F48141708365200A106A9 /* DefaultIOSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45B21708365100A106A9 /* DefaultIOSystem.cpp */; };
+		2B7F48151708365200A106A9 /* DefaultIOSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45B21708365100A106A9 /* DefaultIOSystem.cpp */; };
+		2B7F48161708365200A106A9 /* DefaultIOSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45B21708365100A106A9 /* DefaultIOSystem.cpp */; };
+		2B7F48171708365200A106A9 /* DefaultIOSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45B21708365100A106A9 /* DefaultIOSystem.cpp */; };
+		2B7F48181708365200A106A9 /* DefaultIOSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45B31708365100A106A9 /* DefaultIOSystem.h */; };
+		2B7F48191708365200A106A9 /* DefaultIOSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45B31708365100A106A9 /* DefaultIOSystem.h */; };
+		2B7F481A1708365200A106A9 /* DefaultIOSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45B31708365100A106A9 /* DefaultIOSystem.h */; };
+		2B7F481B1708365200A106A9 /* DefaultIOSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45B31708365100A106A9 /* DefaultIOSystem.h */; };
+		2B7F481C1708365200A106A9 /* DefaultIOSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45B31708365100A106A9 /* DefaultIOSystem.h */; };
+		2B7F481D1708365200A106A9 /* DefaultLogger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45B41708365100A106A9 /* DefaultLogger.cpp */; };
+		2B7F481E1708365200A106A9 /* DefaultLogger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45B41708365100A106A9 /* DefaultLogger.cpp */; };
+		2B7F481F1708365200A106A9 /* DefaultLogger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45B41708365100A106A9 /* DefaultLogger.cpp */; };
+		2B7F48201708365200A106A9 /* DefaultLogger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45B41708365100A106A9 /* DefaultLogger.cpp */; };
+		2B7F48211708365200A106A9 /* DefaultLogger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45B41708365100A106A9 /* DefaultLogger.cpp */; };
+		2B7F48221708365200A106A9 /* DefaultProgressHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45B51708365100A106A9 /* DefaultProgressHandler.h */; };
+		2B7F48231708365200A106A9 /* DefaultProgressHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45B51708365100A106A9 /* DefaultProgressHandler.h */; };
+		2B7F48241708365200A106A9 /* DefaultProgressHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45B51708365100A106A9 /* DefaultProgressHandler.h */; };
+		2B7F48251708365200A106A9 /* DefaultProgressHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45B51708365100A106A9 /* DefaultProgressHandler.h */; };
+		2B7F48261708365200A106A9 /* DefaultProgressHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45B51708365100A106A9 /* DefaultProgressHandler.h */; };
+		2B7F48361708365200A106A9 /* Exceptional.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45B91708365100A106A9 /* Exceptional.h */; };
+		2B7F48371708365200A106A9 /* Exceptional.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45B91708365100A106A9 /* Exceptional.h */; };
+		2B7F48381708365200A106A9 /* Exceptional.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45B91708365100A106A9 /* Exceptional.h */; };
+		2B7F48391708365200A106A9 /* Exceptional.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45B91708365100A106A9 /* Exceptional.h */; };
+		2B7F483A1708365200A106A9 /* Exceptional.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45B91708365100A106A9 /* Exceptional.h */; };
+		2B7F483B1708365200A106A9 /* Exporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45BA1708365100A106A9 /* Exporter.cpp */; };
+		2B7F483C1708365200A106A9 /* Exporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45BA1708365100A106A9 /* Exporter.cpp */; };
+		2B7F483D1708365200A106A9 /* Exporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45BA1708365100A106A9 /* Exporter.cpp */; };
+		2B7F483E1708365200A106A9 /* Exporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45BA1708365100A106A9 /* Exporter.cpp */; };
+		2B7F483F1708365200A106A9 /* Exporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45BA1708365100A106A9 /* Exporter.cpp */; };
+		2B7F48401708365200A106A9 /* fast_atof.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45BB1708365100A106A9 /* fast_atof.h */; };
+		2B7F48411708365200A106A9 /* fast_atof.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45BB1708365100A106A9 /* fast_atof.h */; };
+		2B7F48421708365200A106A9 /* fast_atof.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45BB1708365100A106A9 /* fast_atof.h */; };
+		2B7F48431708365200A106A9 /* fast_atof.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45BB1708365100A106A9 /* fast_atof.h */; };
+		2B7F48441708365200A106A9 /* fast_atof.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45BB1708365100A106A9 /* fast_atof.h */; };
+		2B7F48451708365200A106A9 /* FBXAnimation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45BC1708365100A106A9 /* FBXAnimation.cpp */; };
+		2B7F48461708365200A106A9 /* FBXAnimation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45BC1708365100A106A9 /* FBXAnimation.cpp */; };
+		2B7F48471708365200A106A9 /* FBXAnimation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45BC1708365100A106A9 /* FBXAnimation.cpp */; };
+		2B7F48481708365200A106A9 /* FBXAnimation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45BC1708365100A106A9 /* FBXAnimation.cpp */; };
+		2B7F48491708365200A106A9 /* FBXAnimation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45BC1708365100A106A9 /* FBXAnimation.cpp */; };
+		2B7F484A1708365200A106A9 /* FBXBinaryTokenizer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45BD1708365100A106A9 /* FBXBinaryTokenizer.cpp */; };
+		2B7F484B1708365200A106A9 /* FBXBinaryTokenizer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45BD1708365100A106A9 /* FBXBinaryTokenizer.cpp */; };
+		2B7F484C1708365200A106A9 /* FBXBinaryTokenizer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45BD1708365100A106A9 /* FBXBinaryTokenizer.cpp */; };
+		2B7F484D1708365200A106A9 /* FBXBinaryTokenizer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45BD1708365100A106A9 /* FBXBinaryTokenizer.cpp */; };
+		2B7F484E1708365200A106A9 /* FBXBinaryTokenizer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45BD1708365100A106A9 /* FBXBinaryTokenizer.cpp */; };
+		2B7F484F1708365200A106A9 /* FBXCompileConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45BE1708365100A106A9 /* FBXCompileConfig.h */; };
+		2B7F48501708365200A106A9 /* FBXCompileConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45BE1708365100A106A9 /* FBXCompileConfig.h */; };
+		2B7F48511708365200A106A9 /* FBXCompileConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45BE1708365100A106A9 /* FBXCompileConfig.h */; };
+		2B7F48521708365200A106A9 /* FBXCompileConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45BE1708365100A106A9 /* FBXCompileConfig.h */; };
+		2B7F48531708365200A106A9 /* FBXCompileConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45BE1708365100A106A9 /* FBXCompileConfig.h */; };
+		2B7F48541708365200A106A9 /* FBXConverter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45BF1708365100A106A9 /* FBXConverter.cpp */; };
+		2B7F48551708365200A106A9 /* FBXConverter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45BF1708365100A106A9 /* FBXConverter.cpp */; };
+		2B7F48561708365200A106A9 /* FBXConverter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45BF1708365100A106A9 /* FBXConverter.cpp */; };
+		2B7F48571708365200A106A9 /* FBXConverter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45BF1708365100A106A9 /* FBXConverter.cpp */; };
+		2B7F48581708365200A106A9 /* FBXConverter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45BF1708365100A106A9 /* FBXConverter.cpp */; };
+		2B7F48591708365200A106A9 /* FBXConverter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45C01708365100A106A9 /* FBXConverter.h */; };
+		2B7F485A1708365200A106A9 /* FBXConverter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45C01708365100A106A9 /* FBXConverter.h */; };
+		2B7F485B1708365200A106A9 /* FBXConverter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45C01708365100A106A9 /* FBXConverter.h */; };
+		2B7F485C1708365200A106A9 /* FBXConverter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45C01708365100A106A9 /* FBXConverter.h */; };
+		2B7F485D1708365200A106A9 /* FBXConverter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45C01708365100A106A9 /* FBXConverter.h */; };
+		2B7F485E1708365200A106A9 /* FBXDeformer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45C11708365100A106A9 /* FBXDeformer.cpp */; };
+		2B7F485F1708365200A106A9 /* FBXDeformer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45C11708365100A106A9 /* FBXDeformer.cpp */; };
+		2B7F48601708365200A106A9 /* FBXDeformer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45C11708365100A106A9 /* FBXDeformer.cpp */; };
+		2B7F48611708365200A106A9 /* FBXDeformer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45C11708365100A106A9 /* FBXDeformer.cpp */; };
+		2B7F48621708365200A106A9 /* FBXDeformer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45C11708365100A106A9 /* FBXDeformer.cpp */; };
+		2B7F48631708365200A106A9 /* FBXDocument.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45C21708365100A106A9 /* FBXDocument.cpp */; };
+		2B7F48641708365200A106A9 /* FBXDocument.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45C21708365100A106A9 /* FBXDocument.cpp */; };
+		2B7F48651708365200A106A9 /* FBXDocument.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45C21708365100A106A9 /* FBXDocument.cpp */; };
+		2B7F48661708365200A106A9 /* FBXDocument.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45C21708365100A106A9 /* FBXDocument.cpp */; };
+		2B7F48671708365200A106A9 /* FBXDocument.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45C21708365100A106A9 /* FBXDocument.cpp */; };
+		2B7F48681708365200A106A9 /* FBXDocument.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45C31708365100A106A9 /* FBXDocument.h */; };
+		2B7F48691708365200A106A9 /* FBXDocument.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45C31708365100A106A9 /* FBXDocument.h */; };
+		2B7F486A1708365200A106A9 /* FBXDocument.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45C31708365100A106A9 /* FBXDocument.h */; };
+		2B7F486B1708365200A106A9 /* FBXDocument.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45C31708365100A106A9 /* FBXDocument.h */; };
+		2B7F486C1708365200A106A9 /* FBXDocument.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45C31708365100A106A9 /* FBXDocument.h */; };
+		2B7F486D1708365200A106A9 /* FBXDocumentUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45C41708365100A106A9 /* FBXDocumentUtil.cpp */; };
+		2B7F486E1708365200A106A9 /* FBXDocumentUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45C41708365100A106A9 /* FBXDocumentUtil.cpp */; };
+		2B7F486F1708365200A106A9 /* FBXDocumentUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45C41708365100A106A9 /* FBXDocumentUtil.cpp */; };
+		2B7F48701708365200A106A9 /* FBXDocumentUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45C41708365100A106A9 /* FBXDocumentUtil.cpp */; };
+		2B7F48711708365200A106A9 /* FBXDocumentUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45C41708365100A106A9 /* FBXDocumentUtil.cpp */; };
+		2B7F48721708365200A106A9 /* FBXDocumentUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45C51708365100A106A9 /* FBXDocumentUtil.h */; };
+		2B7F48731708365200A106A9 /* FBXDocumentUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45C51708365100A106A9 /* FBXDocumentUtil.h */; };
+		2B7F48741708365200A106A9 /* FBXDocumentUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45C51708365100A106A9 /* FBXDocumentUtil.h */; };
+		2B7F48751708365200A106A9 /* FBXDocumentUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45C51708365100A106A9 /* FBXDocumentUtil.h */; };
+		2B7F48761708365200A106A9 /* FBXDocumentUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45C51708365100A106A9 /* FBXDocumentUtil.h */; };
+		2B7F48771708365200A106A9 /* FBXImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45C61708365100A106A9 /* FBXImporter.cpp */; };
+		2B7F48781708365200A106A9 /* FBXImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45C61708365100A106A9 /* FBXImporter.cpp */; };
+		2B7F48791708365200A106A9 /* FBXImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45C61708365100A106A9 /* FBXImporter.cpp */; };
+		2B7F487A1708365200A106A9 /* FBXImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45C61708365100A106A9 /* FBXImporter.cpp */; };
+		2B7F487B1708365200A106A9 /* FBXImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45C61708365100A106A9 /* FBXImporter.cpp */; };
+		2B7F487C1708365200A106A9 /* FBXImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45C71708365100A106A9 /* FBXImporter.h */; };
+		2B7F487D1708365200A106A9 /* FBXImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45C71708365100A106A9 /* FBXImporter.h */; };
+		2B7F487E1708365200A106A9 /* FBXImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45C71708365100A106A9 /* FBXImporter.h */; };
+		2B7F487F1708365200A106A9 /* FBXImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45C71708365100A106A9 /* FBXImporter.h */; };
+		2B7F48801708365200A106A9 /* FBXImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45C71708365100A106A9 /* FBXImporter.h */; };
+		2B7F48811708365200A106A9 /* FBXImportSettings.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45C81708365100A106A9 /* FBXImportSettings.h */; };
+		2B7F48821708365200A106A9 /* FBXImportSettings.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45C81708365100A106A9 /* FBXImportSettings.h */; };
+		2B7F48831708365200A106A9 /* FBXImportSettings.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45C81708365100A106A9 /* FBXImportSettings.h */; };
+		2B7F48841708365200A106A9 /* FBXImportSettings.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45C81708365100A106A9 /* FBXImportSettings.h */; };
+		2B7F48851708365200A106A9 /* FBXImportSettings.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45C81708365100A106A9 /* FBXImportSettings.h */; };
+		2B7F48861708365200A106A9 /* FBXMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45C91708365100A106A9 /* FBXMaterial.cpp */; };
+		2B7F48871708365200A106A9 /* FBXMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45C91708365100A106A9 /* FBXMaterial.cpp */; };
+		2B7F48881708365200A106A9 /* FBXMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45C91708365100A106A9 /* FBXMaterial.cpp */; };
+		2B7F48891708365200A106A9 /* FBXMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45C91708365100A106A9 /* FBXMaterial.cpp */; };
+		2B7F488A1708365200A106A9 /* FBXMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45C91708365100A106A9 /* FBXMaterial.cpp */; };
+		2B7F488B1708365200A106A9 /* FBXMeshGeometry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45CA1708365100A106A9 /* FBXMeshGeometry.cpp */; };
+		2B7F488C1708365200A106A9 /* FBXMeshGeometry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45CA1708365100A106A9 /* FBXMeshGeometry.cpp */; };
+		2B7F488D1708365200A106A9 /* FBXMeshGeometry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45CA1708365100A106A9 /* FBXMeshGeometry.cpp */; };
+		2B7F488E1708365200A106A9 /* FBXMeshGeometry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45CA1708365100A106A9 /* FBXMeshGeometry.cpp */; };
+		2B7F488F1708365200A106A9 /* FBXMeshGeometry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45CA1708365100A106A9 /* FBXMeshGeometry.cpp */; };
+		2B7F48901708365200A106A9 /* FBXModel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45CB1708365100A106A9 /* FBXModel.cpp */; };
+		2B7F48911708365200A106A9 /* FBXModel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45CB1708365100A106A9 /* FBXModel.cpp */; };
+		2B7F48921708365200A106A9 /* FBXModel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45CB1708365100A106A9 /* FBXModel.cpp */; };
+		2B7F48931708365200A106A9 /* FBXModel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45CB1708365100A106A9 /* FBXModel.cpp */; };
+		2B7F48941708365200A106A9 /* FBXModel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45CB1708365100A106A9 /* FBXModel.cpp */; };
+		2B7F48951708365200A106A9 /* FBXNodeAttribute.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45CC1708365100A106A9 /* FBXNodeAttribute.cpp */; };
+		2B7F48961708365200A106A9 /* FBXNodeAttribute.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45CC1708365100A106A9 /* FBXNodeAttribute.cpp */; };
+		2B7F48971708365200A106A9 /* FBXNodeAttribute.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45CC1708365100A106A9 /* FBXNodeAttribute.cpp */; };
+		2B7F48981708365200A106A9 /* FBXNodeAttribute.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45CC1708365100A106A9 /* FBXNodeAttribute.cpp */; };
+		2B7F48991708365200A106A9 /* FBXNodeAttribute.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45CC1708365100A106A9 /* FBXNodeAttribute.cpp */; };
+		2B7F489A1708365200A106A9 /* FBXParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45CD1708365100A106A9 /* FBXParser.cpp */; };
+		2B7F489B1708365200A106A9 /* FBXParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45CD1708365100A106A9 /* FBXParser.cpp */; };
+		2B7F489C1708365200A106A9 /* FBXParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45CD1708365100A106A9 /* FBXParser.cpp */; };
+		2B7F489D1708365200A106A9 /* FBXParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45CD1708365100A106A9 /* FBXParser.cpp */; };
+		2B7F489E1708365200A106A9 /* FBXParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45CD1708365100A106A9 /* FBXParser.cpp */; };
+		2B7F489F1708365200A106A9 /* FBXParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45CE1708365100A106A9 /* FBXParser.h */; };
+		2B7F48A01708365200A106A9 /* FBXParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45CE1708365100A106A9 /* FBXParser.h */; };
+		2B7F48A11708365200A106A9 /* FBXParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45CE1708365100A106A9 /* FBXParser.h */; };
+		2B7F48A21708365200A106A9 /* FBXParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45CE1708365100A106A9 /* FBXParser.h */; };
+		2B7F48A31708365200A106A9 /* FBXParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45CE1708365100A106A9 /* FBXParser.h */; };
+		2B7F48A41708365200A106A9 /* FBXProperties.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45CF1708365100A106A9 /* FBXProperties.cpp */; };
+		2B7F48A51708365200A106A9 /* FBXProperties.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45CF1708365100A106A9 /* FBXProperties.cpp */; };
+		2B7F48A61708365200A106A9 /* FBXProperties.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45CF1708365100A106A9 /* FBXProperties.cpp */; };
+		2B7F48A71708365200A106A9 /* FBXProperties.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45CF1708365100A106A9 /* FBXProperties.cpp */; };
+		2B7F48A81708365200A106A9 /* FBXProperties.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45CF1708365100A106A9 /* FBXProperties.cpp */; };
+		2B7F48A91708365200A106A9 /* FBXProperties.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45D01708365100A106A9 /* FBXProperties.h */; };
+		2B7F48AA1708365200A106A9 /* FBXProperties.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45D01708365100A106A9 /* FBXProperties.h */; };
+		2B7F48AB1708365200A106A9 /* FBXProperties.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45D01708365100A106A9 /* FBXProperties.h */; };
+		2B7F48AC1708365200A106A9 /* FBXProperties.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45D01708365100A106A9 /* FBXProperties.h */; };
+		2B7F48AD1708365200A106A9 /* FBXProperties.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45D01708365100A106A9 /* FBXProperties.h */; };
+		2B7F48AE1708365200A106A9 /* FBXTokenizer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45D11708365100A106A9 /* FBXTokenizer.cpp */; };
+		2B7F48AF1708365200A106A9 /* FBXTokenizer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45D11708365100A106A9 /* FBXTokenizer.cpp */; };
+		2B7F48B01708365200A106A9 /* FBXTokenizer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45D11708365100A106A9 /* FBXTokenizer.cpp */; };
+		2B7F48B11708365200A106A9 /* FBXTokenizer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45D11708365100A106A9 /* FBXTokenizer.cpp */; };
+		2B7F48B21708365200A106A9 /* FBXTokenizer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45D11708365100A106A9 /* FBXTokenizer.cpp */; };
+		2B7F48B31708365200A106A9 /* FBXTokenizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45D21708365100A106A9 /* FBXTokenizer.h */; };
+		2B7F48B41708365200A106A9 /* FBXTokenizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45D21708365100A106A9 /* FBXTokenizer.h */; };
+		2B7F48B51708365200A106A9 /* FBXTokenizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45D21708365100A106A9 /* FBXTokenizer.h */; };
+		2B7F48B61708365200A106A9 /* FBXTokenizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45D21708365100A106A9 /* FBXTokenizer.h */; };
+		2B7F48B71708365200A106A9 /* FBXTokenizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45D21708365100A106A9 /* FBXTokenizer.h */; };
+		2B7F48B81708365200A106A9 /* FBXUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45D31708365100A106A9 /* FBXUtil.cpp */; };
+		2B7F48B91708365200A106A9 /* FBXUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45D31708365100A106A9 /* FBXUtil.cpp */; };
+		2B7F48BA1708365200A106A9 /* FBXUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45D31708365100A106A9 /* FBXUtil.cpp */; };
+		2B7F48BB1708365200A106A9 /* FBXUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45D31708365100A106A9 /* FBXUtil.cpp */; };
+		2B7F48BC1708365200A106A9 /* FBXUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45D31708365100A106A9 /* FBXUtil.cpp */; };
+		2B7F48BD1708365200A106A9 /* FBXUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45D41708365100A106A9 /* FBXUtil.h */; };
+		2B7F48BE1708365200A106A9 /* FBXUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45D41708365100A106A9 /* FBXUtil.h */; };
+		2B7F48BF1708365200A106A9 /* FBXUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45D41708365100A106A9 /* FBXUtil.h */; };
+		2B7F48C01708365200A106A9 /* FBXUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45D41708365100A106A9 /* FBXUtil.h */; };
+		2B7F48C11708365200A106A9 /* FBXUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45D41708365100A106A9 /* FBXUtil.h */; };
+		2B7F48C21708365200A106A9 /* FileLogStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45D51708365100A106A9 /* FileLogStream.h */; };
+		2B7F48C31708365200A106A9 /* FileLogStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45D51708365100A106A9 /* FileLogStream.h */; };
+		2B7F48C41708365200A106A9 /* FileLogStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45D51708365100A106A9 /* FileLogStream.h */; };
+		2B7F48C51708365200A106A9 /* FileLogStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45D51708365100A106A9 /* FileLogStream.h */; };
+		2B7F48C61708365200A106A9 /* FileLogStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45D51708365100A106A9 /* FileLogStream.h */; };
+		2B7F48C71708365200A106A9 /* FileSystemFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45D61708365100A106A9 /* FileSystemFilter.h */; };
+		2B7F48C81708365200A106A9 /* FileSystemFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45D61708365100A106A9 /* FileSystemFilter.h */; };
+		2B7F48C91708365200A106A9 /* FileSystemFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45D61708365100A106A9 /* FileSystemFilter.h */; };
+		2B7F48CA1708365200A106A9 /* FileSystemFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45D61708365100A106A9 /* FileSystemFilter.h */; };
+		2B7F48CB1708365200A106A9 /* FileSystemFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45D61708365100A106A9 /* FileSystemFilter.h */; };
+		2B7F48CC1708365200A106A9 /* FindDegenerates.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45D71708365100A106A9 /* FindDegenerates.cpp */; };
+		2B7F48CD1708365200A106A9 /* FindDegenerates.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45D71708365100A106A9 /* FindDegenerates.cpp */; };
+		2B7F48CE1708365200A106A9 /* FindDegenerates.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45D71708365100A106A9 /* FindDegenerates.cpp */; };
+		2B7F48CF1708365200A106A9 /* FindDegenerates.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45D71708365100A106A9 /* FindDegenerates.cpp */; };
+		2B7F48D01708365200A106A9 /* FindDegenerates.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45D71708365100A106A9 /* FindDegenerates.cpp */; };
+		2B7F48D11708365200A106A9 /* FindDegenerates.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45D81708365100A106A9 /* FindDegenerates.h */; };
+		2B7F48D21708365200A106A9 /* FindDegenerates.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45D81708365100A106A9 /* FindDegenerates.h */; };
+		2B7F48D31708365200A106A9 /* FindDegenerates.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45D81708365100A106A9 /* FindDegenerates.h */; };
+		2B7F48D41708365200A106A9 /* FindDegenerates.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45D81708365100A106A9 /* FindDegenerates.h */; };
+		2B7F48D51708365200A106A9 /* FindDegenerates.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45D81708365100A106A9 /* FindDegenerates.h */; };
+		2B7F48D61708365200A106A9 /* FindInstancesProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45D91708365100A106A9 /* FindInstancesProcess.cpp */; };
+		2B7F48D71708365200A106A9 /* FindInstancesProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45D91708365100A106A9 /* FindInstancesProcess.cpp */; };
+		2B7F48D81708365200A106A9 /* FindInstancesProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45D91708365100A106A9 /* FindInstancesProcess.cpp */; };
+		2B7F48D91708365200A106A9 /* FindInstancesProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45D91708365100A106A9 /* FindInstancesProcess.cpp */; };
+		2B7F48DA1708365200A106A9 /* FindInstancesProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45D91708365100A106A9 /* FindInstancesProcess.cpp */; };
+		2B7F48DB1708365200A106A9 /* FindInstancesProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45DA1708365100A106A9 /* FindInstancesProcess.h */; };
+		2B7F48DC1708365200A106A9 /* FindInstancesProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45DA1708365100A106A9 /* FindInstancesProcess.h */; };
+		2B7F48DD1708365200A106A9 /* FindInstancesProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45DA1708365100A106A9 /* FindInstancesProcess.h */; };
+		2B7F48DE1708365200A106A9 /* FindInstancesProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45DA1708365100A106A9 /* FindInstancesProcess.h */; };
+		2B7F48DF1708365200A106A9 /* FindInstancesProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45DA1708365100A106A9 /* FindInstancesProcess.h */; };
+		2B7F48E01708365200A106A9 /* FindInvalidDataProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45DB1708365100A106A9 /* FindInvalidDataProcess.cpp */; };
+		2B7F48E11708365200A106A9 /* FindInvalidDataProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45DB1708365100A106A9 /* FindInvalidDataProcess.cpp */; };
+		2B7F48E21708365200A106A9 /* FindInvalidDataProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45DB1708365100A106A9 /* FindInvalidDataProcess.cpp */; };
+		2B7F48E31708365200A106A9 /* FindInvalidDataProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45DB1708365100A106A9 /* FindInvalidDataProcess.cpp */; };
+		2B7F48E41708365200A106A9 /* FindInvalidDataProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45DB1708365100A106A9 /* FindInvalidDataProcess.cpp */; };
+		2B7F48E51708365200A106A9 /* FindInvalidDataProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45DC1708365100A106A9 /* FindInvalidDataProcess.h */; };
+		2B7F48E61708365200A106A9 /* FindInvalidDataProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45DC1708365100A106A9 /* FindInvalidDataProcess.h */; };
+		2B7F48E71708365200A106A9 /* FindInvalidDataProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45DC1708365100A106A9 /* FindInvalidDataProcess.h */; };
+		2B7F48E81708365200A106A9 /* FindInvalidDataProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45DC1708365100A106A9 /* FindInvalidDataProcess.h */; };
+		2B7F48E91708365200A106A9 /* FindInvalidDataProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45DC1708365100A106A9 /* FindInvalidDataProcess.h */; };
+		2B7F48EA1708365200A106A9 /* FixNormalsStep.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45DD1708365100A106A9 /* FixNormalsStep.cpp */; };
+		2B7F48EB1708365200A106A9 /* FixNormalsStep.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45DD1708365100A106A9 /* FixNormalsStep.cpp */; };
+		2B7F48EC1708365200A106A9 /* FixNormalsStep.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45DD1708365100A106A9 /* FixNormalsStep.cpp */; };
+		2B7F48ED1708365200A106A9 /* FixNormalsStep.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45DD1708365100A106A9 /* FixNormalsStep.cpp */; };
+		2B7F48EE1708365200A106A9 /* FixNormalsStep.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45DD1708365100A106A9 /* FixNormalsStep.cpp */; };
+		2B7F48EF1708365200A106A9 /* FixNormalsStep.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45DE1708365100A106A9 /* FixNormalsStep.h */; };
+		2B7F48F01708365200A106A9 /* FixNormalsStep.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45DE1708365100A106A9 /* FixNormalsStep.h */; };
+		2B7F48F11708365200A106A9 /* FixNormalsStep.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45DE1708365100A106A9 /* FixNormalsStep.h */; };
+		2B7F48F21708365200A106A9 /* FixNormalsStep.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45DE1708365100A106A9 /* FixNormalsStep.h */; };
+		2B7F48F31708365200A106A9 /* FixNormalsStep.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45DE1708365100A106A9 /* FixNormalsStep.h */; };
+		2B7F48F41708365200A106A9 /* GenericProperty.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45DF1708365100A106A9 /* GenericProperty.h */; };
+		2B7F48F51708365200A106A9 /* GenericProperty.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45DF1708365100A106A9 /* GenericProperty.h */; };
+		2B7F48F61708365200A106A9 /* GenericProperty.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45DF1708365100A106A9 /* GenericProperty.h */; };
+		2B7F48F71708365200A106A9 /* GenericProperty.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45DF1708365100A106A9 /* GenericProperty.h */; };
+		2B7F48F81708365200A106A9 /* GenericProperty.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45DF1708365100A106A9 /* GenericProperty.h */; };
+		2B7F48F91708365200A106A9 /* GenFaceNormalsProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45E01708365100A106A9 /* GenFaceNormalsProcess.cpp */; };
+		2B7F48FA1708365200A106A9 /* GenFaceNormalsProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45E01708365100A106A9 /* GenFaceNormalsProcess.cpp */; };
+		2B7F48FB1708365200A106A9 /* GenFaceNormalsProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45E01708365100A106A9 /* GenFaceNormalsProcess.cpp */; };
+		2B7F48FC1708365200A106A9 /* GenFaceNormalsProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45E01708365100A106A9 /* GenFaceNormalsProcess.cpp */; };
+		2B7F48FD1708365200A106A9 /* GenFaceNormalsProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45E01708365100A106A9 /* GenFaceNormalsProcess.cpp */; };
+		2B7F48FE1708365200A106A9 /* GenFaceNormalsProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45E11708365100A106A9 /* GenFaceNormalsProcess.h */; };
+		2B7F48FF1708365200A106A9 /* GenFaceNormalsProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45E11708365100A106A9 /* GenFaceNormalsProcess.h */; };
+		2B7F49001708365200A106A9 /* GenFaceNormalsProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45E11708365100A106A9 /* GenFaceNormalsProcess.h */; };
+		2B7F49011708365200A106A9 /* GenFaceNormalsProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45E11708365100A106A9 /* GenFaceNormalsProcess.h */; };
+		2B7F49021708365200A106A9 /* GenFaceNormalsProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45E11708365100A106A9 /* GenFaceNormalsProcess.h */; };
+		2B7F49031708365200A106A9 /* GenVertexNormalsProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45E21708365100A106A9 /* GenVertexNormalsProcess.cpp */; };
+		2B7F49041708365200A106A9 /* GenVertexNormalsProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45E21708365100A106A9 /* GenVertexNormalsProcess.cpp */; };
+		2B7F49051708365200A106A9 /* GenVertexNormalsProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45E21708365100A106A9 /* GenVertexNormalsProcess.cpp */; };
+		2B7F49061708365200A106A9 /* GenVertexNormalsProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45E21708365100A106A9 /* GenVertexNormalsProcess.cpp */; };
+		2B7F49071708365200A106A9 /* GenVertexNormalsProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45E21708365100A106A9 /* GenVertexNormalsProcess.cpp */; };
+		2B7F49081708365200A106A9 /* GenVertexNormalsProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45E31708365100A106A9 /* GenVertexNormalsProcess.h */; };
+		2B7F49091708365200A106A9 /* GenVertexNormalsProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45E31708365100A106A9 /* GenVertexNormalsProcess.h */; };
+		2B7F490A1708365200A106A9 /* GenVertexNormalsProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45E31708365100A106A9 /* GenVertexNormalsProcess.h */; };
+		2B7F490B1708365200A106A9 /* GenVertexNormalsProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45E31708365100A106A9 /* GenVertexNormalsProcess.h */; };
+		2B7F490C1708365200A106A9 /* GenVertexNormalsProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45E31708365100A106A9 /* GenVertexNormalsProcess.h */; };
+		2B7F49121708365200A106A9 /* Hash.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45E51708365100A106A9 /* Hash.h */; };
+		2B7F49131708365200A106A9 /* Hash.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45E51708365100A106A9 /* Hash.h */; };
+		2B7F49141708365200A106A9 /* Hash.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45E51708365100A106A9 /* Hash.h */; };
+		2B7F49151708365200A106A9 /* Hash.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45E51708365100A106A9 /* Hash.h */; };
+		2B7F49161708365200A106A9 /* Hash.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45E51708365100A106A9 /* Hash.h */; };
+		2B7F49261708365200A106A9 /* IFCBoolean.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45E91708365100A106A9 /* IFCBoolean.cpp */; };
+		2B7F49271708365200A106A9 /* IFCBoolean.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45E91708365100A106A9 /* IFCBoolean.cpp */; };
+		2B7F49281708365200A106A9 /* IFCBoolean.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45E91708365100A106A9 /* IFCBoolean.cpp */; };
+		2B7F49291708365200A106A9 /* IFCBoolean.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45E91708365100A106A9 /* IFCBoolean.cpp */; };
+		2B7F492A1708365200A106A9 /* IFCBoolean.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45E91708365100A106A9 /* IFCBoolean.cpp */; };
+		2B7F492B1708365200A106A9 /* IFCCurve.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45EA1708365100A106A9 /* IFCCurve.cpp */; };
+		2B7F492C1708365200A106A9 /* IFCCurve.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45EA1708365100A106A9 /* IFCCurve.cpp */; };
+		2B7F492D1708365200A106A9 /* IFCCurve.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45EA1708365100A106A9 /* IFCCurve.cpp */; };
+		2B7F492E1708365200A106A9 /* IFCCurve.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45EA1708365100A106A9 /* IFCCurve.cpp */; };
+		2B7F492F1708365200A106A9 /* IFCCurve.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45EA1708365100A106A9 /* IFCCurve.cpp */; };
+		2B7F49301708365200A106A9 /* IFCGeometry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45EB1708365100A106A9 /* IFCGeometry.cpp */; };
+		2B7F49311708365200A106A9 /* IFCGeometry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45EB1708365100A106A9 /* IFCGeometry.cpp */; };
+		2B7F49321708365200A106A9 /* IFCGeometry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45EB1708365100A106A9 /* IFCGeometry.cpp */; };
+		2B7F49331708365200A106A9 /* IFCGeometry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45EB1708365100A106A9 /* IFCGeometry.cpp */; };
+		2B7F49341708365200A106A9 /* IFCGeometry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45EB1708365100A106A9 /* IFCGeometry.cpp */; };
+		2B7F49351708365200A106A9 /* IFCLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45EC1708365100A106A9 /* IFCLoader.cpp */; };
+		2B7F49361708365200A106A9 /* IFCLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45EC1708365100A106A9 /* IFCLoader.cpp */; };
+		2B7F49371708365200A106A9 /* IFCLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45EC1708365100A106A9 /* IFCLoader.cpp */; };
+		2B7F49381708365200A106A9 /* IFCLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45EC1708365100A106A9 /* IFCLoader.cpp */; };
+		2B7F49391708365200A106A9 /* IFCLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45EC1708365100A106A9 /* IFCLoader.cpp */; };
+		2B7F493A1708365200A106A9 /* IFCLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45ED1708365100A106A9 /* IFCLoader.h */; };
+		2B7F493B1708365200A106A9 /* IFCLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45ED1708365100A106A9 /* IFCLoader.h */; };
+		2B7F493C1708365200A106A9 /* IFCLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45ED1708365100A106A9 /* IFCLoader.h */; };
+		2B7F493D1708365200A106A9 /* IFCLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45ED1708365100A106A9 /* IFCLoader.h */; };
+		2B7F493E1708365200A106A9 /* IFCLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45ED1708365100A106A9 /* IFCLoader.h */; };
+		2B7F493F1708365200A106A9 /* IFCMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45EE1708365100A106A9 /* IFCMaterial.cpp */; };
+		2B7F49401708365200A106A9 /* IFCMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45EE1708365100A106A9 /* IFCMaterial.cpp */; };
+		2B7F49411708365200A106A9 /* IFCMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45EE1708365100A106A9 /* IFCMaterial.cpp */; };
+		2B7F49421708365200A106A9 /* IFCMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45EE1708365100A106A9 /* IFCMaterial.cpp */; };
+		2B7F49431708365200A106A9 /* IFCMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45EE1708365100A106A9 /* IFCMaterial.cpp */; };
+		2B7F49441708365200A106A9 /* IFCOpenings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45EF1708365100A106A9 /* IFCOpenings.cpp */; };
+		2B7F49451708365200A106A9 /* IFCOpenings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45EF1708365100A106A9 /* IFCOpenings.cpp */; };
+		2B7F49461708365200A106A9 /* IFCOpenings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45EF1708365100A106A9 /* IFCOpenings.cpp */; };
+		2B7F49471708365200A106A9 /* IFCOpenings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45EF1708365100A106A9 /* IFCOpenings.cpp */; };
+		2B7F49481708365200A106A9 /* IFCOpenings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45EF1708365100A106A9 /* IFCOpenings.cpp */; };
+		2B7F49491708365200A106A9 /* IFCProfile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45F01708365100A106A9 /* IFCProfile.cpp */; };
+		2B7F494A1708365200A106A9 /* IFCProfile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45F01708365100A106A9 /* IFCProfile.cpp */; };
+		2B7F494B1708365200A106A9 /* IFCProfile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45F01708365100A106A9 /* IFCProfile.cpp */; };
+		2B7F494C1708365200A106A9 /* IFCProfile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45F01708365100A106A9 /* IFCProfile.cpp */; };
+		2B7F494D1708365200A106A9 /* IFCProfile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45F01708365100A106A9 /* IFCProfile.cpp */; };
+		2B7F494E1708365200A106A9 /* IFCReaderGen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45F11708365100A106A9 /* IFCReaderGen.cpp */; };
+		2B7F494F1708365200A106A9 /* IFCReaderGen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45F11708365100A106A9 /* IFCReaderGen.cpp */; };
+		2B7F49501708365200A106A9 /* IFCReaderGen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45F11708365100A106A9 /* IFCReaderGen.cpp */; };
+		2B7F49511708365200A106A9 /* IFCReaderGen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45F11708365100A106A9 /* IFCReaderGen.cpp */; };
+		2B7F49521708365200A106A9 /* IFCReaderGen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45F11708365100A106A9 /* IFCReaderGen.cpp */; };
+		2B7F49531708365200A106A9 /* IFCReaderGen.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45F21708365100A106A9 /* IFCReaderGen.h */; };
+		2B7F49541708365200A106A9 /* IFCReaderGen.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45F21708365100A106A9 /* IFCReaderGen.h */; };
+		2B7F49551708365200A106A9 /* IFCReaderGen.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45F21708365100A106A9 /* IFCReaderGen.h */; };
+		2B7F49561708365200A106A9 /* IFCReaderGen.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45F21708365100A106A9 /* IFCReaderGen.h */; };
+		2B7F49571708365200A106A9 /* IFCReaderGen.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45F21708365100A106A9 /* IFCReaderGen.h */; };
+		2B7F49581708365200A106A9 /* IFCUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45F31708365100A106A9 /* IFCUtil.cpp */; };
+		2B7F49591708365200A106A9 /* IFCUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45F31708365100A106A9 /* IFCUtil.cpp */; };
+		2B7F495A1708365200A106A9 /* IFCUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45F31708365100A106A9 /* IFCUtil.cpp */; };
+		2B7F495B1708365200A106A9 /* IFCUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45F31708365100A106A9 /* IFCUtil.cpp */; };
+		2B7F495C1708365200A106A9 /* IFCUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45F31708365100A106A9 /* IFCUtil.cpp */; };
+		2B7F495D1708365200A106A9 /* IFCUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45F41708365100A106A9 /* IFCUtil.h */; };
+		2B7F495E1708365200A106A9 /* IFCUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45F41708365100A106A9 /* IFCUtil.h */; };
+		2B7F495F1708365200A106A9 /* IFCUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45F41708365100A106A9 /* IFCUtil.h */; };
+		2B7F49601708365200A106A9 /* IFCUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45F41708365100A106A9 /* IFCUtil.h */; };
+		2B7F49611708365200A106A9 /* IFCUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45F41708365100A106A9 /* IFCUtil.h */; };
+		2B7F49621708365200A106A9 /* IFF.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45F51708365100A106A9 /* IFF.h */; };
+		2B7F49631708365200A106A9 /* IFF.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45F51708365100A106A9 /* IFF.h */; };
+		2B7F49641708365200A106A9 /* IFF.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45F51708365100A106A9 /* IFF.h */; };
+		2B7F49651708365200A106A9 /* IFF.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45F51708365100A106A9 /* IFF.h */; };
+		2B7F49661708365200A106A9 /* IFF.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45F51708365100A106A9 /* IFF.h */; };
+		2B7F49671708365200A106A9 /* Importer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45F61708365100A106A9 /* Importer.cpp */; };
+		2B7F49681708365200A106A9 /* Importer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45F61708365100A106A9 /* Importer.cpp */; };
+		2B7F49691708365200A106A9 /* Importer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45F61708365100A106A9 /* Importer.cpp */; };
+		2B7F496A1708365200A106A9 /* Importer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45F61708365100A106A9 /* Importer.cpp */; };
+		2B7F496B1708365200A106A9 /* Importer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45F61708365100A106A9 /* Importer.cpp */; };
+		2B7F496C1708365200A106A9 /* Importer.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45F71708365100A106A9 /* Importer.h */; };
+		2B7F496D1708365200A106A9 /* Importer.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45F71708365100A106A9 /* Importer.h */; };
+		2B7F496E1708365200A106A9 /* Importer.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45F71708365100A106A9 /* Importer.h */; };
+		2B7F496F1708365200A106A9 /* Importer.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45F71708365100A106A9 /* Importer.h */; };
+		2B7F49701708365200A106A9 /* Importer.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45F71708365100A106A9 /* Importer.h */; };
+		2B7F49711708365200A106A9 /* ImporterRegistry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45F81708365100A106A9 /* ImporterRegistry.cpp */; };
+		2B7F49721708365200A106A9 /* ImporterRegistry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45F81708365100A106A9 /* ImporterRegistry.cpp */; };
+		2B7F49731708365200A106A9 /* ImporterRegistry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45F81708365100A106A9 /* ImporterRegistry.cpp */; };
+		2B7F49741708365200A106A9 /* ImporterRegistry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45F81708365100A106A9 /* ImporterRegistry.cpp */; };
+		2B7F49751708365200A106A9 /* ImporterRegistry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45F81708365100A106A9 /* ImporterRegistry.cpp */; };
+		2B7F49761708365200A106A9 /* ImproveCacheLocality.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45F91708365100A106A9 /* ImproveCacheLocality.cpp */; };
+		2B7F49771708365200A106A9 /* ImproveCacheLocality.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45F91708365100A106A9 /* ImproveCacheLocality.cpp */; };
+		2B7F49781708365200A106A9 /* ImproveCacheLocality.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45F91708365100A106A9 /* ImproveCacheLocality.cpp */; };
+		2B7F49791708365200A106A9 /* ImproveCacheLocality.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45F91708365100A106A9 /* ImproveCacheLocality.cpp */; };
+		2B7F497A1708365200A106A9 /* ImproveCacheLocality.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F45F91708365100A106A9 /* ImproveCacheLocality.cpp */; };
+		2B7F497B1708365200A106A9 /* ImproveCacheLocality.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45FA1708365100A106A9 /* ImproveCacheLocality.h */; };
+		2B7F497C1708365200A106A9 /* ImproveCacheLocality.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45FA1708365100A106A9 /* ImproveCacheLocality.h */; };
+		2B7F497D1708365200A106A9 /* ImproveCacheLocality.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45FA1708365100A106A9 /* ImproveCacheLocality.h */; };
+		2B7F497E1708365200A106A9 /* ImproveCacheLocality.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45FA1708365100A106A9 /* ImproveCacheLocality.h */; };
+		2B7F497F1708365200A106A9 /* ImproveCacheLocality.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F45FA1708365100A106A9 /* ImproveCacheLocality.h */; };
+		2B7F49A31708365200A106A9 /* JoinVerticesProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46021708365100A106A9 /* JoinVerticesProcess.cpp */; };
+		2B7F49A41708365200A106A9 /* JoinVerticesProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46021708365100A106A9 /* JoinVerticesProcess.cpp */; };
+		2B7F49A51708365200A106A9 /* JoinVerticesProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46021708365100A106A9 /* JoinVerticesProcess.cpp */; };
+		2B7F49A61708365200A106A9 /* JoinVerticesProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46021708365100A106A9 /* JoinVerticesProcess.cpp */; };
+		2B7F49A71708365200A106A9 /* JoinVerticesProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46021708365100A106A9 /* JoinVerticesProcess.cpp */; };
+		2B7F49A81708365200A106A9 /* JoinVerticesProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46031708365100A106A9 /* JoinVerticesProcess.h */; };
+		2B7F49A91708365200A106A9 /* JoinVerticesProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46031708365100A106A9 /* JoinVerticesProcess.h */; };
+		2B7F49AA1708365200A106A9 /* JoinVerticesProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46031708365100A106A9 /* JoinVerticesProcess.h */; };
+		2B7F49AB1708365200A106A9 /* JoinVerticesProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46031708365100A106A9 /* JoinVerticesProcess.h */; };
+		2B7F49AC1708365200A106A9 /* JoinVerticesProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46031708365100A106A9 /* JoinVerticesProcess.h */; };
+		2B7F49AD1708365200A106A9 /* LimitBoneWeightsProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46041708365100A106A9 /* LimitBoneWeightsProcess.cpp */; };
+		2B7F49AE1708365200A106A9 /* LimitBoneWeightsProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46041708365100A106A9 /* LimitBoneWeightsProcess.cpp */; };
+		2B7F49AF1708365200A106A9 /* LimitBoneWeightsProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46041708365100A106A9 /* LimitBoneWeightsProcess.cpp */; };
+		2B7F49B01708365200A106A9 /* LimitBoneWeightsProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46041708365100A106A9 /* LimitBoneWeightsProcess.cpp */; };
+		2B7F49B11708365200A106A9 /* LimitBoneWeightsProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46041708365100A106A9 /* LimitBoneWeightsProcess.cpp */; };
+		2B7F49B21708365200A106A9 /* LimitBoneWeightsProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46051708365100A106A9 /* LimitBoneWeightsProcess.h */; };
+		2B7F49B31708365200A106A9 /* LimitBoneWeightsProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46051708365100A106A9 /* LimitBoneWeightsProcess.h */; };
+		2B7F49B41708365200A106A9 /* LimitBoneWeightsProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46051708365100A106A9 /* LimitBoneWeightsProcess.h */; };
+		2B7F49B51708365200A106A9 /* LimitBoneWeightsProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46051708365100A106A9 /* LimitBoneWeightsProcess.h */; };
+		2B7F49B61708365200A106A9 /* LimitBoneWeightsProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46051708365100A106A9 /* LimitBoneWeightsProcess.h */; };
+		2B7F49B71708365200A106A9 /* LineSplitter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46061708365100A106A9 /* LineSplitter.h */; };
+		2B7F49B81708365200A106A9 /* LineSplitter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46061708365100A106A9 /* LineSplitter.h */; };
+		2B7F49B91708365200A106A9 /* LineSplitter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46061708365100A106A9 /* LineSplitter.h */; };
+		2B7F49BA1708365200A106A9 /* LineSplitter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46061708365100A106A9 /* LineSplitter.h */; };
+		2B7F49BB1708365200A106A9 /* LineSplitter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46061708365100A106A9 /* LineSplitter.h */; };
+		2B7F49BC1708365200A106A9 /* LogAux.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46071708365100A106A9 /* LogAux.h */; };
+		2B7F49BD1708365200A106A9 /* LogAux.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46071708365100A106A9 /* LogAux.h */; };
+		2B7F49BE1708365200A106A9 /* LogAux.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46071708365100A106A9 /* LogAux.h */; };
+		2B7F49BF1708365200A106A9 /* LogAux.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46071708365100A106A9 /* LogAux.h */; };
+		2B7F49C01708365200A106A9 /* LogAux.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46071708365100A106A9 /* LogAux.h */; };
+		2B7F49F81708365200A106A9 /* MakeVerboseFormat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46141708365200A106A9 /* MakeVerboseFormat.cpp */; };
+		2B7F49F91708365200A106A9 /* MakeVerboseFormat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46141708365200A106A9 /* MakeVerboseFormat.cpp */; };
+		2B7F49FA1708365200A106A9 /* MakeVerboseFormat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46141708365200A106A9 /* MakeVerboseFormat.cpp */; };
+		2B7F49FB1708365200A106A9 /* MakeVerboseFormat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46141708365200A106A9 /* MakeVerboseFormat.cpp */; };
+		2B7F49FC1708365200A106A9 /* MakeVerboseFormat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46141708365200A106A9 /* MakeVerboseFormat.cpp */; };
+		2B7F49FD1708365200A106A9 /* MakeVerboseFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46151708365200A106A9 /* MakeVerboseFormat.h */; };
+		2B7F49FE1708365200A106A9 /* MakeVerboseFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46151708365200A106A9 /* MakeVerboseFormat.h */; };
+		2B7F49FF1708365200A106A9 /* MakeVerboseFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46151708365200A106A9 /* MakeVerboseFormat.h */; };
+		2B7F4A001708365200A106A9 /* MakeVerboseFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46151708365200A106A9 /* MakeVerboseFormat.h */; };
+		2B7F4A011708365200A106A9 /* MakeVerboseFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46151708365200A106A9 /* MakeVerboseFormat.h */; };
+		2B7F4A021708365200A106A9 /* MaterialSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46161708365200A106A9 /* MaterialSystem.cpp */; };
+		2B7F4A031708365200A106A9 /* MaterialSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46161708365200A106A9 /* MaterialSystem.cpp */; };
+		2B7F4A041708365200A106A9 /* MaterialSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46161708365200A106A9 /* MaterialSystem.cpp */; };
+		2B7F4A051708365200A106A9 /* MaterialSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46161708365200A106A9 /* MaterialSystem.cpp */; };
+		2B7F4A061708365200A106A9 /* MaterialSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46161708365200A106A9 /* MaterialSystem.cpp */; };
+		2B7F4A071708365200A106A9 /* MaterialSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46171708365200A106A9 /* MaterialSystem.h */; };
+		2B7F4A081708365200A106A9 /* MaterialSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46171708365200A106A9 /* MaterialSystem.h */; };
+		2B7F4A091708365200A106A9 /* MaterialSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46171708365200A106A9 /* MaterialSystem.h */; };
+		2B7F4A0A1708365200A106A9 /* MaterialSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46171708365200A106A9 /* MaterialSystem.h */; };
+		2B7F4A0B1708365200A106A9 /* MaterialSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46171708365200A106A9 /* MaterialSystem.h */; };
+		2B7F4A2F1708365200A106A9 /* MD4FileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F461F1708365200A106A9 /* MD4FileData.h */; };
+		2B7F4A301708365200A106A9 /* MD4FileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F461F1708365200A106A9 /* MD4FileData.h */; };
+		2B7F4A311708365200A106A9 /* MD4FileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F461F1708365200A106A9 /* MD4FileData.h */; };
+		2B7F4A321708365200A106A9 /* MD4FileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F461F1708365200A106A9 /* MD4FileData.h */; };
+		2B7F4A331708365200A106A9 /* MD4FileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F461F1708365200A106A9 /* MD4FileData.h */; };
+		2B7F4A751708365200A106A9 /* MemoryIOWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F462D1708365200A106A9 /* MemoryIOWrapper.h */; };
+		2B7F4A761708365200A106A9 /* MemoryIOWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F462D1708365200A106A9 /* MemoryIOWrapper.h */; };
+		2B7F4A771708365200A106A9 /* MemoryIOWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F462D1708365200A106A9 /* MemoryIOWrapper.h */; };
+		2B7F4A781708365200A106A9 /* MemoryIOWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F462D1708365200A106A9 /* MemoryIOWrapper.h */; };
+		2B7F4A791708365200A106A9 /* MemoryIOWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F462D1708365200A106A9 /* MemoryIOWrapper.h */; };
+		2B7F4A981708365200A106A9 /* ObjExporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46341708365200A106A9 /* ObjExporter.cpp */; };
+		2B7F4A991708365200A106A9 /* ObjExporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46341708365200A106A9 /* ObjExporter.cpp */; };
+		2B7F4A9A1708365200A106A9 /* ObjExporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46341708365200A106A9 /* ObjExporter.cpp */; };
+		2B7F4A9B1708365200A106A9 /* ObjExporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46341708365200A106A9 /* ObjExporter.cpp */; };
+		2B7F4A9C1708365200A106A9 /* ObjExporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46341708365200A106A9 /* ObjExporter.cpp */; };
+		2B7F4A9D1708365200A106A9 /* ObjExporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46351708365200A106A9 /* ObjExporter.h */; };
+		2B7F4A9E1708365200A106A9 /* ObjExporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46351708365200A106A9 /* ObjExporter.h */; };
+		2B7F4A9F1708365200A106A9 /* ObjExporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46351708365200A106A9 /* ObjExporter.h */; };
+		2B7F4AA01708365200A106A9 /* ObjExporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46351708365200A106A9 /* ObjExporter.h */; };
+		2B7F4AA11708365200A106A9 /* ObjExporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46351708365200A106A9 /* ObjExporter.h */; };
+		2B7F4AA21708365200A106A9 /* ObjFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46361708365200A106A9 /* ObjFileData.h */; };
+		2B7F4AA31708365200A106A9 /* ObjFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46361708365200A106A9 /* ObjFileData.h */; };
+		2B7F4AA41708365200A106A9 /* ObjFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46361708365200A106A9 /* ObjFileData.h */; };
+		2B7F4AA51708365200A106A9 /* ObjFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46361708365200A106A9 /* ObjFileData.h */; };
+		2B7F4AA61708365200A106A9 /* ObjFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46361708365200A106A9 /* ObjFileData.h */; };
+		2B7F4AA71708365200A106A9 /* ObjFileImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46371708365200A106A9 /* ObjFileImporter.cpp */; };
+		2B7F4AA81708365200A106A9 /* ObjFileImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46371708365200A106A9 /* ObjFileImporter.cpp */; };
+		2B7F4AA91708365200A106A9 /* ObjFileImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46371708365200A106A9 /* ObjFileImporter.cpp */; };
+		2B7F4AAA1708365200A106A9 /* ObjFileImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46371708365200A106A9 /* ObjFileImporter.cpp */; };
+		2B7F4AAB1708365200A106A9 /* ObjFileImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46371708365200A106A9 /* ObjFileImporter.cpp */; };
+		2B7F4AAC1708365200A106A9 /* ObjFileImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46381708365200A106A9 /* ObjFileImporter.h */; };
+		2B7F4AAD1708365200A106A9 /* ObjFileImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46381708365200A106A9 /* ObjFileImporter.h */; };
+		2B7F4AAE1708365200A106A9 /* ObjFileImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46381708365200A106A9 /* ObjFileImporter.h */; };
+		2B7F4AAF1708365200A106A9 /* ObjFileImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46381708365200A106A9 /* ObjFileImporter.h */; };
+		2B7F4AB01708365200A106A9 /* ObjFileImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46381708365200A106A9 /* ObjFileImporter.h */; };
+		2B7F4AB11708365200A106A9 /* ObjFileMtlImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46391708365200A106A9 /* ObjFileMtlImporter.cpp */; };
+		2B7F4AB21708365200A106A9 /* ObjFileMtlImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46391708365200A106A9 /* ObjFileMtlImporter.cpp */; };
+		2B7F4AB31708365200A106A9 /* ObjFileMtlImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46391708365200A106A9 /* ObjFileMtlImporter.cpp */; };
+		2B7F4AB41708365200A106A9 /* ObjFileMtlImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46391708365200A106A9 /* ObjFileMtlImporter.cpp */; };
+		2B7F4AB51708365200A106A9 /* ObjFileMtlImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46391708365200A106A9 /* ObjFileMtlImporter.cpp */; };
+		2B7F4AB61708365200A106A9 /* ObjFileMtlImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F463A1708365200A106A9 /* ObjFileMtlImporter.h */; };
+		2B7F4AB71708365200A106A9 /* ObjFileMtlImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F463A1708365200A106A9 /* ObjFileMtlImporter.h */; };
+		2B7F4AB81708365200A106A9 /* ObjFileMtlImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F463A1708365200A106A9 /* ObjFileMtlImporter.h */; };
+		2B7F4AB91708365200A106A9 /* ObjFileMtlImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F463A1708365200A106A9 /* ObjFileMtlImporter.h */; };
+		2B7F4ABA1708365200A106A9 /* ObjFileMtlImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F463A1708365200A106A9 /* ObjFileMtlImporter.h */; };
+		2B7F4ABB1708365200A106A9 /* ObjFileParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F463B1708365200A106A9 /* ObjFileParser.cpp */; };
+		2B7F4ABC1708365200A106A9 /* ObjFileParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F463B1708365200A106A9 /* ObjFileParser.cpp */; };
+		2B7F4ABD1708365200A106A9 /* ObjFileParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F463B1708365200A106A9 /* ObjFileParser.cpp */; };
+		2B7F4ABE1708365200A106A9 /* ObjFileParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F463B1708365200A106A9 /* ObjFileParser.cpp */; };
+		2B7F4ABF1708365200A106A9 /* ObjFileParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F463B1708365200A106A9 /* ObjFileParser.cpp */; };
+		2B7F4AC01708365200A106A9 /* ObjFileParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F463C1708365200A106A9 /* ObjFileParser.h */; };
+		2B7F4AC11708365200A106A9 /* ObjFileParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F463C1708365200A106A9 /* ObjFileParser.h */; };
+		2B7F4AC21708365200A106A9 /* ObjFileParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F463C1708365200A106A9 /* ObjFileParser.h */; };
+		2B7F4AC31708365200A106A9 /* ObjFileParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F463C1708365200A106A9 /* ObjFileParser.h */; };
+		2B7F4AC41708365200A106A9 /* ObjFileParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F463C1708365200A106A9 /* ObjFileParser.h */; };
+		2B7F4AC51708365200A106A9 /* ObjTools.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F463D1708365200A106A9 /* ObjTools.h */; };
+		2B7F4AC61708365200A106A9 /* ObjTools.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F463D1708365200A106A9 /* ObjTools.h */; };
+		2B7F4AC71708365200A106A9 /* ObjTools.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F463D1708365200A106A9 /* ObjTools.h */; };
+		2B7F4AC81708365200A106A9 /* ObjTools.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F463D1708365200A106A9 /* ObjTools.h */; };
+		2B7F4AC91708365200A106A9 /* ObjTools.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F463D1708365200A106A9 /* ObjTools.h */; };
+		2B7F4AF21708365200A106A9 /* OptimizeGraph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46461708365200A106A9 /* OptimizeGraph.cpp */; };
+		2B7F4AF31708365200A106A9 /* OptimizeGraph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46461708365200A106A9 /* OptimizeGraph.cpp */; };
+		2B7F4AF41708365200A106A9 /* OptimizeGraph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46461708365200A106A9 /* OptimizeGraph.cpp */; };
+		2B7F4AF51708365200A106A9 /* OptimizeGraph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46461708365200A106A9 /* OptimizeGraph.cpp */; };
+		2B7F4AF61708365200A106A9 /* OptimizeGraph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46461708365200A106A9 /* OptimizeGraph.cpp */; };
+		2B7F4AF71708365200A106A9 /* OptimizeGraph.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46471708365200A106A9 /* OptimizeGraph.h */; };
+		2B7F4AF81708365200A106A9 /* OptimizeGraph.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46471708365200A106A9 /* OptimizeGraph.h */; };
+		2B7F4AF91708365200A106A9 /* OptimizeGraph.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46471708365200A106A9 /* OptimizeGraph.h */; };
+		2B7F4AFA1708365200A106A9 /* OptimizeGraph.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46471708365200A106A9 /* OptimizeGraph.h */; };
+		2B7F4AFB1708365200A106A9 /* OptimizeGraph.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46471708365200A106A9 /* OptimizeGraph.h */; };
+		2B7F4AFC1708365200A106A9 /* OptimizeMeshes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46481708365200A106A9 /* OptimizeMeshes.cpp */; };
+		2B7F4AFD1708365200A106A9 /* OptimizeMeshes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46481708365200A106A9 /* OptimizeMeshes.cpp */; };
+		2B7F4AFE1708365200A106A9 /* OptimizeMeshes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46481708365200A106A9 /* OptimizeMeshes.cpp */; };
+		2B7F4AFF1708365200A106A9 /* OptimizeMeshes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46481708365200A106A9 /* OptimizeMeshes.cpp */; };
+		2B7F4B001708365200A106A9 /* OptimizeMeshes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46481708365200A106A9 /* OptimizeMeshes.cpp */; };
+		2B7F4B011708365200A106A9 /* OptimizeMeshes.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46491708365200A106A9 /* OptimizeMeshes.h */; };
+		2B7F4B021708365200A106A9 /* OptimizeMeshes.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46491708365200A106A9 /* OptimizeMeshes.h */; };
+		2B7F4B031708365200A106A9 /* OptimizeMeshes.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46491708365200A106A9 /* OptimizeMeshes.h */; };
+		2B7F4B041708365200A106A9 /* OptimizeMeshes.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46491708365200A106A9 /* OptimizeMeshes.h */; };
+		2B7F4B051708365200A106A9 /* OptimizeMeshes.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46491708365200A106A9 /* OptimizeMeshes.h */; };
+		2B7F4B061708365200A106A9 /* ParsingUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F464A1708365200A106A9 /* ParsingUtils.h */; };
+		2B7F4B071708365200A106A9 /* ParsingUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F464A1708365200A106A9 /* ParsingUtils.h */; };
+		2B7F4B081708365200A106A9 /* ParsingUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F464A1708365200A106A9 /* ParsingUtils.h */; };
+		2B7F4B091708365200A106A9 /* ParsingUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F464A1708365200A106A9 /* ParsingUtils.h */; };
+		2B7F4B0A1708365200A106A9 /* ParsingUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F464A1708365200A106A9 /* ParsingUtils.h */; };
+		2B7F4B291708365200A106A9 /* PolyTools.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46511708365200A106A9 /* PolyTools.h */; };
+		2B7F4B2A1708365200A106A9 /* PolyTools.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46511708365200A106A9 /* PolyTools.h */; };
+		2B7F4B2B1708365200A106A9 /* PolyTools.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46511708365200A106A9 /* PolyTools.h */; };
+		2B7F4B2C1708365200A106A9 /* PolyTools.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46511708365200A106A9 /* PolyTools.h */; };
+		2B7F4B2D1708365200A106A9 /* PolyTools.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46511708365200A106A9 /* PolyTools.h */; };
+		2B7F4B2E1708365200A106A9 /* PostStepRegistry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46521708365200A106A9 /* PostStepRegistry.cpp */; };
+		2B7F4B2F1708365200A106A9 /* PostStepRegistry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46521708365200A106A9 /* PostStepRegistry.cpp */; };
+		2B7F4B301708365200A106A9 /* PostStepRegistry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46521708365200A106A9 /* PostStepRegistry.cpp */; };
+		2B7F4B311708365200A106A9 /* PostStepRegistry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46521708365200A106A9 /* PostStepRegistry.cpp */; };
+		2B7F4B321708365200A106A9 /* PostStepRegistry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46521708365200A106A9 /* PostStepRegistry.cpp */; };
+		2B7F4B331708365200A106A9 /* PretransformVertices.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46531708365200A106A9 /* PretransformVertices.cpp */; };
+		2B7F4B341708365200A106A9 /* PretransformVertices.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46531708365200A106A9 /* PretransformVertices.cpp */; };
+		2B7F4B351708365200A106A9 /* PretransformVertices.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46531708365200A106A9 /* PretransformVertices.cpp */; };
+		2B7F4B361708365200A106A9 /* PretransformVertices.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46531708365200A106A9 /* PretransformVertices.cpp */; };
+		2B7F4B371708365200A106A9 /* PretransformVertices.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46531708365200A106A9 /* PretransformVertices.cpp */; };
+		2B7F4B381708365200A106A9 /* PretransformVertices.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46541708365200A106A9 /* PretransformVertices.h */; };
+		2B7F4B391708365200A106A9 /* PretransformVertices.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46541708365200A106A9 /* PretransformVertices.h */; };
+		2B7F4B3A1708365200A106A9 /* PretransformVertices.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46541708365200A106A9 /* PretransformVertices.h */; };
+		2B7F4B3B1708365200A106A9 /* PretransformVertices.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46541708365200A106A9 /* PretransformVertices.h */; };
+		2B7F4B3C1708365200A106A9 /* PretransformVertices.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46541708365200A106A9 /* PretransformVertices.h */; };
+		2B7F4B3D1708365200A106A9 /* ProcessHelper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46551708365200A106A9 /* ProcessHelper.cpp */; };
+		2B7F4B3E1708365200A106A9 /* ProcessHelper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46551708365200A106A9 /* ProcessHelper.cpp */; };
+		2B7F4B3F1708365200A106A9 /* ProcessHelper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46551708365200A106A9 /* ProcessHelper.cpp */; };
+		2B7F4B401708365200A106A9 /* ProcessHelper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46551708365200A106A9 /* ProcessHelper.cpp */; };
+		2B7F4B411708365200A106A9 /* ProcessHelper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46551708365200A106A9 /* ProcessHelper.cpp */; };
+		2B7F4B421708365200A106A9 /* ProcessHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46561708365200A106A9 /* ProcessHelper.h */; };
+		2B7F4B431708365200A106A9 /* ProcessHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46561708365200A106A9 /* ProcessHelper.h */; };
+		2B7F4B441708365200A106A9 /* ProcessHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46561708365200A106A9 /* ProcessHelper.h */; };
+		2B7F4B451708365200A106A9 /* ProcessHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46561708365200A106A9 /* ProcessHelper.h */; };
+		2B7F4B461708365200A106A9 /* ProcessHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46561708365200A106A9 /* ProcessHelper.h */; };
+		2B7F4B471708365200A106A9 /* Profiler.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46571708365200A106A9 /* Profiler.h */; };
+		2B7F4B481708365200A106A9 /* Profiler.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46571708365200A106A9 /* Profiler.h */; };
+		2B7F4B491708365200A106A9 /* Profiler.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46571708365200A106A9 /* Profiler.h */; };
+		2B7F4B4A1708365200A106A9 /* Profiler.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46571708365200A106A9 /* Profiler.h */; };
+		2B7F4B4B1708365200A106A9 /* Profiler.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46571708365200A106A9 /* Profiler.h */; };
+		2B7F4B4C1708365200A106A9 /* pstdint.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46581708365200A106A9 /* pstdint.h */; };
+		2B7F4B4D1708365200A106A9 /* pstdint.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46581708365200A106A9 /* pstdint.h */; };
+		2B7F4B4E1708365200A106A9 /* pstdint.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46581708365200A106A9 /* pstdint.h */; };
+		2B7F4B4F1708365200A106A9 /* pstdint.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46581708365200A106A9 /* pstdint.h */; };
+		2B7F4B501708365200A106A9 /* pstdint.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46581708365200A106A9 /* pstdint.h */; };
+		2B7F4B7E1708365200A106A9 /* qnan.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46621708365200A106A9 /* qnan.h */; };
+		2B7F4B7F1708365200A106A9 /* qnan.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46621708365200A106A9 /* qnan.h */; };
+		2B7F4B801708365200A106A9 /* qnan.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46621708365200A106A9 /* qnan.h */; };
+		2B7F4B811708365200A106A9 /* qnan.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46621708365200A106A9 /* qnan.h */; };
+		2B7F4B821708365200A106A9 /* qnan.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46621708365200A106A9 /* qnan.h */; };
+		2B7F4B8D1708365200A106A9 /* RemoveComments.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46651708365200A106A9 /* RemoveComments.cpp */; };
+		2B7F4B8E1708365200A106A9 /* RemoveComments.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46651708365200A106A9 /* RemoveComments.cpp */; };
+		2B7F4B8F1708365200A106A9 /* RemoveComments.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46651708365200A106A9 /* RemoveComments.cpp */; };
+		2B7F4B901708365200A106A9 /* RemoveComments.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46651708365200A106A9 /* RemoveComments.cpp */; };
+		2B7F4B911708365200A106A9 /* RemoveComments.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46651708365200A106A9 /* RemoveComments.cpp */; };
+		2B7F4B921708365200A106A9 /* RemoveComments.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46661708365200A106A9 /* RemoveComments.h */; };
+		2B7F4B931708365200A106A9 /* RemoveComments.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46661708365200A106A9 /* RemoveComments.h */; };
+		2B7F4B941708365200A106A9 /* RemoveComments.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46661708365200A106A9 /* RemoveComments.h */; };
+		2B7F4B951708365200A106A9 /* RemoveComments.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46661708365200A106A9 /* RemoveComments.h */; };
+		2B7F4B961708365200A106A9 /* RemoveComments.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46661708365200A106A9 /* RemoveComments.h */; };
+		2B7F4B971708365200A106A9 /* RemoveRedundantMaterials.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46671708365200A106A9 /* RemoveRedundantMaterials.cpp */; };
+		2B7F4B981708365200A106A9 /* RemoveRedundantMaterials.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46671708365200A106A9 /* RemoveRedundantMaterials.cpp */; };
+		2B7F4B991708365200A106A9 /* RemoveRedundantMaterials.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46671708365200A106A9 /* RemoveRedundantMaterials.cpp */; };
+		2B7F4B9A1708365200A106A9 /* RemoveRedundantMaterials.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46671708365200A106A9 /* RemoveRedundantMaterials.cpp */; };
+		2B7F4B9B1708365200A106A9 /* RemoveRedundantMaterials.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46671708365200A106A9 /* RemoveRedundantMaterials.cpp */; };
+		2B7F4B9C1708365200A106A9 /* RemoveRedundantMaterials.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46681708365200A106A9 /* RemoveRedundantMaterials.h */; };
+		2B7F4B9D1708365200A106A9 /* RemoveRedundantMaterials.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46681708365200A106A9 /* RemoveRedundantMaterials.h */; };
+		2B7F4B9E1708365200A106A9 /* RemoveRedundantMaterials.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46681708365200A106A9 /* RemoveRedundantMaterials.h */; };
+		2B7F4B9F1708365200A106A9 /* RemoveRedundantMaterials.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46681708365200A106A9 /* RemoveRedundantMaterials.h */; };
+		2B7F4BA01708365200A106A9 /* RemoveRedundantMaterials.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46681708365200A106A9 /* RemoveRedundantMaterials.h */; };
+		2B7F4BA11708365200A106A9 /* RemoveVCProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46691708365200A106A9 /* RemoveVCProcess.cpp */; };
+		2B7F4BA21708365200A106A9 /* RemoveVCProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46691708365200A106A9 /* RemoveVCProcess.cpp */; };
+		2B7F4BA31708365200A106A9 /* RemoveVCProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46691708365200A106A9 /* RemoveVCProcess.cpp */; };
+		2B7F4BA41708365200A106A9 /* RemoveVCProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46691708365200A106A9 /* RemoveVCProcess.cpp */; };
+		2B7F4BA51708365200A106A9 /* RemoveVCProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46691708365200A106A9 /* RemoveVCProcess.cpp */; };
+		2B7F4BA61708365200A106A9 /* RemoveVCProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F466A1708365200A106A9 /* RemoveVCProcess.h */; };
+		2B7F4BA71708365200A106A9 /* RemoveVCProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F466A1708365200A106A9 /* RemoveVCProcess.h */; };
+		2B7F4BA81708365200A106A9 /* RemoveVCProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F466A1708365200A106A9 /* RemoveVCProcess.h */; };
+		2B7F4BA91708365200A106A9 /* RemoveVCProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F466A1708365200A106A9 /* RemoveVCProcess.h */; };
+		2B7F4BAA1708365200A106A9 /* RemoveVCProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F466A1708365200A106A9 /* RemoveVCProcess.h */; };
+		2B7F4BB01708365200A106A9 /* SceneCombiner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F466E1708365200A106A9 /* SceneCombiner.cpp */; };
+		2B7F4BB11708365200A106A9 /* SceneCombiner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F466E1708365200A106A9 /* SceneCombiner.cpp */; };
+		2B7F4BB21708365200A106A9 /* SceneCombiner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F466E1708365200A106A9 /* SceneCombiner.cpp */; };
+		2B7F4BB31708365200A106A9 /* SceneCombiner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F466E1708365200A106A9 /* SceneCombiner.cpp */; };
+		2B7F4BB41708365200A106A9 /* SceneCombiner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F466E1708365200A106A9 /* SceneCombiner.cpp */; };
+		2B7F4BB51708365200A106A9 /* SceneCombiner.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F466F1708365200A106A9 /* SceneCombiner.h */; };
+		2B7F4BB61708365200A106A9 /* SceneCombiner.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F466F1708365200A106A9 /* SceneCombiner.h */; };
+		2B7F4BB71708365200A106A9 /* SceneCombiner.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F466F1708365200A106A9 /* SceneCombiner.h */; };
+		2B7F4BB81708365200A106A9 /* SceneCombiner.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F466F1708365200A106A9 /* SceneCombiner.h */; };
+		2B7F4BB91708365200A106A9 /* SceneCombiner.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F466F1708365200A106A9 /* SceneCombiner.h */; };
+		2B7F4BBA1708365200A106A9 /* ScenePreprocessor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46701708365200A106A9 /* ScenePreprocessor.cpp */; };
+		2B7F4BBB1708365200A106A9 /* ScenePreprocessor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46701708365200A106A9 /* ScenePreprocessor.cpp */; };
+		2B7F4BBC1708365200A106A9 /* ScenePreprocessor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46701708365200A106A9 /* ScenePreprocessor.cpp */; };
+		2B7F4BBD1708365200A106A9 /* ScenePreprocessor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46701708365200A106A9 /* ScenePreprocessor.cpp */; };
+		2B7F4BBE1708365200A106A9 /* ScenePreprocessor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46701708365200A106A9 /* ScenePreprocessor.cpp */; };
+		2B7F4BBF1708365200A106A9 /* ScenePreprocessor.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46711708365200A106A9 /* ScenePreprocessor.h */; };
+		2B7F4BC01708365200A106A9 /* ScenePreprocessor.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46711708365200A106A9 /* ScenePreprocessor.h */; };
+		2B7F4BC11708365200A106A9 /* ScenePreprocessor.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46711708365200A106A9 /* ScenePreprocessor.h */; };
+		2B7F4BC21708365200A106A9 /* ScenePreprocessor.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46711708365200A106A9 /* ScenePreprocessor.h */; };
+		2B7F4BC31708365200A106A9 /* ScenePreprocessor.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46711708365200A106A9 /* ScenePreprocessor.h */; };
+		2B7F4BC41708365200A106A9 /* ScenePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46721708365200A106A9 /* ScenePrivate.h */; };
+		2B7F4BC51708365200A106A9 /* ScenePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46721708365200A106A9 /* ScenePrivate.h */; };
+		2B7F4BC61708365200A106A9 /* ScenePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46721708365200A106A9 /* ScenePrivate.h */; };
+		2B7F4BC71708365200A106A9 /* ScenePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46721708365200A106A9 /* ScenePrivate.h */; };
+		2B7F4BC81708365200A106A9 /* ScenePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46721708365200A106A9 /* ScenePrivate.h */; };
+		2B7F4BC91708365200A106A9 /* SGSpatialSort.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46731708365200A106A9 /* SGSpatialSort.cpp */; };
+		2B7F4BCA1708365200A106A9 /* SGSpatialSort.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46731708365200A106A9 /* SGSpatialSort.cpp */; };
+		2B7F4BCB1708365200A106A9 /* SGSpatialSort.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46731708365200A106A9 /* SGSpatialSort.cpp */; };
+		2B7F4BCC1708365200A106A9 /* SGSpatialSort.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46731708365200A106A9 /* SGSpatialSort.cpp */; };
+		2B7F4BCD1708365200A106A9 /* SGSpatialSort.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46731708365200A106A9 /* SGSpatialSort.cpp */; };
+		2B7F4BCE1708365200A106A9 /* SGSpatialSort.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46741708365200A106A9 /* SGSpatialSort.h */; };
+		2B7F4BCF1708365200A106A9 /* SGSpatialSort.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46741708365200A106A9 /* SGSpatialSort.h */; };
+		2B7F4BD01708365200A106A9 /* SGSpatialSort.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46741708365200A106A9 /* SGSpatialSort.h */; };
+		2B7F4BD11708365200A106A9 /* SGSpatialSort.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46741708365200A106A9 /* SGSpatialSort.h */; };
+		2B7F4BD21708365200A106A9 /* SGSpatialSort.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46741708365200A106A9 /* SGSpatialSort.h */; };
+		2B7F4BD31708365200A106A9 /* SkeletonMeshBuilder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46751708365200A106A9 /* SkeletonMeshBuilder.cpp */; };
+		2B7F4BD41708365200A106A9 /* SkeletonMeshBuilder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46751708365200A106A9 /* SkeletonMeshBuilder.cpp */; };
+		2B7F4BD51708365200A106A9 /* SkeletonMeshBuilder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46751708365200A106A9 /* SkeletonMeshBuilder.cpp */; };
+		2B7F4BD61708365200A106A9 /* SkeletonMeshBuilder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46751708365200A106A9 /* SkeletonMeshBuilder.cpp */; };
+		2B7F4BD71708365200A106A9 /* SkeletonMeshBuilder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46751708365200A106A9 /* SkeletonMeshBuilder.cpp */; };
+		2B7F4BD81708365200A106A9 /* SkeletonMeshBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46761708365200A106A9 /* SkeletonMeshBuilder.h */; };
+		2B7F4BD91708365200A106A9 /* SkeletonMeshBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46761708365200A106A9 /* SkeletonMeshBuilder.h */; };
+		2B7F4BDA1708365200A106A9 /* SkeletonMeshBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46761708365200A106A9 /* SkeletonMeshBuilder.h */; };
+		2B7F4BDB1708365200A106A9 /* SkeletonMeshBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46761708365200A106A9 /* SkeletonMeshBuilder.h */; };
+		2B7F4BDC1708365200A106A9 /* SkeletonMeshBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46761708365200A106A9 /* SkeletonMeshBuilder.h */; };
+		2B7F4BE71708365200A106A9 /* SmoothingGroups.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46791708365200A106A9 /* SmoothingGroups.h */; };
+		2B7F4BE81708365200A106A9 /* SmoothingGroups.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46791708365200A106A9 /* SmoothingGroups.h */; };
+		2B7F4BE91708365200A106A9 /* SmoothingGroups.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46791708365200A106A9 /* SmoothingGroups.h */; };
+		2B7F4BEA1708365200A106A9 /* SmoothingGroups.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46791708365200A106A9 /* SmoothingGroups.h */; };
+		2B7F4BEB1708365200A106A9 /* SmoothingGroups.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46791708365200A106A9 /* SmoothingGroups.h */; };
+		2B7F4BEC1708365200A106A9 /* SortByPTypeProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F467B1708365200A106A9 /* SortByPTypeProcess.cpp */; };
+		2B7F4BED1708365200A106A9 /* SortByPTypeProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F467B1708365200A106A9 /* SortByPTypeProcess.cpp */; };
+		2B7F4BEE1708365200A106A9 /* SortByPTypeProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F467B1708365200A106A9 /* SortByPTypeProcess.cpp */; };
+		2B7F4BEF1708365200A106A9 /* SortByPTypeProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F467B1708365200A106A9 /* SortByPTypeProcess.cpp */; };
+		2B7F4BF01708365200A106A9 /* SortByPTypeProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F467B1708365200A106A9 /* SortByPTypeProcess.cpp */; };
+		2B7F4BF11708365200A106A9 /* SortByPTypeProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F467C1708365200A106A9 /* SortByPTypeProcess.h */; };
+		2B7F4BF21708365200A106A9 /* SortByPTypeProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F467C1708365200A106A9 /* SortByPTypeProcess.h */; };
+		2B7F4BF31708365200A106A9 /* SortByPTypeProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F467C1708365200A106A9 /* SortByPTypeProcess.h */; };
+		2B7F4BF41708365200A106A9 /* SortByPTypeProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F467C1708365200A106A9 /* SortByPTypeProcess.h */; };
+		2B7F4BF51708365200A106A9 /* SortByPTypeProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F467C1708365200A106A9 /* SortByPTypeProcess.h */; };
+		2B7F4BF61708365200A106A9 /* SpatialSort.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F467D1708365200A106A9 /* SpatialSort.cpp */; };
+		2B7F4BF71708365200A106A9 /* SpatialSort.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F467D1708365200A106A9 /* SpatialSort.cpp */; };
+		2B7F4BF81708365200A106A9 /* SpatialSort.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F467D1708365200A106A9 /* SpatialSort.cpp */; };
+		2B7F4BF91708365200A106A9 /* SpatialSort.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F467D1708365200A106A9 /* SpatialSort.cpp */; };
+		2B7F4BFA1708365200A106A9 /* SpatialSort.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F467D1708365200A106A9 /* SpatialSort.cpp */; };
+		2B7F4BFB1708365200A106A9 /* SpatialSort.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F467E1708365200A106A9 /* SpatialSort.h */; };
+		2B7F4BFC1708365200A106A9 /* SpatialSort.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F467E1708365200A106A9 /* SpatialSort.h */; };
+		2B7F4BFD1708365200A106A9 /* SpatialSort.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F467E1708365200A106A9 /* SpatialSort.h */; };
+		2B7F4BFE1708365200A106A9 /* SpatialSort.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F467E1708365200A106A9 /* SpatialSort.h */; };
+		2B7F4BFF1708365200A106A9 /* SpatialSort.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F467E1708365200A106A9 /* SpatialSort.h */; };
+		2B7F4C001708365200A106A9 /* SplitByBoneCountProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F467F1708365200A106A9 /* SplitByBoneCountProcess.cpp */; };
+		2B7F4C011708365200A106A9 /* SplitByBoneCountProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F467F1708365200A106A9 /* SplitByBoneCountProcess.cpp */; };
+		2B7F4C021708365200A106A9 /* SplitByBoneCountProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F467F1708365200A106A9 /* SplitByBoneCountProcess.cpp */; };
+		2B7F4C031708365200A106A9 /* SplitByBoneCountProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F467F1708365200A106A9 /* SplitByBoneCountProcess.cpp */; };
+		2B7F4C041708365200A106A9 /* SplitByBoneCountProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F467F1708365200A106A9 /* SplitByBoneCountProcess.cpp */; };
+		2B7F4C051708365200A106A9 /* SplitByBoneCountProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46801708365200A106A9 /* SplitByBoneCountProcess.h */; };
+		2B7F4C061708365200A106A9 /* SplitByBoneCountProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46801708365200A106A9 /* SplitByBoneCountProcess.h */; };
+		2B7F4C071708365200A106A9 /* SplitByBoneCountProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46801708365200A106A9 /* SplitByBoneCountProcess.h */; };
+		2B7F4C081708365200A106A9 /* SplitByBoneCountProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46801708365200A106A9 /* SplitByBoneCountProcess.h */; };
+		2B7F4C091708365200A106A9 /* SplitByBoneCountProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46801708365200A106A9 /* SplitByBoneCountProcess.h */; };
+		2B7F4C0A1708365200A106A9 /* SplitLargeMeshes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46811708365200A106A9 /* SplitLargeMeshes.cpp */; };
+		2B7F4C0B1708365200A106A9 /* SplitLargeMeshes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46811708365200A106A9 /* SplitLargeMeshes.cpp */; };
+		2B7F4C0C1708365200A106A9 /* SplitLargeMeshes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46811708365200A106A9 /* SplitLargeMeshes.cpp */; };
+		2B7F4C0D1708365200A106A9 /* SplitLargeMeshes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46811708365200A106A9 /* SplitLargeMeshes.cpp */; };
+		2B7F4C0E1708365200A106A9 /* SplitLargeMeshes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46811708365200A106A9 /* SplitLargeMeshes.cpp */; };
+		2B7F4C0F1708365200A106A9 /* SplitLargeMeshes.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46821708365200A106A9 /* SplitLargeMeshes.h */; };
+		2B7F4C101708365200A106A9 /* SplitLargeMeshes.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46821708365200A106A9 /* SplitLargeMeshes.h */; };
+		2B7F4C111708365200A106A9 /* SplitLargeMeshes.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46821708365200A106A9 /* SplitLargeMeshes.h */; };
+		2B7F4C121708365200A106A9 /* SplitLargeMeshes.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46821708365200A106A9 /* SplitLargeMeshes.h */; };
+		2B7F4C131708365200A106A9 /* SplitLargeMeshes.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46821708365200A106A9 /* SplitLargeMeshes.h */; };
+		2B7F4C141708365200A106A9 /* StandardShapes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46831708365200A106A9 /* StandardShapes.cpp */; };
+		2B7F4C151708365200A106A9 /* StandardShapes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46831708365200A106A9 /* StandardShapes.cpp */; };
+		2B7F4C161708365200A106A9 /* StandardShapes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46831708365200A106A9 /* StandardShapes.cpp */; };
+		2B7F4C171708365200A106A9 /* StandardShapes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46831708365200A106A9 /* StandardShapes.cpp */; };
+		2B7F4C181708365200A106A9 /* StandardShapes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46831708365200A106A9 /* StandardShapes.cpp */; };
+		2B7F4C191708365200A106A9 /* StandardShapes.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46841708365200A106A9 /* StandardShapes.h */; };
+		2B7F4C1A1708365200A106A9 /* StandardShapes.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46841708365200A106A9 /* StandardShapes.h */; };
+		2B7F4C1B1708365200A106A9 /* StandardShapes.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46841708365200A106A9 /* StandardShapes.h */; };
+		2B7F4C1C1708365200A106A9 /* StandardShapes.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46841708365200A106A9 /* StandardShapes.h */; };
+		2B7F4C1D1708365200A106A9 /* StandardShapes.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46841708365200A106A9 /* StandardShapes.h */; };
+		2B7F4C1E1708365200A106A9 /* StdOStreamLogStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46851708365200A106A9 /* StdOStreamLogStream.h */; };
+		2B7F4C1F1708365200A106A9 /* StdOStreamLogStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46851708365200A106A9 /* StdOStreamLogStream.h */; };
+		2B7F4C201708365200A106A9 /* StdOStreamLogStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46851708365200A106A9 /* StdOStreamLogStream.h */; };
+		2B7F4C211708365200A106A9 /* StdOStreamLogStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46851708365200A106A9 /* StdOStreamLogStream.h */; };
+		2B7F4C221708365200A106A9 /* StdOStreamLogStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46851708365200A106A9 /* StdOStreamLogStream.h */; };
+		2B7F4C231708365200A106A9 /* STEPFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46861708365200A106A9 /* STEPFile.h */; };
+		2B7F4C241708365200A106A9 /* STEPFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46861708365200A106A9 /* STEPFile.h */; };
+		2B7F4C251708365200A106A9 /* STEPFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46861708365200A106A9 /* STEPFile.h */; };
+		2B7F4C261708365200A106A9 /* STEPFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46861708365200A106A9 /* STEPFile.h */; };
+		2B7F4C271708365200A106A9 /* STEPFile.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46861708365200A106A9 /* STEPFile.h */; };
+		2B7F4C281708365200A106A9 /* STEPFileEncoding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46871708365200A106A9 /* STEPFileEncoding.cpp */; };
+		2B7F4C291708365200A106A9 /* STEPFileEncoding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46871708365200A106A9 /* STEPFileEncoding.cpp */; };
+		2B7F4C2A1708365200A106A9 /* STEPFileEncoding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46871708365200A106A9 /* STEPFileEncoding.cpp */; };
+		2B7F4C2B1708365200A106A9 /* STEPFileEncoding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46871708365200A106A9 /* STEPFileEncoding.cpp */; };
+		2B7F4C2C1708365200A106A9 /* STEPFileEncoding.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46871708365200A106A9 /* STEPFileEncoding.cpp */; };
+		2B7F4C2D1708365200A106A9 /* STEPFileEncoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46881708365200A106A9 /* STEPFileEncoding.h */; };
+		2B7F4C2E1708365200A106A9 /* STEPFileEncoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46881708365200A106A9 /* STEPFileEncoding.h */; };
+		2B7F4C2F1708365200A106A9 /* STEPFileEncoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46881708365200A106A9 /* STEPFileEncoding.h */; };
+		2B7F4C301708365200A106A9 /* STEPFileEncoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46881708365200A106A9 /* STEPFileEncoding.h */; };
+		2B7F4C311708365200A106A9 /* STEPFileEncoding.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46881708365200A106A9 /* STEPFileEncoding.h */; };
+		2B7F4C321708365200A106A9 /* STEPFileReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46891708365200A106A9 /* STEPFileReader.cpp */; };
+		2B7F4C331708365200A106A9 /* STEPFileReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46891708365200A106A9 /* STEPFileReader.cpp */; };
+		2B7F4C341708365200A106A9 /* STEPFileReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46891708365200A106A9 /* STEPFileReader.cpp */; };
+		2B7F4C351708365200A106A9 /* STEPFileReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46891708365200A106A9 /* STEPFileReader.cpp */; };
+		2B7F4C361708365200A106A9 /* STEPFileReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46891708365200A106A9 /* STEPFileReader.cpp */; };
+		2B7F4C371708365200A106A9 /* STEPFileReader.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F468A1708365200A106A9 /* STEPFileReader.h */; };
+		2B7F4C381708365200A106A9 /* STEPFileReader.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F468A1708365200A106A9 /* STEPFileReader.h */; };
+		2B7F4C391708365200A106A9 /* STEPFileReader.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F468A1708365200A106A9 /* STEPFileReader.h */; };
+		2B7F4C3A1708365200A106A9 /* STEPFileReader.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F468A1708365200A106A9 /* STEPFileReader.h */; };
+		2B7F4C3B1708365200A106A9 /* STEPFileReader.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F468A1708365200A106A9 /* STEPFileReader.h */; };
+		2B7F4C3C1708365200A106A9 /* STLExporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F468B1708365200A106A9 /* STLExporter.cpp */; };
+		2B7F4C3D1708365200A106A9 /* STLExporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F468B1708365200A106A9 /* STLExporter.cpp */; };
+		2B7F4C3E1708365200A106A9 /* STLExporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F468B1708365200A106A9 /* STLExporter.cpp */; };
+		2B7F4C3F1708365200A106A9 /* STLExporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F468B1708365200A106A9 /* STLExporter.cpp */; };
+		2B7F4C401708365200A106A9 /* STLExporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F468B1708365200A106A9 /* STLExporter.cpp */; };
+		2B7F4C411708365200A106A9 /* STLExporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F468C1708365200A106A9 /* STLExporter.h */; };
+		2B7F4C421708365200A106A9 /* STLExporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F468C1708365200A106A9 /* STLExporter.h */; };
+		2B7F4C431708365200A106A9 /* STLExporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F468C1708365200A106A9 /* STLExporter.h */; };
+		2B7F4C441708365200A106A9 /* STLExporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F468C1708365200A106A9 /* STLExporter.h */; };
+		2B7F4C451708365200A106A9 /* STLExporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F468C1708365200A106A9 /* STLExporter.h */; };
+		2B7F4C461708365200A106A9 /* STLLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F468D1708365200A106A9 /* STLLoader.cpp */; };
+		2B7F4C471708365200A106A9 /* STLLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F468D1708365200A106A9 /* STLLoader.cpp */; };
+		2B7F4C481708365200A106A9 /* STLLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F468D1708365200A106A9 /* STLLoader.cpp */; };
+		2B7F4C491708365200A106A9 /* STLLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F468D1708365200A106A9 /* STLLoader.cpp */; };
+		2B7F4C4A1708365200A106A9 /* STLLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F468D1708365200A106A9 /* STLLoader.cpp */; };
+		2B7F4C4B1708365200A106A9 /* STLLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F468E1708365200A106A9 /* STLLoader.h */; };
+		2B7F4C4C1708365200A106A9 /* STLLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F468E1708365200A106A9 /* STLLoader.h */; };
+		2B7F4C4D1708365200A106A9 /* STLLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F468E1708365200A106A9 /* STLLoader.h */; };
+		2B7F4C4E1708365200A106A9 /* STLLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F468E1708365200A106A9 /* STLLoader.h */; };
+		2B7F4C4F1708365200A106A9 /* STLLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F468E1708365200A106A9 /* STLLoader.h */; };
+		2B7F4C501708365200A106A9 /* StreamReader.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F468F1708365200A106A9 /* StreamReader.h */; };
+		2B7F4C511708365200A106A9 /* StreamReader.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F468F1708365200A106A9 /* StreamReader.h */; };
+		2B7F4C521708365200A106A9 /* StreamReader.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F468F1708365200A106A9 /* StreamReader.h */; };
+		2B7F4C531708365200A106A9 /* StreamReader.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F468F1708365200A106A9 /* StreamReader.h */; };
+		2B7F4C541708365200A106A9 /* StreamReader.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F468F1708365200A106A9 /* StreamReader.h */; };
+		2B7F4C551708365200A106A9 /* StringComparison.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46901708365200A106A9 /* StringComparison.h */; };
+		2B7F4C561708365200A106A9 /* StringComparison.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46901708365200A106A9 /* StringComparison.h */; };
+		2B7F4C571708365200A106A9 /* StringComparison.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46901708365200A106A9 /* StringComparison.h */; };
+		2B7F4C581708365200A106A9 /* StringComparison.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46901708365200A106A9 /* StringComparison.h */; };
+		2B7F4C591708365200A106A9 /* StringComparison.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46901708365200A106A9 /* StringComparison.h */; };
+		2B7F4C5A1708365200A106A9 /* Subdivision.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46911708365200A106A9 /* Subdivision.cpp */; };
+		2B7F4C5B1708365200A106A9 /* Subdivision.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46911708365200A106A9 /* Subdivision.cpp */; };
+		2B7F4C5C1708365200A106A9 /* Subdivision.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46911708365200A106A9 /* Subdivision.cpp */; };
+		2B7F4C5D1708365200A106A9 /* Subdivision.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46911708365200A106A9 /* Subdivision.cpp */; };
+		2B7F4C5E1708365200A106A9 /* Subdivision.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46911708365200A106A9 /* Subdivision.cpp */; };
+		2B7F4C5F1708365200A106A9 /* Subdivision.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46921708365200A106A9 /* Subdivision.h */; };
+		2B7F4C601708365200A106A9 /* Subdivision.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46921708365200A106A9 /* Subdivision.h */; };
+		2B7F4C611708365200A106A9 /* Subdivision.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46921708365200A106A9 /* Subdivision.h */; };
+		2B7F4C621708365200A106A9 /* Subdivision.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46921708365200A106A9 /* Subdivision.h */; };
+		2B7F4C631708365200A106A9 /* Subdivision.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46921708365200A106A9 /* Subdivision.h */; };
+		2B7F4C641708365200A106A9 /* TargetAnimation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46931708365200A106A9 /* TargetAnimation.cpp */; };
+		2B7F4C651708365200A106A9 /* TargetAnimation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46931708365200A106A9 /* TargetAnimation.cpp */; };
+		2B7F4C661708365200A106A9 /* TargetAnimation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46931708365200A106A9 /* TargetAnimation.cpp */; };
+		2B7F4C671708365200A106A9 /* TargetAnimation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46931708365200A106A9 /* TargetAnimation.cpp */; };
+		2B7F4C681708365200A106A9 /* TargetAnimation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46931708365200A106A9 /* TargetAnimation.cpp */; };
+		2B7F4C691708365200A106A9 /* TargetAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46941708365200A106A9 /* TargetAnimation.h */; };
+		2B7F4C6A1708365200A106A9 /* TargetAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46941708365200A106A9 /* TargetAnimation.h */; };
+		2B7F4C6B1708365200A106A9 /* TargetAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46941708365200A106A9 /* TargetAnimation.h */; };
+		2B7F4C6C1708365200A106A9 /* TargetAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46941708365200A106A9 /* TargetAnimation.h */; };
+		2B7F4C6D1708365200A106A9 /* TargetAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46941708365200A106A9 /* TargetAnimation.h */; };
+		2B7F4C781708365200A106A9 /* TextureTransform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46971708365200A106A9 /* TextureTransform.cpp */; };
+		2B7F4C791708365200A106A9 /* TextureTransform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46971708365200A106A9 /* TextureTransform.cpp */; };
+		2B7F4C7A1708365200A106A9 /* TextureTransform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46971708365200A106A9 /* TextureTransform.cpp */; };
+		2B7F4C7B1708365200A106A9 /* TextureTransform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46971708365200A106A9 /* TextureTransform.cpp */; };
+		2B7F4C7C1708365200A106A9 /* TextureTransform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46971708365200A106A9 /* TextureTransform.cpp */; };
+		2B7F4C7D1708365200A106A9 /* TextureTransform.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46981708365200A106A9 /* TextureTransform.h */; };
+		2B7F4C7E1708365200A106A9 /* TextureTransform.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46981708365200A106A9 /* TextureTransform.h */; };
+		2B7F4C7F1708365200A106A9 /* TextureTransform.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46981708365200A106A9 /* TextureTransform.h */; };
+		2B7F4C801708365200A106A9 /* TextureTransform.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46981708365200A106A9 /* TextureTransform.h */; };
+		2B7F4C811708365200A106A9 /* TextureTransform.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46981708365200A106A9 /* TextureTransform.h */; };
+		2B7F4C821708365200A106A9 /* TinyFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46991708365200A106A9 /* TinyFormatter.h */; };
+		2B7F4C831708365200A106A9 /* TinyFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46991708365200A106A9 /* TinyFormatter.h */; };
+		2B7F4C841708365200A106A9 /* TinyFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46991708365200A106A9 /* TinyFormatter.h */; };
+		2B7F4C851708365200A106A9 /* TinyFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46991708365200A106A9 /* TinyFormatter.h */; };
+		2B7F4C861708365200A106A9 /* TinyFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46991708365200A106A9 /* TinyFormatter.h */; };
+		2B7F4C871708365200A106A9 /* TriangulateProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F469A1708365200A106A9 /* TriangulateProcess.cpp */; };
+		2B7F4C881708365200A106A9 /* TriangulateProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F469A1708365200A106A9 /* TriangulateProcess.cpp */; };
+		2B7F4C891708365200A106A9 /* TriangulateProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F469A1708365200A106A9 /* TriangulateProcess.cpp */; };
+		2B7F4C8A1708365200A106A9 /* TriangulateProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F469A1708365200A106A9 /* TriangulateProcess.cpp */; };
+		2B7F4C8B1708365200A106A9 /* TriangulateProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F469A1708365200A106A9 /* TriangulateProcess.cpp */; };
+		2B7F4C8C1708365200A106A9 /* TriangulateProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F469B1708365200A106A9 /* TriangulateProcess.h */; };
+		2B7F4C8D1708365200A106A9 /* TriangulateProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F469B1708365200A106A9 /* TriangulateProcess.h */; };
+		2B7F4C8E1708365200A106A9 /* TriangulateProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F469B1708365200A106A9 /* TriangulateProcess.h */; };
+		2B7F4C8F1708365200A106A9 /* TriangulateProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F469B1708365200A106A9 /* TriangulateProcess.h */; };
+		2B7F4C901708365200A106A9 /* TriangulateProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F469B1708365200A106A9 /* TriangulateProcess.h */; };
+		2B7F4C9B1708365200A106A9 /* ValidateDataStructure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F469E1708365200A106A9 /* ValidateDataStructure.cpp */; };
+		2B7F4C9C1708365200A106A9 /* ValidateDataStructure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F469E1708365200A106A9 /* ValidateDataStructure.cpp */; };
+		2B7F4C9D1708365200A106A9 /* ValidateDataStructure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F469E1708365200A106A9 /* ValidateDataStructure.cpp */; };
+		2B7F4C9E1708365200A106A9 /* ValidateDataStructure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F469E1708365200A106A9 /* ValidateDataStructure.cpp */; };
+		2B7F4C9F1708365200A106A9 /* ValidateDataStructure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F469E1708365200A106A9 /* ValidateDataStructure.cpp */; };
+		2B7F4CA01708365200A106A9 /* ValidateDataStructure.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F469F1708365200A106A9 /* ValidateDataStructure.h */; };
+		2B7F4CA11708365200A106A9 /* ValidateDataStructure.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F469F1708365200A106A9 /* ValidateDataStructure.h */; };
+		2B7F4CA21708365200A106A9 /* ValidateDataStructure.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F469F1708365200A106A9 /* ValidateDataStructure.h */; };
+		2B7F4CA31708365200A106A9 /* ValidateDataStructure.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F469F1708365200A106A9 /* ValidateDataStructure.h */; };
+		2B7F4CA41708365200A106A9 /* ValidateDataStructure.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F469F1708365200A106A9 /* ValidateDataStructure.h */; };
+		2B7F4CA51708365200A106A9 /* Vertex.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46A01708365200A106A9 /* Vertex.h */; };
+		2B7F4CA61708365200A106A9 /* Vertex.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46A01708365200A106A9 /* Vertex.h */; };
+		2B7F4CA71708365200A106A9 /* Vertex.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46A01708365200A106A9 /* Vertex.h */; };
+		2B7F4CA81708365200A106A9 /* Vertex.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46A01708365200A106A9 /* Vertex.h */; };
+		2B7F4CA91708365200A106A9 /* Vertex.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46A01708365200A106A9 /* Vertex.h */; };
+		2B7F4CAA1708365200A106A9 /* VertexTriangleAdjacency.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46A11708365200A106A9 /* VertexTriangleAdjacency.cpp */; };
+		2B7F4CAB1708365200A106A9 /* VertexTriangleAdjacency.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46A11708365200A106A9 /* VertexTriangleAdjacency.cpp */; };
+		2B7F4CAC1708365200A106A9 /* VertexTriangleAdjacency.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46A11708365200A106A9 /* VertexTriangleAdjacency.cpp */; };
+		2B7F4CAD1708365200A106A9 /* VertexTriangleAdjacency.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46A11708365200A106A9 /* VertexTriangleAdjacency.cpp */; };
+		2B7F4CAE1708365200A106A9 /* VertexTriangleAdjacency.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2B7F46A11708365200A106A9 /* VertexTriangleAdjacency.cpp */; };
+		2B7F4CAF1708365200A106A9 /* VertexTriangleAdjacency.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46A21708365200A106A9 /* VertexTriangleAdjacency.h */; };
+		2B7F4CB01708365200A106A9 /* VertexTriangleAdjacency.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46A21708365200A106A9 /* VertexTriangleAdjacency.h */; };
+		2B7F4CB11708365200A106A9 /* VertexTriangleAdjacency.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46A21708365200A106A9 /* VertexTriangleAdjacency.h */; };
+		2B7F4CB21708365200A106A9 /* VertexTriangleAdjacency.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46A21708365200A106A9 /* VertexTriangleAdjacency.h */; };
+		2B7F4CB31708365200A106A9 /* VertexTriangleAdjacency.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46A21708365200A106A9 /* VertexTriangleAdjacency.h */; };
+		2B7F4CB41708365200A106A9 /* Win32DebugLogStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46A31708365200A106A9 /* Win32DebugLogStream.h */; };
+		2B7F4CB51708365200A106A9 /* Win32DebugLogStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46A31708365200A106A9 /* Win32DebugLogStream.h */; };
+		2B7F4CB61708365200A106A9 /* Win32DebugLogStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46A31708365200A106A9 /* Win32DebugLogStream.h */; };
+		2B7F4CB71708365200A106A9 /* Win32DebugLogStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46A31708365200A106A9 /* Win32DebugLogStream.h */; };
+		2B7F4CB81708365200A106A9 /* Win32DebugLogStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 2B7F46A31708365200A106A9 /* Win32DebugLogStream.h */; };
+		2BA44E11170862D800C78A66 /* libstdc++.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 2BA44E10170862D800C78A66 /* libstdc++.dylib */; };
+		2BA44E12170862DE00C78A66 /* libstdc++.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 2BA44E10170862D800C78A66 /* libstdc++.dylib */; };
+		2BA44E13170862E400C78A66 /* libstdc++.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 2BA44E10170862D800C78A66 /* libstdc++.dylib */; };
+		2BA44E14170862EA00C78A66 /* libstdc++.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 2BA44E10170862D800C78A66 /* libstdc++.dylib */; };
+		2BA44E1A1708680600C78A66 /* libstdc++.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 2BA44E10170862D800C78A66 /* libstdc++.dylib */; };
 		3AB8A3AF0E50D67A00606590 /* MDCFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3AB0E50D67A00606590 /* MDCFileData.h */; };
 		3AB8A3B00E50D67A00606590 /* MDCLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AB8A3AC0E50D67A00606590 /* MDCLoader.cpp */; };
 		3AB8A3B10E50D67A00606590 /* MDCLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3AD0E50D67A00606590 /* MDCLoader.h */; };
 		3AB8A3B20E50D67A00606590 /* MDCNormalTable.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3AE0E50D67A00606590 /* MDCNormalTable.h */; };
-		3AB8A3B50E50D69D00606590 /* FixNormalsStep.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AB8A3B30E50D69D00606590 /* FixNormalsStep.cpp */; };
-		3AB8A3B60E50D69D00606590 /* FixNormalsStep.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3B40E50D69D00606590 /* FixNormalsStep.h */; };
 		3AB8A3BA0E50D6DB00606590 /* LWOFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3B70E50D6DB00606590 /* LWOFileData.h */; };
 		3AB8A3BB0E50D6DB00606590 /* LWOLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AB8A3B80E50D6DB00606590 /* LWOLoader.cpp */; };
 		3AB8A3BC0E50D6DB00606590 /* LWOLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3B90E50D6DB00606590 /* LWOLoader.h */; };
-		3AB8A3C40E50D74500606590 /* BaseProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AB8A3C30E50D74500606590 /* BaseProcess.cpp */; };
 		3AB8A3C60E50D77900606590 /* HMPFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3C50E50D77900606590 /* HMPFileData.h */; };
-		3AB8A3CA0E50D7CC00606590 /* IFF.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3C90E50D7CC00606590 /* IFF.h */; };
-		3AB8A3CD0E50D7FF00606590 /* Hash.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3CB0E50D7FF00606590 /* Hash.h */; };
 		3AB8A7DD0E53715F00606590 /* LWOMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AB8A7DC0E53715F00606590 /* LWOMaterial.cpp */; };
 		3AF45AF90E4B716800207D74 /* 3DSConverter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A860E4B716800207D74 /* 3DSConverter.cpp */; };
 		3AF45AFB0E4B716800207D74 /* 3DSHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A880E4B716800207D74 /* 3DSHelper.h */; };
@@ -29,38 +1009,9 @@
 		3AF45B020E4B716800207D74 /* ASELoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A8F0E4B716800207D74 /* ASELoader.h */; };
 		3AF45B030E4B716800207D74 /* ASEParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A900E4B716800207D74 /* ASEParser.cpp */; };
 		3AF45B040E4B716800207D74 /* ASEParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A910E4B716800207D74 /* ASEParser.h */; };
-		3AF45B050E4B716800207D74 /* Assimp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A920E4B716800207D74 /* Assimp.cpp */; };
-		3AF45B060E4B716800207D74 /* BaseImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A930E4B716800207D74 /* BaseImporter.cpp */; };
-		3AF45B070E4B716800207D74 /* BaseImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A940E4B716800207D74 /* BaseImporter.h */; };
-		3AF45B080E4B716800207D74 /* BaseProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A950E4B716800207D74 /* BaseProcess.h */; };
-		3AF45B090E4B716800207D74 /* ByteSwap.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A960E4B716800207D74 /* ByteSwap.h */; };
-		3AF45B0A0E4B716800207D74 /* CalcTangentsProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A970E4B716800207D74 /* CalcTangentsProcess.cpp */; };
-		3AF45B0B0E4B716800207D74 /* CalcTangentsProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A980E4B716800207D74 /* CalcTangentsProcess.h */; };
-		3AF45B0C0E4B716800207D74 /* ConvertToLHProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A990E4B716800207D74 /* ConvertToLHProcess.cpp */; };
-		3AF45B0D0E4B716800207D74 /* ConvertToLHProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A9A0E4B716800207D74 /* ConvertToLHProcess.h */; };
-		3AF45B0E0E4B716800207D74 /* DefaultIOStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A9B0E4B716800207D74 /* DefaultIOStream.cpp */; };
-		3AF45B0F0E4B716800207D74 /* DefaultIOStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A9C0E4B716800207D74 /* DefaultIOStream.h */; };
-		3AF45B100E4B716800207D74 /* DefaultIOSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A9D0E4B716800207D74 /* DefaultIOSystem.cpp */; };
-		3AF45B110E4B716800207D74 /* DefaultIOSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A9E0E4B716800207D74 /* DefaultIOSystem.h */; };
-		3AF45B120E4B716800207D74 /* DefaultLogger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A9F0E4B716800207D74 /* DefaultLogger.cpp */; };
-		3AF45B150E4B716800207D74 /* fast_atof.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AA30E4B716800207D74 /* fast_atof.h */; };
-		3AF45B160E4B716800207D74 /* FileLogStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AA40E4B716800207D74 /* FileLogStream.h */; };
-		3AF45B170E4B716800207D74 /* GenFaceNormalsProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AA50E4B716800207D74 /* GenFaceNormalsProcess.cpp */; };
-		3AF45B180E4B716800207D74 /* GenFaceNormalsProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AA60E4B716800207D74 /* GenFaceNormalsProcess.h */; };
-		3AF45B190E4B716800207D74 /* GenVertexNormalsProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AA70E4B716800207D74 /* GenVertexNormalsProcess.cpp */; };
-		3AF45B1A0E4B716800207D74 /* GenVertexNormalsProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AA80E4B716800207D74 /* GenVertexNormalsProcess.h */; };
 		3AF45B1B0E4B716800207D74 /* HalfLifeFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AA90E4B716800207D74 /* HalfLifeFileData.h */; };
 		3AF45B1D0E4B716800207D74 /* HMPLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AAB0E4B716800207D74 /* HMPLoader.cpp */; };
 		3AF45B1E0E4B716800207D74 /* HMPLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AAC0E4B716800207D74 /* HMPLoader.h */; };
-		3AF45B1F0E4B716800207D74 /* Importer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AAD0E4B716800207D74 /* Importer.cpp */; };
-		3AF45B200E4B716800207D74 /* ImproveCacheLocality.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AAE0E4B716800207D74 /* ImproveCacheLocality.cpp */; };
-		3AF45B210E4B716800207D74 /* ImproveCacheLocality.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AAF0E4B716800207D74 /* ImproveCacheLocality.h */; };
-		3AF45B220E4B716800207D74 /* JoinVerticesProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AB00E4B716800207D74 /* JoinVerticesProcess.cpp */; };
-		3AF45B230E4B716800207D74 /* JoinVerticesProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AB10E4B716800207D74 /* JoinVerticesProcess.h */; };
-		3AF45B260E4B716800207D74 /* LimitBoneWeightsProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AB40E4B716800207D74 /* LimitBoneWeightsProcess.cpp */; };
-		3AF45B270E4B716800207D74 /* LimitBoneWeightsProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AB50E4B716800207D74 /* LimitBoneWeightsProcess.h */; };
-		3AF45B280E4B716800207D74 /* MaterialSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AB60E4B716800207D74 /* MaterialSystem.cpp */; };
-		3AF45B290E4B716800207D74 /* MaterialSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AB70E4B716800207D74 /* MaterialSystem.h */; };
 		3AF45B2A0E4B716800207D74 /* MD2FileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AB80E4B716800207D74 /* MD2FileData.h */; };
 		3AF45B2B0E4B716800207D74 /* MD2Loader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AB90E4B716800207D74 /* MD2Loader.cpp */; };
 		3AF45B2C0E4B716800207D74 /* MD2Loader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45ABA0E4B716800207D74 /* MD2Loader.h */; };
@@ -77,44 +1028,12 @@
 		3AF45B3A0E4B716800207D74 /* MDLLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AC80E4B716800207D74 /* MDLLoader.cpp */; };
 		3AF45B3B0E4B716800207D74 /* MDLLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AC90E4B716800207D74 /* MDLLoader.h */; };
 		3AF45B3C0E4B716800207D74 /* MDLMaterialLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45ACA0E4B716800207D74 /* MDLMaterialLoader.cpp */; };
-		3AF45B3D0E4B716800207D74 /* ObjFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45ACB0E4B716800207D74 /* ObjFileData.h */; };
-		3AF45B3E0E4B716800207D74 /* ObjFileImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45ACC0E4B716800207D74 /* ObjFileImporter.cpp */; };
-		3AF45B3F0E4B716800207D74 /* ObjFileImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45ACD0E4B716800207D74 /* ObjFileImporter.h */; };
-		3AF45B400E4B716800207D74 /* ObjFileMtlImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45ACE0E4B716800207D74 /* ObjFileMtlImporter.cpp */; };
-		3AF45B410E4B716800207D74 /* ObjFileMtlImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45ACF0E4B716800207D74 /* ObjFileMtlImporter.h */; };
-		3AF45B420E4B716800207D74 /* ObjFileParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AD00E4B716800207D74 /* ObjFileParser.cpp */; };
-		3AF45B430E4B716800207D74 /* ObjFileParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AD10E4B716800207D74 /* ObjFileParser.h */; };
-		3AF45B440E4B716800207D74 /* ObjTools.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AD20E4B716800207D74 /* ObjTools.h */; };
-		3AF45B450E4B716800207D74 /* ParsingUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AD30E4B716800207D74 /* ParsingUtils.h */; };
 		3AF45B460E4B716800207D74 /* PlyLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AD40E4B716800207D74 /* PlyLoader.cpp */; };
 		3AF45B470E4B716800207D74 /* PlyLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AD50E4B716800207D74 /* PlyLoader.h */; };
 		3AF45B480E4B716800207D74 /* PlyParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AD60E4B716800207D74 /* PlyParser.cpp */; };
 		3AF45B490E4B716800207D74 /* PlyParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AD70E4B716800207D74 /* PlyParser.h */; };
-		3AF45B4A0E4B716800207D74 /* PretransformVertices.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AD80E4B716800207D74 /* PretransformVertices.cpp */; };
-		3AF45B4B0E4B716800207D74 /* PretransformVertices.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AD90E4B716800207D74 /* PretransformVertices.h */; };
-		3AF45B4C0E4B716800207D74 /* qnan.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45ADA0E4B716800207D74 /* qnan.h */; };
-		3AF45B4D0E4B716800207D74 /* RemoveComments.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45ADB0E4B716800207D74 /* RemoveComments.cpp */; };
-		3AF45B4E0E4B716800207D74 /* RemoveComments.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45ADC0E4B716800207D74 /* RemoveComments.h */; };
-		3AF45B4F0E4B716800207D74 /* RemoveRedundantMaterials.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45ADD0E4B716800207D74 /* RemoveRedundantMaterials.cpp */; };
-		3AF45B500E4B716800207D74 /* RemoveRedundantMaterials.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45ADE0E4B716800207D74 /* RemoveRedundantMaterials.h */; };
 		3AF45B520E4B716800207D74 /* SMDLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AE20E4B716800207D74 /* SMDLoader.cpp */; };
 		3AF45B530E4B716800207D74 /* SMDLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AE30E4B716800207D74 /* SMDLoader.h */; };
-		3AF45B540E4B716800207D74 /* SpatialSort.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AE40E4B716800207D74 /* SpatialSort.cpp */; };
-		3AF45B550E4B716800207D74 /* SpatialSort.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AE50E4B716800207D74 /* SpatialSort.h */; };
-		3AF45B560E4B716800207D74 /* SplitLargeMeshes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AE60E4B716800207D74 /* SplitLargeMeshes.cpp */; };
-		3AF45B570E4B716800207D74 /* SplitLargeMeshes.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AE70E4B716800207D74 /* SplitLargeMeshes.h */; };
-		3AF45B580E4B716800207D74 /* STLLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AE80E4B716800207D74 /* STLLoader.cpp */; };
-		3AF45B590E4B716800207D74 /* STLLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AE90E4B716800207D74 /* STLLoader.h */; };
-		3AF45B5A0E4B716800207D74 /* StringComparison.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AEA0E4B716800207D74 /* StringComparison.h */; };
-		3AF45B5B0E4B716800207D74 /* TextureTransform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AEB0E4B716800207D74 /* TextureTransform.cpp */; };
-		3AF45B5C0E4B716800207D74 /* TextureTransform.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AEC0E4B716800207D74 /* TextureTransform.h */; };
-		3AF45B5D0E4B716800207D74 /* TriangulateProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AED0E4B716800207D74 /* TriangulateProcess.cpp */; };
-		3AF45B5E0E4B716800207D74 /* TriangulateProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AEE0E4B716800207D74 /* TriangulateProcess.h */; };
-		3AF45B5F0E4B716800207D74 /* ValidateDataStructure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AEF0E4B716800207D74 /* ValidateDataStructure.cpp */; };
-		3AF45B600E4B716800207D74 /* ValidateDataStructure.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AF00E4B716800207D74 /* ValidateDataStructure.h */; };
-		3AF45B610E4B716800207D74 /* VertexTriangleAdjacency.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AF10E4B716800207D74 /* VertexTriangleAdjacency.cpp */; };
-		3AF45B620E4B716800207D74 /* VertexTriangleAdjacency.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AF20E4B716800207D74 /* VertexTriangleAdjacency.h */; };
-		3AF45B630E4B716800207D74 /* Win32DebugLogStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AF30E4B716800207D74 /* Win32DebugLogStream.h */; };
 		3AF45B640E4B716800207D74 /* XFileHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AF40E4B716800207D74 /* XFileHelper.h */; };
 		3AF45B650E4B716800207D74 /* XFileImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AF50E4B716800207D74 /* XFileImporter.cpp */; };
 		3AF45B660E4B716800207D74 /* XFileImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AF60E4B716800207D74 /* XFileImporter.h */; };
@@ -160,101 +1079,12 @@
 		7411B19211416EBC00BCD793 /* UnrealLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B18C11416EBC00BCD793 /* UnrealLoader.h */; };
 		7411B19311416EBC00BCD793 /* UnrealLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7411B18B11416EBC00BCD793 /* UnrealLoader.cpp */; };
 		7411B19411416EBC00BCD793 /* UnrealLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B18C11416EBC00BCD793 /* UnrealLoader.h */; };
-		7411B1A611416EF400BCD793 /* FileSystemFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B19711416EF400BCD793 /* FileSystemFilter.h */; };
-		7411B1A711416EF400BCD793 /* GenericProperty.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B19811416EF400BCD793 /* GenericProperty.h */; };
-		7411B1A811416EF400BCD793 /* MemoryIOWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B19911416EF400BCD793 /* MemoryIOWrapper.h */; };
-		7411B1A911416EF400BCD793 /* OptimizeGraph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7411B19A11416EF400BCD793 /* OptimizeGraph.cpp */; };
-		7411B1AA11416EF400BCD793 /* OptimizeGraph.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B19B11416EF400BCD793 /* OptimizeGraph.h */; };
-		7411B1AB11416EF400BCD793 /* OptimizeMeshes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7411B19C11416EF400BCD793 /* OptimizeMeshes.cpp */; };
-		7411B1AC11416EF400BCD793 /* OptimizeMeshes.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B19D11416EF400BCD793 /* OptimizeMeshes.h */; };
-		7411B1AD11416EF400BCD793 /* ProcessHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B19E11416EF400BCD793 /* ProcessHelper.h */; };
-		7411B1AE11416EF400BCD793 /* StdOStreamLogStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B19F11416EF400BCD793 /* StdOStreamLogStream.h */; };
-		7411B1AF11416EF400BCD793 /* StreamReader.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B1A011416EF400BCD793 /* StreamReader.h */; };
-		7411B1B011416EF400BCD793 /* Subdivision.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7411B1A111416EF400BCD793 /* Subdivision.cpp */; };
-		7411B1B111416EF400BCD793 /* Subdivision.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B1A211416EF400BCD793 /* Subdivision.h */; };
-		7411B1B211416EF400BCD793 /* TargetAnimation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7411B1A311416EF400BCD793 /* TargetAnimation.cpp */; };
-		7411B1B311416EF400BCD793 /* TargetAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B1A411416EF400BCD793 /* TargetAnimation.h */; };
-		7411B1B411416EF400BCD793 /* Vertex.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B1A511416EF400BCD793 /* Vertex.h */; };
-		7411B1B511416EF400BCD793 /* FileSystemFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B19711416EF400BCD793 /* FileSystemFilter.h */; };
-		7411B1B611416EF400BCD793 /* GenericProperty.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B19811416EF400BCD793 /* GenericProperty.h */; };
-		7411B1B711416EF400BCD793 /* MemoryIOWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B19911416EF400BCD793 /* MemoryIOWrapper.h */; };
-		7411B1B811416EF400BCD793 /* OptimizeGraph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7411B19A11416EF400BCD793 /* OptimizeGraph.cpp */; };
-		7411B1B911416EF400BCD793 /* OptimizeGraph.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B19B11416EF400BCD793 /* OptimizeGraph.h */; };
-		7411B1BA11416EF400BCD793 /* OptimizeMeshes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7411B19C11416EF400BCD793 /* OptimizeMeshes.cpp */; };
-		7411B1BB11416EF400BCD793 /* OptimizeMeshes.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B19D11416EF400BCD793 /* OptimizeMeshes.h */; };
-		7411B1BC11416EF400BCD793 /* ProcessHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B19E11416EF400BCD793 /* ProcessHelper.h */; };
-		7411B1BD11416EF400BCD793 /* StdOStreamLogStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B19F11416EF400BCD793 /* StdOStreamLogStream.h */; };
-		7411B1BE11416EF400BCD793 /* StreamReader.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B1A011416EF400BCD793 /* StreamReader.h */; };
-		7411B1BF11416EF400BCD793 /* Subdivision.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7411B1A111416EF400BCD793 /* Subdivision.cpp */; };
-		7411B1C011416EF400BCD793 /* Subdivision.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B1A211416EF400BCD793 /* Subdivision.h */; };
-		7411B1C111416EF400BCD793 /* TargetAnimation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7411B1A311416EF400BCD793 /* TargetAnimation.cpp */; };
-		7411B1C211416EF400BCD793 /* TargetAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B1A411416EF400BCD793 /* TargetAnimation.h */; };
-		7411B1C311416EF400BCD793 /* Vertex.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B1A511416EF400BCD793 /* Vertex.h */; };
-		7411B1C411416EF400BCD793 /* FileSystemFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B19711416EF400BCD793 /* FileSystemFilter.h */; };
-		7411B1C511416EF400BCD793 /* GenericProperty.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B19811416EF400BCD793 /* GenericProperty.h */; };
-		7411B1C611416EF400BCD793 /* MemoryIOWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B19911416EF400BCD793 /* MemoryIOWrapper.h */; };
-		7411B1C711416EF400BCD793 /* OptimizeGraph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7411B19A11416EF400BCD793 /* OptimizeGraph.cpp */; };
-		7411B1C811416EF400BCD793 /* OptimizeGraph.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B19B11416EF400BCD793 /* OptimizeGraph.h */; };
-		7411B1C911416EF400BCD793 /* OptimizeMeshes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7411B19C11416EF400BCD793 /* OptimizeMeshes.cpp */; };
-		7411B1CA11416EF400BCD793 /* OptimizeMeshes.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B19D11416EF400BCD793 /* OptimizeMeshes.h */; };
-		7411B1CB11416EF400BCD793 /* ProcessHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B19E11416EF400BCD793 /* ProcessHelper.h */; };
-		7411B1CC11416EF400BCD793 /* StdOStreamLogStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B19F11416EF400BCD793 /* StdOStreamLogStream.h */; };
-		7411B1CD11416EF400BCD793 /* StreamReader.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B1A011416EF400BCD793 /* StreamReader.h */; };
-		7411B1CE11416EF400BCD793 /* Subdivision.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7411B1A111416EF400BCD793 /* Subdivision.cpp */; };
-		7411B1CF11416EF400BCD793 /* Subdivision.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B1A211416EF400BCD793 /* Subdivision.h */; };
-		7411B1D011416EF400BCD793 /* TargetAnimation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7411B1A311416EF400BCD793 /* TargetAnimation.cpp */; };
-		7411B1D111416EF400BCD793 /* TargetAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B1A411416EF400BCD793 /* TargetAnimation.h */; };
-		7411B1D211416EF400BCD793 /* Vertex.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B1A511416EF400BCD793 /* Vertex.h */; };
-		7411B1D311416EF400BCD793 /* FileSystemFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B19711416EF400BCD793 /* FileSystemFilter.h */; };
-		7411B1D411416EF400BCD793 /* GenericProperty.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B19811416EF400BCD793 /* GenericProperty.h */; };
-		7411B1D511416EF400BCD793 /* MemoryIOWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B19911416EF400BCD793 /* MemoryIOWrapper.h */; };
-		7411B1D611416EF400BCD793 /* OptimizeGraph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7411B19A11416EF400BCD793 /* OptimizeGraph.cpp */; };
-		7411B1D711416EF400BCD793 /* OptimizeGraph.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B19B11416EF400BCD793 /* OptimizeGraph.h */; };
-		7411B1D811416EF400BCD793 /* OptimizeMeshes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7411B19C11416EF400BCD793 /* OptimizeMeshes.cpp */; };
-		7411B1D911416EF400BCD793 /* OptimizeMeshes.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B19D11416EF400BCD793 /* OptimizeMeshes.h */; };
-		7411B1DA11416EF400BCD793 /* ProcessHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B19E11416EF400BCD793 /* ProcessHelper.h */; };
-		7411B1DB11416EF400BCD793 /* StdOStreamLogStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B19F11416EF400BCD793 /* StdOStreamLogStream.h */; };
-		7411B1DC11416EF400BCD793 /* StreamReader.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B1A011416EF400BCD793 /* StreamReader.h */; };
-		7411B1DD11416EF400BCD793 /* Subdivision.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7411B1A111416EF400BCD793 /* Subdivision.cpp */; };
-		7411B1DE11416EF400BCD793 /* Subdivision.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B1A211416EF400BCD793 /* Subdivision.h */; };
-		7411B1DF11416EF400BCD793 /* TargetAnimation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7411B1A311416EF400BCD793 /* TargetAnimation.cpp */; };
-		7411B1E011416EF400BCD793 /* TargetAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B1A411416EF400BCD793 /* TargetAnimation.h */; };
-		7411B1E111416EF400BCD793 /* Vertex.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B1A511416EF400BCD793 /* Vertex.h */; };
-		7437C959113F18C70067B9B9 /* foreach.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 7437C950113F18C70067B9B9 /* foreach.hpp */; };
-		7437C95A113F18C70067B9B9 /* format.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 7437C951113F18C70067B9B9 /* format.hpp */; };
-		7437C95B113F18C70067B9B9 /* common_factor_rt.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 7437C953113F18C70067B9B9 /* common_factor_rt.hpp */; };
-		7437C95C113F18C70067B9B9 /* scoped_array.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 7437C954113F18C70067B9B9 /* scoped_array.hpp */; };
-		7437C95D113F18C70067B9B9 /* scoped_ptr.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 7437C955113F18C70067B9B9 /* scoped_ptr.hpp */; };
-		7437C95E113F18C70067B9B9 /* static_assert.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 7437C956113F18C70067B9B9 /* static_assert.hpp */; };
-		7437C95F113F18C70067B9B9 /* tuple.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 7437C958113F18C70067B9B9 /* tuple.hpp */; };
-		7437C960113F18C70067B9B9 /* foreach.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 7437C950113F18C70067B9B9 /* foreach.hpp */; };
-		7437C961113F18C70067B9B9 /* format.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 7437C951113F18C70067B9B9 /* format.hpp */; };
-		7437C962113F18C70067B9B9 /* common_factor_rt.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 7437C953113F18C70067B9B9 /* common_factor_rt.hpp */; };
-		7437C963113F18C70067B9B9 /* scoped_array.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 7437C954113F18C70067B9B9 /* scoped_array.hpp */; };
-		7437C964113F18C70067B9B9 /* scoped_ptr.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 7437C955113F18C70067B9B9 /* scoped_ptr.hpp */; };
-		7437C965113F18C70067B9B9 /* static_assert.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 7437C956113F18C70067B9B9 /* static_assert.hpp */; };
-		7437C966113F18C70067B9B9 /* tuple.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 7437C958113F18C70067B9B9 /* tuple.hpp */; };
 		745FF840113ECB080020C31B /* 3DSHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A880E4B716800207D74 /* 3DSHelper.h */; };
 		745FF841113ECB080020C31B /* 3DSLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A8A0E4B716800207D74 /* 3DSLoader.h */; };
 		745FF842113ECB080020C31B /* ASELoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A8F0E4B716800207D74 /* ASELoader.h */; };
 		745FF843113ECB080020C31B /* ASEParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A910E4B716800207D74 /* ASEParser.h */; };
-		745FF844113ECB080020C31B /* BaseImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A940E4B716800207D74 /* BaseImporter.h */; };
-		745FF845113ECB080020C31B /* BaseProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A950E4B716800207D74 /* BaseProcess.h */; };
-		745FF846113ECB080020C31B /* ByteSwap.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A960E4B716800207D74 /* ByteSwap.h */; };
-		745FF847113ECB080020C31B /* CalcTangentsProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A980E4B716800207D74 /* CalcTangentsProcess.h */; };
-		745FF848113ECB080020C31B /* ConvertToLHProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A9A0E4B716800207D74 /* ConvertToLHProcess.h */; };
-		745FF849113ECB080020C31B /* DefaultIOStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A9C0E4B716800207D74 /* DefaultIOStream.h */; };
-		745FF84A113ECB080020C31B /* DefaultIOSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A9E0E4B716800207D74 /* DefaultIOSystem.h */; };
-		745FF84C113ECB080020C31B /* fast_atof.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AA30E4B716800207D74 /* fast_atof.h */; };
-		745FF84D113ECB080020C31B /* FileLogStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AA40E4B716800207D74 /* FileLogStream.h */; };
-		745FF84E113ECB080020C31B /* GenFaceNormalsProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AA60E4B716800207D74 /* GenFaceNormalsProcess.h */; };
-		745FF84F113ECB080020C31B /* GenVertexNormalsProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AA80E4B716800207D74 /* GenVertexNormalsProcess.h */; };
 		745FF850113ECB080020C31B /* HalfLifeFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AA90E4B716800207D74 /* HalfLifeFileData.h */; };
 		745FF851113ECB080020C31B /* HMPLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AAC0E4B716800207D74 /* HMPLoader.h */; };
-		745FF852113ECB080020C31B /* ImproveCacheLocality.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AAF0E4B716800207D74 /* ImproveCacheLocality.h */; };
-		745FF853113ECB080020C31B /* JoinVerticesProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AB10E4B716800207D74 /* JoinVerticesProcess.h */; };
-		745FF854113ECB080020C31B /* LimitBoneWeightsProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AB50E4B716800207D74 /* LimitBoneWeightsProcess.h */; };
-		745FF855113ECB080020C31B /* MaterialSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AB70E4B716800207D74 /* MaterialSystem.h */; };
 		745FF856113ECB080020C31B /* MD2FileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AB80E4B716800207D74 /* MD2FileData.h */; };
 		745FF857113ECB080020C31B /* MD2Loader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45ABA0E4B716800207D74 /* MD2Loader.h */; };
 		745FF858113ECB080020C31B /* MD2NormalTable.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45ABB0E4B716800207D74 /* MD2NormalTable.h */; };
@@ -265,49 +1095,23 @@
 		745FF85D113ECB080020C31B /* MDLDefaultColorMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AC60E4B716800207D74 /* MDLDefaultColorMap.h */; };
 		745FF85E113ECB080020C31B /* MDLFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AC70E4B716800207D74 /* MDLFileData.h */; };
 		745FF85F113ECB080020C31B /* MDLLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AC90E4B716800207D74 /* MDLLoader.h */; };
-		745FF860113ECB080020C31B /* ObjFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45ACB0E4B716800207D74 /* ObjFileData.h */; };
-		745FF861113ECB080020C31B /* ObjFileImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45ACD0E4B716800207D74 /* ObjFileImporter.h */; };
-		745FF862113ECB080020C31B /* ObjFileMtlImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45ACF0E4B716800207D74 /* ObjFileMtlImporter.h */; };
-		745FF863113ECB080020C31B /* ObjFileParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AD10E4B716800207D74 /* ObjFileParser.h */; };
-		745FF864113ECB080020C31B /* ObjTools.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AD20E4B716800207D74 /* ObjTools.h */; };
-		745FF865113ECB080020C31B /* ParsingUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AD30E4B716800207D74 /* ParsingUtils.h */; };
 		745FF866113ECB080020C31B /* PlyLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AD50E4B716800207D74 /* PlyLoader.h */; };
 		745FF867113ECB080020C31B /* PlyParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AD70E4B716800207D74 /* PlyParser.h */; };
-		745FF868113ECB080020C31B /* PretransformVertices.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AD90E4B716800207D74 /* PretransformVertices.h */; };
-		745FF869113ECB080020C31B /* qnan.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45ADA0E4B716800207D74 /* qnan.h */; };
-		745FF86A113ECB080020C31B /* RemoveComments.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45ADC0E4B716800207D74 /* RemoveComments.h */; };
-		745FF86B113ECB080020C31B /* RemoveRedundantMaterials.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45ADE0E4B716800207D74 /* RemoveRedundantMaterials.h */; };
 		745FF86C113ECB080020C31B /* SMDLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AE30E4B716800207D74 /* SMDLoader.h */; };
-		745FF86D113ECB080020C31B /* SpatialSort.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AE50E4B716800207D74 /* SpatialSort.h */; };
-		745FF86E113ECB080020C31B /* SplitLargeMeshes.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AE70E4B716800207D74 /* SplitLargeMeshes.h */; };
-		745FF86F113ECB080020C31B /* STLLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AE90E4B716800207D74 /* STLLoader.h */; };
-		745FF870113ECB080020C31B /* StringComparison.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AEA0E4B716800207D74 /* StringComparison.h */; };
-		745FF871113ECB080020C31B /* TextureTransform.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AEC0E4B716800207D74 /* TextureTransform.h */; };
-		745FF872113ECB080020C31B /* TriangulateProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AEE0E4B716800207D74 /* TriangulateProcess.h */; };
-		745FF873113ECB080020C31B /* ValidateDataStructure.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AF00E4B716800207D74 /* ValidateDataStructure.h */; };
-		745FF874113ECB080020C31B /* VertexTriangleAdjacency.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AF20E4B716800207D74 /* VertexTriangleAdjacency.h */; };
-		745FF875113ECB080020C31B /* Win32DebugLogStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AF30E4B716800207D74 /* Win32DebugLogStream.h */; };
 		745FF876113ECB080020C31B /* XFileHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AF40E4B716800207D74 /* XFileHelper.h */; };
 		745FF877113ECB080020C31B /* XFileImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AF60E4B716800207D74 /* XFileImporter.h */; };
 		745FF878113ECB080020C31B /* XFileParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AF80E4B716800207D74 /* XFileParser.h */; };
 		745FF87B113ECB080020C31B /* MDCFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3AB0E50D67A00606590 /* MDCFileData.h */; };
 		745FF87C113ECB080020C31B /* MDCLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3AD0E50D67A00606590 /* MDCLoader.h */; };
 		745FF87D113ECB080020C31B /* MDCNormalTable.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3AE0E50D67A00606590 /* MDCNormalTable.h */; };
-		745FF87E113ECB080020C31B /* FixNormalsStep.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3B40E50D69D00606590 /* FixNormalsStep.h */; };
 		745FF87F113ECB080020C31B /* LWOFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3B70E50D6DB00606590 /* LWOFileData.h */; };
 		745FF880113ECB080020C31B /* LWOLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3B90E50D6DB00606590 /* LWOLoader.h */; };
 		745FF881113ECB080020C31B /* HMPFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3C50E50D77900606590 /* HMPFileData.h */; };
-		745FF883113ECB080020C31B /* IFF.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3C90E50D7CC00606590 /* IFF.h */; };
-		745FF884113ECB080020C31B /* Hash.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3CB0E50D7FF00606590 /* Hash.h */; };
 		745FF889113ECB080020C31B /* ACLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFD10F5DD87000124155 /* ACLoader.h */; };
 		745FF88A113ECB080020C31B /* IRRLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFDA0F5DD90800124155 /* IRRLoader.h */; };
 		745FF88B113ECB080020C31B /* IRRMeshLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFDC0F5DD90800124155 /* IRRMeshLoader.h */; };
 		745FF88C113ECB080020C31B /* IRRShared.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFDE0F5DD90800124155 /* IRRShared.h */; };
-		745FF88D113ECB080020C31B /* ColladaHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFE80F5DD93600124155 /* ColladaHelper.h */; };
-		745FF88E113ECB080020C31B /* ColladaLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFEA0F5DD93600124155 /* ColladaLoader.h */; };
-		745FF88F113ECB080020C31B /* ColladaParser.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFEC0F5DD93600124155 /* ColladaParser.h */; };
 		745FF890113ECB080020C31B /* NFFLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFF50F5DD96100124155 /* NFFLoader.h */; };
-		745FF891113ECB080020C31B /* SGSpatialSort.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFFB0F5DD9A000124155 /* SGSpatialSort.h */; };
 		745FF892113ECB080020C31B /* Q3DLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0070F5DD9DD00124155 /* Q3DLoader.h */; };
 		745FF893113ECB080020C31B /* BVHLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB00C0F5DD9F400124155 /* BVHLoader.h */; };
 		745FF894113ECB080020C31B /* OFFLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0130F5DDA1400124155 /* OFFLoader.h */; };
@@ -315,75 +1119,31 @@
 		745FF896113ECB080020C31B /* DXFLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0210F5DDA5700124155 /* DXFLoader.h */; };
 		745FF897113ECB080020C31B /* TerragenLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB02F0F5DDAB500124155 /* TerragenLoader.h */; };
 		745FF898113ECB080020C31B /* irrXMLWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0360F5DDB1B00124155 /* irrXMLWrapper.h */; };
-		745FF899113ECB080020C31B /* ScenePreprocessor.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0390F5DDB3200124155 /* ScenePreprocessor.h */; };
-		745FF89A113ECB080020C31B /* SceneCombiner.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB03B0F5DDB3200124155 /* SceneCombiner.h */; };
-		745FF89B113ECB080020C31B /* SortByPTypeProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0420F5DDB4600124155 /* SortByPTypeProcess.h */; };
-		745FF89C113ECB080020C31B /* FindDegenerates.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0470F5DDB6100124155 /* FindDegenerates.h */; };
-		745FF89D113ECB080020C31B /* ComputeUVMappingProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB04C0F5DDB8D00124155 /* ComputeUVMappingProcess.h */; };
-		745FF89E113ECB080020C31B /* StandardShapes.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0510F5DDBA800124155 /* StandardShapes.h */; };
-		745FF89F113ECB080020C31B /* FindInstancesProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0560F5DDBBF00124155 /* FindInstancesProcess.h */; };
-		745FF8A0113ECB080020C31B /* RemoveVCProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB05A0F5DDBCB00124155 /* RemoveVCProcess.h */; };
-		745FF8A1113ECB080020C31B /* FindInvalidDataProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0600F5DDBE600124155 /* FindInvalidDataProcess.h */; };
-		745FF8A2113ECB080020C31B /* SkeletonMeshBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0640F5DDC0700124155 /* SkeletonMeshBuilder.h */; };
-		745FF8A3113ECB080020C31B /* SmoothingGroups.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0690F5DDC1E00124155 /* SmoothingGroups.h */; };
 		745FF8AA113ECB080020C31B /* B3DImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0870F5DDE0700124155 /* B3DImporter.h */; };
-		745FF8AE113ECB080020C31B /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = F90BB06D0F5DDCFC00124155 /* libz.dylib */; };
 		745FF8B0113ECB080020C31B /* 3DSConverter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A860E4B716800207D74 /* 3DSConverter.cpp */; };
 		745FF8B1113ECB080020C31B /* 3DSLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A890E4B716800207D74 /* 3DSLoader.cpp */; };
 		745FF8B3113ECB080020C31B /* ASELoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A8E0E4B716800207D74 /* ASELoader.cpp */; };
 		745FF8B4113ECB080020C31B /* ASEParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A900E4B716800207D74 /* ASEParser.cpp */; };
-		745FF8B5113ECB080020C31B /* Assimp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A920E4B716800207D74 /* Assimp.cpp */; };
-		745FF8B6113ECB080020C31B /* BaseImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A930E4B716800207D74 /* BaseImporter.cpp */; };
-		745FF8B7113ECB080020C31B /* CalcTangentsProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A970E4B716800207D74 /* CalcTangentsProcess.cpp */; };
-		745FF8B8113ECB080020C31B /* ConvertToLHProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A990E4B716800207D74 /* ConvertToLHProcess.cpp */; };
-		745FF8B9113ECB080020C31B /* DefaultIOStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A9B0E4B716800207D74 /* DefaultIOStream.cpp */; };
-		745FF8BA113ECB080020C31B /* DefaultIOSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A9D0E4B716800207D74 /* DefaultIOSystem.cpp */; };
-		745FF8BB113ECB080020C31B /* DefaultLogger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A9F0E4B716800207D74 /* DefaultLogger.cpp */; };
-		745FF8BD113ECB080020C31B /* GenFaceNormalsProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AA50E4B716800207D74 /* GenFaceNormalsProcess.cpp */; };
-		745FF8BE113ECB080020C31B /* GenVertexNormalsProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AA70E4B716800207D74 /* GenVertexNormalsProcess.cpp */; };
 		745FF8BF113ECB080020C31B /* HMPLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AAB0E4B716800207D74 /* HMPLoader.cpp */; };
-		745FF8C0113ECB080020C31B /* Importer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AAD0E4B716800207D74 /* Importer.cpp */; };
-		745FF8C1113ECB080020C31B /* ImproveCacheLocality.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AAE0E4B716800207D74 /* ImproveCacheLocality.cpp */; };
-		745FF8C2113ECB080020C31B /* JoinVerticesProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AB00E4B716800207D74 /* JoinVerticesProcess.cpp */; };
-		745FF8C3113ECB080020C31B /* LimitBoneWeightsProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AB40E4B716800207D74 /* LimitBoneWeightsProcess.cpp */; };
-		745FF8C4113ECB080020C31B /* MaterialSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AB60E4B716800207D74 /* MaterialSystem.cpp */; };
 		745FF8C5113ECB080020C31B /* MD2Loader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AB90E4B716800207D74 /* MD2Loader.cpp */; };
 		745FF8C6113ECB080020C31B /* MD3Loader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45ABD0E4B716800207D74 /* MD3Loader.cpp */; };
 		745FF8C7113ECB080020C31B /* MD5Loader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AC20E4B716800207D74 /* MD5Loader.cpp */; };
 		745FF8C8113ECB080020C31B /* MD5Parser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AC40E4B716800207D74 /* MD5Parser.cpp */; };
 		745FF8C9113ECB080020C31B /* MDLLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AC80E4B716800207D74 /* MDLLoader.cpp */; };
 		745FF8CA113ECB080020C31B /* MDLMaterialLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45ACA0E4B716800207D74 /* MDLMaterialLoader.cpp */; };
-		745FF8CB113ECB080020C31B /* ObjFileImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45ACC0E4B716800207D74 /* ObjFileImporter.cpp */; };
-		745FF8CC113ECB080020C31B /* ObjFileMtlImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45ACE0E4B716800207D74 /* ObjFileMtlImporter.cpp */; };
-		745FF8CD113ECB080020C31B /* ObjFileParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AD00E4B716800207D74 /* ObjFileParser.cpp */; };
 		745FF8CE113ECB080020C31B /* PlyLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AD40E4B716800207D74 /* PlyLoader.cpp */; };
 		745FF8CF113ECB080020C31B /* PlyParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AD60E4B716800207D74 /* PlyParser.cpp */; };
-		745FF8D0113ECB080020C31B /* PretransformVertices.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AD80E4B716800207D74 /* PretransformVertices.cpp */; };
-		745FF8D1113ECB080020C31B /* RemoveComments.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45ADB0E4B716800207D74 /* RemoveComments.cpp */; };
-		745FF8D2113ECB080020C31B /* RemoveRedundantMaterials.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45ADD0E4B716800207D74 /* RemoveRedundantMaterials.cpp */; };
 		745FF8D3113ECB080020C31B /* SMDLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AE20E4B716800207D74 /* SMDLoader.cpp */; };
-		745FF8D4113ECB080020C31B /* SpatialSort.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AE40E4B716800207D74 /* SpatialSort.cpp */; };
-		745FF8D5113ECB080020C31B /* SplitLargeMeshes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AE60E4B716800207D74 /* SplitLargeMeshes.cpp */; };
-		745FF8D6113ECB080020C31B /* STLLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AE80E4B716800207D74 /* STLLoader.cpp */; };
-		745FF8D7113ECB080020C31B /* TextureTransform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AEB0E4B716800207D74 /* TextureTransform.cpp */; };
-		745FF8D8113ECB080020C31B /* TriangulateProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AED0E4B716800207D74 /* TriangulateProcess.cpp */; };
-		745FF8D9113ECB080020C31B /* ValidateDataStructure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AEF0E4B716800207D74 /* ValidateDataStructure.cpp */; };
-		745FF8DA113ECB080020C31B /* VertexTriangleAdjacency.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AF10E4B716800207D74 /* VertexTriangleAdjacency.cpp */; };
 		745FF8DB113ECB080020C31B /* XFileImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AF50E4B716800207D74 /* XFileImporter.cpp */; };
 		745FF8DC113ECB080020C31B /* XFileParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AF70E4B716800207D74 /* XFileParser.cpp */; };
 		745FF8DD113ECB080020C31B /* MDCLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AB8A3AC0E50D67A00606590 /* MDCLoader.cpp */; };
-		745FF8DE113ECB080020C31B /* FixNormalsStep.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AB8A3B30E50D69D00606590 /* FixNormalsStep.cpp */; };
 		745FF8DF113ECB080020C31B /* LWOLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AB8A3B80E50D6DB00606590 /* LWOLoader.cpp */; };
-		745FF8E0113ECB080020C31B /* BaseProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AB8A3C30E50D74500606590 /* BaseProcess.cpp */; };
 		745FF8E1113ECB080020C31B /* LWOMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AB8A7DC0E53715F00606590 /* LWOMaterial.cpp */; };
 		745FF8E2113ECB080020C31B /* ACLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BAFD00F5DD87000124155 /* ACLoader.cpp */; };
 		745FF8E3113ECB080020C31B /* IRRLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BAFD90F5DD90800124155 /* IRRLoader.cpp */; };
 		745FF8E4113ECB080020C31B /* IRRMeshLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BAFDB0F5DD90800124155 /* IRRMeshLoader.cpp */; };
 		745FF8E5113ECB080020C31B /* IRRShared.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BAFDD0F5DD90800124155 /* IRRShared.cpp */; };
-		745FF8E6113ECB080020C31B /* ColladaLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BAFE90F5DD93600124155 /* ColladaLoader.cpp */; };
-		745FF8E7113ECB080020C31B /* ColladaParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BAFEB0F5DD93600124155 /* ColladaParser.cpp */; };
 		745FF8E8113ECB080020C31B /* NFFLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BAFF60F5DD96100124155 /* NFFLoader.cpp */; };
-		745FF8E9113ECB080020C31B /* SGSpatialSort.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BAFFC0F5DD9A000124155 /* SGSpatialSort.cpp */; };
 		745FF8EA113ECB080020C31B /* Q3DLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0060F5DD9DD00124155 /* Q3DLoader.cpp */; };
 		745FF8EB113ECB080020C31B /* BVHLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB00D0F5DD9F400124155 /* BVHLoader.cpp */; };
 		745FF8EC113ECB080020C31B /* OFFLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0140F5DDA1400124155 /* OFFLoader.cpp */; };
@@ -391,38 +1151,13 @@
 		745FF8EE113ECB080020C31B /* DXFLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0220F5DDA5700124155 /* DXFLoader.cpp */; };
 		745FF8EF113ECB080020C31B /* LWOBLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0270F5DDA9200124155 /* LWOBLoader.cpp */; };
 		745FF8F0113ECB080020C31B /* TerragenLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0300F5DDAB500124155 /* TerragenLoader.cpp */; };
-		745FF8F1113ECB080020C31B /* SceneCombiner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB03A0F5DDB3200124155 /* SceneCombiner.cpp */; };
-		745FF8F2113ECB080020C31B /* ScenePreprocessor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB03C0F5DDB3200124155 /* ScenePreprocessor.cpp */; };
-		745FF8F3113ECB080020C31B /* SortByPTypeProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0430F5DDB4600124155 /* SortByPTypeProcess.cpp */; };
-		745FF8F4113ECB080020C31B /* FindDegenerates.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0480F5DDB6100124155 /* FindDegenerates.cpp */; };
-		745FF8F5113ECB080020C31B /* ComputeUVMappingProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB04D0F5DDB8D00124155 /* ComputeUVMappingProcess.cpp */; };
-		745FF8F6113ECB080020C31B /* StandardShapes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0520F5DDBA800124155 /* StandardShapes.cpp */; };
-		745FF8F7113ECB080020C31B /* FindInstancesProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0570F5DDBBF00124155 /* FindInstancesProcess.cpp */; };
-		745FF8F8113ECB080020C31B /* RemoveVCProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB05B0F5DDBCB00124155 /* RemoveVCProcess.cpp */; };
-		745FF8F9113ECB080020C31B /* FindInvalidDataProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB05F0F5DDBE600124155 /* FindInvalidDataProcess.cpp */; };
-		745FF8FA113ECB080020C31B /* SkeletonMeshBuilder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0650F5DDC0700124155 /* SkeletonMeshBuilder.cpp */; };
 		745FF8FC113ECB080020C31B /* B3DImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0880F5DDE0700124155 /* B3DImporter.cpp */; };
 		745FF923113ECC660020C31B /* 3DSHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A880E4B716800207D74 /* 3DSHelper.h */; };
 		745FF924113ECC660020C31B /* 3DSLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A8A0E4B716800207D74 /* 3DSLoader.h */; };
 		745FF925113ECC660020C31B /* ASELoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A8F0E4B716800207D74 /* ASELoader.h */; };
 		745FF926113ECC660020C31B /* ASEParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A910E4B716800207D74 /* ASEParser.h */; };
-		745FF927113ECC660020C31B /* BaseImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A940E4B716800207D74 /* BaseImporter.h */; };
-		745FF928113ECC660020C31B /* BaseProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A950E4B716800207D74 /* BaseProcess.h */; };
-		745FF929113ECC660020C31B /* ByteSwap.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A960E4B716800207D74 /* ByteSwap.h */; };
-		745FF92A113ECC660020C31B /* CalcTangentsProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A980E4B716800207D74 /* CalcTangentsProcess.h */; };
-		745FF92B113ECC660020C31B /* ConvertToLHProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A9A0E4B716800207D74 /* ConvertToLHProcess.h */; };
-		745FF92C113ECC660020C31B /* DefaultIOStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A9C0E4B716800207D74 /* DefaultIOStream.h */; };
-		745FF92D113ECC660020C31B /* DefaultIOSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A9E0E4B716800207D74 /* DefaultIOSystem.h */; };
-		745FF92F113ECC660020C31B /* fast_atof.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AA30E4B716800207D74 /* fast_atof.h */; };
-		745FF930113ECC660020C31B /* FileLogStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AA40E4B716800207D74 /* FileLogStream.h */; };
-		745FF931113ECC660020C31B /* GenFaceNormalsProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AA60E4B716800207D74 /* GenFaceNormalsProcess.h */; };
-		745FF932113ECC660020C31B /* GenVertexNormalsProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AA80E4B716800207D74 /* GenVertexNormalsProcess.h */; };
 		745FF933113ECC660020C31B /* HalfLifeFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AA90E4B716800207D74 /* HalfLifeFileData.h */; };
 		745FF934113ECC660020C31B /* HMPLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AAC0E4B716800207D74 /* HMPLoader.h */; };
-		745FF935113ECC660020C31B /* ImproveCacheLocality.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AAF0E4B716800207D74 /* ImproveCacheLocality.h */; };
-		745FF936113ECC660020C31B /* JoinVerticesProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AB10E4B716800207D74 /* JoinVerticesProcess.h */; };
-		745FF937113ECC660020C31B /* LimitBoneWeightsProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AB50E4B716800207D74 /* LimitBoneWeightsProcess.h */; };
-		745FF938113ECC660020C31B /* MaterialSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AB70E4B716800207D74 /* MaterialSystem.h */; };
 		745FF939113ECC660020C31B /* MD2FileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AB80E4B716800207D74 /* MD2FileData.h */; };
 		745FF93A113ECC660020C31B /* MD2Loader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45ABA0E4B716800207D74 /* MD2Loader.h */; };
 		745FF93B113ECC660020C31B /* MD2NormalTable.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45ABB0E4B716800207D74 /* MD2NormalTable.h */; };
@@ -433,49 +1168,23 @@
 		745FF940113ECC660020C31B /* MDLDefaultColorMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AC60E4B716800207D74 /* MDLDefaultColorMap.h */; };
 		745FF941113ECC660020C31B /* MDLFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AC70E4B716800207D74 /* MDLFileData.h */; };
 		745FF942113ECC660020C31B /* MDLLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AC90E4B716800207D74 /* MDLLoader.h */; };
-		745FF943113ECC660020C31B /* ObjFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45ACB0E4B716800207D74 /* ObjFileData.h */; };
-		745FF944113ECC660020C31B /* ObjFileImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45ACD0E4B716800207D74 /* ObjFileImporter.h */; };
-		745FF945113ECC660020C31B /* ObjFileMtlImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45ACF0E4B716800207D74 /* ObjFileMtlImporter.h */; };
-		745FF946113ECC660020C31B /* ObjFileParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AD10E4B716800207D74 /* ObjFileParser.h */; };
-		745FF947113ECC660020C31B /* ObjTools.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AD20E4B716800207D74 /* ObjTools.h */; };
-		745FF948113ECC660020C31B /* ParsingUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AD30E4B716800207D74 /* ParsingUtils.h */; };
 		745FF949113ECC660020C31B /* PlyLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AD50E4B716800207D74 /* PlyLoader.h */; };
 		745FF94A113ECC660020C31B /* PlyParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AD70E4B716800207D74 /* PlyParser.h */; };
-		745FF94B113ECC660020C31B /* PretransformVertices.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AD90E4B716800207D74 /* PretransformVertices.h */; };
-		745FF94C113ECC660020C31B /* qnan.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45ADA0E4B716800207D74 /* qnan.h */; };
-		745FF94D113ECC660020C31B /* RemoveComments.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45ADC0E4B716800207D74 /* RemoveComments.h */; };
-		745FF94E113ECC660020C31B /* RemoveRedundantMaterials.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45ADE0E4B716800207D74 /* RemoveRedundantMaterials.h */; };
 		745FF94F113ECC660020C31B /* SMDLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AE30E4B716800207D74 /* SMDLoader.h */; };
-		745FF950113ECC660020C31B /* SpatialSort.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AE50E4B716800207D74 /* SpatialSort.h */; };
-		745FF951113ECC660020C31B /* SplitLargeMeshes.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AE70E4B716800207D74 /* SplitLargeMeshes.h */; };
-		745FF952113ECC660020C31B /* STLLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AE90E4B716800207D74 /* STLLoader.h */; };
-		745FF953113ECC660020C31B /* StringComparison.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AEA0E4B716800207D74 /* StringComparison.h */; };
-		745FF954113ECC660020C31B /* TextureTransform.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AEC0E4B716800207D74 /* TextureTransform.h */; };
-		745FF955113ECC660020C31B /* TriangulateProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AEE0E4B716800207D74 /* TriangulateProcess.h */; };
-		745FF956113ECC660020C31B /* ValidateDataStructure.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AF00E4B716800207D74 /* ValidateDataStructure.h */; };
-		745FF957113ECC660020C31B /* VertexTriangleAdjacency.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AF20E4B716800207D74 /* VertexTriangleAdjacency.h */; };
-		745FF958113ECC660020C31B /* Win32DebugLogStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AF30E4B716800207D74 /* Win32DebugLogStream.h */; };
 		745FF959113ECC660020C31B /* XFileHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AF40E4B716800207D74 /* XFileHelper.h */; };
 		745FF95A113ECC660020C31B /* XFileImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AF60E4B716800207D74 /* XFileImporter.h */; };
 		745FF95B113ECC660020C31B /* XFileParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AF80E4B716800207D74 /* XFileParser.h */; };
 		745FF95E113ECC660020C31B /* MDCFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3AB0E50D67A00606590 /* MDCFileData.h */; };
 		745FF95F113ECC660020C31B /* MDCLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3AD0E50D67A00606590 /* MDCLoader.h */; };
 		745FF960113ECC660020C31B /* MDCNormalTable.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3AE0E50D67A00606590 /* MDCNormalTable.h */; };
-		745FF961113ECC660020C31B /* FixNormalsStep.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3B40E50D69D00606590 /* FixNormalsStep.h */; };
 		745FF962113ECC660020C31B /* LWOFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3B70E50D6DB00606590 /* LWOFileData.h */; };
 		745FF963113ECC660020C31B /* LWOLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3B90E50D6DB00606590 /* LWOLoader.h */; };
 		745FF964113ECC660020C31B /* HMPFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3C50E50D77900606590 /* HMPFileData.h */; };
-		745FF966113ECC660020C31B /* IFF.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3C90E50D7CC00606590 /* IFF.h */; };
-		745FF967113ECC660020C31B /* Hash.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3CB0E50D7FF00606590 /* Hash.h */; };
 		745FF96C113ECC660020C31B /* ACLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFD10F5DD87000124155 /* ACLoader.h */; };
 		745FF96D113ECC660020C31B /* IRRLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFDA0F5DD90800124155 /* IRRLoader.h */; };
 		745FF96E113ECC660020C31B /* IRRMeshLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFDC0F5DD90800124155 /* IRRMeshLoader.h */; };
 		745FF96F113ECC660020C31B /* IRRShared.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFDE0F5DD90800124155 /* IRRShared.h */; };
-		745FF970113ECC660020C31B /* ColladaHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFE80F5DD93600124155 /* ColladaHelper.h */; };
-		745FF971113ECC660020C31B /* ColladaLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFEA0F5DD93600124155 /* ColladaLoader.h */; };
-		745FF972113ECC660020C31B /* ColladaParser.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFEC0F5DD93600124155 /* ColladaParser.h */; };
 		745FF973113ECC660020C31B /* NFFLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFF50F5DD96100124155 /* NFFLoader.h */; };
-		745FF974113ECC660020C31B /* SGSpatialSort.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFFB0F5DD9A000124155 /* SGSpatialSort.h */; };
 		745FF975113ECC660020C31B /* Q3DLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0070F5DD9DD00124155 /* Q3DLoader.h */; };
 		745FF976113ECC660020C31B /* BVHLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB00C0F5DD9F400124155 /* BVHLoader.h */; };
 		745FF977113ECC660020C31B /* OFFLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0130F5DDA1400124155 /* OFFLoader.h */; };
@@ -483,75 +1192,31 @@
 		745FF979113ECC660020C31B /* DXFLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0210F5DDA5700124155 /* DXFLoader.h */; };
 		745FF97A113ECC660020C31B /* TerragenLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB02F0F5DDAB500124155 /* TerragenLoader.h */; };
 		745FF97B113ECC660020C31B /* irrXMLWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0360F5DDB1B00124155 /* irrXMLWrapper.h */; };
-		745FF97C113ECC660020C31B /* ScenePreprocessor.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0390F5DDB3200124155 /* ScenePreprocessor.h */; };
-		745FF97D113ECC660020C31B /* SceneCombiner.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB03B0F5DDB3200124155 /* SceneCombiner.h */; };
-		745FF97E113ECC660020C31B /* SortByPTypeProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0420F5DDB4600124155 /* SortByPTypeProcess.h */; };
-		745FF97F113ECC660020C31B /* FindDegenerates.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0470F5DDB6100124155 /* FindDegenerates.h */; };
-		745FF980113ECC660020C31B /* ComputeUVMappingProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB04C0F5DDB8D00124155 /* ComputeUVMappingProcess.h */; };
-		745FF981113ECC660020C31B /* StandardShapes.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0510F5DDBA800124155 /* StandardShapes.h */; };
-		745FF982113ECC660020C31B /* FindInstancesProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0560F5DDBBF00124155 /* FindInstancesProcess.h */; };
-		745FF983113ECC660020C31B /* RemoveVCProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB05A0F5DDBCB00124155 /* RemoveVCProcess.h */; };
-		745FF984113ECC660020C31B /* FindInvalidDataProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0600F5DDBE600124155 /* FindInvalidDataProcess.h */; };
-		745FF985113ECC660020C31B /* SkeletonMeshBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0640F5DDC0700124155 /* SkeletonMeshBuilder.h */; };
-		745FF986113ECC660020C31B /* SmoothingGroups.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0690F5DDC1E00124155 /* SmoothingGroups.h */; };
 		745FF98D113ECC660020C31B /* B3DImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0870F5DDE0700124155 /* B3DImporter.h */; };
-		745FF991113ECC660020C31B /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = F90BB06D0F5DDCFC00124155 /* libz.dylib */; };
 		745FF993113ECC660020C31B /* 3DSConverter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A860E4B716800207D74 /* 3DSConverter.cpp */; };
 		745FF994113ECC660020C31B /* 3DSLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A890E4B716800207D74 /* 3DSLoader.cpp */; };
 		745FF996113ECC660020C31B /* ASELoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A8E0E4B716800207D74 /* ASELoader.cpp */; };
 		745FF997113ECC660020C31B /* ASEParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A900E4B716800207D74 /* ASEParser.cpp */; };
-		745FF998113ECC660020C31B /* Assimp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A920E4B716800207D74 /* Assimp.cpp */; };
-		745FF999113ECC660020C31B /* BaseImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A930E4B716800207D74 /* BaseImporter.cpp */; };
-		745FF99A113ECC660020C31B /* CalcTangentsProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A970E4B716800207D74 /* CalcTangentsProcess.cpp */; };
-		745FF99B113ECC660020C31B /* ConvertToLHProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A990E4B716800207D74 /* ConvertToLHProcess.cpp */; };
-		745FF99C113ECC660020C31B /* DefaultIOStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A9B0E4B716800207D74 /* DefaultIOStream.cpp */; };
-		745FF99D113ECC660020C31B /* DefaultIOSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A9D0E4B716800207D74 /* DefaultIOSystem.cpp */; };
-		745FF99E113ECC660020C31B /* DefaultLogger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A9F0E4B716800207D74 /* DefaultLogger.cpp */; };
-		745FF9A0113ECC660020C31B /* GenFaceNormalsProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AA50E4B716800207D74 /* GenFaceNormalsProcess.cpp */; };
-		745FF9A1113ECC660020C31B /* GenVertexNormalsProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AA70E4B716800207D74 /* GenVertexNormalsProcess.cpp */; };
 		745FF9A2113ECC660020C31B /* HMPLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AAB0E4B716800207D74 /* HMPLoader.cpp */; };
-		745FF9A3113ECC660020C31B /* Importer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AAD0E4B716800207D74 /* Importer.cpp */; };
-		745FF9A4113ECC660020C31B /* ImproveCacheLocality.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AAE0E4B716800207D74 /* ImproveCacheLocality.cpp */; };
-		745FF9A5113ECC660020C31B /* JoinVerticesProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AB00E4B716800207D74 /* JoinVerticesProcess.cpp */; };
-		745FF9A6113ECC660020C31B /* LimitBoneWeightsProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AB40E4B716800207D74 /* LimitBoneWeightsProcess.cpp */; };
-		745FF9A7113ECC660020C31B /* MaterialSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AB60E4B716800207D74 /* MaterialSystem.cpp */; };
 		745FF9A8113ECC660020C31B /* MD2Loader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AB90E4B716800207D74 /* MD2Loader.cpp */; };
 		745FF9A9113ECC660020C31B /* MD3Loader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45ABD0E4B716800207D74 /* MD3Loader.cpp */; };
 		745FF9AA113ECC660020C31B /* MD5Loader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AC20E4B716800207D74 /* MD5Loader.cpp */; };
 		745FF9AB113ECC660020C31B /* MD5Parser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AC40E4B716800207D74 /* MD5Parser.cpp */; };
 		745FF9AC113ECC660020C31B /* MDLLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AC80E4B716800207D74 /* MDLLoader.cpp */; };
 		745FF9AD113ECC660020C31B /* MDLMaterialLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45ACA0E4B716800207D74 /* MDLMaterialLoader.cpp */; };
-		745FF9AE113ECC660020C31B /* ObjFileImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45ACC0E4B716800207D74 /* ObjFileImporter.cpp */; };
-		745FF9AF113ECC660020C31B /* ObjFileMtlImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45ACE0E4B716800207D74 /* ObjFileMtlImporter.cpp */; };
-		745FF9B0113ECC660020C31B /* ObjFileParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AD00E4B716800207D74 /* ObjFileParser.cpp */; };
 		745FF9B1113ECC660020C31B /* PlyLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AD40E4B716800207D74 /* PlyLoader.cpp */; };
 		745FF9B2113ECC660020C31B /* PlyParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AD60E4B716800207D74 /* PlyParser.cpp */; };
-		745FF9B3113ECC660020C31B /* PretransformVertices.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AD80E4B716800207D74 /* PretransformVertices.cpp */; };
-		745FF9B4113ECC660020C31B /* RemoveComments.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45ADB0E4B716800207D74 /* RemoveComments.cpp */; };
-		745FF9B5113ECC660020C31B /* RemoveRedundantMaterials.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45ADD0E4B716800207D74 /* RemoveRedundantMaterials.cpp */; };
 		745FF9B6113ECC660020C31B /* SMDLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AE20E4B716800207D74 /* SMDLoader.cpp */; };
-		745FF9B7113ECC660020C31B /* SpatialSort.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AE40E4B716800207D74 /* SpatialSort.cpp */; };
-		745FF9B8113ECC660020C31B /* SplitLargeMeshes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AE60E4B716800207D74 /* SplitLargeMeshes.cpp */; };
-		745FF9B9113ECC660020C31B /* STLLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AE80E4B716800207D74 /* STLLoader.cpp */; };
-		745FF9BA113ECC660020C31B /* TextureTransform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AEB0E4B716800207D74 /* TextureTransform.cpp */; };
-		745FF9BB113ECC660020C31B /* TriangulateProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AED0E4B716800207D74 /* TriangulateProcess.cpp */; };
-		745FF9BC113ECC660020C31B /* ValidateDataStructure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AEF0E4B716800207D74 /* ValidateDataStructure.cpp */; };
-		745FF9BD113ECC660020C31B /* VertexTriangleAdjacency.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AF10E4B716800207D74 /* VertexTriangleAdjacency.cpp */; };
 		745FF9BE113ECC660020C31B /* XFileImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AF50E4B716800207D74 /* XFileImporter.cpp */; };
 		745FF9BF113ECC660020C31B /* XFileParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AF70E4B716800207D74 /* XFileParser.cpp */; };
 		745FF9C0113ECC660020C31B /* MDCLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AB8A3AC0E50D67A00606590 /* MDCLoader.cpp */; };
-		745FF9C1113ECC660020C31B /* FixNormalsStep.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AB8A3B30E50D69D00606590 /* FixNormalsStep.cpp */; };
 		745FF9C2113ECC660020C31B /* LWOLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AB8A3B80E50D6DB00606590 /* LWOLoader.cpp */; };
-		745FF9C3113ECC660020C31B /* BaseProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AB8A3C30E50D74500606590 /* BaseProcess.cpp */; };
 		745FF9C4113ECC660020C31B /* LWOMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AB8A7DC0E53715F00606590 /* LWOMaterial.cpp */; };
 		745FF9C5113ECC660020C31B /* ACLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BAFD00F5DD87000124155 /* ACLoader.cpp */; };
 		745FF9C6113ECC660020C31B /* IRRLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BAFD90F5DD90800124155 /* IRRLoader.cpp */; };
 		745FF9C7113ECC660020C31B /* IRRMeshLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BAFDB0F5DD90800124155 /* IRRMeshLoader.cpp */; };
 		745FF9C8113ECC660020C31B /* IRRShared.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BAFDD0F5DD90800124155 /* IRRShared.cpp */; };
-		745FF9C9113ECC660020C31B /* ColladaLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BAFE90F5DD93600124155 /* ColladaLoader.cpp */; };
-		745FF9CA113ECC660020C31B /* ColladaParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BAFEB0F5DD93600124155 /* ColladaParser.cpp */; };
 		745FF9CB113ECC660020C31B /* NFFLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BAFF60F5DD96100124155 /* NFFLoader.cpp */; };
-		745FF9CC113ECC660020C31B /* SGSpatialSort.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BAFFC0F5DD9A000124155 /* SGSpatialSort.cpp */; };
 		745FF9CD113ECC660020C31B /* Q3DLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0060F5DD9DD00124155 /* Q3DLoader.cpp */; };
 		745FF9CE113ECC660020C31B /* BVHLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB00D0F5DD9F400124155 /* BVHLoader.cpp */; };
 		745FF9CF113ECC660020C31B /* OFFLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0140F5DDA1400124155 /* OFFLoader.cpp */; };
@@ -559,16 +1224,6 @@
 		745FF9D1113ECC660020C31B /* DXFLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0220F5DDA5700124155 /* DXFLoader.cpp */; };
 		745FF9D2113ECC660020C31B /* LWOBLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0270F5DDA9200124155 /* LWOBLoader.cpp */; };
 		745FF9D3113ECC660020C31B /* TerragenLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0300F5DDAB500124155 /* TerragenLoader.cpp */; };
-		745FF9D4113ECC660020C31B /* SceneCombiner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB03A0F5DDB3200124155 /* SceneCombiner.cpp */; };
-		745FF9D5113ECC660020C31B /* ScenePreprocessor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB03C0F5DDB3200124155 /* ScenePreprocessor.cpp */; };
-		745FF9D6113ECC660020C31B /* SortByPTypeProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0430F5DDB4600124155 /* SortByPTypeProcess.cpp */; };
-		745FF9D7113ECC660020C31B /* FindDegenerates.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0480F5DDB6100124155 /* FindDegenerates.cpp */; };
-		745FF9D8113ECC660020C31B /* ComputeUVMappingProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB04D0F5DDB8D00124155 /* ComputeUVMappingProcess.cpp */; };
-		745FF9D9113ECC660020C31B /* StandardShapes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0520F5DDBA800124155 /* StandardShapes.cpp */; };
-		745FF9DA113ECC660020C31B /* FindInstancesProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0570F5DDBBF00124155 /* FindInstancesProcess.cpp */; };
-		745FF9DB113ECC660020C31B /* RemoveVCProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB05B0F5DDBCB00124155 /* RemoveVCProcess.cpp */; };
-		745FF9DC113ECC660020C31B /* FindInvalidDataProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB05F0F5DDBE600124155 /* FindInvalidDataProcess.cpp */; };
-		745FF9DD113ECC660020C31B /* SkeletonMeshBuilder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0650F5DDC0700124155 /* SkeletonMeshBuilder.cpp */; };
 		745FF9DF113ECC660020C31B /* B3DImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0880F5DDE0700124155 /* B3DImporter.cpp */; };
 		74C9BB5111ACBB1000AF885C /* BlenderDNA.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 74C9BB4911ACBB1000AF885C /* BlenderDNA.cpp */; };
 		74C9BB5211ACBB1000AF885C /* BlenderDNA.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BB4A11ACBB1000AF885C /* BlenderDNA.h */; };
@@ -598,20 +1253,6 @@
 		74C9BB6A11ACBB1000AF885C /* BlenderScene.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 74C9BB4E11ACBB1000AF885C /* BlenderScene.cpp */; };
 		74C9BB6B11ACBB1000AF885C /* BlenderScene.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BB4F11ACBB1000AF885C /* BlenderScene.h */; };
 		74C9BB6C11ACBB1000AF885C /* BlenderSceneGen.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BB5011ACBB1000AF885C /* BlenderSceneGen.h */; };
-		74C9BB7211ACBB3600AF885C /* pointer_cast.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BB6F11ACBB3600AF885C /* pointer_cast.hpp */; };
-		74C9BB7311ACBB3600AF885C /* shared_array.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BB7011ACBB3600AF885C /* shared_array.hpp */; };
-		74C9BB7411ACBB3600AF885C /* shared_ptr.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BB7111ACBB3600AF885C /* shared_ptr.hpp */; };
-		74C9BB7511ACBB3600AF885C /* pointer_cast.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BB6F11ACBB3600AF885C /* pointer_cast.hpp */; };
-		74C9BB7611ACBB3600AF885C /* shared_array.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BB7011ACBB3600AF885C /* shared_array.hpp */; };
-		74C9BB7711ACBB3600AF885C /* shared_ptr.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BB7111ACBB3600AF885C /* shared_ptr.hpp */; };
-		74C9BB7E11ACBB7800AF885C /* MakeVerboseFormat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 74C9BB7C11ACBB7800AF885C /* MakeVerboseFormat.cpp */; };
-		74C9BB7F11ACBB7800AF885C /* MakeVerboseFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BB7D11ACBB7800AF885C /* MakeVerboseFormat.h */; };
-		74C9BB8011ACBB7800AF885C /* MakeVerboseFormat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 74C9BB7C11ACBB7800AF885C /* MakeVerboseFormat.cpp */; };
-		74C9BB8111ACBB7800AF885C /* MakeVerboseFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BB7D11ACBB7800AF885C /* MakeVerboseFormat.h */; };
-		74C9BB8211ACBB7800AF885C /* MakeVerboseFormat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 74C9BB7C11ACBB7800AF885C /* MakeVerboseFormat.cpp */; };
-		74C9BB8311ACBB7800AF885C /* MakeVerboseFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BB7D11ACBB7800AF885C /* MakeVerboseFormat.h */; };
-		74C9BB8411ACBB7800AF885C /* MakeVerboseFormat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 74C9BB7C11ACBB7800AF885C /* MakeVerboseFormat.cpp */; };
-		74C9BB8511ACBB7800AF885C /* MakeVerboseFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BB7D11ACBB7800AF885C /* MakeVerboseFormat.h */; };
 		74C9BB8811ACBB9900AF885C /* AssimpPCH.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 74C9BB8611ACBB9900AF885C /* AssimpPCH.cpp */; };
 		74C9BB8911ACBB9900AF885C /* AssimpPCH.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BB8711ACBB9900AF885C /* AssimpPCH.h */; };
 		74C9BB8A11ACBB9900AF885C /* AssimpPCH.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 74C9BB8611ACBB9900AF885C /* AssimpPCH.cpp */; };
@@ -636,22 +1277,6 @@
 		74C9BBB511ACBC2600AF885C /* revision.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BBB311ACBC2600AF885C /* revision.h */; };
 		74C9BBB611ACBC2600AF885C /* revision.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BBB311ACBC2600AF885C /* revision.h */; };
 		74C9BBB711ACBC2600AF885C /* revision.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BBB311ACBC2600AF885C /* revision.h */; };
-		74C9BBBF11ACBC6C00AF885C /* Exceptional.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BBBB11ACBC6C00AF885C /* Exceptional.h */; };
-		74C9BBC011ACBC6C00AF885C /* LineSplitter.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BBBC11ACBC6C00AF885C /* LineSplitter.h */; };
-		74C9BBC111ACBC6C00AF885C /* MD4FileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BBBD11ACBC6C00AF885C /* MD4FileData.h */; };
-		74C9BBC211ACBC6C00AF885C /* TinyFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BBBE11ACBC6C00AF885C /* TinyFormatter.h */; };
-		74C9BBC311ACBC6C00AF885C /* Exceptional.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BBBB11ACBC6C00AF885C /* Exceptional.h */; };
-		74C9BBC411ACBC6C00AF885C /* LineSplitter.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BBBC11ACBC6C00AF885C /* LineSplitter.h */; };
-		74C9BBC511ACBC6C00AF885C /* MD4FileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BBBD11ACBC6C00AF885C /* MD4FileData.h */; };
-		74C9BBC611ACBC6C00AF885C /* TinyFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BBBE11ACBC6C00AF885C /* TinyFormatter.h */; };
-		74C9BBC711ACBC6C00AF885C /* Exceptional.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BBBB11ACBC6C00AF885C /* Exceptional.h */; };
-		74C9BBC811ACBC6C00AF885C /* LineSplitter.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BBBC11ACBC6C00AF885C /* LineSplitter.h */; };
-		74C9BBC911ACBC6C00AF885C /* MD4FileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BBBD11ACBC6C00AF885C /* MD4FileData.h */; };
-		74C9BBCA11ACBC6C00AF885C /* TinyFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BBBE11ACBC6C00AF885C /* TinyFormatter.h */; };
-		74C9BBCB11ACBC6C00AF885C /* Exceptional.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BBBB11ACBC6C00AF885C /* Exceptional.h */; };
-		74C9BBCC11ACBC6C00AF885C /* LineSplitter.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BBBC11ACBC6C00AF885C /* LineSplitter.h */; };
-		74C9BBCD11ACBC6C00AF885C /* MD4FileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BBBD11ACBC6C00AF885C /* MD4FileData.h */; };
-		74C9BBCE11ACBC6C00AF885C /* TinyFormatter.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BBBE11ACBC6C00AF885C /* TinyFormatter.h */; };
 		8E7ABBA8127E0F1A00512ED1 /* Q3BSPFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E7ABBA1127E0F1A00512ED1 /* Q3BSPFileData.h */; };
 		8E7ABBA9127E0F1A00512ED1 /* Q3BSPFileImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8E7ABBA2127E0F1A00512ED1 /* Q3BSPFileImporter.cpp */; };
 		8E7ABBAA127E0F1A00512ED1 /* Q3BSPFileImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E7ABBA3127E0F1A00512ED1 /* Q3BSPFileImporter.h */; };
@@ -700,22 +1325,6 @@
 		8E7ABBDA127E0F3800512ED1 /* BlenderIntermediate.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E7ABBCE127E0F3800512ED1 /* BlenderIntermediate.h */; };
 		8E7ABBDB127E0F3800512ED1 /* BlenderModifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8E7ABBCF127E0F3800512ED1 /* BlenderModifier.cpp */; };
 		8E7ABBDC127E0F3800512ED1 /* BlenderModifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E7ABBD0127E0F3800512ED1 /* BlenderModifier.h */; };
-		8E7ABBE3127E0FA400512ED1 /* assbin_chunks.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E7ABBDF127E0FA400512ED1 /* assbin_chunks.h */; };
-		8E7ABBE4127E0FA400512ED1 /* DefaultProgressHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E7ABBE0127E0FA400512ED1 /* DefaultProgressHandler.h */; };
-		8E7ABBE5127E0FA400512ED1 /* Profiler.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E7ABBE1127E0FA400512ED1 /* Profiler.h */; };
-		8E7ABBE6127E0FA400512ED1 /* pstdint.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E7ABBE2127E0FA400512ED1 /* pstdint.h */; };
-		8E7ABBE7127E0FA400512ED1 /* assbin_chunks.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E7ABBDF127E0FA400512ED1 /* assbin_chunks.h */; };
-		8E7ABBE8127E0FA400512ED1 /* DefaultProgressHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E7ABBE0127E0FA400512ED1 /* DefaultProgressHandler.h */; };
-		8E7ABBE9127E0FA400512ED1 /* Profiler.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E7ABBE1127E0FA400512ED1 /* Profiler.h */; };
-		8E7ABBEA127E0FA400512ED1 /* pstdint.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E7ABBE2127E0FA400512ED1 /* pstdint.h */; };
-		8E7ABBEB127E0FA400512ED1 /* assbin_chunks.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E7ABBDF127E0FA400512ED1 /* assbin_chunks.h */; };
-		8E7ABBEC127E0FA400512ED1 /* DefaultProgressHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E7ABBE0127E0FA400512ED1 /* DefaultProgressHandler.h */; };
-		8E7ABBED127E0FA400512ED1 /* Profiler.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E7ABBE1127E0FA400512ED1 /* Profiler.h */; };
-		8E7ABBEE127E0FA400512ED1 /* pstdint.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E7ABBE2127E0FA400512ED1 /* pstdint.h */; };
-		8E7ABBEF127E0FA400512ED1 /* assbin_chunks.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E7ABBDF127E0FA400512ED1 /* assbin_chunks.h */; };
-		8E7ABBF0127E0FA400512ED1 /* DefaultProgressHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E7ABBE0127E0FA400512ED1 /* DefaultProgressHandler.h */; };
-		8E7ABBF1127E0FA400512ED1 /* Profiler.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E7ABBE1127E0FA400512ED1 /* Profiler.h */; };
-		8E7ABBF2127E0FA400512ED1 /* pstdint.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E7ABBE2127E0FA400512ED1 /* pstdint.h */; };
 		8E8DEE5C127E2B78005EF64D /* ConvertUTF.c in Sources */ = {isa = PBXBuildFile; fileRef = 8E8DEE4B127E2B78005EF64D /* ConvertUTF.c */; };
 		8E8DEE5D127E2B78005EF64D /* ConvertUTF.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E8DEE4C127E2B78005EF64D /* ConvertUTF.h */; };
 		8E8DEE5E127E2B78005EF64D /* CXMLReaderImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E8DEE4F127E2B78005EF64D /* CXMLReaderImpl.h */; };
@@ -772,8 +1381,208 @@
 		8E8DEE91127E2B78005EF64D /* ioapi.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E8DEE59127E2B78005EF64D /* ioapi.h */; };
 		8E8DEE92127E2B78005EF64D /* unzip.c in Sources */ = {isa = PBXBuildFile; fileRef = 8E8DEE5A127E2B78005EF64D /* unzip.c */; };
 		8E8DEE93127E2B78005EF64D /* unzip.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E8DEE5B127E2B78005EF64D /* unzip.h */; };
-		F90BAFBA0F5DD68F00124155 /* libboost_date_time-xgcc40-mt.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F90BAFB90F5DD68F00124155 /* libboost_date_time-xgcc40-mt.a */; };
-		F90BAFBC0F5DD6A800124155 /* libboost_thread-xgcc40-mt.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F90BAFBB0F5DD6A800124155 /* libboost_thread-xgcc40-mt.a */; };
+		B91974D1163AEA54009C397B /* 3DSHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A880E4B716800207D74 /* 3DSHelper.h */; };
+		B91974D2163AEA54009C397B /* 3DSLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A8A0E4B716800207D74 /* 3DSLoader.h */; };
+		B91974D3163AEA54009C397B /* ASELoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A8F0E4B716800207D74 /* ASELoader.h */; };
+		B91974D4163AEA54009C397B /* ASEParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A910E4B716800207D74 /* ASEParser.h */; };
+		B91974E0163AEA54009C397B /* HalfLifeFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AA90E4B716800207D74 /* HalfLifeFileData.h */; };
+		B91974E1163AEA54009C397B /* HMPLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AAC0E4B716800207D74 /* HMPLoader.h */; };
+		B91974E6163AEA54009C397B /* MD2FileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AB80E4B716800207D74 /* MD2FileData.h */; };
+		B91974E7163AEA54009C397B /* MD2Loader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45ABA0E4B716800207D74 /* MD2Loader.h */; };
+		B91974E8163AEA54009C397B /* MD2NormalTable.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45ABB0E4B716800207D74 /* MD2NormalTable.h */; };
+		B91974E9163AEA54009C397B /* MD3FileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45ABC0E4B716800207D74 /* MD3FileData.h */; };
+		B91974EA163AEA54009C397B /* MD3Loader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45ABE0E4B716800207D74 /* MD3Loader.h */; };
+		B91974EB163AEA54009C397B /* MD5Loader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AC30E4B716800207D74 /* MD5Loader.h */; };
+		B91974EC163AEA54009C397B /* MD5Parser.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AC50E4B716800207D74 /* MD5Parser.h */; };
+		B91974ED163AEA54009C397B /* MDLDefaultColorMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AC60E4B716800207D74 /* MDLDefaultColorMap.h */; };
+		B91974EE163AEA54009C397B /* MDLFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AC70E4B716800207D74 /* MDLFileData.h */; };
+		B91974EF163AEA54009C397B /* MDLLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AC90E4B716800207D74 /* MDLLoader.h */; };
+		B91974F6163AEA54009C397B /* PlyLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AD50E4B716800207D74 /* PlyLoader.h */; };
+		B91974F7163AEA54009C397B /* PlyParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AD70E4B716800207D74 /* PlyParser.h */; };
+		B91974FC163AEA54009C397B /* SMDLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AE30E4B716800207D74 /* SMDLoader.h */; };
+		B9197506163AEA54009C397B /* XFileHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AF40E4B716800207D74 /* XFileHelper.h */; };
+		B9197507163AEA54009C397B /* XFileImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AF60E4B716800207D74 /* XFileImporter.h */; };
+		B9197508163AEA54009C397B /* XFileParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AF80E4B716800207D74 /* XFileParser.h */; };
+		B9197509163AEA54009C397B /* MDCFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3AB0E50D67A00606590 /* MDCFileData.h */; };
+		B919750A163AEA54009C397B /* MDCLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3AD0E50D67A00606590 /* MDCLoader.h */; };
+		B919750B163AEA54009C397B /* MDCNormalTable.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3AE0E50D67A00606590 /* MDCNormalTable.h */; };
+		B919750D163AEA54009C397B /* LWOFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3B70E50D6DB00606590 /* LWOFileData.h */; };
+		B919750E163AEA54009C397B /* LWOLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3B90E50D6DB00606590 /* LWOLoader.h */; };
+		B919750F163AEA54009C397B /* HMPFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3C50E50D77900606590 /* HMPFileData.h */; };
+		B9197512163AEA54009C397B /* ACLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFD10F5DD87000124155 /* ACLoader.h */; };
+		B9197513163AEA54009C397B /* IRRLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFDA0F5DD90800124155 /* IRRLoader.h */; };
+		B9197514163AEA54009C397B /* IRRMeshLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFDC0F5DD90800124155 /* IRRMeshLoader.h */; };
+		B9197515163AEA54009C397B /* IRRShared.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFDE0F5DD90800124155 /* IRRShared.h */; };
+		B9197519163AEA54009C397B /* NFFLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFF50F5DD96100124155 /* NFFLoader.h */; };
+		B919751B163AEA54009C397B /* Q3DLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0070F5DD9DD00124155 /* Q3DLoader.h */; };
+		B919751C163AEA54009C397B /* BVHLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB00C0F5DD9F400124155 /* BVHLoader.h */; };
+		B919751D163AEA54009C397B /* OFFLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0130F5DDA1400124155 /* OFFLoader.h */; };
+		B919751E163AEA54009C397B /* RawLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB01B0F5DDA4400124155 /* RawLoader.h */; };
+		B919751F163AEA54009C397B /* DXFLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0210F5DDA5700124155 /* DXFLoader.h */; };
+		B9197520163AEA54009C397B /* TerragenLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB02F0F5DDAB500124155 /* TerragenLoader.h */; };
+		B9197521163AEA54009C397B /* irrXMLWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0360F5DDB1B00124155 /* irrXMLWrapper.h */; };
+		B919752D163AEA54009C397B /* B3DImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0870F5DDE0700124155 /* B3DImporter.h */; };
+		B9197535163AEA54009C397B /* CSMLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B14F11416D5E00BCD793 /* CSMLoader.h */; };
+		B9197536163AEA54009C397B /* LWSLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B15A11416DDD00BCD793 /* LWSLoader.h */; };
+		B9197537163AEA54009C397B /* LWOAnimation.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B16411416DF400BCD793 /* LWOAnimation.h */; };
+		B9197538163AEA54009C397B /* MS3DLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B17111416E2500BCD793 /* MS3DLoader.h */; };
+		B9197539163AEA54009C397B /* UnrealLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 7411B18C11416EBC00BCD793 /* UnrealLoader.h */; };
+		B9197545163AEA54009C397B /* BlenderDNA.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BB4A11ACBB1000AF885C /* BlenderDNA.h */; };
+		B9197546163AEA54009C397B /* BlenderLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BB4D11ACBB1000AF885C /* BlenderLoader.h */; };
+		B9197547163AEA54009C397B /* BlenderScene.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BB4F11ACBB1000AF885C /* BlenderScene.h */; };
+		B9197548163AEA54009C397B /* BlenderSceneGen.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BB5011ACBB1000AF885C /* BlenderSceneGen.h */; };
+		B919754D163AEA54009C397B /* AssimpPCH.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BB8711ACBB9900AF885C /* AssimpPCH.h */; };
+		B919754E163AEA54009C397B /* COBLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BB9411ACBBBC00AF885C /* COBLoader.h */; };
+		B919754F163AEA54009C397B /* COBScene.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BB9511ACBBBC00AF885C /* COBScene.h */; };
+		B9197550163AEA54009C397B /* revision.h in Headers */ = {isa = PBXBuildFile; fileRef = 74C9BBB311ACBC2600AF885C /* revision.h */; };
+		B9197555163AEA54009C397B /* Q3BSPFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E7ABBA1127E0F1A00512ED1 /* Q3BSPFileData.h */; };
+		B9197556163AEA54009C397B /* Q3BSPFileImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E7ABBA3127E0F1A00512ED1 /* Q3BSPFileImporter.h */; };
+		B9197557163AEA54009C397B /* Q3BSPFileParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E7ABBA5127E0F1A00512ED1 /* Q3BSPFileParser.h */; };
+		B9197558163AEA54009C397B /* Q3BSPZipArchive.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E7ABBA7127E0F1A00512ED1 /* Q3BSPZipArchive.h */; };
+		B9197559163AEA54009C397B /* NDOLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E7ABBC5127E0F2A00512ED1 /* NDOLoader.h */; };
+		B919755A163AEA54009C397B /* BlenderIntermediate.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E7ABBCE127E0F3800512ED1 /* BlenderIntermediate.h */; };
+		B919755B163AEA54009C397B /* BlenderModifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E7ABBD0127E0F3800512ED1 /* BlenderModifier.h */; };
+		B9197560163AEA54009C397B /* ConvertUTF.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E8DEE4C127E2B78005EF64D /* ConvertUTF.h */; };
+		B9197561163AEA54009C397B /* CXMLReaderImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E8DEE4F127E2B78005EF64D /* CXMLReaderImpl.h */; };
+		B9197562163AEA54009C397B /* heapsort.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E8DEE50127E2B78005EF64D /* heapsort.h */; };
+		B9197563163AEA54009C397B /* irrArray.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E8DEE51127E2B78005EF64D /* irrArray.h */; };
+		B9197564163AEA54009C397B /* irrString.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E8DEE52127E2B78005EF64D /* irrString.h */; };
+		B9197565163AEA54009C397B /* irrTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E8DEE53127E2B78005EF64D /* irrTypes.h */; };
+		B9197566163AEA54009C397B /* irrXML.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E8DEE55127E2B78005EF64D /* irrXML.h */; };
+		B9197567163AEA54009C397B /* crypt.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E8DEE57127E2B78005EF64D /* crypt.h */; };
+		B9197568163AEA54009C397B /* ioapi.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E8DEE59127E2B78005EF64D /* ioapi.h */; };
+		B9197569163AEA54009C397B /* unzip.h in Headers */ = {isa = PBXBuildFile; fileRef = 8E8DEE5B127E2B78005EF64D /* unzip.h */; };
+		B919756A163AEA54009C397B /* anim.h in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8B751543268400E63FFE /* anim.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B919756B163AEA54009C397B /* camera.h in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8B771543268400E63FFE /* camera.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B919756C163AEA54009C397B /* cexport.h in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8B781543268400E63FFE /* cexport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B919756D163AEA54009C397B /* cfileio.h in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8B791543268400E63FFE /* cfileio.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B919756E163AEA54009C397B /* cimport.h in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8B7A1543268400E63FFE /* cimport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B919756F163AEA54009C397B /* color4.h in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8B7B1543268400E63FFE /* color4.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B9197570163AEA54009C397B /* poppack1.h in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8B7E1543268400E63FFE /* poppack1.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B9197571163AEA54009C397B /* pushpack1.h in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8B7F1543268400E63FFE /* pushpack1.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B9197572163AEA54009C397B /* config.h in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8B801543268400E63FFE /* config.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B9197573163AEA54009C397B /* DefaultLogger.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8B811543268400E63FFE /* DefaultLogger.hpp */; settings = {ATTRIBUTES = (Public, ); }; };
+		B9197574163AEA54009C397B /* defs.h in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8B821543268400E63FFE /* defs.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B9197575163AEA54009C397B /* Exporter.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8B831543268400E63FFE /* Exporter.hpp */; settings = {ATTRIBUTES = (Public, ); }; };
+		B9197576163AEA54009C397B /* Importer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8B841543268400E63FFE /* Importer.hpp */; settings = {ATTRIBUTES = (Public, ); }; };
+		B9197577163AEA54009C397B /* importerdesc.h in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8B851543268400E63FFE /* importerdesc.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B9197578163AEA54009C397B /* IOStream.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8B861543268400E63FFE /* IOStream.hpp */; settings = {ATTRIBUTES = (Public, ); }; };
+		B9197579163AEA54009C397B /* IOSystem.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8B871543268400E63FFE /* IOSystem.hpp */; settings = {ATTRIBUTES = (Public, ); }; };
+		B919757A163AEA54009C397B /* light.h in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8B881543268400E63FFE /* light.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B919757B163AEA54009C397B /* Logger.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8B891543268400E63FFE /* Logger.hpp */; settings = {ATTRIBUTES = (Public, ); }; };
+		B919757C163AEA54009C397B /* LogStream.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8B8A1543268400E63FFE /* LogStream.hpp */; settings = {ATTRIBUTES = (Public, ); }; };
+		B919757D163AEA54009C397B /* material.h in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8B8B1543268400E63FFE /* material.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B919757E163AEA54009C397B /* matrix3x3.h in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8B8D1543268400E63FFE /* matrix3x3.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B919757F163AEA54009C397B /* matrix4x4.h in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8B8F1543268400E63FFE /* matrix4x4.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B9197580163AEA54009C397B /* mesh.h in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8B911543268400E63FFE /* mesh.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B9197581163AEA54009C397B /* NullLogger.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8B921543268400E63FFE /* NullLogger.hpp */; settings = {ATTRIBUTES = (Public, ); }; };
+		B9197582163AEA54009C397B /* postprocess.h in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8B931543268400E63FFE /* postprocess.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B9197583163AEA54009C397B /* ProgressHandler.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8B941543268400E63FFE /* ProgressHandler.hpp */; settings = {ATTRIBUTES = (Public, ); }; };
+		B9197584163AEA54009C397B /* quaternion.h in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8B951543268400E63FFE /* quaternion.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B9197585163AEA54009C397B /* scene.h in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8B971543268400E63FFE /* scene.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B9197586163AEA54009C397B /* texture.h in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8B981543268400E63FFE /* texture.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B9197587163AEA54009C397B /* types.h in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8B991543268400E63FFE /* types.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B9197588163AEA54009C397B /* vector2.h in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8B9A1543268400E63FFE /* vector2.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B9197589163AEA54009C397B /* vector3.h in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8B9C1543268400E63FFE /* vector3.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B919758A163AEA54009C397B /* version.h in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8B9E1543268400E63FFE /* version.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B919758B163AEA54009C397B /* OgreImporter.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8C36154328B600E63FFE /* OgreImporter.hpp */; };
+		B919758C163AEA54009C397B /* OgreXmlHelper.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8C3A154328B600E63FFE /* OgreXmlHelper.hpp */; };
+		B9197595163AEA54009C397B /* M3Importer.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9F2715436207000682F3 /* M3Importer.h */; };
+		B9197596163AEA54009C397B /* PlyExporter.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9F3115436269000682F3 /* PlyExporter.h */; };
+		B919759C163AEA54009C397B /* crc32.h in Headers */ = {isa = PBXBuildFile; fileRef = F960704B154366AB004D91DD /* crc32.h */; };
+		B919759D163AEA54009C397B /* deflate.h in Headers */ = {isa = PBXBuildFile; fileRef = F960704D154366AB004D91DD /* deflate.h */; };
+		B919759E163AEA54009C397B /* inffast.h in Headers */ = {isa = PBXBuildFile; fileRef = F960704F154366AB004D91DD /* inffast.h */; };
+		B919759F163AEA54009C397B /* inffixed.h in Headers */ = {isa = PBXBuildFile; fileRef = F9607050154366AB004D91DD /* inffixed.h */; };
+		B91975A0163AEA54009C397B /* inflate.h in Headers */ = {isa = PBXBuildFile; fileRef = F9607052154366AB004D91DD /* inflate.h */; };
+		B91975A1163AEA54009C397B /* inftrees.h in Headers */ = {isa = PBXBuildFile; fileRef = F9607054154366AB004D91DD /* inftrees.h */; };
+		B91975A2163AEA54009C397B /* trees.h in Headers */ = {isa = PBXBuildFile; fileRef = F9607057154366AB004D91DD /* trees.h */; };
+		B91975A3163AEA54009C397B /* zconf.h in Headers */ = {isa = PBXBuildFile; fileRef = F9607058154366AB004D91DD /* zconf.h */; };
+		B91975A4163AEA54009C397B /* zconf.in.h in Headers */ = {isa = PBXBuildFile; fileRef = F9607059154366AB004D91DD /* zconf.in.h */; };
+		B91975A5163AEA54009C397B /* zlib.h in Headers */ = {isa = PBXBuildFile; fileRef = F960705A154366AB004D91DD /* zlib.h */; };
+		B91975A6163AEA54009C397B /* zutil.h in Headers */ = {isa = PBXBuildFile; fileRef = F960705C154366AB004D91DD /* zutil.h */; };
+		B91975A7163AEA54009C397B /* XGLLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F96070B6154366ED004D91DD /* XGLLoader.h */; };
+		B91975A8163AEA54009C397B /* clipper.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F96070C61543673B004D91DD /* clipper.hpp */; };
+		B91975A9163AEA54009C397B /* shapes.h in Headers */ = {isa = PBXBuildFile; fileRef = F96070D31543675E004D91DD /* shapes.h */; };
+		B91975AA163AEA54009C397B /* utils.h in Headers */ = {isa = PBXBuildFile; fileRef = F96070D41543675E004D91DD /* utils.h */; };
+		B91975AB163AEA54009C397B /* poly2tri.h in Headers */ = {isa = PBXBuildFile; fileRef = F96070D51543675E004D91DD /* poly2tri.h */; };
+		B91975AC163AEA54009C397B /* advancing_front.h in Headers */ = {isa = PBXBuildFile; fileRef = F96070D81543675E004D91DD /* advancing_front.h */; };
+		B91975AD163AEA54009C397B /* cdt.h in Headers */ = {isa = PBXBuildFile; fileRef = F96070DA1543675E004D91DD /* cdt.h */; };
+		B91975AE163AEA54009C397B /* sweep.h in Headers */ = {isa = PBXBuildFile; fileRef = F96070DC1543675E004D91DD /* sweep.h */; };
+		B91975AF163AEA54009C397B /* sweep_context.h in Headers */ = {isa = PBXBuildFile; fileRef = F96070DE1543675E004D91DD /* sweep_context.h */; };
+		B91975B0163AEA54009C397B /* ai_assert.h in Headers */ = {isa = PBXBuildFile; fileRef = F97BA03515439DB3009EB9DD /* ai_assert.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B91975B7163AEA54009C397B /* 3DSConverter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A860E4B716800207D74 /* 3DSConverter.cpp */; };
+		B91975B8163AEA54009C397B /* 3DSLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A890E4B716800207D74 /* 3DSLoader.cpp */; };
+		B91975B9163AEA54009C397B /* ASELoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A8E0E4B716800207D74 /* ASELoader.cpp */; };
+		B91975BA163AEA54009C397B /* ASEParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A900E4B716800207D74 /* ASEParser.cpp */; };
+		B91975C4163AEA54009C397B /* HMPLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AAB0E4B716800207D74 /* HMPLoader.cpp */; };
+		B91975CA163AEA54009C397B /* MD2Loader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AB90E4B716800207D74 /* MD2Loader.cpp */; };
+		B91975CB163AEA54009C397B /* MD3Loader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45ABD0E4B716800207D74 /* MD3Loader.cpp */; };
+		B91975CC163AEA54009C397B /* MD5Loader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AC20E4B716800207D74 /* MD5Loader.cpp */; };
+		B91975CD163AEA54009C397B /* MD5Parser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AC40E4B716800207D74 /* MD5Parser.cpp */; };
+		B91975CE163AEA54009C397B /* MDLLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AC80E4B716800207D74 /* MDLLoader.cpp */; };
+		B91975CF163AEA54009C397B /* MDLMaterialLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45ACA0E4B716800207D74 /* MDLMaterialLoader.cpp */; };
+		B91975D3163AEA54009C397B /* PlyLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AD40E4B716800207D74 /* PlyLoader.cpp */; };
+		B91975D4163AEA54009C397B /* PlyParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AD60E4B716800207D74 /* PlyParser.cpp */; };
+		B91975D8163AEA54009C397B /* SMDLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AE20E4B716800207D74 /* SMDLoader.cpp */; };
+		B91975E0163AEA54009C397B /* XFileImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AF50E4B716800207D74 /* XFileImporter.cpp */; };
+		B91975E1163AEA54009C397B /* XFileParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AF70E4B716800207D74 /* XFileParser.cpp */; };
+		B91975E2163AEA54009C397B /* MDCLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AB8A3AC0E50D67A00606590 /* MDCLoader.cpp */; };
+		B91975E4163AEA54009C397B /* LWOLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AB8A3B80E50D6DB00606590 /* LWOLoader.cpp */; };
+		B91975E6163AEA54009C397B /* LWOMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AB8A7DC0E53715F00606590 /* LWOMaterial.cpp */; };
+		B91975E7163AEA54009C397B /* ACLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BAFD00F5DD87000124155 /* ACLoader.cpp */; };
+		B91975E8163AEA54009C397B /* IRRLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BAFD90F5DD90800124155 /* IRRLoader.cpp */; };
+		B91975E9163AEA54009C397B /* IRRMeshLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BAFDB0F5DD90800124155 /* IRRMeshLoader.cpp */; };
+		B91975EA163AEA54009C397B /* IRRShared.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BAFDD0F5DD90800124155 /* IRRShared.cpp */; };
+		B91975ED163AEA54009C397B /* NFFLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BAFF60F5DD96100124155 /* NFFLoader.cpp */; };
+		B91975EF163AEA54009C397B /* Q3DLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0060F5DD9DD00124155 /* Q3DLoader.cpp */; };
+		B91975F0163AEA54009C397B /* BVHLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB00D0F5DD9F400124155 /* BVHLoader.cpp */; };
+		B91975F1163AEA54009C397B /* OFFLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0140F5DDA1400124155 /* OFFLoader.cpp */; };
+		B91975F2163AEA54009C397B /* RawLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB01C0F5DDA4400124155 /* RawLoader.cpp */; };
+		B91975F3163AEA54009C397B /* DXFLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0220F5DDA5700124155 /* DXFLoader.cpp */; };
+		B91975F4163AEA54009C397B /* LWOBLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0270F5DDA9200124155 /* LWOBLoader.cpp */; };
+		B91975F5163AEA54009C397B /* TerragenLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0300F5DDAB500124155 /* TerragenLoader.cpp */; };
+		B9197600163AEA54009C397B /* B3DImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0880F5DDE0700124155 /* B3DImporter.cpp */; };
+		B9197601163AEA54009C397B /* CSMLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7411B14E11416D5E00BCD793 /* CSMLoader.cpp */; };
+		B9197602163AEA54009C397B /* LWSLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7411B15911416DDD00BCD793 /* LWSLoader.cpp */; };
+		B9197603163AEA54009C397B /* LWOAnimation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7411B16311416DF400BCD793 /* LWOAnimation.cpp */; };
+		B9197604163AEA54009C397B /* MS3DLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7411B17011416E2500BCD793 /* MS3DLoader.cpp */; };
+		B9197605163AEA54009C397B /* UnrealLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7411B18B11416EBC00BCD793 /* UnrealLoader.cpp */; };
+		B919760A163AEA54009C397B /* BlenderDNA.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 74C9BB4911ACBB1000AF885C /* BlenderDNA.cpp */; };
+		B919760B163AEA54009C397B /* BlenderLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 74C9BB4C11ACBB1000AF885C /* BlenderLoader.cpp */; };
+		B919760C163AEA54009C397B /* BlenderScene.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 74C9BB4E11ACBB1000AF885C /* BlenderScene.cpp */; };
+		B919760E163AEA54009C397B /* AssimpPCH.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 74C9BB8611ACBB9900AF885C /* AssimpPCH.cpp */; };
+		B919760F163AEA54009C397B /* COBLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 74C9BB9311ACBBBC00AF885C /* COBLoader.cpp */; };
+		B9197610163AEA54009C397B /* Q3BSPFileImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8E7ABBA2127E0F1A00512ED1 /* Q3BSPFileImporter.cpp */; };
+		B9197611163AEA54009C397B /* Q3BSPFileParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8E7ABBA4127E0F1A00512ED1 /* Q3BSPFileParser.cpp */; };
+		B9197612163AEA54009C397B /* Q3BSPZipArchive.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8E7ABBA6127E0F1A00512ED1 /* Q3BSPZipArchive.cpp */; };
+		B9197613163AEA54009C397B /* NDOLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8E7ABBC4127E0F2A00512ED1 /* NDOLoader.cpp */; };
+		B9197614163AEA54009C397B /* BlenderModifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8E7ABBCF127E0F3800512ED1 /* BlenderModifier.cpp */; };
+		B9197615163AEA54009C397B /* ConvertUTF.c in Sources */ = {isa = PBXBuildFile; fileRef = 8E8DEE4B127E2B78005EF64D /* ConvertUTF.c */; };
+		B9197616163AEA54009C397B /* irrXML.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8E8DEE54127E2B78005EF64D /* irrXML.cpp */; };
+		B9197617163AEA54009C397B /* ioapi.c in Sources */ = {isa = PBXBuildFile; fileRef = 8E8DEE58127E2B78005EF64D /* ioapi.c */; };
+		B9197618163AEA54009C397B /* unzip.c in Sources */ = {isa = PBXBuildFile; fileRef = 8E8DEE5A127E2B78005EF64D /* unzip.c */; };
+		B9197619163AEA54009C397B /* OgreImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9BA8C35154328B600E63FFE /* OgreImporter.cpp */; };
+		B919761A163AEA54009C397B /* OgreMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9BA8C37154328B600E63FFE /* OgreMaterial.cpp */; };
+		B919761B163AEA54009C397B /* OgreMesh.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9BA8C38154328B600E63FFE /* OgreMesh.cpp */; };
+		B919761C163AEA54009C397B /* OgreSkeleton.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9BA8C39154328B600E63FFE /* OgreSkeleton.cpp */; };
+		B919761F163AEA54009C397B /* M3Importer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F99A9F2615436207000682F3 /* M3Importer.cpp */; };
+		B9197620163AEA54009C397B /* PlyExporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F99A9F3015436269000682F3 /* PlyExporter.cpp */; };
+		B9197625163AEA54009C397B /* adler32.c in Sources */ = {isa = PBXBuildFile; fileRef = F9607047154366AB004D91DD /* adler32.c */; };
+		B9197626163AEA54009C397B /* compress.c in Sources */ = {isa = PBXBuildFile; fileRef = F9607049154366AB004D91DD /* compress.c */; };
+		B9197627163AEA54009C397B /* crc32.c in Sources */ = {isa = PBXBuildFile; fileRef = F960704A154366AB004D91DD /* crc32.c */; };
+		B9197628163AEA54009C397B /* deflate.c in Sources */ = {isa = PBXBuildFile; fileRef = F960704C154366AB004D91DD /* deflate.c */; };
+		B9197629163AEA54009C397B /* inffast.c in Sources */ = {isa = PBXBuildFile; fileRef = F960704E154366AB004D91DD /* inffast.c */; };
+		B919762A163AEA54009C397B /* inflate.c in Sources */ = {isa = PBXBuildFile; fileRef = F9607051154366AB004D91DD /* inflate.c */; };
+		B919762B163AEA54009C397B /* inftrees.c in Sources */ = {isa = PBXBuildFile; fileRef = F9607053154366AB004D91DD /* inftrees.c */; };
+		B919762C163AEA54009C397B /* trees.c in Sources */ = {isa = PBXBuildFile; fileRef = F9607056154366AB004D91DD /* trees.c */; };
+		B919762D163AEA54009C397B /* zutil.c in Sources */ = {isa = PBXBuildFile; fileRef = F960705B154366AB004D91DD /* zutil.c */; };
+		B919762E163AEA54009C397B /* XGLLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F96070B5154366ED004D91DD /* XGLLoader.cpp */; };
+		B919762F163AEA54009C397B /* clipper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F96070C51543673B004D91DD /* clipper.cpp */; };
+		B9197630163AEA54009C397B /* shapes.cc in Sources */ = {isa = PBXBuildFile; fileRef = F96070D21543675E004D91DD /* shapes.cc */; };
+		B9197631163AEA54009C397B /* advancing_front.cc in Sources */ = {isa = PBXBuildFile; fileRef = F96070D71543675E004D91DD /* advancing_front.cc */; };
+		B9197632163AEA54009C397B /* cdt.cc in Sources */ = {isa = PBXBuildFile; fileRef = F96070D91543675E004D91DD /* cdt.cc */; };
+		B9197633163AEA54009C397B /* sweep.cc in Sources */ = {isa = PBXBuildFile; fileRef = F96070DB1543675E004D91DD /* sweep.cc */; };
+		B9197634163AEA54009C397B /* sweep_context.cc in Sources */ = {isa = PBXBuildFile; fileRef = F96070DD1543675E004D91DD /* sweep_context.cc */; };
 		F90BAFD20F5DD87000124155 /* ACLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BAFD00F5DD87000124155 /* ACLoader.cpp */; };
 		F90BAFD30F5DD87000124155 /* ACLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFD10F5DD87000124155 /* ACLoader.h */; };
 		F90BAFDF0F5DD90800124155 /* IRRLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BAFD90F5DD90800124155 /* IRRLoader.cpp */; };
@@ -782,15 +1591,8 @@
 		F90BAFE20F5DD90800124155 /* IRRMeshLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFDC0F5DD90800124155 /* IRRMeshLoader.h */; };
 		F90BAFE30F5DD90800124155 /* IRRShared.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BAFDD0F5DD90800124155 /* IRRShared.cpp */; };
 		F90BAFE40F5DD90800124155 /* IRRShared.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFDE0F5DD90800124155 /* IRRShared.h */; };
-		F90BAFED0F5DD93600124155 /* ColladaHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFE80F5DD93600124155 /* ColladaHelper.h */; };
-		F90BAFEE0F5DD93600124155 /* ColladaLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BAFE90F5DD93600124155 /* ColladaLoader.cpp */; };
-		F90BAFEF0F5DD93600124155 /* ColladaLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFEA0F5DD93600124155 /* ColladaLoader.h */; };
-		F90BAFF00F5DD93600124155 /* ColladaParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BAFEB0F5DD93600124155 /* ColladaParser.cpp */; };
-		F90BAFF10F5DD93600124155 /* ColladaParser.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFEC0F5DD93600124155 /* ColladaParser.h */; };
 		F90BAFF70F5DD96100124155 /* NFFLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFF50F5DD96100124155 /* NFFLoader.h */; };
 		F90BAFF80F5DD96100124155 /* NFFLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BAFF60F5DD96100124155 /* NFFLoader.cpp */; };
-		F90BAFFD0F5DD9A000124155 /* SGSpatialSort.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFFB0F5DD9A000124155 /* SGSpatialSort.h */; };
-		F90BAFFE0F5DD9A000124155 /* SGSpatialSort.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BAFFC0F5DD9A000124155 /* SGSpatialSort.cpp */; };
 		F90BB0080F5DD9DD00124155 /* Q3DLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0060F5DD9DD00124155 /* Q3DLoader.cpp */; };
 		F90BB0090F5DD9DD00124155 /* Q3DLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0070F5DD9DD00124155 /* Q3DLoader.h */; };
 		F90BB00E0F5DD9F400124155 /* BVHLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB00C0F5DD9F400124155 /* BVHLoader.h */; };
@@ -805,34 +1607,8 @@
 		F90BB0310F5DDAB500124155 /* TerragenLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB02F0F5DDAB500124155 /* TerragenLoader.h */; };
 		F90BB0320F5DDAB500124155 /* TerragenLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0300F5DDAB500124155 /* TerragenLoader.cpp */; };
 		F90BB0370F5DDB1B00124155 /* irrXMLWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0360F5DDB1B00124155 /* irrXMLWrapper.h */; };
-		F90BB03D0F5DDB3200124155 /* ScenePreprocessor.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0390F5DDB3200124155 /* ScenePreprocessor.h */; };
-		F90BB03E0F5DDB3200124155 /* SceneCombiner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB03A0F5DDB3200124155 /* SceneCombiner.cpp */; };
-		F90BB03F0F5DDB3200124155 /* SceneCombiner.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB03B0F5DDB3200124155 /* SceneCombiner.h */; };
-		F90BB0400F5DDB3200124155 /* ScenePreprocessor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB03C0F5DDB3200124155 /* ScenePreprocessor.cpp */; };
-		F90BB0440F5DDB4600124155 /* SortByPTypeProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0420F5DDB4600124155 /* SortByPTypeProcess.h */; };
-		F90BB0450F5DDB4600124155 /* SortByPTypeProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0430F5DDB4600124155 /* SortByPTypeProcess.cpp */; };
-		F90BB0490F5DDB6100124155 /* FindDegenerates.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0470F5DDB6100124155 /* FindDegenerates.h */; };
-		F90BB04A0F5DDB6100124155 /* FindDegenerates.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0480F5DDB6100124155 /* FindDegenerates.cpp */; };
-		F90BB04E0F5DDB8D00124155 /* ComputeUVMappingProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB04C0F5DDB8D00124155 /* ComputeUVMappingProcess.h */; };
-		F90BB04F0F5DDB8D00124155 /* ComputeUVMappingProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB04D0F5DDB8D00124155 /* ComputeUVMappingProcess.cpp */; };
-		F90BB0530F5DDBA800124155 /* StandardShapes.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0510F5DDBA800124155 /* StandardShapes.h */; };
-		F90BB0540F5DDBA800124155 /* StandardShapes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0520F5DDBA800124155 /* StandardShapes.cpp */; };
-		F90BB0580F5DDBBF00124155 /* FindInstancesProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0560F5DDBBF00124155 /* FindInstancesProcess.h */; };
-		F90BB0590F5DDBBF00124155 /* FindInstancesProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0570F5DDBBF00124155 /* FindInstancesProcess.cpp */; };
-		F90BB05C0F5DDBCB00124155 /* RemoveVCProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB05A0F5DDBCB00124155 /* RemoveVCProcess.h */; };
-		F90BB05D0F5DDBCB00124155 /* RemoveVCProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB05B0F5DDBCB00124155 /* RemoveVCProcess.cpp */; };
-		F90BB0610F5DDBE600124155 /* FindInvalidDataProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB05F0F5DDBE600124155 /* FindInvalidDataProcess.cpp */; };
-		F90BB0620F5DDBE600124155 /* FindInvalidDataProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0600F5DDBE600124155 /* FindInvalidDataProcess.h */; };
-		F90BB0660F5DDC0700124155 /* SkeletonMeshBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0640F5DDC0700124155 /* SkeletonMeshBuilder.h */; };
-		F90BB0670F5DDC0700124155 /* SkeletonMeshBuilder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0650F5DDC0700124155 /* SkeletonMeshBuilder.cpp */; };
-		F90BB06B0F5DDC1E00124155 /* SmoothingGroups.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0690F5DDC1E00124155 /* SmoothingGroups.h */; };
-		F90BB06E0F5DDCFC00124155 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = F90BB06D0F5DDCFC00124155 /* libz.dylib */; };
 		F90BB0890F5DDE0700124155 /* B3DImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0870F5DDE0700124155 /* B3DImporter.h */; };
 		F90BB08A0F5DDE0700124155 /* B3DImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0880F5DDE0700124155 /* B3DImporter.cpp */; };
-		F9606FF3154364E5004D91DD /* ProcessHelper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9606FF2154364E5004D91DD /* ProcessHelper.cpp */; };
-		F9606FF4154364E5004D91DD /* ProcessHelper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9606FF2154364E5004D91DD /* ProcessHelper.cpp */; };
-		F9606FF5154364E5004D91DD /* ProcessHelper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9606FF2154364E5004D91DD /* ProcessHelper.cpp */; };
-		F9606FF6154364E5004D91DD /* ProcessHelper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F9606FF2154364E5004D91DD /* ProcessHelper.cpp */; };
 		F960705D154366AB004D91DD /* adler32.c in Sources */ = {isa = PBXBuildFile; fileRef = F9607047154366AB004D91DD /* adler32.c */; };
 		F960705E154366AB004D91DD /* compress.c in Sources */ = {isa = PBXBuildFile; fileRef = F9607049154366AB004D91DD /* compress.c */; };
 		F960705F154366AB004D91DD /* crc32.c in Sources */ = {isa = PBXBuildFile; fileRef = F960704A154366AB004D91DD /* crc32.c */; };
@@ -977,65 +1753,30 @@
 		F960710C1543675E004D91DD /* sweep.h in Headers */ = {isa = PBXBuildFile; fileRef = F96070DC1543675E004D91DD /* sweep.h */; };
 		F960710D1543675E004D91DD /* sweep_context.cc in Sources */ = {isa = PBXBuildFile; fileRef = F96070DD1543675E004D91DD /* sweep_context.cc */; };
 		F960710E1543675E004D91DD /* sweep_context.h in Headers */ = {isa = PBXBuildFile; fileRef = F96070DE1543675E004D91DD /* sweep_context.h */; };
-		F962E8880F5DE6B4009A5495 /* libboost_date_time-xgcc40-mt.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F90BAFB90F5DD68F00124155 /* libboost_date_time-xgcc40-mt.a */; };
-		F962E8890F5DE6B4009A5495 /* libboost_thread-xgcc40-mt.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F90BAFBB0F5DD6A800124155 /* libboost_thread-xgcc40-mt.a */; };
-		F962E88A0F5DE6B4009A5495 /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = F90BB06D0F5DDCFC00124155 /* libz.dylib */; };
 		F962E88B0F5DE6C8009A5495 /* 3DSConverter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A860E4B716800207D74 /* 3DSConverter.cpp */; };
 		F962E88C0F5DE6C8009A5495 /* 3DSLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A890E4B716800207D74 /* 3DSLoader.cpp */; };
 		F962E88E0F5DE6C8009A5495 /* ASELoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A8E0E4B716800207D74 /* ASELoader.cpp */; };
 		F962E88F0F5DE6C8009A5495 /* ASEParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A900E4B716800207D74 /* ASEParser.cpp */; };
-		F962E8900F5DE6C8009A5495 /* Assimp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A920E4B716800207D74 /* Assimp.cpp */; };
-		F962E8910F5DE6C8009A5495 /* BaseImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A930E4B716800207D74 /* BaseImporter.cpp */; };
-		F962E8920F5DE6C8009A5495 /* CalcTangentsProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A970E4B716800207D74 /* CalcTangentsProcess.cpp */; };
-		F962E8930F5DE6C8009A5495 /* ConvertToLHProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A990E4B716800207D74 /* ConvertToLHProcess.cpp */; };
-		F962E8940F5DE6C8009A5495 /* DefaultIOStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A9B0E4B716800207D74 /* DefaultIOStream.cpp */; };
-		F962E8950F5DE6C8009A5495 /* DefaultIOSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A9D0E4B716800207D74 /* DefaultIOSystem.cpp */; };
-		F962E8960F5DE6C8009A5495 /* DefaultLogger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45A9F0E4B716800207D74 /* DefaultLogger.cpp */; };
-		F962E8980F5DE6C8009A5495 /* GenFaceNormalsProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AA50E4B716800207D74 /* GenFaceNormalsProcess.cpp */; };
-		F962E8990F5DE6C8009A5495 /* GenVertexNormalsProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AA70E4B716800207D74 /* GenVertexNormalsProcess.cpp */; };
 		F962E89A0F5DE6C8009A5495 /* HMPLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AAB0E4B716800207D74 /* HMPLoader.cpp */; };
-		F962E89B0F5DE6C8009A5495 /* Importer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AAD0E4B716800207D74 /* Importer.cpp */; };
-		F962E89C0F5DE6C8009A5495 /* ImproveCacheLocality.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AAE0E4B716800207D74 /* ImproveCacheLocality.cpp */; };
-		F962E89D0F5DE6C8009A5495 /* JoinVerticesProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AB00E4B716800207D74 /* JoinVerticesProcess.cpp */; };
-		F962E89E0F5DE6C8009A5495 /* LimitBoneWeightsProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AB40E4B716800207D74 /* LimitBoneWeightsProcess.cpp */; };
-		F962E89F0F5DE6C8009A5495 /* MaterialSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AB60E4B716800207D74 /* MaterialSystem.cpp */; };
 		F962E8A00F5DE6C8009A5495 /* MD2Loader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AB90E4B716800207D74 /* MD2Loader.cpp */; };
 		F962E8A10F5DE6C8009A5495 /* MD3Loader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45ABD0E4B716800207D74 /* MD3Loader.cpp */; };
 		F962E8A20F5DE6C8009A5495 /* MD5Loader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AC20E4B716800207D74 /* MD5Loader.cpp */; };
 		F962E8A30F5DE6C8009A5495 /* MD5Parser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AC40E4B716800207D74 /* MD5Parser.cpp */; };
 		F962E8A40F5DE6C8009A5495 /* MDLLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AC80E4B716800207D74 /* MDLLoader.cpp */; };
 		F962E8A50F5DE6C8009A5495 /* MDLMaterialLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45ACA0E4B716800207D74 /* MDLMaterialLoader.cpp */; };
-		F962E8A60F5DE6C8009A5495 /* ObjFileImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45ACC0E4B716800207D74 /* ObjFileImporter.cpp */; };
-		F962E8A70F5DE6C8009A5495 /* ObjFileMtlImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45ACE0E4B716800207D74 /* ObjFileMtlImporter.cpp */; };
-		F962E8A80F5DE6C8009A5495 /* ObjFileParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AD00E4B716800207D74 /* ObjFileParser.cpp */; };
 		F962E8A90F5DE6C8009A5495 /* PlyLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AD40E4B716800207D74 /* PlyLoader.cpp */; };
 		F962E8AA0F5DE6C8009A5495 /* PlyParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AD60E4B716800207D74 /* PlyParser.cpp */; };
-		F962E8AB0F5DE6C8009A5495 /* PretransformVertices.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AD80E4B716800207D74 /* PretransformVertices.cpp */; };
-		F962E8AC0F5DE6C8009A5495 /* RemoveComments.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45ADB0E4B716800207D74 /* RemoveComments.cpp */; };
-		F962E8AD0F5DE6C8009A5495 /* RemoveRedundantMaterials.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45ADD0E4B716800207D74 /* RemoveRedundantMaterials.cpp */; };
 		F962E8AE0F5DE6C8009A5495 /* SMDLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AE20E4B716800207D74 /* SMDLoader.cpp */; };
-		F962E8AF0F5DE6C8009A5495 /* SpatialSort.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AE40E4B716800207D74 /* SpatialSort.cpp */; };
-		F962E8B00F5DE6C8009A5495 /* SplitLargeMeshes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AE60E4B716800207D74 /* SplitLargeMeshes.cpp */; };
-		F962E8B10F5DE6C8009A5495 /* STLLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AE80E4B716800207D74 /* STLLoader.cpp */; };
-		F962E8B20F5DE6C8009A5495 /* TextureTransform.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AEB0E4B716800207D74 /* TextureTransform.cpp */; };
-		F962E8B30F5DE6C8009A5495 /* TriangulateProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AED0E4B716800207D74 /* TriangulateProcess.cpp */; };
-		F962E8B40F5DE6C8009A5495 /* ValidateDataStructure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AEF0E4B716800207D74 /* ValidateDataStructure.cpp */; };
-		F962E8B50F5DE6C8009A5495 /* VertexTriangleAdjacency.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AF10E4B716800207D74 /* VertexTriangleAdjacency.cpp */; };
 		F962E8B60F5DE6C8009A5495 /* XFileImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AF50E4B716800207D74 /* XFileImporter.cpp */; };
 		F962E8B70F5DE6C8009A5495 /* XFileParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AF45AF70E4B716800207D74 /* XFileParser.cpp */; };
 		F962E8B80F5DE6C8009A5495 /* MDCLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AB8A3AC0E50D67A00606590 /* MDCLoader.cpp */; };
-		F962E8B90F5DE6C8009A5495 /* FixNormalsStep.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AB8A3B30E50D69D00606590 /* FixNormalsStep.cpp */; };
 		F962E8BA0F5DE6C8009A5495 /* LWOLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AB8A3B80E50D6DB00606590 /* LWOLoader.cpp */; };
-		F962E8BB0F5DE6C8009A5495 /* BaseProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AB8A3C30E50D74500606590 /* BaseProcess.cpp */; };
 		F962E8BC0F5DE6C8009A5495 /* LWOMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 3AB8A7DC0E53715F00606590 /* LWOMaterial.cpp */; };
 		F962E8BD0F5DE6C8009A5495 /* ACLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BAFD00F5DD87000124155 /* ACLoader.cpp */; };
 		F962E8BE0F5DE6C8009A5495 /* IRRLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BAFD90F5DD90800124155 /* IRRLoader.cpp */; };
 		F962E8BF0F5DE6C8009A5495 /* IRRMeshLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BAFDB0F5DD90800124155 /* IRRMeshLoader.cpp */; };
 		F962E8C00F5DE6C8009A5495 /* IRRShared.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BAFDD0F5DD90800124155 /* IRRShared.cpp */; };
-		F962E8C10F5DE6C8009A5495 /* ColladaLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BAFE90F5DD93600124155 /* ColladaLoader.cpp */; };
-		F962E8C20F5DE6C8009A5495 /* ColladaParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BAFEB0F5DD93600124155 /* ColladaParser.cpp */; };
 		F962E8C30F5DE6C8009A5495 /* NFFLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BAFF60F5DD96100124155 /* NFFLoader.cpp */; };
-		F962E8C40F5DE6C8009A5495 /* SGSpatialSort.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BAFFC0F5DD9A000124155 /* SGSpatialSort.cpp */; };
 		F962E8C50F5DE6C8009A5495 /* Q3DLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0060F5DD9DD00124155 /* Q3DLoader.cpp */; };
 		F962E8C60F5DE6C8009A5495 /* BVHLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB00D0F5DD9F400124155 /* BVHLoader.cpp */; };
 		F962E8C70F5DE6C8009A5495 /* OFFLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0140F5DDA1400124155 /* OFFLoader.cpp */; };
@@ -1043,38 +1784,13 @@
 		F962E8C90F5DE6C8009A5495 /* DXFLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0220F5DDA5700124155 /* DXFLoader.cpp */; };
 		F962E8CA0F5DE6C8009A5495 /* LWOBLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0270F5DDA9200124155 /* LWOBLoader.cpp */; };
 		F962E8CB0F5DE6C8009A5495 /* TerragenLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0300F5DDAB500124155 /* TerragenLoader.cpp */; };
-		F962E8CC0F5DE6C8009A5495 /* SceneCombiner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB03A0F5DDB3200124155 /* SceneCombiner.cpp */; };
-		F962E8CD0F5DE6C8009A5495 /* ScenePreprocessor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB03C0F5DDB3200124155 /* ScenePreprocessor.cpp */; };
-		F962E8CE0F5DE6C8009A5495 /* SortByPTypeProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0430F5DDB4600124155 /* SortByPTypeProcess.cpp */; };
-		F962E8CF0F5DE6C8009A5495 /* FindDegenerates.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0480F5DDB6100124155 /* FindDegenerates.cpp */; };
-		F962E8D00F5DE6C8009A5495 /* ComputeUVMappingProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB04D0F5DDB8D00124155 /* ComputeUVMappingProcess.cpp */; };
-		F962E8D10F5DE6C8009A5495 /* StandardShapes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0520F5DDBA800124155 /* StandardShapes.cpp */; };
-		F962E8D20F5DE6C8009A5495 /* FindInstancesProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0570F5DDBBF00124155 /* FindInstancesProcess.cpp */; };
-		F962E8D30F5DE6C8009A5495 /* RemoveVCProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB05B0F5DDBCB00124155 /* RemoveVCProcess.cpp */; };
-		F962E8D40F5DE6C8009A5495 /* FindInvalidDataProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB05F0F5DDBE600124155 /* FindInvalidDataProcess.cpp */; };
-		F962E8D50F5DE6C8009A5495 /* SkeletonMeshBuilder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0650F5DDC0700124155 /* SkeletonMeshBuilder.cpp */; };
 		F962E8D70F5DE6C8009A5495 /* B3DImporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F90BB0880F5DDE0700124155 /* B3DImporter.cpp */; };
 		F962E8ED0F5DE6E2009A5495 /* 3DSHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A880E4B716800207D74 /* 3DSHelper.h */; };
 		F962E8EE0F5DE6E2009A5495 /* 3DSLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A8A0E4B716800207D74 /* 3DSLoader.h */; };
 		F962E8EF0F5DE6E2009A5495 /* ASELoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A8F0E4B716800207D74 /* ASELoader.h */; };
 		F962E8F00F5DE6E2009A5495 /* ASEParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A910E4B716800207D74 /* ASEParser.h */; };
-		F962E8F10F5DE6E2009A5495 /* BaseImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A940E4B716800207D74 /* BaseImporter.h */; };
-		F962E8F20F5DE6E2009A5495 /* BaseProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A950E4B716800207D74 /* BaseProcess.h */; };
-		F962E8F30F5DE6E2009A5495 /* ByteSwap.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A960E4B716800207D74 /* ByteSwap.h */; };
-		F962E8F40F5DE6E2009A5495 /* CalcTangentsProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A980E4B716800207D74 /* CalcTangentsProcess.h */; };
-		F962E8F50F5DE6E2009A5495 /* ConvertToLHProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A9A0E4B716800207D74 /* ConvertToLHProcess.h */; };
-		F962E8F60F5DE6E2009A5495 /* DefaultIOStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A9C0E4B716800207D74 /* DefaultIOStream.h */; };
-		F962E8F70F5DE6E2009A5495 /* DefaultIOSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45A9E0E4B716800207D74 /* DefaultIOSystem.h */; };
-		F962E8F90F5DE6E2009A5495 /* fast_atof.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AA30E4B716800207D74 /* fast_atof.h */; };
-		F962E8FA0F5DE6E2009A5495 /* FileLogStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AA40E4B716800207D74 /* FileLogStream.h */; };
-		F962E8FB0F5DE6E2009A5495 /* GenFaceNormalsProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AA60E4B716800207D74 /* GenFaceNormalsProcess.h */; };
-		F962E8FC0F5DE6E2009A5495 /* GenVertexNormalsProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AA80E4B716800207D74 /* GenVertexNormalsProcess.h */; };
 		F962E8FD0F5DE6E2009A5495 /* HalfLifeFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AA90E4B716800207D74 /* HalfLifeFileData.h */; };
 		F962E8FE0F5DE6E2009A5495 /* HMPLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AAC0E4B716800207D74 /* HMPLoader.h */; };
-		F962E8FF0F5DE6E2009A5495 /* ImproveCacheLocality.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AAF0E4B716800207D74 /* ImproveCacheLocality.h */; };
-		F962E9000F5DE6E2009A5495 /* JoinVerticesProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AB10E4B716800207D74 /* JoinVerticesProcess.h */; };
-		F962E9010F5DE6E2009A5495 /* LimitBoneWeightsProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AB50E4B716800207D74 /* LimitBoneWeightsProcess.h */; };
-		F962E9020F5DE6E2009A5495 /* MaterialSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AB70E4B716800207D74 /* MaterialSystem.h */; };
 		F962E9030F5DE6E2009A5495 /* MD2FileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AB80E4B716800207D74 /* MD2FileData.h */; };
 		F962E9040F5DE6E2009A5495 /* MD2Loader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45ABA0E4B716800207D74 /* MD2Loader.h */; };
 		F962E9050F5DE6E2009A5495 /* MD2NormalTable.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45ABB0E4B716800207D74 /* MD2NormalTable.h */; };
@@ -1085,49 +1801,23 @@
 		F962E90A0F5DE6E2009A5495 /* MDLDefaultColorMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AC60E4B716800207D74 /* MDLDefaultColorMap.h */; };
 		F962E90B0F5DE6E2009A5495 /* MDLFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AC70E4B716800207D74 /* MDLFileData.h */; };
 		F962E90C0F5DE6E2009A5495 /* MDLLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AC90E4B716800207D74 /* MDLLoader.h */; };
-		F962E90D0F5DE6E2009A5495 /* ObjFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45ACB0E4B716800207D74 /* ObjFileData.h */; };
-		F962E90E0F5DE6E2009A5495 /* ObjFileImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45ACD0E4B716800207D74 /* ObjFileImporter.h */; };
-		F962E90F0F5DE6E2009A5495 /* ObjFileMtlImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45ACF0E4B716800207D74 /* ObjFileMtlImporter.h */; };
-		F962E9100F5DE6E2009A5495 /* ObjFileParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AD10E4B716800207D74 /* ObjFileParser.h */; };
-		F962E9110F5DE6E2009A5495 /* ObjTools.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AD20E4B716800207D74 /* ObjTools.h */; };
-		F962E9120F5DE6E2009A5495 /* ParsingUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AD30E4B716800207D74 /* ParsingUtils.h */; };
 		F962E9130F5DE6E2009A5495 /* PlyLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AD50E4B716800207D74 /* PlyLoader.h */; };
 		F962E9140F5DE6E2009A5495 /* PlyParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AD70E4B716800207D74 /* PlyParser.h */; };
-		F962E9150F5DE6E2009A5495 /* PretransformVertices.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AD90E4B716800207D74 /* PretransformVertices.h */; };
-		F962E9160F5DE6E2009A5495 /* qnan.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45ADA0E4B716800207D74 /* qnan.h */; };
-		F962E9170F5DE6E2009A5495 /* RemoveComments.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45ADC0E4B716800207D74 /* RemoveComments.h */; };
-		F962E9180F5DE6E2009A5495 /* RemoveRedundantMaterials.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45ADE0E4B716800207D74 /* RemoveRedundantMaterials.h */; };
 		F962E9190F5DE6E2009A5495 /* SMDLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AE30E4B716800207D74 /* SMDLoader.h */; };
-		F962E91A0F5DE6E2009A5495 /* SpatialSort.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AE50E4B716800207D74 /* SpatialSort.h */; };
-		F962E91B0F5DE6E2009A5495 /* SplitLargeMeshes.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AE70E4B716800207D74 /* SplitLargeMeshes.h */; };
-		F962E91C0F5DE6E2009A5495 /* STLLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AE90E4B716800207D74 /* STLLoader.h */; };
-		F962E91D0F5DE6E2009A5495 /* StringComparison.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AEA0E4B716800207D74 /* StringComparison.h */; };
-		F962E91E0F5DE6E2009A5495 /* TextureTransform.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AEC0E4B716800207D74 /* TextureTransform.h */; };
-		F962E91F0F5DE6E2009A5495 /* TriangulateProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AEE0E4B716800207D74 /* TriangulateProcess.h */; };
-		F962E9200F5DE6E2009A5495 /* ValidateDataStructure.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AF00E4B716800207D74 /* ValidateDataStructure.h */; };
-		F962E9210F5DE6E2009A5495 /* VertexTriangleAdjacency.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AF20E4B716800207D74 /* VertexTriangleAdjacency.h */; };
-		F962E9220F5DE6E2009A5495 /* Win32DebugLogStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AF30E4B716800207D74 /* Win32DebugLogStream.h */; };
 		F962E9230F5DE6E2009A5495 /* XFileHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AF40E4B716800207D74 /* XFileHelper.h */; };
 		F962E9240F5DE6E2009A5495 /* XFileImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AF60E4B716800207D74 /* XFileImporter.h */; };
 		F962E9250F5DE6E2009A5495 /* XFileParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AF45AF80E4B716800207D74 /* XFileParser.h */; };
 		F962E9280F5DE6E2009A5495 /* MDCFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3AB0E50D67A00606590 /* MDCFileData.h */; };
 		F962E9290F5DE6E2009A5495 /* MDCLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3AD0E50D67A00606590 /* MDCLoader.h */; };
 		F962E92A0F5DE6E2009A5495 /* MDCNormalTable.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3AE0E50D67A00606590 /* MDCNormalTable.h */; };
-		F962E92B0F5DE6E2009A5495 /* FixNormalsStep.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3B40E50D69D00606590 /* FixNormalsStep.h */; };
 		F962E92C0F5DE6E2009A5495 /* LWOFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3B70E50D6DB00606590 /* LWOFileData.h */; };
 		F962E92D0F5DE6E2009A5495 /* LWOLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3B90E50D6DB00606590 /* LWOLoader.h */; };
 		F962E92E0F5DE6E2009A5495 /* HMPFileData.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3C50E50D77900606590 /* HMPFileData.h */; };
-		F962E9300F5DE6E2009A5495 /* IFF.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3C90E50D7CC00606590 /* IFF.h */; };
-		F962E9310F5DE6E2009A5495 /* Hash.h in Headers */ = {isa = PBXBuildFile; fileRef = 3AB8A3CB0E50D7FF00606590 /* Hash.h */; };
 		F962E9360F5DE6E2009A5495 /* ACLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFD10F5DD87000124155 /* ACLoader.h */; };
 		F962E9370F5DE6E2009A5495 /* IRRLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFDA0F5DD90800124155 /* IRRLoader.h */; };
 		F962E9380F5DE6E2009A5495 /* IRRMeshLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFDC0F5DD90800124155 /* IRRMeshLoader.h */; };
 		F962E9390F5DE6E2009A5495 /* IRRShared.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFDE0F5DD90800124155 /* IRRShared.h */; };
-		F962E93A0F5DE6E2009A5495 /* ColladaHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFE80F5DD93600124155 /* ColladaHelper.h */; };
-		F962E93B0F5DE6E2009A5495 /* ColladaLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFEA0F5DD93600124155 /* ColladaLoader.h */; };
-		F962E93C0F5DE6E2009A5495 /* ColladaParser.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFEC0F5DD93600124155 /* ColladaParser.h */; };
 		F962E93D0F5DE6E2009A5495 /* NFFLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFF50F5DD96100124155 /* NFFLoader.h */; };
-		F962E93E0F5DE6E2009A5495 /* SGSpatialSort.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BAFFB0F5DD9A000124155 /* SGSpatialSort.h */; };
 		F962E93F0F5DE6E2009A5495 /* Q3DLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0070F5DD9DD00124155 /* Q3DLoader.h */; };
 		F962E9400F5DE6E2009A5495 /* BVHLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB00C0F5DD9F400124155 /* BVHLoader.h */; };
 		F962E9410F5DE6E2009A5495 /* OFFLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0130F5DDA1400124155 /* OFFLoader.h */; };
@@ -1135,102 +1825,11 @@
 		F962E9430F5DE6E2009A5495 /* DXFLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0210F5DDA5700124155 /* DXFLoader.h */; };
 		F962E9440F5DE6E2009A5495 /* TerragenLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB02F0F5DDAB500124155 /* TerragenLoader.h */; };
 		F962E9450F5DE6E2009A5495 /* irrXMLWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0360F5DDB1B00124155 /* irrXMLWrapper.h */; };
-		F962E9460F5DE6E2009A5495 /* ScenePreprocessor.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0390F5DDB3200124155 /* ScenePreprocessor.h */; };
-		F962E9470F5DE6E2009A5495 /* SceneCombiner.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB03B0F5DDB3200124155 /* SceneCombiner.h */; };
-		F962E9480F5DE6E2009A5495 /* SortByPTypeProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0420F5DDB4600124155 /* SortByPTypeProcess.h */; };
-		F962E9490F5DE6E2009A5495 /* FindDegenerates.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0470F5DDB6100124155 /* FindDegenerates.h */; };
-		F962E94A0F5DE6E2009A5495 /* ComputeUVMappingProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB04C0F5DDB8D00124155 /* ComputeUVMappingProcess.h */; };
-		F962E94B0F5DE6E2009A5495 /* StandardShapes.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0510F5DDBA800124155 /* StandardShapes.h */; };
-		F962E94C0F5DE6E2009A5495 /* FindInstancesProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0560F5DDBBF00124155 /* FindInstancesProcess.h */; };
-		F962E94D0F5DE6E2009A5495 /* RemoveVCProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB05A0F5DDBCB00124155 /* RemoveVCProcess.h */; };
-		F962E94E0F5DE6E2009A5495 /* FindInvalidDataProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0600F5DDBE600124155 /* FindInvalidDataProcess.h */; };
-		F962E94F0F5DE6E2009A5495 /* SkeletonMeshBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0640F5DDC0700124155 /* SkeletonMeshBuilder.h */; };
-		F962E9500F5DE6E2009A5495 /* SmoothingGroups.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0690F5DDC1E00124155 /* SmoothingGroups.h */; };
 		F962E9570F5DE6E2009A5495 /* B3DImporter.h in Headers */ = {isa = PBXBuildFile; fileRef = F90BB0870F5DDE0700124155 /* B3DImporter.h */; };
 		F97BA03615439DB3009EB9DD /* ai_assert.h in Headers */ = {isa = PBXBuildFile; fileRef = F97BA03515439DB3009EB9DD /* ai_assert.h */; };
 		F97BA03715439DB3009EB9DD /* ai_assert.h in Headers */ = {isa = PBXBuildFile; fileRef = F97BA03515439DB3009EB9DD /* ai_assert.h */; };
 		F97BA03815439DB3009EB9DD /* ai_assert.h in Headers */ = {isa = PBXBuildFile; fileRef = F97BA03515439DB3009EB9DD /* ai_assert.h */; };
 		F97BA03915439DB3009EB9DD /* ai_assert.h in Headers */ = {isa = PBXBuildFile; fileRef = F97BA03515439DB3009EB9DD /* ai_assert.h */; };
-		F97BA07015439FC3009EB9DD /* IFCCurve.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F97BA06615439FC3009EB9DD /* IFCCurve.cpp */; };
-		F97BA07115439FC3009EB9DD /* IFCGeometry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F97BA06715439FC3009EB9DD /* IFCGeometry.cpp */; };
-		F97BA07215439FC3009EB9DD /* IFCLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F97BA06815439FC3009EB9DD /* IFCLoader.cpp */; };
-		F97BA07315439FC3009EB9DD /* IFCLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F97BA06915439FC3009EB9DD /* IFCLoader.h */; };
-		F97BA07415439FC3009EB9DD /* IFCMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F97BA06A15439FC3009EB9DD /* IFCMaterial.cpp */; };
-		F97BA07515439FC3009EB9DD /* IFCProfile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F97BA06B15439FC3009EB9DD /* IFCProfile.cpp */; };
-		F97BA07615439FC3009EB9DD /* IFCReaderGen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F97BA06C15439FC3009EB9DD /* IFCReaderGen.cpp */; };
-		F97BA07715439FC3009EB9DD /* IFCReaderGen.h in Headers */ = {isa = PBXBuildFile; fileRef = F97BA06D15439FC3009EB9DD /* IFCReaderGen.h */; };
-		F97BA07815439FC3009EB9DD /* IFCUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F97BA06E15439FC3009EB9DD /* IFCUtil.cpp */; };
-		F97BA07915439FC3009EB9DD /* IFCUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = F97BA06F15439FC3009EB9DD /* IFCUtil.h */; };
-		F97BA07A15439FC3009EB9DD /* IFCCurve.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F97BA06615439FC3009EB9DD /* IFCCurve.cpp */; };
-		F97BA07B15439FC3009EB9DD /* IFCGeometry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F97BA06715439FC3009EB9DD /* IFCGeometry.cpp */; };
-		F97BA07C15439FC3009EB9DD /* IFCLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F97BA06815439FC3009EB9DD /* IFCLoader.cpp */; };
-		F97BA07D15439FC3009EB9DD /* IFCLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F97BA06915439FC3009EB9DD /* IFCLoader.h */; };
-		F97BA07E15439FC3009EB9DD /* IFCMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F97BA06A15439FC3009EB9DD /* IFCMaterial.cpp */; };
-		F97BA07F15439FC3009EB9DD /* IFCProfile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F97BA06B15439FC3009EB9DD /* IFCProfile.cpp */; };
-		F97BA08015439FC3009EB9DD /* IFCReaderGen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F97BA06C15439FC3009EB9DD /* IFCReaderGen.cpp */; };
-		F97BA08115439FC3009EB9DD /* IFCReaderGen.h in Headers */ = {isa = PBXBuildFile; fileRef = F97BA06D15439FC3009EB9DD /* IFCReaderGen.h */; };
-		F97BA08215439FC3009EB9DD /* IFCUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F97BA06E15439FC3009EB9DD /* IFCUtil.cpp */; };
-		F97BA08315439FC3009EB9DD /* IFCUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = F97BA06F15439FC3009EB9DD /* IFCUtil.h */; };
-		F97BA08415439FC3009EB9DD /* IFCCurve.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F97BA06615439FC3009EB9DD /* IFCCurve.cpp */; };
-		F97BA08515439FC3009EB9DD /* IFCGeometry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F97BA06715439FC3009EB9DD /* IFCGeometry.cpp */; };
-		F97BA08615439FC3009EB9DD /* IFCLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F97BA06815439FC3009EB9DD /* IFCLoader.cpp */; };
-		F97BA08715439FC3009EB9DD /* IFCLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F97BA06915439FC3009EB9DD /* IFCLoader.h */; };
-		F97BA08815439FC3009EB9DD /* IFCMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F97BA06A15439FC3009EB9DD /* IFCMaterial.cpp */; };
-		F97BA08915439FC3009EB9DD /* IFCProfile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F97BA06B15439FC3009EB9DD /* IFCProfile.cpp */; };
-		F97BA08A15439FC3009EB9DD /* IFCReaderGen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F97BA06C15439FC3009EB9DD /* IFCReaderGen.cpp */; };
-		F97BA08B15439FC3009EB9DD /* IFCReaderGen.h in Headers */ = {isa = PBXBuildFile; fileRef = F97BA06D15439FC3009EB9DD /* IFCReaderGen.h */; };
-		F97BA08C15439FC3009EB9DD /* IFCUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F97BA06E15439FC3009EB9DD /* IFCUtil.cpp */; };
-		F97BA08D15439FC3009EB9DD /* IFCUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = F97BA06F15439FC3009EB9DD /* IFCUtil.h */; };
-		F97BA08E15439FC3009EB9DD /* IFCCurve.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F97BA06615439FC3009EB9DD /* IFCCurve.cpp */; };
-		F97BA08F15439FC3009EB9DD /* IFCGeometry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F97BA06715439FC3009EB9DD /* IFCGeometry.cpp */; };
-		F97BA09015439FC3009EB9DD /* IFCLoader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F97BA06815439FC3009EB9DD /* IFCLoader.cpp */; };
-		F97BA09115439FC3009EB9DD /* IFCLoader.h in Headers */ = {isa = PBXBuildFile; fileRef = F97BA06915439FC3009EB9DD /* IFCLoader.h */; };
-		F97BA09215439FC3009EB9DD /* IFCMaterial.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F97BA06A15439FC3009EB9DD /* IFCMaterial.cpp */; };
-		F97BA09315439FC3009EB9DD /* IFCProfile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F97BA06B15439FC3009EB9DD /* IFCProfile.cpp */; };
-		F97BA09415439FC3009EB9DD /* IFCReaderGen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F97BA06C15439FC3009EB9DD /* IFCReaderGen.cpp */; };
-		F97BA09515439FC3009EB9DD /* IFCReaderGen.h in Headers */ = {isa = PBXBuildFile; fileRef = F97BA06D15439FC3009EB9DD /* IFCReaderGen.h */; };
-		F97BA09615439FC3009EB9DD /* IFCUtil.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F97BA06E15439FC3009EB9DD /* IFCUtil.cpp */; };
-		F97BA09715439FC3009EB9DD /* IFCUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = F97BA06F15439FC3009EB9DD /* IFCUtil.h */; };
-		F99A9EB415436077000682F3 /* BlobIOSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9EB315436077000682F3 /* BlobIOSystem.h */; };
-		F99A9EB515436077000682F3 /* BlobIOSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9EB315436077000682F3 /* BlobIOSystem.h */; };
-		F99A9EB615436077000682F3 /* BlobIOSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9EB315436077000682F3 /* BlobIOSystem.h */; };
-		F99A9EB715436077000682F3 /* BlobIOSystem.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9EB315436077000682F3 /* BlobIOSystem.h */; };
-		F99A9EB915436098000682F3 /* lexical_cast.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F99A9EB815436098000682F3 /* lexical_cast.hpp */; };
-		F99A9EBA15436098000682F3 /* lexical_cast.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F99A9EB815436098000682F3 /* lexical_cast.hpp */; };
-		F99A9EBB15436098000682F3 /* lexical_cast.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F99A9EB815436098000682F3 /* lexical_cast.hpp */; };
-		F99A9EBC15436098000682F3 /* lexical_cast.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F99A9EB815436098000682F3 /* lexical_cast.hpp */; };
-		F99A9EBE154360A0000682F3 /* make_shared.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F99A9EBD154360A0000682F3 /* make_shared.hpp */; };
-		F99A9EBF154360A0000682F3 /* make_shared.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F99A9EBD154360A0000682F3 /* make_shared.hpp */; };
-		F99A9EC0154360A0000682F3 /* make_shared.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F99A9EBD154360A0000682F3 /* make_shared.hpp */; };
-		F99A9EC1154360A0000682F3 /* make_shared.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F99A9EBD154360A0000682F3 /* make_shared.hpp */; };
-		F99A9EC3154360A5000682F3 /* noncopyable.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F99A9EC2154360A5000682F3 /* noncopyable.hpp */; };
-		F99A9EC4154360A5000682F3 /* noncopyable.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F99A9EC2154360A5000682F3 /* noncopyable.hpp */; };
-		F99A9EC5154360A5000682F3 /* noncopyable.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F99A9EC2154360A5000682F3 /* noncopyable.hpp */; };
-		F99A9EC6154360A5000682F3 /* noncopyable.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F99A9EC2154360A5000682F3 /* noncopyable.hpp */; };
-		F99A9EC8154360B5000682F3 /* timer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F99A9EC7154360B5000682F3 /* timer.hpp */; };
-		F99A9EC9154360B5000682F3 /* timer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F99A9EC7154360B5000682F3 /* timer.hpp */; };
-		F99A9ECA154360B5000682F3 /* timer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F99A9EC7154360B5000682F3 /* timer.hpp */; };
-		F99A9ECB154360B5000682F3 /* timer.hpp in Headers */ = {isa = PBXBuildFile; fileRef = F99A9EC7154360B5000682F3 /* timer.hpp */; };
-		F99A9ECD154360E2000682F3 /* CInterfaceIOWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9ECC154360E2000682F3 /* CInterfaceIOWrapper.h */; };
-		F99A9ECE154360E2000682F3 /* CInterfaceIOWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9ECC154360E2000682F3 /* CInterfaceIOWrapper.h */; };
-		F99A9ECF154360E2000682F3 /* CInterfaceIOWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9ECC154360E2000682F3 /* CInterfaceIOWrapper.h */; };
-		F99A9ED0154360E2000682F3 /* CInterfaceIOWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9ECC154360E2000682F3 /* CInterfaceIOWrapper.h */; };
-		F99A9ED315436125000682F3 /* DeboneProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F99A9ED115436125000682F3 /* DeboneProcess.cpp */; };
-		F99A9ED415436125000682F3 /* DeboneProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9ED215436125000682F3 /* DeboneProcess.h */; };
-		F99A9ED515436125000682F3 /* DeboneProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F99A9ED115436125000682F3 /* DeboneProcess.cpp */; };
-		F99A9ED615436125000682F3 /* DeboneProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9ED215436125000682F3 /* DeboneProcess.h */; };
-		F99A9ED715436125000682F3 /* DeboneProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F99A9ED115436125000682F3 /* DeboneProcess.cpp */; };
-		F99A9ED815436125000682F3 /* DeboneProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9ED215436125000682F3 /* DeboneProcess.h */; };
-		F99A9ED915436125000682F3 /* DeboneProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F99A9ED115436125000682F3 /* DeboneProcess.cpp */; };
-		F99A9EDA15436125000682F3 /* DeboneProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9ED215436125000682F3 /* DeboneProcess.h */; };
-		F99A9F18154361AD000682F3 /* ImporterRegistry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F99A9F17154361AD000682F3 /* ImporterRegistry.cpp */; };
-		F99A9F19154361AD000682F3 /* ImporterRegistry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F99A9F17154361AD000682F3 /* ImporterRegistry.cpp */; };
-		F99A9F1A154361AD000682F3 /* ImporterRegistry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F99A9F17154361AD000682F3 /* ImporterRegistry.cpp */; };
-		F99A9F1B154361AD000682F3 /* ImporterRegistry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F99A9F17154361AD000682F3 /* ImporterRegistry.cpp */; };
-		F99A9F1D154361D4000682F3 /* LogAux.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9F1C154361D4000682F3 /* LogAux.h */; };
-		F99A9F1E154361D4000682F3 /* LogAux.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9F1C154361D4000682F3 /* LogAux.h */; };
-		F99A9F1F154361D4000682F3 /* LogAux.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9F1C154361D4000682F3 /* LogAux.h */; };
-		F99A9F20154361D4000682F3 /* LogAux.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9F1C154361D4000682F3 /* LogAux.h */; };
 		F99A9F2815436207000682F3 /* M3Importer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F99A9F2615436207000682F3 /* M3Importer.cpp */; };
 		F99A9F2915436207000682F3 /* M3Importer.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9F2715436207000682F3 /* M3Importer.h */; };
 		F99A9F2A15436207000682F3 /* M3Importer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F99A9F2615436207000682F3 /* M3Importer.cpp */; };
@@ -1247,38 +1846,6 @@
 		F99A9F3715436269000682F3 /* PlyExporter.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9F3115436269000682F3 /* PlyExporter.h */; };
 		F99A9F3815436269000682F3 /* PlyExporter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F99A9F3015436269000682F3 /* PlyExporter.cpp */; };
 		F99A9F3915436269000682F3 /* PlyExporter.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9F3115436269000682F3 /* PlyExporter.h */; };
-		F99A9F3B15436286000682F3 /* PolyTools.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9F3A15436286000682F3 /* PolyTools.h */; };
-		F99A9F3C15436286000682F3 /* PolyTools.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9F3A15436286000682F3 /* PolyTools.h */; };
-		F99A9F3D15436286000682F3 /* PolyTools.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9F3A15436286000682F3 /* PolyTools.h */; };
-		F99A9F3E15436286000682F3 /* PolyTools.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9F3A15436286000682F3 /* PolyTools.h */; };
-		F99A9F401543629F000682F3 /* PostStepRegistry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F99A9F3F1543629F000682F3 /* PostStepRegistry.cpp */; };
-		F99A9F411543629F000682F3 /* PostStepRegistry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F99A9F3F1543629F000682F3 /* PostStepRegistry.cpp */; };
-		F99A9F421543629F000682F3 /* PostStepRegistry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F99A9F3F1543629F000682F3 /* PostStepRegistry.cpp */; };
-		F99A9F431543629F000682F3 /* PostStepRegistry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F99A9F3F1543629F000682F3 /* PostStepRegistry.cpp */; };
-		F99A9F45154362DE000682F3 /* ScenePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9F44154362DE000682F3 /* ScenePrivate.h */; };
-		F99A9F46154362DE000682F3 /* ScenePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9F44154362DE000682F3 /* ScenePrivate.h */; };
-		F99A9F47154362DE000682F3 /* ScenePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9F44154362DE000682F3 /* ScenePrivate.h */; };
-		F99A9F48154362DE000682F3 /* ScenePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9F44154362DE000682F3 /* ScenePrivate.h */; };
-		F99A9F4B15436304000682F3 /* SplitByBoneCountProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F99A9F4915436304000682F3 /* SplitByBoneCountProcess.cpp */; };
-		F99A9F4C15436304000682F3 /* SplitByBoneCountProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9F4A15436304000682F3 /* SplitByBoneCountProcess.h */; };
-		F99A9F4D15436304000682F3 /* SplitByBoneCountProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F99A9F4915436304000682F3 /* SplitByBoneCountProcess.cpp */; };
-		F99A9F4E15436304000682F3 /* SplitByBoneCountProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9F4A15436304000682F3 /* SplitByBoneCountProcess.h */; };
-		F99A9F4F15436304000682F3 /* SplitByBoneCountProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F99A9F4915436304000682F3 /* SplitByBoneCountProcess.cpp */; };
-		F99A9F5015436304000682F3 /* SplitByBoneCountProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9F4A15436304000682F3 /* SplitByBoneCountProcess.h */; };
-		F99A9F5115436304000682F3 /* SplitByBoneCountProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F99A9F4915436304000682F3 /* SplitByBoneCountProcess.cpp */; };
-		F99A9F5215436304000682F3 /* SplitByBoneCountProcess.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9F4A15436304000682F3 /* SplitByBoneCountProcess.h */; };
-		F99A9F5C15436323000682F3 /* STEPFile.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9F5915436323000682F3 /* STEPFile.h */; };
-		F99A9F5D15436323000682F3 /* STEPFileReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F99A9F5A15436323000682F3 /* STEPFileReader.cpp */; };
-		F99A9F5E15436323000682F3 /* STEPFileReader.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9F5B15436323000682F3 /* STEPFileReader.h */; };
-		F99A9F5F15436323000682F3 /* STEPFile.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9F5915436323000682F3 /* STEPFile.h */; };
-		F99A9F6015436323000682F3 /* STEPFileReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F99A9F5A15436323000682F3 /* STEPFileReader.cpp */; };
-		F99A9F6115436323000682F3 /* STEPFileReader.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9F5B15436323000682F3 /* STEPFileReader.h */; };
-		F99A9F6215436323000682F3 /* STEPFile.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9F5915436323000682F3 /* STEPFile.h */; };
-		F99A9F6315436323000682F3 /* STEPFileReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F99A9F5A15436323000682F3 /* STEPFileReader.cpp */; };
-		F99A9F6415436323000682F3 /* STEPFileReader.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9F5B15436323000682F3 /* STEPFileReader.h */; };
-		F99A9F6515436323000682F3 /* STEPFile.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9F5915436323000682F3 /* STEPFile.h */; };
-		F99A9F6615436323000682F3 /* STEPFileReader.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F99A9F5A15436323000682F3 /* STEPFileReader.cpp */; };
-		F99A9F6715436323000682F3 /* STEPFileReader.h in Headers */ = {isa = PBXBuildFile; fileRef = F99A9F5B15436323000682F3 /* STEPFileReader.h */; };
 		F9BA8B9F1543268400E63FFE /* anim.h in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8B751543268400E63FFE /* anim.h */; };
 		F9BA8BA11543268400E63FFE /* camera.h in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8B771543268400E63FFE /* camera.h */; };
 		F9BA8BA21543268400E63FFE /* cexport.h in Headers */ = {isa = PBXBuildFile; fileRef = F9BA8B781543268400E63FFE /* cexport.h */; };
@@ -1438,19 +2005,213 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		2B7F456D1708365100A106A9 /* assbin_chunks.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = assbin_chunks.h; sourceTree = "<group>"; };
+		2B7F456E1708365100A106A9 /* Assimp.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Assimp.cpp; sourceTree = "<group>"; };
+		2B7F456F1708365100A106A9 /* AssimpCExport.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AssimpCExport.cpp; sourceTree = "<group>"; };
+		2B7F45741708365100A106A9 /* BaseImporter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BaseImporter.cpp; sourceTree = "<group>"; };
+		2B7F45751708365100A106A9 /* BaseImporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BaseImporter.h; sourceTree = "<group>"; };
+		2B7F45761708365100A106A9 /* BaseProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BaseProcess.cpp; sourceTree = "<group>"; };
+		2B7F45771708365100A106A9 /* BaseProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BaseProcess.h; sourceTree = "<group>"; };
+		2B7F45831708365100A106A9 /* BlobIOSystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BlobIOSystem.h; sourceTree = "<group>"; };
+		2B7F45861708365100A106A9 /* foreach.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = foreach.hpp; sourceTree = "<group>"; };
+		2B7F45871708365100A106A9 /* format.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = format.hpp; sourceTree = "<group>"; };
+		2B7F45881708365100A106A9 /* lexical_cast.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = lexical_cast.hpp; sourceTree = "<group>"; };
+		2B7F45891708365100A106A9 /* LICENSE_1_0.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE_1_0.txt; sourceTree = "<group>"; };
+		2B7F458A1708365100A106A9 /* make_shared.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = make_shared.hpp; sourceTree = "<group>"; };
+		2B7F458C1708365100A106A9 /* common_factor_rt.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = common_factor_rt.hpp; sourceTree = "<group>"; };
+		2B7F458D1708365100A106A9 /* noncopyable.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = noncopyable.hpp; sourceTree = "<group>"; };
+		2B7F458E1708365100A106A9 /* pointer_cast.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = pointer_cast.hpp; sourceTree = "<group>"; };
+		2B7F458F1708365100A106A9 /* scoped_array.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = scoped_array.hpp; sourceTree = "<group>"; };
+		2B7F45901708365100A106A9 /* scoped_ptr.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = scoped_ptr.hpp; sourceTree = "<group>"; };
+		2B7F45911708365100A106A9 /* shared_array.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = shared_array.hpp; sourceTree = "<group>"; };
+		2B7F45921708365100A106A9 /* shared_ptr.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = shared_ptr.hpp; sourceTree = "<group>"; };
+		2B7F45931708365100A106A9 /* static_assert.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = static_assert.hpp; sourceTree = "<group>"; };
+		2B7F45941708365100A106A9 /* timer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = timer.hpp; sourceTree = "<group>"; };
+		2B7F45961708365100A106A9 /* tuple.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = tuple.hpp; sourceTree = "<group>"; };
+		2B7F45991708365100A106A9 /* ByteSwap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ByteSwap.h; sourceTree = "<group>"; };
+		2B7F459A1708365100A106A9 /* CalcTangentsProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CalcTangentsProcess.cpp; sourceTree = "<group>"; };
+		2B7F459B1708365100A106A9 /* CalcTangentsProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CalcTangentsProcess.h; sourceTree = "<group>"; };
+		2B7F459C1708365100A106A9 /* CInterfaceIOWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CInterfaceIOWrapper.h; sourceTree = "<group>"; };
+		2B7F45A11708365100A106A9 /* ColladaExporter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ColladaExporter.cpp; sourceTree = "<group>"; };
+		2B7F45A21708365100A106A9 /* ColladaExporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ColladaExporter.h; sourceTree = "<group>"; };
+		2B7F45A31708365100A106A9 /* ColladaHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ColladaHelper.h; sourceTree = "<group>"; };
+		2B7F45A41708365100A106A9 /* ColladaLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ColladaLoader.cpp; sourceTree = "<group>"; };
+		2B7F45A51708365100A106A9 /* ColladaLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ColladaLoader.h; sourceTree = "<group>"; };
+		2B7F45A61708365100A106A9 /* ColladaParser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ColladaParser.cpp; sourceTree = "<group>"; };
+		2B7F45A71708365100A106A9 /* ColladaParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ColladaParser.h; sourceTree = "<group>"; };
+		2B7F45A81708365100A106A9 /* ComputeUVMappingProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ComputeUVMappingProcess.cpp; sourceTree = "<group>"; };
+		2B7F45A91708365100A106A9 /* ComputeUVMappingProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ComputeUVMappingProcess.h; sourceTree = "<group>"; };
+		2B7F45AA1708365100A106A9 /* ConvertToLHProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConvertToLHProcess.cpp; sourceTree = "<group>"; };
+		2B7F45AB1708365100A106A9 /* ConvertToLHProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConvertToLHProcess.h; sourceTree = "<group>"; };
+		2B7F45AE1708365100A106A9 /* DeboneProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DeboneProcess.cpp; sourceTree = "<group>"; };
+		2B7F45AF1708365100A106A9 /* DeboneProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DeboneProcess.h; sourceTree = "<group>"; };
+		2B7F45B01708365100A106A9 /* DefaultIOStream.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DefaultIOStream.cpp; sourceTree = "<group>"; };
+		2B7F45B11708365100A106A9 /* DefaultIOStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DefaultIOStream.h; sourceTree = "<group>"; };
+		2B7F45B21708365100A106A9 /* DefaultIOSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DefaultIOSystem.cpp; sourceTree = "<group>"; };
+		2B7F45B31708365100A106A9 /* DefaultIOSystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DefaultIOSystem.h; sourceTree = "<group>"; };
+		2B7F45B41708365100A106A9 /* DefaultLogger.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DefaultLogger.cpp; sourceTree = "<group>"; };
+		2B7F45B51708365100A106A9 /* DefaultProgressHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DefaultProgressHandler.h; sourceTree = "<group>"; };
+		2B7F45B91708365100A106A9 /* Exceptional.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Exceptional.h; sourceTree = "<group>"; };
+		2B7F45BA1708365100A106A9 /* Exporter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Exporter.cpp; sourceTree = "<group>"; };
+		2B7F45BB1708365100A106A9 /* fast_atof.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fast_atof.h; sourceTree = "<group>"; };
+		2B7F45BC1708365100A106A9 /* FBXAnimation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FBXAnimation.cpp; sourceTree = "<group>"; };
+		2B7F45BD1708365100A106A9 /* FBXBinaryTokenizer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FBXBinaryTokenizer.cpp; sourceTree = "<group>"; };
+		2B7F45BE1708365100A106A9 /* FBXCompileConfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBXCompileConfig.h; sourceTree = "<group>"; };
+		2B7F45BF1708365100A106A9 /* FBXConverter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FBXConverter.cpp; sourceTree = "<group>"; };
+		2B7F45C01708365100A106A9 /* FBXConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBXConverter.h; sourceTree = "<group>"; };
+		2B7F45C11708365100A106A9 /* FBXDeformer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FBXDeformer.cpp; sourceTree = "<group>"; };
+		2B7F45C21708365100A106A9 /* FBXDocument.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FBXDocument.cpp; sourceTree = "<group>"; };
+		2B7F45C31708365100A106A9 /* FBXDocument.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBXDocument.h; sourceTree = "<group>"; };
+		2B7F45C41708365100A106A9 /* FBXDocumentUtil.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FBXDocumentUtil.cpp; sourceTree = "<group>"; };
+		2B7F45C51708365100A106A9 /* FBXDocumentUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBXDocumentUtil.h; sourceTree = "<group>"; };
+		2B7F45C61708365100A106A9 /* FBXImporter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FBXImporter.cpp; sourceTree = "<group>"; };
+		2B7F45C71708365100A106A9 /* FBXImporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBXImporter.h; sourceTree = "<group>"; };
+		2B7F45C81708365100A106A9 /* FBXImportSettings.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBXImportSettings.h; sourceTree = "<group>"; };
+		2B7F45C91708365100A106A9 /* FBXMaterial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FBXMaterial.cpp; sourceTree = "<group>"; };
+		2B7F45CA1708365100A106A9 /* FBXMeshGeometry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FBXMeshGeometry.cpp; sourceTree = "<group>"; };
+		2B7F45CB1708365100A106A9 /* FBXModel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FBXModel.cpp; sourceTree = "<group>"; };
+		2B7F45CC1708365100A106A9 /* FBXNodeAttribute.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FBXNodeAttribute.cpp; sourceTree = "<group>"; };
+		2B7F45CD1708365100A106A9 /* FBXParser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FBXParser.cpp; sourceTree = "<group>"; };
+		2B7F45CE1708365100A106A9 /* FBXParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBXParser.h; sourceTree = "<group>"; };
+		2B7F45CF1708365100A106A9 /* FBXProperties.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FBXProperties.cpp; sourceTree = "<group>"; };
+		2B7F45D01708365100A106A9 /* FBXProperties.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBXProperties.h; sourceTree = "<group>"; };
+		2B7F45D11708365100A106A9 /* FBXTokenizer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FBXTokenizer.cpp; sourceTree = "<group>"; };
+		2B7F45D21708365100A106A9 /* FBXTokenizer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBXTokenizer.h; sourceTree = "<group>"; };
+		2B7F45D31708365100A106A9 /* FBXUtil.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FBXUtil.cpp; sourceTree = "<group>"; };
+		2B7F45D41708365100A106A9 /* FBXUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBXUtil.h; sourceTree = "<group>"; };
+		2B7F45D51708365100A106A9 /* FileLogStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FileLogStream.h; sourceTree = "<group>"; };
+		2B7F45D61708365100A106A9 /* FileSystemFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FileSystemFilter.h; sourceTree = "<group>"; };
+		2B7F45D71708365100A106A9 /* FindDegenerates.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FindDegenerates.cpp; sourceTree = "<group>"; };
+		2B7F45D81708365100A106A9 /* FindDegenerates.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FindDegenerates.h; sourceTree = "<group>"; };
+		2B7F45D91708365100A106A9 /* FindInstancesProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FindInstancesProcess.cpp; sourceTree = "<group>"; };
+		2B7F45DA1708365100A106A9 /* FindInstancesProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FindInstancesProcess.h; sourceTree = "<group>"; };
+		2B7F45DB1708365100A106A9 /* FindInvalidDataProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FindInvalidDataProcess.cpp; sourceTree = "<group>"; };
+		2B7F45DC1708365100A106A9 /* FindInvalidDataProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FindInvalidDataProcess.h; sourceTree = "<group>"; };
+		2B7F45DD1708365100A106A9 /* FixNormalsStep.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FixNormalsStep.cpp; sourceTree = "<group>"; };
+		2B7F45DE1708365100A106A9 /* FixNormalsStep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FixNormalsStep.h; sourceTree = "<group>"; };
+		2B7F45DF1708365100A106A9 /* GenericProperty.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GenericProperty.h; sourceTree = "<group>"; };
+		2B7F45E01708365100A106A9 /* GenFaceNormalsProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GenFaceNormalsProcess.cpp; sourceTree = "<group>"; };
+		2B7F45E11708365100A106A9 /* GenFaceNormalsProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GenFaceNormalsProcess.h; sourceTree = "<group>"; };
+		2B7F45E21708365100A106A9 /* GenVertexNormalsProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GenVertexNormalsProcess.cpp; sourceTree = "<group>"; };
+		2B7F45E31708365100A106A9 /* GenVertexNormalsProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GenVertexNormalsProcess.h; sourceTree = "<group>"; };
+		2B7F45E51708365100A106A9 /* Hash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Hash.h; sourceTree = "<group>"; };
+		2B7F45E91708365100A106A9 /* IFCBoolean.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IFCBoolean.cpp; path = ../../code/IFCBoolean.cpp; sourceTree = "<group>"; };
+		2B7F45EA1708365100A106A9 /* IFCCurve.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IFCCurve.cpp; path = ../../code/IFCCurve.cpp; sourceTree = "<group>"; };
+		2B7F45EB1708365100A106A9 /* IFCGeometry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IFCGeometry.cpp; path = ../../code/IFCGeometry.cpp; sourceTree = "<group>"; };
+		2B7F45EC1708365100A106A9 /* IFCLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IFCLoader.cpp; path = ../../code/IFCLoader.cpp; sourceTree = "<group>"; };
+		2B7F45ED1708365100A106A9 /* IFCLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IFCLoader.h; path = ../../code/IFCLoader.h; sourceTree = "<group>"; };
+		2B7F45EE1708365100A106A9 /* IFCMaterial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IFCMaterial.cpp; path = ../../code/IFCMaterial.cpp; sourceTree = "<group>"; };
+		2B7F45EF1708365100A106A9 /* IFCOpenings.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IFCOpenings.cpp; path = ../../code/IFCOpenings.cpp; sourceTree = "<group>"; };
+		2B7F45F01708365100A106A9 /* IFCProfile.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IFCProfile.cpp; path = ../../code/IFCProfile.cpp; sourceTree = "<group>"; };
+		2B7F45F11708365100A106A9 /* IFCReaderGen.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IFCReaderGen.cpp; path = ../../code/IFCReaderGen.cpp; sourceTree = "<group>"; };
+		2B7F45F21708365100A106A9 /* IFCReaderGen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IFCReaderGen.h; path = ../../code/IFCReaderGen.h; sourceTree = "<group>"; };
+		2B7F45F31708365100A106A9 /* IFCUtil.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IFCUtil.cpp; path = ../../code/IFCUtil.cpp; sourceTree = "<group>"; };
+		2B7F45F41708365100A106A9 /* IFCUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IFCUtil.h; path = ../../code/IFCUtil.h; sourceTree = "<group>"; };
+		2B7F45F51708365100A106A9 /* IFF.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IFF.h; sourceTree = "<group>"; };
+		2B7F45F61708365100A106A9 /* Importer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Importer.cpp; sourceTree = "<group>"; };
+		2B7F45F71708365100A106A9 /* Importer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Importer.h; sourceTree = "<group>"; };
+		2B7F45F81708365100A106A9 /* ImporterRegistry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ImporterRegistry.cpp; sourceTree = "<group>"; };
+		2B7F45F91708365100A106A9 /* ImproveCacheLocality.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ImproveCacheLocality.cpp; sourceTree = "<group>"; };
+		2B7F45FA1708365100A106A9 /* ImproveCacheLocality.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ImproveCacheLocality.h; sourceTree = "<group>"; };
+		2B7F46021708365100A106A9 /* JoinVerticesProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JoinVerticesProcess.cpp; sourceTree = "<group>"; };
+		2B7F46031708365100A106A9 /* JoinVerticesProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JoinVerticesProcess.h; sourceTree = "<group>"; };
+		2B7F46041708365100A106A9 /* LimitBoneWeightsProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LimitBoneWeightsProcess.cpp; sourceTree = "<group>"; };
+		2B7F46051708365100A106A9 /* LimitBoneWeightsProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LimitBoneWeightsProcess.h; sourceTree = "<group>"; };
+		2B7F46061708365100A106A9 /* LineSplitter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LineSplitter.h; sourceTree = "<group>"; };
+		2B7F46071708365100A106A9 /* LogAux.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LogAux.h; sourceTree = "<group>"; };
+		2B7F46141708365200A106A9 /* MakeVerboseFormat.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MakeVerboseFormat.cpp; sourceTree = "<group>"; };
+		2B7F46151708365200A106A9 /* MakeVerboseFormat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MakeVerboseFormat.h; sourceTree = "<group>"; };
+		2B7F46161708365200A106A9 /* MaterialSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MaterialSystem.cpp; sourceTree = "<group>"; };
+		2B7F46171708365200A106A9 /* MaterialSystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MaterialSystem.h; sourceTree = "<group>"; };
+		2B7F461F1708365200A106A9 /* MD4FileData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MD4FileData.h; sourceTree = "<group>"; };
+		2B7F462D1708365200A106A9 /* MemoryIOWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MemoryIOWrapper.h; sourceTree = "<group>"; };
+		2B7F46341708365200A106A9 /* ObjExporter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ObjExporter.cpp; sourceTree = "<group>"; };
+		2B7F46351708365200A106A9 /* ObjExporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjExporter.h; sourceTree = "<group>"; };
+		2B7F46361708365200A106A9 /* ObjFileData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjFileData.h; sourceTree = "<group>"; };
+		2B7F46371708365200A106A9 /* ObjFileImporter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ObjFileImporter.cpp; sourceTree = "<group>"; };
+		2B7F46381708365200A106A9 /* ObjFileImporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjFileImporter.h; sourceTree = "<group>"; };
+		2B7F46391708365200A106A9 /* ObjFileMtlImporter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ObjFileMtlImporter.cpp; sourceTree = "<group>"; };
+		2B7F463A1708365200A106A9 /* ObjFileMtlImporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjFileMtlImporter.h; sourceTree = "<group>"; };
+		2B7F463B1708365200A106A9 /* ObjFileParser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ObjFileParser.cpp; sourceTree = "<group>"; };
+		2B7F463C1708365200A106A9 /* ObjFileParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjFileParser.h; sourceTree = "<group>"; };
+		2B7F463D1708365200A106A9 /* ObjTools.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjTools.h; sourceTree = "<group>"; };
+		2B7F46461708365200A106A9 /* OptimizeGraph.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OptimizeGraph.cpp; sourceTree = "<group>"; };
+		2B7F46471708365200A106A9 /* OptimizeGraph.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OptimizeGraph.h; sourceTree = "<group>"; };
+		2B7F46481708365200A106A9 /* OptimizeMeshes.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OptimizeMeshes.cpp; sourceTree = "<group>"; };
+		2B7F46491708365200A106A9 /* OptimizeMeshes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OptimizeMeshes.h; sourceTree = "<group>"; };
+		2B7F464A1708365200A106A9 /* ParsingUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ParsingUtils.h; sourceTree = "<group>"; };
+		2B7F46511708365200A106A9 /* PolyTools.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PolyTools.h; sourceTree = "<group>"; };
+		2B7F46521708365200A106A9 /* PostStepRegistry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PostStepRegistry.cpp; sourceTree = "<group>"; };
+		2B7F46531708365200A106A9 /* PretransformVertices.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PretransformVertices.cpp; sourceTree = "<group>"; };
+		2B7F46541708365200A106A9 /* PretransformVertices.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PretransformVertices.h; sourceTree = "<group>"; };
+		2B7F46551708365200A106A9 /* ProcessHelper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ProcessHelper.cpp; sourceTree = "<group>"; };
+		2B7F46561708365200A106A9 /* ProcessHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ProcessHelper.h; sourceTree = "<group>"; };
+		2B7F46571708365200A106A9 /* Profiler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Profiler.h; sourceTree = "<group>"; };
+		2B7F46581708365200A106A9 /* pstdint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pstdint.h; sourceTree = "<group>"; };
+		2B7F46621708365200A106A9 /* qnan.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qnan.h; sourceTree = "<group>"; };
+		2B7F46651708365200A106A9 /* RemoveComments.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RemoveComments.cpp; sourceTree = "<group>"; };
+		2B7F46661708365200A106A9 /* RemoveComments.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RemoveComments.h; sourceTree = "<group>"; };
+		2B7F46671708365200A106A9 /* RemoveRedundantMaterials.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RemoveRedundantMaterials.cpp; sourceTree = "<group>"; };
+		2B7F46681708365200A106A9 /* RemoveRedundantMaterials.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RemoveRedundantMaterials.h; sourceTree = "<group>"; };
+		2B7F46691708365200A106A9 /* RemoveVCProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RemoveVCProcess.cpp; sourceTree = "<group>"; };
+		2B7F466A1708365200A106A9 /* RemoveVCProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RemoveVCProcess.h; sourceTree = "<group>"; };
+		2B7F466E1708365200A106A9 /* SceneCombiner.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SceneCombiner.cpp; sourceTree = "<group>"; };
+		2B7F466F1708365200A106A9 /* SceneCombiner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SceneCombiner.h; sourceTree = "<group>"; };
+		2B7F46701708365200A106A9 /* ScenePreprocessor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ScenePreprocessor.cpp; sourceTree = "<group>"; };
+		2B7F46711708365200A106A9 /* ScenePreprocessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScenePreprocessor.h; sourceTree = "<group>"; };
+		2B7F46721708365200A106A9 /* ScenePrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScenePrivate.h; sourceTree = "<group>"; };
+		2B7F46731708365200A106A9 /* SGSpatialSort.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SGSpatialSort.cpp; sourceTree = "<group>"; };
+		2B7F46741708365200A106A9 /* SGSpatialSort.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SGSpatialSort.h; sourceTree = "<group>"; };
+		2B7F46751708365200A106A9 /* SkeletonMeshBuilder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SkeletonMeshBuilder.cpp; sourceTree = "<group>"; };
+		2B7F46761708365200A106A9 /* SkeletonMeshBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SkeletonMeshBuilder.h; sourceTree = "<group>"; };
+		2B7F46791708365200A106A9 /* SmoothingGroups.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SmoothingGroups.h; sourceTree = "<group>"; };
+		2B7F467A1708365200A106A9 /* SmoothingGroups.inl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = SmoothingGroups.inl; sourceTree = "<group>"; };
+		2B7F467B1708365200A106A9 /* SortByPTypeProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SortByPTypeProcess.cpp; sourceTree = "<group>"; };
+		2B7F467C1708365200A106A9 /* SortByPTypeProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SortByPTypeProcess.h; sourceTree = "<group>"; };
+		2B7F467D1708365200A106A9 /* SpatialSort.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpatialSort.cpp; sourceTree = "<group>"; };
+		2B7F467E1708365200A106A9 /* SpatialSort.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpatialSort.h; sourceTree = "<group>"; };
+		2B7F467F1708365200A106A9 /* SplitByBoneCountProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SplitByBoneCountProcess.cpp; sourceTree = "<group>"; };
+		2B7F46801708365200A106A9 /* SplitByBoneCountProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SplitByBoneCountProcess.h; sourceTree = "<group>"; };
+		2B7F46811708365200A106A9 /* SplitLargeMeshes.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SplitLargeMeshes.cpp; sourceTree = "<group>"; };
+		2B7F46821708365200A106A9 /* SplitLargeMeshes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SplitLargeMeshes.h; sourceTree = "<group>"; };
+		2B7F46831708365200A106A9 /* StandardShapes.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StandardShapes.cpp; sourceTree = "<group>"; };
+		2B7F46841708365200A106A9 /* StandardShapes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StandardShapes.h; sourceTree = "<group>"; };
+		2B7F46851708365200A106A9 /* StdOStreamLogStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StdOStreamLogStream.h; sourceTree = "<group>"; };
+		2B7F46861708365200A106A9 /* STEPFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STEPFile.h; path = ../../code/STEPFile.h; sourceTree = "<group>"; };
+		2B7F46871708365200A106A9 /* STEPFileEncoding.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = STEPFileEncoding.cpp; path = ../../code/STEPFileEncoding.cpp; sourceTree = "<group>"; };
+		2B7F46881708365200A106A9 /* STEPFileEncoding.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STEPFileEncoding.h; path = ../../code/STEPFileEncoding.h; sourceTree = "<group>"; };
+		2B7F46891708365200A106A9 /* STEPFileReader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = STEPFileReader.cpp; path = ../../code/STEPFileReader.cpp; sourceTree = "<group>"; };
+		2B7F468A1708365200A106A9 /* STEPFileReader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STEPFileReader.h; path = ../../code/STEPFileReader.h; sourceTree = "<group>"; };
+		2B7F468B1708365200A106A9 /* STLExporter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = STLExporter.cpp; sourceTree = "<group>"; };
+		2B7F468C1708365200A106A9 /* STLExporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STLExporter.h; sourceTree = "<group>"; };
+		2B7F468D1708365200A106A9 /* STLLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = STLLoader.cpp; sourceTree = "<group>"; };
+		2B7F468E1708365200A106A9 /* STLLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STLLoader.h; sourceTree = "<group>"; };
+		2B7F468F1708365200A106A9 /* StreamReader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StreamReader.h; sourceTree = "<group>"; };
+		2B7F46901708365200A106A9 /* StringComparison.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StringComparison.h; sourceTree = "<group>"; };
+		2B7F46911708365200A106A9 /* Subdivision.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Subdivision.cpp; sourceTree = "<group>"; };
+		2B7F46921708365200A106A9 /* Subdivision.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Subdivision.h; sourceTree = "<group>"; };
+		2B7F46931708365200A106A9 /* TargetAnimation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TargetAnimation.cpp; sourceTree = "<group>"; };
+		2B7F46941708365200A106A9 /* TargetAnimation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TargetAnimation.h; sourceTree = "<group>"; };
+		2B7F46971708365200A106A9 /* TextureTransform.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextureTransform.cpp; sourceTree = "<group>"; };
+		2B7F46981708365200A106A9 /* TextureTransform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextureTransform.h; sourceTree = "<group>"; };
+		2B7F46991708365200A106A9 /* TinyFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TinyFormatter.h; sourceTree = "<group>"; };
+		2B7F469A1708365200A106A9 /* TriangulateProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TriangulateProcess.cpp; sourceTree = "<group>"; };
+		2B7F469B1708365200A106A9 /* TriangulateProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TriangulateProcess.h; sourceTree = "<group>"; };
+		2B7F469E1708365200A106A9 /* ValidateDataStructure.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ValidateDataStructure.cpp; sourceTree = "<group>"; };
+		2B7F469F1708365200A106A9 /* ValidateDataStructure.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ValidateDataStructure.h; sourceTree = "<group>"; };
+		2B7F46A01708365200A106A9 /* Vertex.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Vertex.h; sourceTree = "<group>"; };
+		2B7F46A11708365200A106A9 /* VertexTriangleAdjacency.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VertexTriangleAdjacency.cpp; sourceTree = "<group>"; };
+		2B7F46A21708365200A106A9 /* VertexTriangleAdjacency.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VertexTriangleAdjacency.h; sourceTree = "<group>"; };
+		2B7F46A31708365200A106A9 /* Win32DebugLogStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Win32DebugLogStream.h; sourceTree = "<group>"; };
+		2BA44E10170862D800C78A66 /* libstdc++.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libstdc++.dylib"; path = "Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.8.sdk/usr/lib/libstdc++.dylib"; sourceTree = DEVELOPER_DIR; };
 		3AB8A3AB0E50D67A00606590 /* MDCFileData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MDCFileData.h; sourceTree = "<group>"; };
 		3AB8A3AC0E50D67A00606590 /* MDCLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MDCLoader.cpp; sourceTree = "<group>"; };
 		3AB8A3AD0E50D67A00606590 /* MDCLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MDCLoader.h; sourceTree = "<group>"; };
 		3AB8A3AE0E50D67A00606590 /* MDCNormalTable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MDCNormalTable.h; sourceTree = "<group>"; };
-		3AB8A3B30E50D69D00606590 /* FixNormalsStep.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FixNormalsStep.cpp; sourceTree = "<group>"; };
-		3AB8A3B40E50D69D00606590 /* FixNormalsStep.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FixNormalsStep.h; sourceTree = "<group>"; };
 		3AB8A3B70E50D6DB00606590 /* LWOFileData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LWOFileData.h; sourceTree = "<group>"; };
 		3AB8A3B80E50D6DB00606590 /* LWOLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LWOLoader.cpp; sourceTree = "<group>"; };
 		3AB8A3B90E50D6DB00606590 /* LWOLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LWOLoader.h; sourceTree = "<group>"; };
-		3AB8A3C30E50D74500606590 /* BaseProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BaseProcess.cpp; sourceTree = "<group>"; };
 		3AB8A3C50E50D77900606590 /* HMPFileData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HMPFileData.h; sourceTree = "<group>"; };
-		3AB8A3C90E50D7CC00606590 /* IFF.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IFF.h; sourceTree = "<group>"; };
-		3AB8A3CB0E50D7FF00606590 /* Hash.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Hash.h; sourceTree = "<group>"; };
 		3AB8A7DC0E53715F00606590 /* LWOMaterial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LWOMaterial.cpp; sourceTree = "<group>"; };
 		3AF45A860E4B716800207D74 /* 3DSConverter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = 3DSConverter.cpp; sourceTree = "<group>"; };
 		3AF45A880E4B716800207D74 /* 3DSHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = 3DSHelper.h; sourceTree = "<group>"; };
@@ -1460,38 +2221,9 @@
 		3AF45A8F0E4B716800207D74 /* ASELoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASELoader.h; sourceTree = "<group>"; };
 		3AF45A900E4B716800207D74 /* ASEParser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ASEParser.cpp; sourceTree = "<group>"; };
 		3AF45A910E4B716800207D74 /* ASEParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ASEParser.h; sourceTree = "<group>"; };
-		3AF45A920E4B716800207D74 /* Assimp.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Assimp.cpp; sourceTree = "<group>"; };
-		3AF45A930E4B716800207D74 /* BaseImporter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BaseImporter.cpp; sourceTree = "<group>"; };
-		3AF45A940E4B716800207D74 /* BaseImporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BaseImporter.h; sourceTree = "<group>"; };
-		3AF45A950E4B716800207D74 /* BaseProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BaseProcess.h; sourceTree = "<group>"; };
-		3AF45A960E4B716800207D74 /* ByteSwap.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ByteSwap.h; sourceTree = "<group>"; };
-		3AF45A970E4B716800207D74 /* CalcTangentsProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CalcTangentsProcess.cpp; sourceTree = "<group>"; };
-		3AF45A980E4B716800207D74 /* CalcTangentsProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CalcTangentsProcess.h; sourceTree = "<group>"; };
-		3AF45A990E4B716800207D74 /* ConvertToLHProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConvertToLHProcess.cpp; sourceTree = "<group>"; };
-		3AF45A9A0E4B716800207D74 /* ConvertToLHProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConvertToLHProcess.h; sourceTree = "<group>"; };
-		3AF45A9B0E4B716800207D74 /* DefaultIOStream.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DefaultIOStream.cpp; sourceTree = "<group>"; };
-		3AF45A9C0E4B716800207D74 /* DefaultIOStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DefaultIOStream.h; sourceTree = "<group>"; };
-		3AF45A9D0E4B716800207D74 /* DefaultIOSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DefaultIOSystem.cpp; sourceTree = "<group>"; };
-		3AF45A9E0E4B716800207D74 /* DefaultIOSystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DefaultIOSystem.h; sourceTree = "<group>"; };
-		3AF45A9F0E4B716800207D74 /* DefaultLogger.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DefaultLogger.cpp; sourceTree = "<group>"; };
-		3AF45AA30E4B716800207D74 /* fast_atof.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = fast_atof.h; sourceTree = "<group>"; };
-		3AF45AA40E4B716800207D74 /* FileLogStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FileLogStream.h; sourceTree = "<group>"; };
-		3AF45AA50E4B716800207D74 /* GenFaceNormalsProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GenFaceNormalsProcess.cpp; sourceTree = "<group>"; };
-		3AF45AA60E4B716800207D74 /* GenFaceNormalsProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GenFaceNormalsProcess.h; sourceTree = "<group>"; };
-		3AF45AA70E4B716800207D74 /* GenVertexNormalsProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GenVertexNormalsProcess.cpp; sourceTree = "<group>"; };
-		3AF45AA80E4B716800207D74 /* GenVertexNormalsProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GenVertexNormalsProcess.h; sourceTree = "<group>"; };
 		3AF45AA90E4B716800207D74 /* HalfLifeFileData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HalfLifeFileData.h; sourceTree = "<group>"; };
 		3AF45AAB0E4B716800207D74 /* HMPLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = HMPLoader.cpp; sourceTree = "<group>"; };
 		3AF45AAC0E4B716800207D74 /* HMPLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HMPLoader.h; sourceTree = "<group>"; };
-		3AF45AAD0E4B716800207D74 /* Importer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Importer.cpp; sourceTree = "<group>"; };
-		3AF45AAE0E4B716800207D74 /* ImproveCacheLocality.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ImproveCacheLocality.cpp; sourceTree = "<group>"; };
-		3AF45AAF0E4B716800207D74 /* ImproveCacheLocality.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ImproveCacheLocality.h; sourceTree = "<group>"; };
-		3AF45AB00E4B716800207D74 /* JoinVerticesProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JoinVerticesProcess.cpp; sourceTree = "<group>"; };
-		3AF45AB10E4B716800207D74 /* JoinVerticesProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JoinVerticesProcess.h; sourceTree = "<group>"; };
-		3AF45AB40E4B716800207D74 /* LimitBoneWeightsProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = LimitBoneWeightsProcess.cpp; sourceTree = "<group>"; };
-		3AF45AB50E4B716800207D74 /* LimitBoneWeightsProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LimitBoneWeightsProcess.h; sourceTree = "<group>"; };
-		3AF45AB60E4B716800207D74 /* MaterialSystem.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MaterialSystem.cpp; sourceTree = "<group>"; };
-		3AF45AB70E4B716800207D74 /* MaterialSystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MaterialSystem.h; sourceTree = "<group>"; };
 		3AF45AB80E4B716800207D74 /* MD2FileData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MD2FileData.h; sourceTree = "<group>"; };
 		3AF45AB90E4B716800207D74 /* MD2Loader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MD2Loader.cpp; sourceTree = "<group>"; };
 		3AF45ABA0E4B716800207D74 /* MD2Loader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MD2Loader.h; sourceTree = "<group>"; };
@@ -1508,44 +2240,12 @@
 		3AF45AC80E4B716800207D74 /* MDLLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MDLLoader.cpp; sourceTree = "<group>"; };
 		3AF45AC90E4B716800207D74 /* MDLLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MDLLoader.h; sourceTree = "<group>"; };
 		3AF45ACA0E4B716800207D74 /* MDLMaterialLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = MDLMaterialLoader.cpp; sourceTree = "<group>"; };
-		3AF45ACB0E4B716800207D74 /* ObjFileData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjFileData.h; sourceTree = "<group>"; };
-		3AF45ACC0E4B716800207D74 /* ObjFileImporter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ObjFileImporter.cpp; sourceTree = "<group>"; };
-		3AF45ACD0E4B716800207D74 /* ObjFileImporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjFileImporter.h; sourceTree = "<group>"; };
-		3AF45ACE0E4B716800207D74 /* ObjFileMtlImporter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ObjFileMtlImporter.cpp; sourceTree = "<group>"; };
-		3AF45ACF0E4B716800207D74 /* ObjFileMtlImporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjFileMtlImporter.h; sourceTree = "<group>"; };
-		3AF45AD00E4B716800207D74 /* ObjFileParser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ObjFileParser.cpp; sourceTree = "<group>"; };
-		3AF45AD10E4B716800207D74 /* ObjFileParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjFileParser.h; sourceTree = "<group>"; };
-		3AF45AD20E4B716800207D74 /* ObjTools.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ObjTools.h; sourceTree = "<group>"; };
-		3AF45AD30E4B716800207D74 /* ParsingUtils.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ParsingUtils.h; sourceTree = "<group>"; };
 		3AF45AD40E4B716800207D74 /* PlyLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PlyLoader.cpp; sourceTree = "<group>"; };
 		3AF45AD50E4B716800207D74 /* PlyLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PlyLoader.h; sourceTree = "<group>"; };
 		3AF45AD60E4B716800207D74 /* PlyParser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PlyParser.cpp; sourceTree = "<group>"; };
 		3AF45AD70E4B716800207D74 /* PlyParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PlyParser.h; sourceTree = "<group>"; };
-		3AF45AD80E4B716800207D74 /* PretransformVertices.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PretransformVertices.cpp; sourceTree = "<group>"; };
-		3AF45AD90E4B716800207D74 /* PretransformVertices.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PretransformVertices.h; sourceTree = "<group>"; };
-		3AF45ADA0E4B716800207D74 /* qnan.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = qnan.h; sourceTree = "<group>"; };
-		3AF45ADB0E4B716800207D74 /* RemoveComments.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RemoveComments.cpp; sourceTree = "<group>"; };
-		3AF45ADC0E4B716800207D74 /* RemoveComments.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RemoveComments.h; sourceTree = "<group>"; };
-		3AF45ADD0E4B716800207D74 /* RemoveRedundantMaterials.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RemoveRedundantMaterials.cpp; sourceTree = "<group>"; };
-		3AF45ADE0E4B716800207D74 /* RemoveRedundantMaterials.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RemoveRedundantMaterials.h; sourceTree = "<group>"; };
 		3AF45AE20E4B716800207D74 /* SMDLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SMDLoader.cpp; sourceTree = "<group>"; };
 		3AF45AE30E4B716800207D74 /* SMDLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SMDLoader.h; sourceTree = "<group>"; };
-		3AF45AE40E4B716800207D74 /* SpatialSort.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SpatialSort.cpp; sourceTree = "<group>"; };
-		3AF45AE50E4B716800207D74 /* SpatialSort.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpatialSort.h; sourceTree = "<group>"; };
-		3AF45AE60E4B716800207D74 /* SplitLargeMeshes.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SplitLargeMeshes.cpp; sourceTree = "<group>"; };
-		3AF45AE70E4B716800207D74 /* SplitLargeMeshes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SplitLargeMeshes.h; sourceTree = "<group>"; };
-		3AF45AE80E4B716800207D74 /* STLLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = STLLoader.cpp; sourceTree = "<group>"; };
-		3AF45AE90E4B716800207D74 /* STLLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = STLLoader.h; sourceTree = "<group>"; };
-		3AF45AEA0E4B716800207D74 /* StringComparison.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StringComparison.h; sourceTree = "<group>"; };
-		3AF45AEB0E4B716800207D74 /* TextureTransform.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextureTransform.cpp; sourceTree = "<group>"; };
-		3AF45AEC0E4B716800207D74 /* TextureTransform.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextureTransform.h; sourceTree = "<group>"; };
-		3AF45AED0E4B716800207D74 /* TriangulateProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TriangulateProcess.cpp; sourceTree = "<group>"; };
-		3AF45AEE0E4B716800207D74 /* TriangulateProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TriangulateProcess.h; sourceTree = "<group>"; };
-		3AF45AEF0E4B716800207D74 /* ValidateDataStructure.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ValidateDataStructure.cpp; sourceTree = "<group>"; };
-		3AF45AF00E4B716800207D74 /* ValidateDataStructure.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ValidateDataStructure.h; sourceTree = "<group>"; };
-		3AF45AF10E4B716800207D74 /* VertexTriangleAdjacency.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = VertexTriangleAdjacency.cpp; sourceTree = "<group>"; };
-		3AF45AF20E4B716800207D74 /* VertexTriangleAdjacency.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VertexTriangleAdjacency.h; sourceTree = "<group>"; };
-		3AF45AF30E4B716800207D74 /* Win32DebugLogStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Win32DebugLogStream.h; sourceTree = "<group>"; };
 		3AF45AF40E4B716800207D74 /* XFileHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XFileHelper.h; sourceTree = "<group>"; };
 		3AF45AF50E4B716800207D74 /* XFileImporter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = XFileImporter.cpp; sourceTree = "<group>"; };
 		3AF45AF60E4B716800207D74 /* XFileImporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = XFileImporter.h; sourceTree = "<group>"; };
@@ -1561,28 +2261,6 @@
 		7411B17111416E2500BCD793 /* MS3DLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MS3DLoader.h; path = ../../code/MS3DLoader.h; sourceTree = SOURCE_ROOT; };
 		7411B18B11416EBC00BCD793 /* UnrealLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UnrealLoader.cpp; path = ../../code/UnrealLoader.cpp; sourceTree = SOURCE_ROOT; };
 		7411B18C11416EBC00BCD793 /* UnrealLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = UnrealLoader.h; path = ../../code/UnrealLoader.h; sourceTree = SOURCE_ROOT; };
-		7411B19711416EF400BCD793 /* FileSystemFilter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = FileSystemFilter.h; path = ../../code/FileSystemFilter.h; sourceTree = SOURCE_ROOT; };
-		7411B19811416EF400BCD793 /* GenericProperty.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = GenericProperty.h; path = ../../code/GenericProperty.h; sourceTree = SOURCE_ROOT; };
-		7411B19911416EF400BCD793 /* MemoryIOWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MemoryIOWrapper.h; path = ../../code/MemoryIOWrapper.h; sourceTree = SOURCE_ROOT; };
-		7411B19A11416EF400BCD793 /* OptimizeGraph.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = OptimizeGraph.cpp; path = ../../code/OptimizeGraph.cpp; sourceTree = SOURCE_ROOT; };
-		7411B19B11416EF400BCD793 /* OptimizeGraph.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OptimizeGraph.h; path = ../../code/OptimizeGraph.h; sourceTree = SOURCE_ROOT; };
-		7411B19C11416EF400BCD793 /* OptimizeMeshes.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = OptimizeMeshes.cpp; path = ../../code/OptimizeMeshes.cpp; sourceTree = SOURCE_ROOT; };
-		7411B19D11416EF400BCD793 /* OptimizeMeshes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = OptimizeMeshes.h; path = ../../code/OptimizeMeshes.h; sourceTree = SOURCE_ROOT; };
-		7411B19E11416EF400BCD793 /* ProcessHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ProcessHelper.h; path = ../../code/ProcessHelper.h; sourceTree = SOURCE_ROOT; };
-		7411B19F11416EF400BCD793 /* StdOStreamLogStream.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = StdOStreamLogStream.h; path = ../../code/StdOStreamLogStream.h; sourceTree = SOURCE_ROOT; };
-		7411B1A011416EF400BCD793 /* StreamReader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = StreamReader.h; path = ../../code/StreamReader.h; sourceTree = SOURCE_ROOT; };
-		7411B1A111416EF400BCD793 /* Subdivision.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Subdivision.cpp; path = ../../code/Subdivision.cpp; sourceTree = SOURCE_ROOT; };
-		7411B1A211416EF400BCD793 /* Subdivision.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Subdivision.h; path = ../../code/Subdivision.h; sourceTree = SOURCE_ROOT; };
-		7411B1A311416EF400BCD793 /* TargetAnimation.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TargetAnimation.cpp; path = ../../code/TargetAnimation.cpp; sourceTree = SOURCE_ROOT; };
-		7411B1A411416EF400BCD793 /* TargetAnimation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TargetAnimation.h; path = ../../code/TargetAnimation.h; sourceTree = SOURCE_ROOT; };
-		7411B1A511416EF400BCD793 /* Vertex.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Vertex.h; path = ../../code/Vertex.h; sourceTree = SOURCE_ROOT; };
-		7437C950113F18C70067B9B9 /* foreach.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = foreach.hpp; path = ../../code/BoostWorkaround/boost/foreach.hpp; sourceTree = SOURCE_ROOT; };
-		7437C951113F18C70067B9B9 /* format.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = format.hpp; path = ../../code/BoostWorkaround/boost/format.hpp; sourceTree = SOURCE_ROOT; };
-		7437C953113F18C70067B9B9 /* common_factor_rt.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = common_factor_rt.hpp; path = ../../code/BoostWorkaround/boost/math/common_factor_rt.hpp; sourceTree = SOURCE_ROOT; };
-		7437C954113F18C70067B9B9 /* scoped_array.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = scoped_array.hpp; path = ../../code/BoostWorkaround/boost/scoped_array.hpp; sourceTree = SOURCE_ROOT; };
-		7437C955113F18C70067B9B9 /* scoped_ptr.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = scoped_ptr.hpp; path = ../../code/BoostWorkaround/boost/scoped_ptr.hpp; sourceTree = SOURCE_ROOT; };
-		7437C956113F18C70067B9B9 /* static_assert.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = static_assert.hpp; path = ../../code/BoostWorkaround/boost/static_assert.hpp; sourceTree = SOURCE_ROOT; };
-		7437C958113F18C70067B9B9 /* tuple.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = tuple.hpp; path = ../../code/BoostWorkaround/boost/tuple/tuple.hpp; sourceTree = SOURCE_ROOT; };
 		74C9BB4911ACBB1000AF885C /* BlenderDNA.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = BlenderDNA.cpp; path = ../../code/BlenderDNA.cpp; sourceTree = SOURCE_ROOT; };
 		74C9BB4A11ACBB1000AF885C /* BlenderDNA.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BlenderDNA.h; path = ../../code/BlenderDNA.h; sourceTree = SOURCE_ROOT; };
 		74C9BB4B11ACBB1000AF885C /* BlenderDNA.inl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = BlenderDNA.inl; path = ../../code/BlenderDNA.inl; sourceTree = SOURCE_ROOT; };
@@ -1591,21 +2269,12 @@
 		74C9BB4E11ACBB1000AF885C /* BlenderScene.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = BlenderScene.cpp; path = ../../code/BlenderScene.cpp; sourceTree = SOURCE_ROOT; };
 		74C9BB4F11ACBB1000AF885C /* BlenderScene.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BlenderScene.h; path = ../../code/BlenderScene.h; sourceTree = SOURCE_ROOT; };
 		74C9BB5011ACBB1000AF885C /* BlenderSceneGen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BlenderSceneGen.h; path = ../../code/BlenderSceneGen.h; sourceTree = SOURCE_ROOT; };
-		74C9BB6F11ACBB3600AF885C /* pointer_cast.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = pointer_cast.hpp; path = ../../code/BoostWorkaround/boost/pointer_cast.hpp; sourceTree = SOURCE_ROOT; };
-		74C9BB7011ACBB3600AF885C /* shared_array.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = shared_array.hpp; path = ../../code/BoostWorkaround/boost/shared_array.hpp; sourceTree = SOURCE_ROOT; };
-		74C9BB7111ACBB3600AF885C /* shared_ptr.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; name = shared_ptr.hpp; path = ../../code/BoostWorkaround/boost/shared_ptr.hpp; sourceTree = SOURCE_ROOT; };
-		74C9BB7C11ACBB7800AF885C /* MakeVerboseFormat.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = MakeVerboseFormat.cpp; path = ../../code/MakeVerboseFormat.cpp; sourceTree = SOURCE_ROOT; };
-		74C9BB7D11ACBB7800AF885C /* MakeVerboseFormat.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MakeVerboseFormat.h; path = ../../code/MakeVerboseFormat.h; sourceTree = SOURCE_ROOT; };
 		74C9BB8611ACBB9900AF885C /* AssimpPCH.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = AssimpPCH.cpp; path = ../../code/AssimpPCH.cpp; sourceTree = SOURCE_ROOT; };
 		74C9BB8711ACBB9900AF885C /* AssimpPCH.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AssimpPCH.h; path = ../../code/AssimpPCH.h; sourceTree = SOURCE_ROOT; };
 		74C9BB9311ACBBBC00AF885C /* COBLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = COBLoader.cpp; path = ../../code/COBLoader.cpp; sourceTree = SOURCE_ROOT; };
 		74C9BB9411ACBBBC00AF885C /* COBLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = COBLoader.h; path = ../../code/COBLoader.h; sourceTree = SOURCE_ROOT; };
 		74C9BB9511ACBBBC00AF885C /* COBScene.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = COBScene.h; path = ../../code/COBScene.h; sourceTree = SOURCE_ROOT; };
 		74C9BBB311ACBC2600AF885C /* revision.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = revision.h; path = ../../revision.h; sourceTree = SOURCE_ROOT; };
-		74C9BBBB11ACBC6C00AF885C /* Exceptional.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Exceptional.h; path = ../../code/Exceptional.h; sourceTree = SOURCE_ROOT; };
-		74C9BBBC11ACBC6C00AF885C /* LineSplitter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = LineSplitter.h; path = ../../code/LineSplitter.h; sourceTree = SOURCE_ROOT; };
-		74C9BBBD11ACBC6C00AF885C /* MD4FileData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MD4FileData.h; path = ../../code/MD4FileData.h; sourceTree = SOURCE_ROOT; };
-		74C9BBBE11ACBC6C00AF885C /* TinyFormatter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TinyFormatter.h; path = ../../code/TinyFormatter.h; sourceTree = SOURCE_ROOT; };
 		8E7ABBA1127E0F1A00512ED1 /* Q3BSPFileData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Q3BSPFileData.h; path = ../../code/Q3BSPFileData.h; sourceTree = SOURCE_ROOT; };
 		8E7ABBA2127E0F1A00512ED1 /* Q3BSPFileImporter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Q3BSPFileImporter.cpp; path = ../../code/Q3BSPFileImporter.cpp; sourceTree = SOURCE_ROOT; };
 		8E7ABBA3127E0F1A00512ED1 /* Q3BSPFileImporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = Q3BSPFileImporter.h; path = ../../code/Q3BSPFileImporter.h; sourceTree = SOURCE_ROOT; };
@@ -1618,10 +2287,6 @@
 		8E7ABBCE127E0F3800512ED1 /* BlenderIntermediate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BlenderIntermediate.h; path = ../../code/BlenderIntermediate.h; sourceTree = SOURCE_ROOT; };
 		8E7ABBCF127E0F3800512ED1 /* BlenderModifier.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = BlenderModifier.cpp; path = ../../code/BlenderModifier.cpp; sourceTree = SOURCE_ROOT; };
 		8E7ABBD0127E0F3800512ED1 /* BlenderModifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = BlenderModifier.h; path = ../../code/BlenderModifier.h; sourceTree = SOURCE_ROOT; };
-		8E7ABBDF127E0FA400512ED1 /* assbin_chunks.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = assbin_chunks.h; sourceTree = "<group>"; };
-		8E7ABBE0127E0FA400512ED1 /* DefaultProgressHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DefaultProgressHandler.h; sourceTree = "<group>"; };
-		8E7ABBE1127E0FA400512ED1 /* Profiler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Profiler.h; sourceTree = "<group>"; };
-		8E7ABBE2127E0FA400512ED1 /* pstdint.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = pstdint.h; sourceTree = "<group>"; };
 		8E8DEE4B127E2B78005EF64D /* ConvertUTF.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = ConvertUTF.c; sourceTree = "<group>"; };
 		8E8DEE4C127E2B78005EF64D /* ConvertUTF.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ConvertUTF.h; sourceTree = "<group>"; };
 		8E8DEE4F127E2B78005EF64D /* CXMLReaderImpl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CXMLReaderImpl.h; sourceTree = "<group>"; };
@@ -1636,12 +2301,11 @@
 		8E8DEE59127E2B78005EF64D /* ioapi.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ioapi.h; sourceTree = "<group>"; };
 		8E8DEE5A127E2B78005EF64D /* unzip.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = unzip.c; sourceTree = "<group>"; };
 		8E8DEE5B127E2B78005EF64D /* unzip.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = unzip.h; sourceTree = "<group>"; };
-		8E8DEEA3127E2D59005EF64D /* libassimp.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libassimp.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
-		8E8DEEA4127E2D59005EF64D /* libassimp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libassimp.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		8E8DEEA5127E2D59005EF64D /* libassimp.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libassimp.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
-		8E8DEEA6127E2D59005EF64D /* libassimp.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libassimp.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		F90BAFB90F5DD68F00124155 /* libboost_date_time-xgcc40-mt.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libboost_date_time-xgcc40-mt.a"; path = "/usr/local/lib/libboost_date_time-xgcc40-mt.a"; sourceTree = "<absolute>"; };
-		F90BAFBB0F5DD6A800124155 /* libboost_thread-xgcc40-mt.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libboost_thread-xgcc40-mt.a"; path = "/usr/local/lib/libboost_thread-xgcc40-mt.a"; sourceTree = "<absolute>"; };
+		8E8DEEA3127E2D59005EF64D /* libassimpd.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libassimpd.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+		8E8DEEA4127E2D59005EF64D /* libassimpd.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libassimpd.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		8E8DEEA5127E2D59005EF64D /* libassimpd.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libassimpd.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+		8E8DEEA6127E2D59005EF64D /* libassimpd.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libassimpd.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		B919763F163AEA54009C397B /* libassimp-ios.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libassimp-ios.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F90BAFD00F5DD87000124155 /* ACLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ACLoader.cpp; sourceTree = "<group>"; };
 		F90BAFD10F5DD87000124155 /* ACLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ACLoader.h; sourceTree = "<group>"; };
 		F90BAFD90F5DD90800124155 /* IRRLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IRRLoader.cpp; sourceTree = "<group>"; };
@@ -1650,15 +2314,8 @@
 		F90BAFDC0F5DD90800124155 /* IRRMeshLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IRRMeshLoader.h; sourceTree = "<group>"; };
 		F90BAFDD0F5DD90800124155 /* IRRShared.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IRRShared.cpp; sourceTree = "<group>"; };
 		F90BAFDE0F5DD90800124155 /* IRRShared.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IRRShared.h; sourceTree = "<group>"; };
-		F90BAFE80F5DD93600124155 /* ColladaHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ColladaHelper.h; sourceTree = "<group>"; };
-		F90BAFE90F5DD93600124155 /* ColladaLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ColladaLoader.cpp; sourceTree = "<group>"; };
-		F90BAFEA0F5DD93600124155 /* ColladaLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ColladaLoader.h; sourceTree = "<group>"; };
-		F90BAFEB0F5DD93600124155 /* ColladaParser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ColladaParser.cpp; sourceTree = "<group>"; };
-		F90BAFEC0F5DD93600124155 /* ColladaParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ColladaParser.h; sourceTree = "<group>"; };
 		F90BAFF50F5DD96100124155 /* NFFLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NFFLoader.h; sourceTree = "<group>"; };
 		F90BAFF60F5DD96100124155 /* NFFLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NFFLoader.cpp; sourceTree = "<group>"; };
-		F90BAFFB0F5DD9A000124155 /* SGSpatialSort.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SGSpatialSort.h; sourceTree = "<group>"; };
-		F90BAFFC0F5DD9A000124155 /* SGSpatialSort.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SGSpatialSort.cpp; sourceTree = "<group>"; };
 		F90BB0060F5DD9DD00124155 /* Q3DLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Q3DLoader.cpp; sourceTree = "<group>"; };
 		F90BB0070F5DD9DD00124155 /* Q3DLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Q3DLoader.h; sourceTree = "<group>"; };
 		F90BB00C0F5DD9F400124155 /* BVHLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BVHLoader.h; sourceTree = "<group>"; };
@@ -1673,32 +2330,8 @@
 		F90BB02F0F5DDAB500124155 /* TerragenLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TerragenLoader.h; sourceTree = "<group>"; };
 		F90BB0300F5DDAB500124155 /* TerragenLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TerragenLoader.cpp; sourceTree = "<group>"; };
 		F90BB0360F5DDB1B00124155 /* irrXMLWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = irrXMLWrapper.h; sourceTree = "<group>"; };
-		F90BB0390F5DDB3200124155 /* ScenePreprocessor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScenePreprocessor.h; sourceTree = "<group>"; };
-		F90BB03A0F5DDB3200124155 /* SceneCombiner.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SceneCombiner.cpp; sourceTree = "<group>"; };
-		F90BB03B0F5DDB3200124155 /* SceneCombiner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SceneCombiner.h; sourceTree = "<group>"; };
-		F90BB03C0F5DDB3200124155 /* ScenePreprocessor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ScenePreprocessor.cpp; sourceTree = "<group>"; };
-		F90BB0420F5DDB4600124155 /* SortByPTypeProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SortByPTypeProcess.h; sourceTree = "<group>"; };
-		F90BB0430F5DDB4600124155 /* SortByPTypeProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SortByPTypeProcess.cpp; sourceTree = "<group>"; };
-		F90BB0470F5DDB6100124155 /* FindDegenerates.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FindDegenerates.h; sourceTree = "<group>"; };
-		F90BB0480F5DDB6100124155 /* FindDegenerates.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FindDegenerates.cpp; sourceTree = "<group>"; };
-		F90BB04C0F5DDB8D00124155 /* ComputeUVMappingProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ComputeUVMappingProcess.h; sourceTree = "<group>"; };
-		F90BB04D0F5DDB8D00124155 /* ComputeUVMappingProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ComputeUVMappingProcess.cpp; sourceTree = "<group>"; };
-		F90BB0510F5DDBA800124155 /* StandardShapes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StandardShapes.h; sourceTree = "<group>"; };
-		F90BB0520F5DDBA800124155 /* StandardShapes.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = StandardShapes.cpp; sourceTree = "<group>"; };
-		F90BB0560F5DDBBF00124155 /* FindInstancesProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FindInstancesProcess.h; sourceTree = "<group>"; };
-		F90BB0570F5DDBBF00124155 /* FindInstancesProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FindInstancesProcess.cpp; sourceTree = "<group>"; };
-		F90BB05A0F5DDBCB00124155 /* RemoveVCProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RemoveVCProcess.h; sourceTree = "<group>"; };
-		F90BB05B0F5DDBCB00124155 /* RemoveVCProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RemoveVCProcess.cpp; sourceTree = "<group>"; };
-		F90BB05F0F5DDBE600124155 /* FindInvalidDataProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FindInvalidDataProcess.cpp; sourceTree = "<group>"; };
-		F90BB0600F5DDBE600124155 /* FindInvalidDataProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FindInvalidDataProcess.h; sourceTree = "<group>"; };
-		F90BB0640F5DDC0700124155 /* SkeletonMeshBuilder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SkeletonMeshBuilder.h; sourceTree = "<group>"; };
-		F90BB0650F5DDC0700124155 /* SkeletonMeshBuilder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SkeletonMeshBuilder.cpp; sourceTree = "<group>"; };
-		F90BB0690F5DDC1E00124155 /* SmoothingGroups.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SmoothingGroups.h; sourceTree = "<group>"; };
-		F90BB06A0F5DDC1E00124155 /* SmoothingGroups.inl */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = SmoothingGroups.inl; sourceTree = "<group>"; };
-		F90BB06D0F5DDCFC00124155 /* libz.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libz.dylib; path = /usr/lib/libz.dylib; sourceTree = "<absolute>"; };
 		F90BB0870F5DDE0700124155 /* B3DImporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = B3DImporter.h; path = ../../code/B3DImporter.h; sourceTree = SOURCE_ROOT; };
 		F90BB0880F5DDE0700124155 /* B3DImporter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = B3DImporter.cpp; path = ../../code/B3DImporter.cpp; sourceTree = SOURCE_ROOT; };
-		F9606FF2154364E5004D91DD /* ProcessHelper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ProcessHelper.cpp; sourceTree = "<group>"; };
 		F9607047154366AB004D91DD /* adler32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = adler32.c; sourceTree = "<group>"; };
 		F9607049154366AB004D91DD /* compress.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = compress.c; sourceTree = "<group>"; };
 		F960704A154366AB004D91DD /* crc32.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = crc32.c; sourceTree = "<group>"; };
@@ -1736,38 +2369,10 @@
 		F96070DD1543675E004D91DD /* sweep_context.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = sweep_context.cc; sourceTree = "<group>"; };
 		F96070DE1543675E004D91DD /* sweep_context.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = sweep_context.h; sourceTree = "<group>"; };
 		F97BA03515439DB3009EB9DD /* ai_assert.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ai_assert.h; sourceTree = "<group>"; };
-		F97BA06615439FC3009EB9DD /* IFCCurve.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IFCCurve.cpp; path = ../../code/IFCCurve.cpp; sourceTree = SOURCE_ROOT; };
-		F97BA06715439FC3009EB9DD /* IFCGeometry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IFCGeometry.cpp; path = ../../code/IFCGeometry.cpp; sourceTree = SOURCE_ROOT; };
-		F97BA06815439FC3009EB9DD /* IFCLoader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IFCLoader.cpp; path = ../../code/IFCLoader.cpp; sourceTree = SOURCE_ROOT; };
-		F97BA06915439FC3009EB9DD /* IFCLoader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IFCLoader.h; path = ../../code/IFCLoader.h; sourceTree = SOURCE_ROOT; };
-		F97BA06A15439FC3009EB9DD /* IFCMaterial.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IFCMaterial.cpp; path = ../../code/IFCMaterial.cpp; sourceTree = SOURCE_ROOT; };
-		F97BA06B15439FC3009EB9DD /* IFCProfile.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IFCProfile.cpp; path = ../../code/IFCProfile.cpp; sourceTree = SOURCE_ROOT; };
-		F97BA06C15439FC3009EB9DD /* IFCReaderGen.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IFCReaderGen.cpp; path = ../../code/IFCReaderGen.cpp; sourceTree = SOURCE_ROOT; };
-		F97BA06D15439FC3009EB9DD /* IFCReaderGen.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IFCReaderGen.h; path = ../../code/IFCReaderGen.h; sourceTree = SOURCE_ROOT; };
-		F97BA06E15439FC3009EB9DD /* IFCUtil.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = IFCUtil.cpp; path = ../../code/IFCUtil.cpp; sourceTree = SOURCE_ROOT; };
-		F97BA06F15439FC3009EB9DD /* IFCUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = IFCUtil.h; path = ../../code/IFCUtil.h; sourceTree = SOURCE_ROOT; };
-		F99A9EB315436077000682F3 /* BlobIOSystem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BlobIOSystem.h; sourceTree = "<group>"; };
-		F99A9EB815436098000682F3 /* lexical_cast.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = lexical_cast.hpp; sourceTree = "<group>"; };
-		F99A9EBD154360A0000682F3 /* make_shared.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = make_shared.hpp; sourceTree = "<group>"; };
-		F99A9EC2154360A5000682F3 /* noncopyable.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = noncopyable.hpp; sourceTree = "<group>"; };
-		F99A9EC7154360B5000682F3 /* timer.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = timer.hpp; sourceTree = "<group>"; };
-		F99A9ECC154360E2000682F3 /* CInterfaceIOWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CInterfaceIOWrapper.h; sourceTree = "<group>"; };
-		F99A9ED115436125000682F3 /* DeboneProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DeboneProcess.cpp; sourceTree = "<group>"; };
-		F99A9ED215436125000682F3 /* DeboneProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DeboneProcess.h; sourceTree = "<group>"; };
-		F99A9F17154361AD000682F3 /* ImporterRegistry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ImporterRegistry.cpp; sourceTree = "<group>"; };
-		F99A9F1C154361D4000682F3 /* LogAux.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LogAux.h; sourceTree = "<group>"; };
 		F99A9F2615436207000682F3 /* M3Importer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = M3Importer.cpp; path = ../../code/M3Importer.cpp; sourceTree = SOURCE_ROOT; };
 		F99A9F2715436207000682F3 /* M3Importer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = M3Importer.h; path = ../../code/M3Importer.h; sourceTree = SOURCE_ROOT; };
 		F99A9F3015436269000682F3 /* PlyExporter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PlyExporter.cpp; sourceTree = "<group>"; };
 		F99A9F3115436269000682F3 /* PlyExporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PlyExporter.h; sourceTree = "<group>"; };
-		F99A9F3A15436286000682F3 /* PolyTools.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PolyTools.h; sourceTree = "<group>"; };
-		F99A9F3F1543629F000682F3 /* PostStepRegistry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PostStepRegistry.cpp; sourceTree = "<group>"; };
-		F99A9F44154362DE000682F3 /* ScenePrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScenePrivate.h; sourceTree = "<group>"; };
-		F99A9F4915436304000682F3 /* SplitByBoneCountProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SplitByBoneCountProcess.cpp; sourceTree = "<group>"; };
-		F99A9F4A15436304000682F3 /* SplitByBoneCountProcess.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SplitByBoneCountProcess.h; sourceTree = "<group>"; };
-		F99A9F5915436323000682F3 /* STEPFile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STEPFile.h; path = ../../code/STEPFile.h; sourceTree = SOURCE_ROOT; };
-		F99A9F5A15436323000682F3 /* STEPFileReader.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = STEPFileReader.cpp; path = ../../code/STEPFileReader.cpp; sourceTree = SOURCE_ROOT; };
-		F99A9F5B15436323000682F3 /* STEPFileReader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = STEPFileReader.h; path = ../../code/STEPFileReader.h; sourceTree = SOURCE_ROOT; };
 		F9BA8B751543268400E63FFE /* anim.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = anim.h; sourceTree = "<group>"; };
 		F9BA8B771543268400E63FFE /* camera.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = camera.h; sourceTree = "<group>"; };
 		F9BA8B781543268400E63FFE /* cexport.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cexport.h; sourceTree = "<group>"; };
@@ -1821,7 +2426,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				745FF8AE113ECB080020C31B /* libz.dylib in Frameworks */,
+				2BA44E13170862E400C78A66 /* libstdc++.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1829,7 +2434,15 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				745FF991113ECC660020C31B /* libz.dylib in Frameworks */,
+				2BA44E14170862EA00C78A66 /* libstdc++.dylib in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B91975B4163AEA54009C397B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2BA44E1A1708680600C78A66 /* libstdc++.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1837,9 +2450,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F90BAFBA0F5DD68F00124155 /* libboost_date_time-xgcc40-mt.a in Frameworks */,
-				F90BAFBC0F5DD6A800124155 /* libboost_thread-xgcc40-mt.a in Frameworks */,
-				F90BB06E0F5DDCFC00124155 /* libz.dylib in Frameworks */,
+				2BA44E11170862D800C78A66 /* libstdc++.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1847,9 +2458,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F962E8880F5DE6B4009A5495 /* libboost_date_time-xgcc40-mt.a in Frameworks */,
-				F962E8890F5DE6B4009A5495 /* libboost_thread-xgcc40-mt.a in Frameworks */,
-				F962E88A0F5DE6B4009A5495 /* libz.dylib in Frameworks */,
+				2BA44E12170862DE00C78A66 /* libstdc++.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1859,10 +2468,11 @@
 		034768DDFF38A45A11DB9C8B /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				8E8DEEA3127E2D59005EF64D /* libassimp.dylib */,
-				8E8DEEA4127E2D59005EF64D /* libassimp.a */,
-				8E8DEEA5127E2D59005EF64D /* libassimp.dylib */,
-				8E8DEEA6127E2D59005EF64D /* libassimp.a */,
+				8E8DEEA3127E2D59005EF64D /* libassimpd.dylib */,
+				8E8DEEA4127E2D59005EF64D /* libassimpd.a */,
+				8E8DEEA5127E2D59005EF64D /* libassimpd.dylib */,
+				8E8DEEA6127E2D59005EF64D /* libassimpd.a */,
+				B919763F163AEA54009C397B /* libassimp-ios.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1881,9 +2491,7 @@
 		0867D69AFE84028FC02AAC07 /* External Frameworks and Libraries */ = {
 			isa = PBXGroup;
 			children = (
-				F90BB06D0F5DDCFC00124155 /* libz.dylib */,
-				F90BAFBB0F5DD6A800124155 /* libboost_thread-xgcc40-mt.a */,
-				F90BAFB90F5DD68F00124155 /* libboost_date_time-xgcc40-mt.a */,
+				2BA44E10170862D800C78A66 /* libstdc++.dylib */,
 			);
 			name = "External Frameworks and Libraries";
 			sourceTree = "<group>";
@@ -1891,7 +2499,7 @@
 		08FB77ACFE841707C02AAC07 /* Source */ = {
 			isa = PBXGroup;
 			children = (
-				3AF45A850E4B716800207D74 /* code */,
+				2B7F45621708365100A106A9 /* code */,
 				F90BB0830F5DDDC700124155 /* importers */,
 				3AF45A520E4B715000207D74 /* include */,
 				74C9BB8611ACBB9900AF885C /* AssimpPCH.cpp */,
@@ -1899,6 +2507,206 @@
 				74C9BBB311ACBC2600AF885C /* revision.h */,
 			);
 			name = Source;
+			sourceTree = "<group>";
+		};
+		2B7F45621708365100A106A9 /* code */ = {
+			isa = PBXGroup;
+			children = (
+				2B7F45841708365100A106A9 /* BoostWorkaround */,
+				2B7F456D1708365100A106A9 /* assbin_chunks.h */,
+				2B7F456E1708365100A106A9 /* Assimp.cpp */,
+				2B7F456F1708365100A106A9 /* AssimpCExport.cpp */,
+				2B7F45741708365100A106A9 /* BaseImporter.cpp */,
+				2B7F45751708365100A106A9 /* BaseImporter.h */,
+				2B7F45761708365100A106A9 /* BaseProcess.cpp */,
+				2B7F45771708365100A106A9 /* BaseProcess.h */,
+				2B7F45831708365100A106A9 /* BlobIOSystem.h */,
+				2B7F45991708365100A106A9 /* ByteSwap.h */,
+				2B7F459A1708365100A106A9 /* CalcTangentsProcess.cpp */,
+				2B7F459B1708365100A106A9 /* CalcTangentsProcess.h */,
+				2B7F459C1708365100A106A9 /* CInterfaceIOWrapper.h */,
+				2B7F45A81708365100A106A9 /* ComputeUVMappingProcess.cpp */,
+				2B7F45A91708365100A106A9 /* ComputeUVMappingProcess.h */,
+				2B7F45AA1708365100A106A9 /* ConvertToLHProcess.cpp */,
+				2B7F45AB1708365100A106A9 /* ConvertToLHProcess.h */,
+				2B7F45AE1708365100A106A9 /* DeboneProcess.cpp */,
+				2B7F45AF1708365100A106A9 /* DeboneProcess.h */,
+				2B7F45B01708365100A106A9 /* DefaultIOStream.cpp */,
+				2B7F45B11708365100A106A9 /* DefaultIOStream.h */,
+				2B7F45B21708365100A106A9 /* DefaultIOSystem.cpp */,
+				2B7F45B31708365100A106A9 /* DefaultIOSystem.h */,
+				2B7F45B41708365100A106A9 /* DefaultLogger.cpp */,
+				2B7F45B51708365100A106A9 /* DefaultProgressHandler.h */,
+				2B7F45B91708365100A106A9 /* Exceptional.h */,
+				2B7F45BA1708365100A106A9 /* Exporter.cpp */,
+				2B7F45BB1708365100A106A9 /* fast_atof.h */,
+				2B7F45BC1708365100A106A9 /* FBXAnimation.cpp */,
+				2B7F45BD1708365100A106A9 /* FBXBinaryTokenizer.cpp */,
+				2B7F45BE1708365100A106A9 /* FBXCompileConfig.h */,
+				2B7F45BF1708365100A106A9 /* FBXConverter.cpp */,
+				2B7F45C01708365100A106A9 /* FBXConverter.h */,
+				2B7F45C11708365100A106A9 /* FBXDeformer.cpp */,
+				2B7F45C21708365100A106A9 /* FBXDocument.cpp */,
+				2B7F45C31708365100A106A9 /* FBXDocument.h */,
+				2B7F45C41708365100A106A9 /* FBXDocumentUtil.cpp */,
+				2B7F45C51708365100A106A9 /* FBXDocumentUtil.h */,
+				2B7F45C61708365100A106A9 /* FBXImporter.cpp */,
+				2B7F45C71708365100A106A9 /* FBXImporter.h */,
+				2B7F45C81708365100A106A9 /* FBXImportSettings.h */,
+				2B7F45C91708365100A106A9 /* FBXMaterial.cpp */,
+				2B7F45CA1708365100A106A9 /* FBXMeshGeometry.cpp */,
+				2B7F45CB1708365100A106A9 /* FBXModel.cpp */,
+				2B7F45CC1708365100A106A9 /* FBXNodeAttribute.cpp */,
+				2B7F45CD1708365100A106A9 /* FBXParser.cpp */,
+				2B7F45CE1708365100A106A9 /* FBXParser.h */,
+				2B7F45CF1708365100A106A9 /* FBXProperties.cpp */,
+				2B7F45D01708365100A106A9 /* FBXProperties.h */,
+				2B7F45D11708365100A106A9 /* FBXTokenizer.cpp */,
+				2B7F45D21708365100A106A9 /* FBXTokenizer.h */,
+				2B7F45D31708365100A106A9 /* FBXUtil.cpp */,
+				2B7F45D41708365100A106A9 /* FBXUtil.h */,
+				2B7F45D51708365100A106A9 /* FileLogStream.h */,
+				2B7F45D61708365100A106A9 /* FileSystemFilter.h */,
+				2B7F45D71708365100A106A9 /* FindDegenerates.cpp */,
+				2B7F45D81708365100A106A9 /* FindDegenerates.h */,
+				2B7F45D91708365100A106A9 /* FindInstancesProcess.cpp */,
+				2B7F45DA1708365100A106A9 /* FindInstancesProcess.h */,
+				2B7F45DB1708365100A106A9 /* FindInvalidDataProcess.cpp */,
+				2B7F45DC1708365100A106A9 /* FindInvalidDataProcess.h */,
+				2B7F45DD1708365100A106A9 /* FixNormalsStep.cpp */,
+				2B7F45DE1708365100A106A9 /* FixNormalsStep.h */,
+				2B7F45DF1708365100A106A9 /* GenericProperty.h */,
+				2B7F45E01708365100A106A9 /* GenFaceNormalsProcess.cpp */,
+				2B7F45E11708365100A106A9 /* GenFaceNormalsProcess.h */,
+				2B7F45E21708365100A106A9 /* GenVertexNormalsProcess.cpp */,
+				2B7F45E31708365100A106A9 /* GenVertexNormalsProcess.h */,
+				2B7F45E51708365100A106A9 /* Hash.h */,
+				2B7F45F51708365100A106A9 /* IFF.h */,
+				2B7F45F61708365100A106A9 /* Importer.cpp */,
+				2B7F45F71708365100A106A9 /* Importer.h */,
+				2B7F45F81708365100A106A9 /* ImporterRegistry.cpp */,
+				2B7F45F91708365100A106A9 /* ImproveCacheLocality.cpp */,
+				2B7F45FA1708365100A106A9 /* ImproveCacheLocality.h */,
+				2B7F46021708365100A106A9 /* JoinVerticesProcess.cpp */,
+				2B7F46031708365100A106A9 /* JoinVerticesProcess.h */,
+				2B7F46041708365100A106A9 /* LimitBoneWeightsProcess.cpp */,
+				2B7F46051708365100A106A9 /* LimitBoneWeightsProcess.h */,
+				2B7F46061708365100A106A9 /* LineSplitter.h */,
+				2B7F46071708365100A106A9 /* LogAux.h */,
+				2B7F46141708365200A106A9 /* MakeVerboseFormat.cpp */,
+				2B7F46151708365200A106A9 /* MakeVerboseFormat.h */,
+				2B7F46161708365200A106A9 /* MaterialSystem.cpp */,
+				2B7F46171708365200A106A9 /* MaterialSystem.h */,
+				2B7F461F1708365200A106A9 /* MD4FileData.h */,
+				2B7F462D1708365200A106A9 /* MemoryIOWrapper.h */,
+				2B7F46461708365200A106A9 /* OptimizeGraph.cpp */,
+				2B7F46471708365200A106A9 /* OptimizeGraph.h */,
+				2B7F46481708365200A106A9 /* OptimizeMeshes.cpp */,
+				2B7F46491708365200A106A9 /* OptimizeMeshes.h */,
+				2B7F464A1708365200A106A9 /* ParsingUtils.h */,
+				2B7F46511708365200A106A9 /* PolyTools.h */,
+				2B7F46521708365200A106A9 /* PostStepRegistry.cpp */,
+				2B7F46531708365200A106A9 /* PretransformVertices.cpp */,
+				2B7F46541708365200A106A9 /* PretransformVertices.h */,
+				2B7F46551708365200A106A9 /* ProcessHelper.cpp */,
+				2B7F46561708365200A106A9 /* ProcessHelper.h */,
+				2B7F46571708365200A106A9 /* Profiler.h */,
+				2B7F46581708365200A106A9 /* pstdint.h */,
+				2B7F46621708365200A106A9 /* qnan.h */,
+				2B7F46651708365200A106A9 /* RemoveComments.cpp */,
+				2B7F46661708365200A106A9 /* RemoveComments.h */,
+				2B7F46671708365200A106A9 /* RemoveRedundantMaterials.cpp */,
+				2B7F46681708365200A106A9 /* RemoveRedundantMaterials.h */,
+				2B7F46691708365200A106A9 /* RemoveVCProcess.cpp */,
+				2B7F466A1708365200A106A9 /* RemoveVCProcess.h */,
+				2B7F466E1708365200A106A9 /* SceneCombiner.cpp */,
+				2B7F466F1708365200A106A9 /* SceneCombiner.h */,
+				2B7F46701708365200A106A9 /* ScenePreprocessor.cpp */,
+				2B7F46711708365200A106A9 /* ScenePreprocessor.h */,
+				2B7F46721708365200A106A9 /* ScenePrivate.h */,
+				2B7F46731708365200A106A9 /* SGSpatialSort.cpp */,
+				2B7F46741708365200A106A9 /* SGSpatialSort.h */,
+				2B7F46751708365200A106A9 /* SkeletonMeshBuilder.cpp */,
+				2B7F46761708365200A106A9 /* SkeletonMeshBuilder.h */,
+				2B7F46791708365200A106A9 /* SmoothingGroups.h */,
+				2B7F467A1708365200A106A9 /* SmoothingGroups.inl */,
+				2B7F467B1708365200A106A9 /* SortByPTypeProcess.cpp */,
+				2B7F467C1708365200A106A9 /* SortByPTypeProcess.h */,
+				2B7F467D1708365200A106A9 /* SpatialSort.cpp */,
+				2B7F467E1708365200A106A9 /* SpatialSort.h */,
+				2B7F467F1708365200A106A9 /* SplitByBoneCountProcess.cpp */,
+				2B7F46801708365200A106A9 /* SplitByBoneCountProcess.h */,
+				2B7F46811708365200A106A9 /* SplitLargeMeshes.cpp */,
+				2B7F46821708365200A106A9 /* SplitLargeMeshes.h */,
+				2B7F46831708365200A106A9 /* StandardShapes.cpp */,
+				2B7F46841708365200A106A9 /* StandardShapes.h */,
+				2B7F46851708365200A106A9 /* StdOStreamLogStream.h */,
+				2B7F468F1708365200A106A9 /* StreamReader.h */,
+				2B7F46901708365200A106A9 /* StringComparison.h */,
+				2B7F46911708365200A106A9 /* Subdivision.cpp */,
+				2B7F46921708365200A106A9 /* Subdivision.h */,
+				2B7F46931708365200A106A9 /* TargetAnimation.cpp */,
+				2B7F46941708365200A106A9 /* TargetAnimation.h */,
+				2B7F46971708365200A106A9 /* TextureTransform.cpp */,
+				2B7F46981708365200A106A9 /* TextureTransform.h */,
+				2B7F46991708365200A106A9 /* TinyFormatter.h */,
+				2B7F469A1708365200A106A9 /* TriangulateProcess.cpp */,
+				2B7F469B1708365200A106A9 /* TriangulateProcess.h */,
+				2B7F469E1708365200A106A9 /* ValidateDataStructure.cpp */,
+				2B7F469F1708365200A106A9 /* ValidateDataStructure.h */,
+				2B7F46A01708365200A106A9 /* Vertex.h */,
+				2B7F46A11708365200A106A9 /* VertexTriangleAdjacency.cpp */,
+				2B7F46A21708365200A106A9 /* VertexTriangleAdjacency.h */,
+				2B7F46A31708365200A106A9 /* Win32DebugLogStream.h */,
+			);
+			name = code;
+			path = ../../code;
+			sourceTree = "<group>";
+		};
+		2B7F45841708365100A106A9 /* BoostWorkaround */ = {
+			isa = PBXGroup;
+			children = (
+				2B7F45851708365100A106A9 /* boost */,
+			);
+			path = BoostWorkaround;
+			sourceTree = "<group>";
+		};
+		2B7F45851708365100A106A9 /* boost */ = {
+			isa = PBXGroup;
+			children = (
+				2B7F45861708365100A106A9 /* foreach.hpp */,
+				2B7F45871708365100A106A9 /* format.hpp */,
+				2B7F45881708365100A106A9 /* lexical_cast.hpp */,
+				2B7F45891708365100A106A9 /* LICENSE_1_0.txt */,
+				2B7F458A1708365100A106A9 /* make_shared.hpp */,
+				2B7F458B1708365100A106A9 /* math */,
+				2B7F458D1708365100A106A9 /* noncopyable.hpp */,
+				2B7F458E1708365100A106A9 /* pointer_cast.hpp */,
+				2B7F458F1708365100A106A9 /* scoped_array.hpp */,
+				2B7F45901708365100A106A9 /* scoped_ptr.hpp */,
+				2B7F45911708365100A106A9 /* shared_array.hpp */,
+				2B7F45921708365100A106A9 /* shared_ptr.hpp */,
+				2B7F45931708365100A106A9 /* static_assert.hpp */,
+				2B7F45941708365100A106A9 /* timer.hpp */,
+				2B7F45951708365100A106A9 /* tuple */,
+			);
+			path = boost;
+			sourceTree = "<group>";
+		};
+		2B7F458B1708365100A106A9 /* math */ = {
+			isa = PBXGroup;
+			children = (
+				2B7F458C1708365100A106A9 /* common_factor_rt.hpp */,
+			);
+			path = math;
+			sourceTree = "<group>";
+		};
+		2B7F45951708365100A106A9 /* tuple */ = {
+			isa = PBXGroup;
+			children = (
+				2B7F45961708365100A106A9 /* tuple.hpp */,
+			);
+			path = tuple;
 			sourceTree = "<group>";
 		};
 		3AB8A3A70E50D59500606590 /* MDC */ = {
@@ -1935,132 +2743,6 @@
 			);
 			name = include;
 			path = ../../include;
-			sourceTree = SOURCE_ROOT;
-		};
-		3AF45A850E4B716800207D74 /* code */ = {
-			isa = PBXGroup;
-			children = (
-				7437C94E113F18C70067B9B9 /* BoostWorkaround */,
-				8E7ABBDF127E0FA400512ED1 /* assbin_chunks.h */,
-				3AF45A920E4B716800207D74 /* Assimp.cpp */,
-				3AF45A930E4B716800207D74 /* BaseImporter.cpp */,
-				3AF45A940E4B716800207D74 /* BaseImporter.h */,
-				3AB8A3C30E50D74500606590 /* BaseProcess.cpp */,
-				3AF45A950E4B716800207D74 /* BaseProcess.h */,
-				F99A9EB315436077000682F3 /* BlobIOSystem.h */,
-				3AF45A960E4B716800207D74 /* ByteSwap.h */,
-				3AF45A970E4B716800207D74 /* CalcTangentsProcess.cpp */,
-				3AF45A980E4B716800207D74 /* CalcTangentsProcess.h */,
-				F99A9ECC154360E2000682F3 /* CInterfaceIOWrapper.h */,
-				F90BB04D0F5DDB8D00124155 /* ComputeUVMappingProcess.cpp */,
-				F90BB04C0F5DDB8D00124155 /* ComputeUVMappingProcess.h */,
-				3AF45A990E4B716800207D74 /* ConvertToLHProcess.cpp */,
-				3AF45A9A0E4B716800207D74 /* ConvertToLHProcess.h */,
-				F99A9ED115436125000682F3 /* DeboneProcess.cpp */,
-				F99A9ED215436125000682F3 /* DeboneProcess.h */,
-				3AF45A9B0E4B716800207D74 /* DefaultIOStream.cpp */,
-				3AF45A9C0E4B716800207D74 /* DefaultIOStream.h */,
-				3AF45A9D0E4B716800207D74 /* DefaultIOSystem.cpp */,
-				3AF45A9E0E4B716800207D74 /* DefaultIOSystem.h */,
-				3AF45A9F0E4B716800207D74 /* DefaultLogger.cpp */,
-				8E7ABBE0127E0FA400512ED1 /* DefaultProgressHandler.h */,
-				74C9BBBB11ACBC6C00AF885C /* Exceptional.h */,
-				3AF45AA30E4B716800207D74 /* fast_atof.h */,
-				3AF45AA40E4B716800207D74 /* FileLogStream.h */,
-				7411B19711416EF400BCD793 /* FileSystemFilter.h */,
-				F90BB0480F5DDB6100124155 /* FindDegenerates.cpp */,
-				F90BB0470F5DDB6100124155 /* FindDegenerates.h */,
-				F90BB0570F5DDBBF00124155 /* FindInstancesProcess.cpp */,
-				F90BB0560F5DDBBF00124155 /* FindInstancesProcess.h */,
-				F90BB05F0F5DDBE600124155 /* FindInvalidDataProcess.cpp */,
-				F90BB0600F5DDBE600124155 /* FindInvalidDataProcess.h */,
-				3AB8A3B30E50D69D00606590 /* FixNormalsStep.cpp */,
-				3AB8A3B40E50D69D00606590 /* FixNormalsStep.h */,
-				7411B19811416EF400BCD793 /* GenericProperty.h */,
-				3AF45AA50E4B716800207D74 /* GenFaceNormalsProcess.cpp */,
-				3AF45AA60E4B716800207D74 /* GenFaceNormalsProcess.h */,
-				3AF45AA70E4B716800207D74 /* GenVertexNormalsProcess.cpp */,
-				3AF45AA80E4B716800207D74 /* GenVertexNormalsProcess.h */,
-				3AB8A3CB0E50D7FF00606590 /* Hash.h */,
-				3AB8A3C90E50D7CC00606590 /* IFF.h */,
-				3AF45AAD0E4B716800207D74 /* Importer.cpp */,
-				F99A9F17154361AD000682F3 /* ImporterRegistry.cpp */,
-				3AF45AAE0E4B716800207D74 /* ImproveCacheLocality.cpp */,
-				3AF45AAF0E4B716800207D74 /* ImproveCacheLocality.h */,
-				3AF45AB00E4B716800207D74 /* JoinVerticesProcess.cpp */,
-				3AF45AB10E4B716800207D74 /* JoinVerticesProcess.h */,
-				3AF45AB40E4B716800207D74 /* LimitBoneWeightsProcess.cpp */,
-				3AF45AB50E4B716800207D74 /* LimitBoneWeightsProcess.h */,
-				74C9BBBC11ACBC6C00AF885C /* LineSplitter.h */,
-				F99A9F1C154361D4000682F3 /* LogAux.h */,
-				74C9BB7C11ACBB7800AF885C /* MakeVerboseFormat.cpp */,
-				74C9BB7D11ACBB7800AF885C /* MakeVerboseFormat.h */,
-				3AF45AB60E4B716800207D74 /* MaterialSystem.cpp */,
-				3AF45AB70E4B716800207D74 /* MaterialSystem.h */,
-				74C9BBBD11ACBC6C00AF885C /* MD4FileData.h */,
-				7411B19911416EF400BCD793 /* MemoryIOWrapper.h */,
-				7411B19A11416EF400BCD793 /* OptimizeGraph.cpp */,
-				7411B19B11416EF400BCD793 /* OptimizeGraph.h */,
-				7411B19C11416EF400BCD793 /* OptimizeMeshes.cpp */,
-				7411B19D11416EF400BCD793 /* OptimizeMeshes.h */,
-				3AF45AD30E4B716800207D74 /* ParsingUtils.h */,
-				F99A9F3A15436286000682F3 /* PolyTools.h */,
-				F99A9F3F1543629F000682F3 /* PostStepRegistry.cpp */,
-				3AF45AD80E4B716800207D74 /* PretransformVertices.cpp */,
-				3AF45AD90E4B716800207D74 /* PretransformVertices.h */,
-				F9606FF2154364E5004D91DD /* ProcessHelper.cpp */,
-				7411B19E11416EF400BCD793 /* ProcessHelper.h */,
-				8E7ABBE1127E0FA400512ED1 /* Profiler.h */,
-				8E7ABBE2127E0FA400512ED1 /* pstdint.h */,
-				3AF45ADA0E4B716800207D74 /* qnan.h */,
-				3AF45ADB0E4B716800207D74 /* RemoveComments.cpp */,
-				3AF45ADC0E4B716800207D74 /* RemoveComments.h */,
-				3AF45ADD0E4B716800207D74 /* RemoveRedundantMaterials.cpp */,
-				3AF45ADE0E4B716800207D74 /* RemoveRedundantMaterials.h */,
-				F90BB05B0F5DDBCB00124155 /* RemoveVCProcess.cpp */,
-				F90BB05A0F5DDBCB00124155 /* RemoveVCProcess.h */,
-				F90BB03A0F5DDB3200124155 /* SceneCombiner.cpp */,
-				F90BB03B0F5DDB3200124155 /* SceneCombiner.h */,
-				F90BB03C0F5DDB3200124155 /* ScenePreprocessor.cpp */,
-				F90BB0390F5DDB3200124155 /* ScenePreprocessor.h */,
-				F99A9F44154362DE000682F3 /* ScenePrivate.h */,
-				F90BAFFC0F5DD9A000124155 /* SGSpatialSort.cpp */,
-				F90BAFFB0F5DD9A000124155 /* SGSpatialSort.h */,
-				F90BB0650F5DDC0700124155 /* SkeletonMeshBuilder.cpp */,
-				F90BB0640F5DDC0700124155 /* SkeletonMeshBuilder.h */,
-				F90BB0690F5DDC1E00124155 /* SmoothingGroups.h */,
-				F90BB06A0F5DDC1E00124155 /* SmoothingGroups.inl */,
-				F90BB0430F5DDB4600124155 /* SortByPTypeProcess.cpp */,
-				F90BB0420F5DDB4600124155 /* SortByPTypeProcess.h */,
-				3AF45AE40E4B716800207D74 /* SpatialSort.cpp */,
-				3AF45AE50E4B716800207D74 /* SpatialSort.h */,
-				F99A9F4915436304000682F3 /* SplitByBoneCountProcess.cpp */,
-				F99A9F4A15436304000682F3 /* SplitByBoneCountProcess.h */,
-				3AF45AE60E4B716800207D74 /* SplitLargeMeshes.cpp */,
-				3AF45AE70E4B716800207D74 /* SplitLargeMeshes.h */,
-				F90BB0520F5DDBA800124155 /* StandardShapes.cpp */,
-				F90BB0510F5DDBA800124155 /* StandardShapes.h */,
-				7411B19F11416EF400BCD793 /* StdOStreamLogStream.h */,
-				7411B1A011416EF400BCD793 /* StreamReader.h */,
-				3AF45AEA0E4B716800207D74 /* StringComparison.h */,
-				7411B1A111416EF400BCD793 /* Subdivision.cpp */,
-				7411B1A211416EF400BCD793 /* Subdivision.h */,
-				7411B1A311416EF400BCD793 /* TargetAnimation.cpp */,
-				7411B1A411416EF400BCD793 /* TargetAnimation.h */,
-				3AF45AEB0E4B716800207D74 /* TextureTransform.cpp */,
-				3AF45AEC0E4B716800207D74 /* TextureTransform.h */,
-				74C9BBBE11ACBC6C00AF885C /* TinyFormatter.h */,
-				3AF45AED0E4B716800207D74 /* TriangulateProcess.cpp */,
-				3AF45AEE0E4B716800207D74 /* TriangulateProcess.h */,
-				3AF45AEF0E4B716800207D74 /* ValidateDataStructure.cpp */,
-				3AF45AF00E4B716800207D74 /* ValidateDataStructure.h */,
-				7411B1A511416EF400BCD793 /* Vertex.h */,
-				3AF45AF10E4B716800207D74 /* VertexTriangleAdjacency.cpp */,
-				3AF45AF20E4B716800207D74 /* VertexTriangleAdjacency.h */,
-				3AF45AF30E4B716800207D74 /* Win32DebugLogStream.h */,
-			);
-			name = code;
-			path = ../../code;
 			sourceTree = SOURCE_ROOT;
 		};
 		3AF45B690E4B722000207D74 /* 3DS */ = {
@@ -2150,14 +2832,16 @@
 		3AF45B8C0E4B75F200207D74 /* Obj */ = {
 			isa = PBXGroup;
 			children = (
-				3AF45ACB0E4B716800207D74 /* ObjFileData.h */,
-				3AF45ACC0E4B716800207D74 /* ObjFileImporter.cpp */,
-				3AF45ACD0E4B716800207D74 /* ObjFileImporter.h */,
-				3AF45ACE0E4B716800207D74 /* ObjFileMtlImporter.cpp */,
-				3AF45ACF0E4B716800207D74 /* ObjFileMtlImporter.h */,
-				3AF45AD00E4B716800207D74 /* ObjFileParser.cpp */,
-				3AF45AD10E4B716800207D74 /* ObjFileParser.h */,
-				3AF45AD20E4B716800207D74 /* ObjTools.h */,
+				2B7F46341708365200A106A9 /* ObjExporter.cpp */,
+				2B7F46351708365200A106A9 /* ObjExporter.h */,
+				2B7F46361708365200A106A9 /* ObjFileData.h */,
+				2B7F46371708365200A106A9 /* ObjFileImporter.cpp */,
+				2B7F46381708365200A106A9 /* ObjFileImporter.h */,
+				2B7F46391708365200A106A9 /* ObjFileMtlImporter.cpp */,
+				2B7F463A1708365200A106A9 /* ObjFileMtlImporter.h */,
+				2B7F463B1708365200A106A9 /* ObjFileParser.cpp */,
+				2B7F463C1708365200A106A9 /* ObjFileParser.h */,
+				2B7F463D1708365200A106A9 /* ObjTools.h */,
 			);
 			name = Obj;
 			path = ../../code;
@@ -2203,8 +2887,10 @@
 		3AF45B910E4B77BE00207D74 /* STL */ = {
 			isa = PBXGroup;
 			children = (
-				3AF45AE80E4B716800207D74 /* STLLoader.cpp */,
-				3AF45AE90E4B716800207D74 /* STLLoader.h */,
+				2B7F468B1708365200A106A9 /* STLExporter.cpp */,
+				2B7F468C1708365200A106A9 /* STLExporter.h */,
+				2B7F468D1708365200A106A9 /* STLLoader.cpp */,
+				2B7F468E1708365200A106A9 /* STLLoader.h */,
 			);
 			name = STL;
 			path = ../../code;
@@ -2258,55 +2944,6 @@
 			);
 			name = Unreal;
 			sourceTree = "<group>";
-		};
-		7437C94E113F18C70067B9B9 /* BoostWorkaround */ = {
-			isa = PBXGroup;
-			children = (
-				7437C94F113F18C70067B9B9 /* boost */,
-			);
-			name = BoostWorkaround;
-			path = ../../code/BoostWorkaround;
-			sourceTree = SOURCE_ROOT;
-		};
-		7437C94F113F18C70067B9B9 /* boost */ = {
-			isa = PBXGroup;
-			children = (
-				7437C952113F18C70067B9B9 /* math */,
-				7437C957113F18C70067B9B9 /* tuple */,
-				7437C950113F18C70067B9B9 /* foreach.hpp */,
-				7437C951113F18C70067B9B9 /* format.hpp */,
-				F99A9EB815436098000682F3 /* lexical_cast.hpp */,
-				F99A9EBD154360A0000682F3 /* make_shared.hpp */,
-				F99A9EC2154360A5000682F3 /* noncopyable.hpp */,
-				74C9BB6F11ACBB3600AF885C /* pointer_cast.hpp */,
-				7437C954113F18C70067B9B9 /* scoped_array.hpp */,
-				7437C955113F18C70067B9B9 /* scoped_ptr.hpp */,
-				74C9BB7011ACBB3600AF885C /* shared_array.hpp */,
-				74C9BB7111ACBB3600AF885C /* shared_ptr.hpp */,
-				7437C956113F18C70067B9B9 /* static_assert.hpp */,
-				F99A9EC7154360B5000682F3 /* timer.hpp */,
-			);
-			name = boost;
-			path = ../../code/BoostWorkaround/boost;
-			sourceTree = SOURCE_ROOT;
-		};
-		7437C952113F18C70067B9B9 /* math */ = {
-			isa = PBXGroup;
-			children = (
-				7437C953113F18C70067B9B9 /* common_factor_rt.hpp */,
-			);
-			name = math;
-			path = ../../code/BoostWorkaround/boost/math;
-			sourceTree = SOURCE_ROOT;
-		};
-		7437C957113F18C70067B9B9 /* tuple */ = {
-			isa = PBXGroup;
-			children = (
-				7437C958113F18C70067B9B9 /* tuple.hpp */,
-			);
-			name = tuple;
-			path = ../../code/BoostWorkaround/boost/tuple;
-			sourceTree = SOURCE_ROOT;
 		};
 		74C9BB4611ACBAE500AF885C /* Blender */ = {
 			isa = PBXGroup;
@@ -2422,11 +3059,13 @@
 		F90BAFE60F5DD91F00124155 /* COLLADA */ = {
 			isa = PBXGroup;
 			children = (
-				F90BAFE80F5DD93600124155 /* ColladaHelper.h */,
-				F90BAFE90F5DD93600124155 /* ColladaLoader.cpp */,
-				F90BAFEA0F5DD93600124155 /* ColladaLoader.h */,
-				F90BAFEB0F5DD93600124155 /* ColladaParser.cpp */,
-				F90BAFEC0F5DD93600124155 /* ColladaParser.h */,
+				2B7F45A11708365100A106A9 /* ColladaExporter.cpp */,
+				2B7F45A21708365100A106A9 /* ColladaExporter.h */,
+				2B7F45A31708365100A106A9 /* ColladaHelper.h */,
+				2B7F45A41708365100A106A9 /* ColladaLoader.cpp */,
+				2B7F45A51708365100A106A9 /* ColladaLoader.h */,
+				2B7F45A61708365100A106A9 /* ColladaParser.cpp */,
+				2B7F45A71708365100A106A9 /* ColladaParser.h */,
 			);
 			name = COLLADA;
 			path = ../../code;
@@ -2654,16 +3293,18 @@
 		F97BA06415439FB2009EB9DD /* IFC */ = {
 			isa = PBXGroup;
 			children = (
-				F97BA06615439FC3009EB9DD /* IFCCurve.cpp */,
-				F97BA06715439FC3009EB9DD /* IFCGeometry.cpp */,
-				F97BA06815439FC3009EB9DD /* IFCLoader.cpp */,
-				F97BA06915439FC3009EB9DD /* IFCLoader.h */,
-				F97BA06A15439FC3009EB9DD /* IFCMaterial.cpp */,
-				F97BA06B15439FC3009EB9DD /* IFCProfile.cpp */,
-				F97BA06C15439FC3009EB9DD /* IFCReaderGen.cpp */,
-				F97BA06D15439FC3009EB9DD /* IFCReaderGen.h */,
-				F97BA06E15439FC3009EB9DD /* IFCUtil.cpp */,
-				F97BA06F15439FC3009EB9DD /* IFCUtil.h */,
+				2B7F45E91708365100A106A9 /* IFCBoolean.cpp */,
+				2B7F45EA1708365100A106A9 /* IFCCurve.cpp */,
+				2B7F45EB1708365100A106A9 /* IFCGeometry.cpp */,
+				2B7F45EC1708365100A106A9 /* IFCLoader.cpp */,
+				2B7F45ED1708365100A106A9 /* IFCLoader.h */,
+				2B7F45EE1708365100A106A9 /* IFCMaterial.cpp */,
+				2B7F45EF1708365100A106A9 /* IFCOpenings.cpp */,
+				2B7F45F01708365100A106A9 /* IFCProfile.cpp */,
+				2B7F45F11708365100A106A9 /* IFCReaderGen.cpp */,
+				2B7F45F21708365100A106A9 /* IFCReaderGen.h */,
+				2B7F45F31708365100A106A9 /* IFCUtil.cpp */,
+				2B7F45F41708365100A106A9 /* IFCUtil.h */,
 			);
 			name = IFC;
 			sourceTree = "<group>";
@@ -2680,9 +3321,11 @@
 		F99A9F5315436318000682F3 /* STEP */ = {
 			isa = PBXGroup;
 			children = (
-				F99A9F5915436323000682F3 /* STEPFile.h */,
-				F99A9F5A15436323000682F3 /* STEPFileReader.cpp */,
-				F99A9F5B15436323000682F3 /* STEPFileReader.h */,
+				2B7F46861708365200A106A9 /* STEPFile.h */,
+				2B7F46871708365200A106A9 /* STEPFileEncoding.cpp */,
+				2B7F46881708365200A106A9 /* STEPFileEncoding.h */,
+				2B7F46891708365200A106A9 /* STEPFileReader.cpp */,
+				2B7F468A1708365200A106A9 /* STEPFileReader.h */,
 			);
 			name = STEP;
 			sourceTree = "<group>";
@@ -2754,23 +3397,8 @@
 				745FF841113ECB080020C31B /* 3DSLoader.h in Headers */,
 				745FF842113ECB080020C31B /* ASELoader.h in Headers */,
 				745FF843113ECB080020C31B /* ASEParser.h in Headers */,
-				745FF844113ECB080020C31B /* BaseImporter.h in Headers */,
-				745FF845113ECB080020C31B /* BaseProcess.h in Headers */,
-				745FF846113ECB080020C31B /* ByteSwap.h in Headers */,
-				745FF847113ECB080020C31B /* CalcTangentsProcess.h in Headers */,
-				745FF848113ECB080020C31B /* ConvertToLHProcess.h in Headers */,
-				745FF849113ECB080020C31B /* DefaultIOStream.h in Headers */,
-				745FF84A113ECB080020C31B /* DefaultIOSystem.h in Headers */,
-				745FF84C113ECB080020C31B /* fast_atof.h in Headers */,
-				745FF84D113ECB080020C31B /* FileLogStream.h in Headers */,
-				745FF84E113ECB080020C31B /* GenFaceNormalsProcess.h in Headers */,
-				745FF84F113ECB080020C31B /* GenVertexNormalsProcess.h in Headers */,
 				745FF850113ECB080020C31B /* HalfLifeFileData.h in Headers */,
 				745FF851113ECB080020C31B /* HMPLoader.h in Headers */,
-				745FF852113ECB080020C31B /* ImproveCacheLocality.h in Headers */,
-				745FF853113ECB080020C31B /* JoinVerticesProcess.h in Headers */,
-				745FF854113ECB080020C31B /* LimitBoneWeightsProcess.h in Headers */,
-				745FF855113ECB080020C31B /* MaterialSystem.h in Headers */,
 				745FF856113ECB080020C31B /* MD2FileData.h in Headers */,
 				745FF857113ECB080020C31B /* MD2Loader.h in Headers */,
 				745FF858113ECB080020C31B /* MD2NormalTable.h in Headers */,
@@ -2781,49 +3409,23 @@
 				745FF85D113ECB080020C31B /* MDLDefaultColorMap.h in Headers */,
 				745FF85E113ECB080020C31B /* MDLFileData.h in Headers */,
 				745FF85F113ECB080020C31B /* MDLLoader.h in Headers */,
-				745FF860113ECB080020C31B /* ObjFileData.h in Headers */,
-				745FF861113ECB080020C31B /* ObjFileImporter.h in Headers */,
-				745FF862113ECB080020C31B /* ObjFileMtlImporter.h in Headers */,
-				745FF863113ECB080020C31B /* ObjFileParser.h in Headers */,
-				745FF864113ECB080020C31B /* ObjTools.h in Headers */,
-				745FF865113ECB080020C31B /* ParsingUtils.h in Headers */,
 				745FF866113ECB080020C31B /* PlyLoader.h in Headers */,
 				745FF867113ECB080020C31B /* PlyParser.h in Headers */,
-				745FF868113ECB080020C31B /* PretransformVertices.h in Headers */,
-				745FF869113ECB080020C31B /* qnan.h in Headers */,
-				745FF86A113ECB080020C31B /* RemoveComments.h in Headers */,
-				745FF86B113ECB080020C31B /* RemoveRedundantMaterials.h in Headers */,
 				745FF86C113ECB080020C31B /* SMDLoader.h in Headers */,
-				745FF86D113ECB080020C31B /* SpatialSort.h in Headers */,
-				745FF86E113ECB080020C31B /* SplitLargeMeshes.h in Headers */,
-				745FF86F113ECB080020C31B /* STLLoader.h in Headers */,
-				745FF870113ECB080020C31B /* StringComparison.h in Headers */,
-				745FF871113ECB080020C31B /* TextureTransform.h in Headers */,
-				745FF872113ECB080020C31B /* TriangulateProcess.h in Headers */,
-				745FF873113ECB080020C31B /* ValidateDataStructure.h in Headers */,
-				745FF874113ECB080020C31B /* VertexTriangleAdjacency.h in Headers */,
-				745FF875113ECB080020C31B /* Win32DebugLogStream.h in Headers */,
 				745FF876113ECB080020C31B /* XFileHelper.h in Headers */,
 				745FF877113ECB080020C31B /* XFileImporter.h in Headers */,
 				745FF878113ECB080020C31B /* XFileParser.h in Headers */,
 				745FF87B113ECB080020C31B /* MDCFileData.h in Headers */,
 				745FF87C113ECB080020C31B /* MDCLoader.h in Headers */,
 				745FF87D113ECB080020C31B /* MDCNormalTable.h in Headers */,
-				745FF87E113ECB080020C31B /* FixNormalsStep.h in Headers */,
 				745FF87F113ECB080020C31B /* LWOFileData.h in Headers */,
 				745FF880113ECB080020C31B /* LWOLoader.h in Headers */,
 				745FF881113ECB080020C31B /* HMPFileData.h in Headers */,
-				745FF883113ECB080020C31B /* IFF.h in Headers */,
-				745FF884113ECB080020C31B /* Hash.h in Headers */,
 				745FF889113ECB080020C31B /* ACLoader.h in Headers */,
 				745FF88A113ECB080020C31B /* IRRLoader.h in Headers */,
 				745FF88B113ECB080020C31B /* IRRMeshLoader.h in Headers */,
 				745FF88C113ECB080020C31B /* IRRShared.h in Headers */,
-				745FF88D113ECB080020C31B /* ColladaHelper.h in Headers */,
-				745FF88E113ECB080020C31B /* ColladaLoader.h in Headers */,
-				745FF88F113ECB080020C31B /* ColladaParser.h in Headers */,
 				745FF890113ECB080020C31B /* NFFLoader.h in Headers */,
-				745FF891113ECB080020C31B /* SGSpatialSort.h in Headers */,
 				745FF892113ECB080020C31B /* Q3DLoader.h in Headers */,
 				745FF893113ECB080020C31B /* BVHLoader.h in Headers */,
 				745FF894113ECB080020C31B /* OFFLoader.h in Headers */,
@@ -2831,57 +3433,20 @@
 				745FF896113ECB080020C31B /* DXFLoader.h in Headers */,
 				745FF897113ECB080020C31B /* TerragenLoader.h in Headers */,
 				745FF898113ECB080020C31B /* irrXMLWrapper.h in Headers */,
-				745FF899113ECB080020C31B /* ScenePreprocessor.h in Headers */,
-				745FF89A113ECB080020C31B /* SceneCombiner.h in Headers */,
-				745FF89B113ECB080020C31B /* SortByPTypeProcess.h in Headers */,
-				745FF89C113ECB080020C31B /* FindDegenerates.h in Headers */,
-				745FF89D113ECB080020C31B /* ComputeUVMappingProcess.h in Headers */,
-				745FF89E113ECB080020C31B /* StandardShapes.h in Headers */,
-				745FF89F113ECB080020C31B /* FindInstancesProcess.h in Headers */,
-				745FF8A0113ECB080020C31B /* RemoveVCProcess.h in Headers */,
-				745FF8A1113ECB080020C31B /* FindInvalidDataProcess.h in Headers */,
-				745FF8A2113ECB080020C31B /* SkeletonMeshBuilder.h in Headers */,
-				745FF8A3113ECB080020C31B /* SmoothingGroups.h in Headers */,
 				745FF8AA113ECB080020C31B /* B3DImporter.h in Headers */,
-				7437C960113F18C70067B9B9 /* foreach.hpp in Headers */,
-				7437C961113F18C70067B9B9 /* format.hpp in Headers */,
-				7437C962113F18C70067B9B9 /* common_factor_rt.hpp in Headers */,
-				7437C963113F18C70067B9B9 /* scoped_array.hpp in Headers */,
-				7437C964113F18C70067B9B9 /* scoped_ptr.hpp in Headers */,
-				7437C965113F18C70067B9B9 /* static_assert.hpp in Headers */,
-				7437C966113F18C70067B9B9 /* tuple.hpp in Headers */,
 				7411B15311416D5E00BCD793 /* CSMLoader.h in Headers */,
 				7411B15E11416DDD00BCD793 /* LWSLoader.h in Headers */,
 				7411B16811416DF400BCD793 /* LWOAnimation.h in Headers */,
 				7411B17511416E2500BCD793 /* MS3DLoader.h in Headers */,
 				7411B19011416EBC00BCD793 /* UnrealLoader.h in Headers */,
-				7411B1B511416EF400BCD793 /* FileSystemFilter.h in Headers */,
-				7411B1B611416EF400BCD793 /* GenericProperty.h in Headers */,
-				7411B1B711416EF400BCD793 /* MemoryIOWrapper.h in Headers */,
-				7411B1B911416EF400BCD793 /* OptimizeGraph.h in Headers */,
-				7411B1BB11416EF400BCD793 /* OptimizeMeshes.h in Headers */,
-				7411B1BC11416EF400BCD793 /* ProcessHelper.h in Headers */,
-				7411B1BD11416EF400BCD793 /* StdOStreamLogStream.h in Headers */,
-				7411B1BE11416EF400BCD793 /* StreamReader.h in Headers */,
-				7411B1C011416EF400BCD793 /* Subdivision.h in Headers */,
-				7411B1C211416EF400BCD793 /* TargetAnimation.h in Headers */,
-				7411B1C311416EF400BCD793 /* Vertex.h in Headers */,
 				74C9BB6011ACBB1000AF885C /* BlenderDNA.h in Headers */,
 				74C9BB6211ACBB1000AF885C /* BlenderLoader.h in Headers */,
 				74C9BB6411ACBB1000AF885C /* BlenderScene.h in Headers */,
 				74C9BB6511ACBB1000AF885C /* BlenderSceneGen.h in Headers */,
-				74C9BB7211ACBB3600AF885C /* pointer_cast.hpp in Headers */,
-				74C9BB7311ACBB3600AF885C /* shared_array.hpp in Headers */,
-				74C9BB7411ACBB3600AF885C /* shared_ptr.hpp in Headers */,
-				74C9BB7F11ACBB7800AF885C /* MakeVerboseFormat.h in Headers */,
 				74C9BB8911ACBB9900AF885C /* AssimpPCH.h in Headers */,
 				74C9BB9711ACBBBC00AF885C /* COBLoader.h in Headers */,
 				74C9BB9811ACBBBC00AF885C /* COBScene.h in Headers */,
 				74C9BBB411ACBC2600AF885C /* revision.h in Headers */,
-				74C9BBBF11ACBC6C00AF885C /* Exceptional.h in Headers */,
-				74C9BBC011ACBC6C00AF885C /* LineSplitter.h in Headers */,
-				74C9BBC111ACBC6C00AF885C /* MD4FileData.h in Headers */,
-				74C9BBC211ACBC6C00AF885C /* TinyFormatter.h in Headers */,
 				8E7ABBA8127E0F1A00512ED1 /* Q3BSPFileData.h in Headers */,
 				8E7ABBAA127E0F1A00512ED1 /* Q3BSPFileImporter.h in Headers */,
 				8E7ABBAC127E0F1A00512ED1 /* Q3BSPFileParser.h in Headers */,
@@ -2889,10 +3454,6 @@
 				8E7ABBC7127E0F2A00512ED1 /* NDOLoader.h in Headers */,
 				8E7ABBD1127E0F3800512ED1 /* BlenderIntermediate.h in Headers */,
 				8E7ABBD3127E0F3800512ED1 /* BlenderModifier.h in Headers */,
-				8E7ABBE3127E0FA400512ED1 /* assbin_chunks.h in Headers */,
-				8E7ABBE4127E0FA400512ED1 /* DefaultProgressHandler.h in Headers */,
-				8E7ABBE5127E0FA400512ED1 /* Profiler.h in Headers */,
-				8E7ABBE6127E0FA400512ED1 /* pstdint.h in Headers */,
 				8E8DEE5D127E2B78005EF64D /* ConvertUTF.h in Headers */,
 				8E8DEE5E127E2B78005EF64D /* CXMLReaderImpl.h in Headers */,
 				8E8DEE5F127E2B78005EF64D /* heapsort.h in Headers */,
@@ -2938,21 +3499,8 @@
 				F9BA8C041543268400E63FFE /* version.h in Headers */,
 				F9BA8C48154328B600E63FFE /* OgreImporter.hpp in Headers */,
 				F9BA8C4C154328B600E63FFE /* OgreXmlHelper.hpp in Headers */,
-				F99A9EB615436077000682F3 /* BlobIOSystem.h in Headers */,
-				F99A9EBB15436098000682F3 /* lexical_cast.hpp in Headers */,
-				F99A9EC0154360A0000682F3 /* make_shared.hpp in Headers */,
-				F99A9EC5154360A5000682F3 /* noncopyable.hpp in Headers */,
-				F99A9ECA154360B5000682F3 /* timer.hpp in Headers */,
-				F99A9ECF154360E2000682F3 /* CInterfaceIOWrapper.h in Headers */,
-				F99A9ED815436125000682F3 /* DeboneProcess.h in Headers */,
-				F99A9F1F154361D4000682F3 /* LogAux.h in Headers */,
 				F99A9F2D15436207000682F3 /* M3Importer.h in Headers */,
 				F99A9F3715436269000682F3 /* PlyExporter.h in Headers */,
-				F99A9F3D15436286000682F3 /* PolyTools.h in Headers */,
-				F99A9F47154362DE000682F3 /* ScenePrivate.h in Headers */,
-				F99A9F5015436304000682F3 /* SplitByBoneCountProcess.h in Headers */,
-				F99A9F6215436323000682F3 /* STEPFile.h in Headers */,
-				F99A9F6415436323000682F3 /* STEPFileReader.h in Headers */,
 				F9607088154366AB004D91DD /* crc32.h in Headers */,
 				F960708A154366AB004D91DD /* deflate.h in Headers */,
 				F960708C154366AB004D91DD /* inffast.h in Headers */,
@@ -2974,9 +3522,119 @@
 				F96071001543675E004D91DD /* sweep.h in Headers */,
 				F96071021543675E004D91DD /* sweep_context.h in Headers */,
 				F97BA03815439DB3009EB9DD /* ai_assert.h in Headers */,
-				F97BA08715439FC3009EB9DD /* IFCLoader.h in Headers */,
-				F97BA08B15439FC3009EB9DD /* IFCReaderGen.h in Headers */,
-				F97BA08D15439FC3009EB9DD /* IFCUtil.h in Headers */,
+				2B7F46DF1708365200A106A9 /* assbin_chunks.h in Headers */,
+				2B7F47071708365200A106A9 /* BaseImporter.h in Headers */,
+				2B7F47111708365200A106A9 /* BaseProcess.h in Headers */,
+				2B7F47481708365200A106A9 /* BlobIOSystem.h in Headers */,
+				2B7F474D1708365200A106A9 /* foreach.hpp in Headers */,
+				2B7F47521708365200A106A9 /* format.hpp in Headers */,
+				2B7F47571708365200A106A9 /* lexical_cast.hpp in Headers */,
+				2B7F475C1708365200A106A9 /* make_shared.hpp in Headers */,
+				2B7F47611708365200A106A9 /* common_factor_rt.hpp in Headers */,
+				2B7F47661708365200A106A9 /* noncopyable.hpp in Headers */,
+				2B7F476B1708365200A106A9 /* pointer_cast.hpp in Headers */,
+				2B7F47701708365200A106A9 /* scoped_array.hpp in Headers */,
+				2B7F47751708365200A106A9 /* scoped_ptr.hpp in Headers */,
+				2B7F477A1708365200A106A9 /* shared_array.hpp in Headers */,
+				2B7F477F1708365200A106A9 /* shared_ptr.hpp in Headers */,
+				2B7F47841708365200A106A9 /* static_assert.hpp in Headers */,
+				2B7F47891708365200A106A9 /* timer.hpp in Headers */,
+				2B7F478E1708365200A106A9 /* tuple.hpp in Headers */,
+				2B7F479D1708365200A106A9 /* ByteSwap.h in Headers */,
+				2B7F47A71708365200A106A9 /* CalcTangentsProcess.h in Headers */,
+				2B7F47AC1708365200A106A9 /* CInterfaceIOWrapper.h in Headers */,
+				2B7F47C51708365200A106A9 /* ColladaExporter.h in Headers */,
+				2B7F47CA1708365200A106A9 /* ColladaHelper.h in Headers */,
+				2B7F47D41708365200A106A9 /* ColladaLoader.h in Headers */,
+				2B7F47DE1708365200A106A9 /* ColladaParser.h in Headers */,
+				2B7F47E81708365200A106A9 /* ComputeUVMappingProcess.h in Headers */,
+				2B7F47F21708365200A106A9 /* ConvertToLHProcess.h in Headers */,
+				2B7F48061708365200A106A9 /* DeboneProcess.h in Headers */,
+				2B7F48101708365200A106A9 /* DefaultIOStream.h in Headers */,
+				2B7F481A1708365200A106A9 /* DefaultIOSystem.h in Headers */,
+				2B7F48241708365200A106A9 /* DefaultProgressHandler.h in Headers */,
+				2B7F48381708365200A106A9 /* Exceptional.h in Headers */,
+				2B7F48421708365200A106A9 /* fast_atof.h in Headers */,
+				2B7F48511708365200A106A9 /* FBXCompileConfig.h in Headers */,
+				2B7F485B1708365200A106A9 /* FBXConverter.h in Headers */,
+				2B7F486A1708365200A106A9 /* FBXDocument.h in Headers */,
+				2B7F48741708365200A106A9 /* FBXDocumentUtil.h in Headers */,
+				2B7F487E1708365200A106A9 /* FBXImporter.h in Headers */,
+				2B7F48831708365200A106A9 /* FBXImportSettings.h in Headers */,
+				2B7F48A11708365200A106A9 /* FBXParser.h in Headers */,
+				2B7F48AB1708365200A106A9 /* FBXProperties.h in Headers */,
+				2B7F48B51708365200A106A9 /* FBXTokenizer.h in Headers */,
+				2B7F48BF1708365200A106A9 /* FBXUtil.h in Headers */,
+				2B7F48C41708365200A106A9 /* FileLogStream.h in Headers */,
+				2B7F48C91708365200A106A9 /* FileSystemFilter.h in Headers */,
+				2B7F48D31708365200A106A9 /* FindDegenerates.h in Headers */,
+				2B7F48DD1708365200A106A9 /* FindInstancesProcess.h in Headers */,
+				2B7F48E71708365200A106A9 /* FindInvalidDataProcess.h in Headers */,
+				2B7F48F11708365200A106A9 /* FixNormalsStep.h in Headers */,
+				2B7F48F61708365200A106A9 /* GenericProperty.h in Headers */,
+				2B7F49001708365200A106A9 /* GenFaceNormalsProcess.h in Headers */,
+				2B7F490A1708365200A106A9 /* GenVertexNormalsProcess.h in Headers */,
+				2B7F49141708365200A106A9 /* Hash.h in Headers */,
+				2B7F493C1708365200A106A9 /* IFCLoader.h in Headers */,
+				2B7F49551708365200A106A9 /* IFCReaderGen.h in Headers */,
+				2B7F495F1708365200A106A9 /* IFCUtil.h in Headers */,
+				2B7F49641708365200A106A9 /* IFF.h in Headers */,
+				2B7F496E1708365200A106A9 /* Importer.h in Headers */,
+				2B7F497D1708365200A106A9 /* ImproveCacheLocality.h in Headers */,
+				2B7F49AA1708365200A106A9 /* JoinVerticesProcess.h in Headers */,
+				2B7F49B41708365200A106A9 /* LimitBoneWeightsProcess.h in Headers */,
+				2B7F49B91708365200A106A9 /* LineSplitter.h in Headers */,
+				2B7F49BE1708365200A106A9 /* LogAux.h in Headers */,
+				2B7F49FF1708365200A106A9 /* MakeVerboseFormat.h in Headers */,
+				2B7F4A091708365200A106A9 /* MaterialSystem.h in Headers */,
+				2B7F4A311708365200A106A9 /* MD4FileData.h in Headers */,
+				2B7F4A771708365200A106A9 /* MemoryIOWrapper.h in Headers */,
+				2B7F4A9F1708365200A106A9 /* ObjExporter.h in Headers */,
+				2B7F4AA41708365200A106A9 /* ObjFileData.h in Headers */,
+				2B7F4AAE1708365200A106A9 /* ObjFileImporter.h in Headers */,
+				2B7F4AB81708365200A106A9 /* ObjFileMtlImporter.h in Headers */,
+				2B7F4AC21708365200A106A9 /* ObjFileParser.h in Headers */,
+				2B7F4AC71708365200A106A9 /* ObjTools.h in Headers */,
+				2B7F4AF91708365200A106A9 /* OptimizeGraph.h in Headers */,
+				2B7F4B031708365200A106A9 /* OptimizeMeshes.h in Headers */,
+				2B7F4B081708365200A106A9 /* ParsingUtils.h in Headers */,
+				2B7F4B2B1708365200A106A9 /* PolyTools.h in Headers */,
+				2B7F4B3A1708365200A106A9 /* PretransformVertices.h in Headers */,
+				2B7F4B441708365200A106A9 /* ProcessHelper.h in Headers */,
+				2B7F4B491708365200A106A9 /* Profiler.h in Headers */,
+				2B7F4B4E1708365200A106A9 /* pstdint.h in Headers */,
+				2B7F4B801708365200A106A9 /* qnan.h in Headers */,
+				2B7F4B941708365200A106A9 /* RemoveComments.h in Headers */,
+				2B7F4B9E1708365200A106A9 /* RemoveRedundantMaterials.h in Headers */,
+				2B7F4BA81708365200A106A9 /* RemoveVCProcess.h in Headers */,
+				2B7F4BB71708365200A106A9 /* SceneCombiner.h in Headers */,
+				2B7F4BC11708365200A106A9 /* ScenePreprocessor.h in Headers */,
+				2B7F4BC61708365200A106A9 /* ScenePrivate.h in Headers */,
+				2B7F4BD01708365200A106A9 /* SGSpatialSort.h in Headers */,
+				2B7F4BDA1708365200A106A9 /* SkeletonMeshBuilder.h in Headers */,
+				2B7F4BE91708365200A106A9 /* SmoothingGroups.h in Headers */,
+				2B7F4BF31708365200A106A9 /* SortByPTypeProcess.h in Headers */,
+				2B7F4BFD1708365200A106A9 /* SpatialSort.h in Headers */,
+				2B7F4C071708365200A106A9 /* SplitByBoneCountProcess.h in Headers */,
+				2B7F4C111708365200A106A9 /* SplitLargeMeshes.h in Headers */,
+				2B7F4C1B1708365200A106A9 /* StandardShapes.h in Headers */,
+				2B7F4C201708365200A106A9 /* StdOStreamLogStream.h in Headers */,
+				2B7F4C251708365200A106A9 /* STEPFile.h in Headers */,
+				2B7F4C2F1708365200A106A9 /* STEPFileEncoding.h in Headers */,
+				2B7F4C391708365200A106A9 /* STEPFileReader.h in Headers */,
+				2B7F4C431708365200A106A9 /* STLExporter.h in Headers */,
+				2B7F4C4D1708365200A106A9 /* STLLoader.h in Headers */,
+				2B7F4C521708365200A106A9 /* StreamReader.h in Headers */,
+				2B7F4C571708365200A106A9 /* StringComparison.h in Headers */,
+				2B7F4C611708365200A106A9 /* Subdivision.h in Headers */,
+				2B7F4C6B1708365200A106A9 /* TargetAnimation.h in Headers */,
+				2B7F4C7F1708365200A106A9 /* TextureTransform.h in Headers */,
+				2B7F4C841708365200A106A9 /* TinyFormatter.h in Headers */,
+				2B7F4C8E1708365200A106A9 /* TriangulateProcess.h in Headers */,
+				2B7F4CA21708365200A106A9 /* ValidateDataStructure.h in Headers */,
+				2B7F4CA71708365200A106A9 /* Vertex.h in Headers */,
+				2B7F4CB11708365200A106A9 /* VertexTriangleAdjacency.h in Headers */,
+				2B7F4CB61708365200A106A9 /* Win32DebugLogStream.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2988,23 +3646,8 @@
 				745FF924113ECC660020C31B /* 3DSLoader.h in Headers */,
 				745FF925113ECC660020C31B /* ASELoader.h in Headers */,
 				745FF926113ECC660020C31B /* ASEParser.h in Headers */,
-				745FF927113ECC660020C31B /* BaseImporter.h in Headers */,
-				745FF928113ECC660020C31B /* BaseProcess.h in Headers */,
-				745FF929113ECC660020C31B /* ByteSwap.h in Headers */,
-				745FF92A113ECC660020C31B /* CalcTangentsProcess.h in Headers */,
-				745FF92B113ECC660020C31B /* ConvertToLHProcess.h in Headers */,
-				745FF92C113ECC660020C31B /* DefaultIOStream.h in Headers */,
-				745FF92D113ECC660020C31B /* DefaultIOSystem.h in Headers */,
-				745FF92F113ECC660020C31B /* fast_atof.h in Headers */,
-				745FF930113ECC660020C31B /* FileLogStream.h in Headers */,
-				745FF931113ECC660020C31B /* GenFaceNormalsProcess.h in Headers */,
-				745FF932113ECC660020C31B /* GenVertexNormalsProcess.h in Headers */,
 				745FF933113ECC660020C31B /* HalfLifeFileData.h in Headers */,
 				745FF934113ECC660020C31B /* HMPLoader.h in Headers */,
-				745FF935113ECC660020C31B /* ImproveCacheLocality.h in Headers */,
-				745FF936113ECC660020C31B /* JoinVerticesProcess.h in Headers */,
-				745FF937113ECC660020C31B /* LimitBoneWeightsProcess.h in Headers */,
-				745FF938113ECC660020C31B /* MaterialSystem.h in Headers */,
 				745FF939113ECC660020C31B /* MD2FileData.h in Headers */,
 				745FF93A113ECC660020C31B /* MD2Loader.h in Headers */,
 				745FF93B113ECC660020C31B /* MD2NormalTable.h in Headers */,
@@ -3015,49 +3658,23 @@
 				745FF940113ECC660020C31B /* MDLDefaultColorMap.h in Headers */,
 				745FF941113ECC660020C31B /* MDLFileData.h in Headers */,
 				745FF942113ECC660020C31B /* MDLLoader.h in Headers */,
-				745FF943113ECC660020C31B /* ObjFileData.h in Headers */,
-				745FF944113ECC660020C31B /* ObjFileImporter.h in Headers */,
-				745FF945113ECC660020C31B /* ObjFileMtlImporter.h in Headers */,
-				745FF946113ECC660020C31B /* ObjFileParser.h in Headers */,
-				745FF947113ECC660020C31B /* ObjTools.h in Headers */,
-				745FF948113ECC660020C31B /* ParsingUtils.h in Headers */,
 				745FF949113ECC660020C31B /* PlyLoader.h in Headers */,
 				745FF94A113ECC660020C31B /* PlyParser.h in Headers */,
-				745FF94B113ECC660020C31B /* PretransformVertices.h in Headers */,
-				745FF94C113ECC660020C31B /* qnan.h in Headers */,
-				745FF94D113ECC660020C31B /* RemoveComments.h in Headers */,
-				745FF94E113ECC660020C31B /* RemoveRedundantMaterials.h in Headers */,
 				745FF94F113ECC660020C31B /* SMDLoader.h in Headers */,
-				745FF950113ECC660020C31B /* SpatialSort.h in Headers */,
-				745FF951113ECC660020C31B /* SplitLargeMeshes.h in Headers */,
-				745FF952113ECC660020C31B /* STLLoader.h in Headers */,
-				745FF953113ECC660020C31B /* StringComparison.h in Headers */,
-				745FF954113ECC660020C31B /* TextureTransform.h in Headers */,
-				745FF955113ECC660020C31B /* TriangulateProcess.h in Headers */,
-				745FF956113ECC660020C31B /* ValidateDataStructure.h in Headers */,
-				745FF957113ECC660020C31B /* VertexTriangleAdjacency.h in Headers */,
-				745FF958113ECC660020C31B /* Win32DebugLogStream.h in Headers */,
 				745FF959113ECC660020C31B /* XFileHelper.h in Headers */,
 				745FF95A113ECC660020C31B /* XFileImporter.h in Headers */,
 				745FF95B113ECC660020C31B /* XFileParser.h in Headers */,
 				745FF95E113ECC660020C31B /* MDCFileData.h in Headers */,
 				745FF95F113ECC660020C31B /* MDCLoader.h in Headers */,
 				745FF960113ECC660020C31B /* MDCNormalTable.h in Headers */,
-				745FF961113ECC660020C31B /* FixNormalsStep.h in Headers */,
 				745FF962113ECC660020C31B /* LWOFileData.h in Headers */,
 				745FF963113ECC660020C31B /* LWOLoader.h in Headers */,
 				745FF964113ECC660020C31B /* HMPFileData.h in Headers */,
-				745FF966113ECC660020C31B /* IFF.h in Headers */,
-				745FF967113ECC660020C31B /* Hash.h in Headers */,
 				745FF96C113ECC660020C31B /* ACLoader.h in Headers */,
 				745FF96D113ECC660020C31B /* IRRLoader.h in Headers */,
 				745FF96E113ECC660020C31B /* IRRMeshLoader.h in Headers */,
 				745FF96F113ECC660020C31B /* IRRShared.h in Headers */,
-				745FF970113ECC660020C31B /* ColladaHelper.h in Headers */,
-				745FF971113ECC660020C31B /* ColladaLoader.h in Headers */,
-				745FF972113ECC660020C31B /* ColladaParser.h in Headers */,
 				745FF973113ECC660020C31B /* NFFLoader.h in Headers */,
-				745FF974113ECC660020C31B /* SGSpatialSort.h in Headers */,
 				745FF975113ECC660020C31B /* Q3DLoader.h in Headers */,
 				745FF976113ECC660020C31B /* BVHLoader.h in Headers */,
 				745FF977113ECC660020C31B /* OFFLoader.h in Headers */,
@@ -3065,57 +3682,20 @@
 				745FF979113ECC660020C31B /* DXFLoader.h in Headers */,
 				745FF97A113ECC660020C31B /* TerragenLoader.h in Headers */,
 				745FF97B113ECC660020C31B /* irrXMLWrapper.h in Headers */,
-				745FF97C113ECC660020C31B /* ScenePreprocessor.h in Headers */,
-				745FF97D113ECC660020C31B /* SceneCombiner.h in Headers */,
-				745FF97E113ECC660020C31B /* SortByPTypeProcess.h in Headers */,
-				745FF97F113ECC660020C31B /* FindDegenerates.h in Headers */,
-				745FF980113ECC660020C31B /* ComputeUVMappingProcess.h in Headers */,
-				745FF981113ECC660020C31B /* StandardShapes.h in Headers */,
-				745FF982113ECC660020C31B /* FindInstancesProcess.h in Headers */,
-				745FF983113ECC660020C31B /* RemoveVCProcess.h in Headers */,
-				745FF984113ECC660020C31B /* FindInvalidDataProcess.h in Headers */,
-				745FF985113ECC660020C31B /* SkeletonMeshBuilder.h in Headers */,
-				745FF986113ECC660020C31B /* SmoothingGroups.h in Headers */,
 				745FF98D113ECC660020C31B /* B3DImporter.h in Headers */,
-				7437C959113F18C70067B9B9 /* foreach.hpp in Headers */,
-				7437C95A113F18C70067B9B9 /* format.hpp in Headers */,
-				7437C95B113F18C70067B9B9 /* common_factor_rt.hpp in Headers */,
-				7437C95C113F18C70067B9B9 /* scoped_array.hpp in Headers */,
-				7437C95D113F18C70067B9B9 /* scoped_ptr.hpp in Headers */,
-				7437C95E113F18C70067B9B9 /* static_assert.hpp in Headers */,
-				7437C95F113F18C70067B9B9 /* tuple.hpp in Headers */,
 				7411B15111416D5E00BCD793 /* CSMLoader.h in Headers */,
 				7411B15C11416DDD00BCD793 /* LWSLoader.h in Headers */,
 				7411B16611416DF400BCD793 /* LWOAnimation.h in Headers */,
 				7411B17311416E2500BCD793 /* MS3DLoader.h in Headers */,
 				7411B18E11416EBC00BCD793 /* UnrealLoader.h in Headers */,
-				7411B1A611416EF400BCD793 /* FileSystemFilter.h in Headers */,
-				7411B1A711416EF400BCD793 /* GenericProperty.h in Headers */,
-				7411B1A811416EF400BCD793 /* MemoryIOWrapper.h in Headers */,
-				7411B1AA11416EF400BCD793 /* OptimizeGraph.h in Headers */,
-				7411B1AC11416EF400BCD793 /* OptimizeMeshes.h in Headers */,
-				7411B1AD11416EF400BCD793 /* ProcessHelper.h in Headers */,
-				7411B1AE11416EF400BCD793 /* StdOStreamLogStream.h in Headers */,
-				7411B1AF11416EF400BCD793 /* StreamReader.h in Headers */,
-				7411B1B111416EF400BCD793 /* Subdivision.h in Headers */,
-				7411B1B311416EF400BCD793 /* TargetAnimation.h in Headers */,
-				7411B1B411416EF400BCD793 /* Vertex.h in Headers */,
 				74C9BB6711ACBB1000AF885C /* BlenderDNA.h in Headers */,
 				74C9BB6911ACBB1000AF885C /* BlenderLoader.h in Headers */,
 				74C9BB6B11ACBB1000AF885C /* BlenderScene.h in Headers */,
 				74C9BB6C11ACBB1000AF885C /* BlenderSceneGen.h in Headers */,
-				74C9BB7511ACBB3600AF885C /* pointer_cast.hpp in Headers */,
-				74C9BB7611ACBB3600AF885C /* shared_array.hpp in Headers */,
-				74C9BB7711ACBB3600AF885C /* shared_ptr.hpp in Headers */,
-				74C9BB8111ACBB7800AF885C /* MakeVerboseFormat.h in Headers */,
 				74C9BB8B11ACBB9900AF885C /* AssimpPCH.h in Headers */,
 				74C9BB9A11ACBBBC00AF885C /* COBLoader.h in Headers */,
 				74C9BB9B11ACBBBC00AF885C /* COBScene.h in Headers */,
 				74C9BBB511ACBC2600AF885C /* revision.h in Headers */,
-				74C9BBC311ACBC6C00AF885C /* Exceptional.h in Headers */,
-				74C9BBC411ACBC6C00AF885C /* LineSplitter.h in Headers */,
-				74C9BBC511ACBC6C00AF885C /* MD4FileData.h in Headers */,
-				74C9BBC611ACBC6C00AF885C /* TinyFormatter.h in Headers */,
 				8E7ABBBD127E0F1A00512ED1 /* Q3BSPFileData.h in Headers */,
 				8E7ABBBF127E0F1A00512ED1 /* Q3BSPFileImporter.h in Headers */,
 				8E7ABBC1127E0F1A00512ED1 /* Q3BSPFileParser.h in Headers */,
@@ -3123,10 +3703,6 @@
 				8E7ABBCD127E0F2A00512ED1 /* NDOLoader.h in Headers */,
 				8E7ABBDA127E0F3800512ED1 /* BlenderIntermediate.h in Headers */,
 				8E7ABBDC127E0F3800512ED1 /* BlenderModifier.h in Headers */,
-				8E7ABBEF127E0FA400512ED1 /* assbin_chunks.h in Headers */,
-				8E7ABBF0127E0FA400512ED1 /* DefaultProgressHandler.h in Headers */,
-				8E7ABBF1127E0FA400512ED1 /* Profiler.h in Headers */,
-				8E7ABBF2127E0FA400512ED1 /* pstdint.h in Headers */,
 				8E8DEE87127E2B78005EF64D /* ConvertUTF.h in Headers */,
 				8E8DEE88127E2B78005EF64D /* CXMLReaderImpl.h in Headers */,
 				8E8DEE89127E2B78005EF64D /* heapsort.h in Headers */,
@@ -3172,21 +3748,8 @@
 				F9BA8C261543268400E63FFE /* version.h in Headers */,
 				F9BA8C4E154328B600E63FFE /* OgreImporter.hpp in Headers */,
 				F9BA8C52154328B600E63FFE /* OgreXmlHelper.hpp in Headers */,
-				F99A9EB715436077000682F3 /* BlobIOSystem.h in Headers */,
-				F99A9EBC15436098000682F3 /* lexical_cast.hpp in Headers */,
-				F99A9EC1154360A0000682F3 /* make_shared.hpp in Headers */,
-				F99A9EC6154360A5000682F3 /* noncopyable.hpp in Headers */,
-				F99A9ECB154360B5000682F3 /* timer.hpp in Headers */,
-				F99A9ED0154360E2000682F3 /* CInterfaceIOWrapper.h in Headers */,
-				F99A9EDA15436125000682F3 /* DeboneProcess.h in Headers */,
-				F99A9F20154361D4000682F3 /* LogAux.h in Headers */,
 				F99A9F2F15436207000682F3 /* M3Importer.h in Headers */,
 				F99A9F3915436269000682F3 /* PlyExporter.h in Headers */,
-				F99A9F3E15436286000682F3 /* PolyTools.h in Headers */,
-				F99A9F48154362DE000682F3 /* ScenePrivate.h in Headers */,
-				F99A9F5215436304000682F3 /* SplitByBoneCountProcess.h in Headers */,
-				F99A9F6515436323000682F3 /* STEPFile.h in Headers */,
-				F99A9F6715436323000682F3 /* STEPFileReader.h in Headers */,
 				F960709C154366AB004D91DD /* crc32.h in Headers */,
 				F960709E154366AB004D91DD /* deflate.h in Headers */,
 				F96070A0154366AB004D91DD /* inffast.h in Headers */,
@@ -3208,9 +3771,368 @@
 				F960710C1543675E004D91DD /* sweep.h in Headers */,
 				F960710E1543675E004D91DD /* sweep_context.h in Headers */,
 				F97BA03915439DB3009EB9DD /* ai_assert.h in Headers */,
-				F97BA09115439FC3009EB9DD /* IFCLoader.h in Headers */,
-				F97BA09515439FC3009EB9DD /* IFCReaderGen.h in Headers */,
-				F97BA09715439FC3009EB9DD /* IFCUtil.h in Headers */,
+				2B7F46E01708365200A106A9 /* assbin_chunks.h in Headers */,
+				2B7F47081708365200A106A9 /* BaseImporter.h in Headers */,
+				2B7F47121708365200A106A9 /* BaseProcess.h in Headers */,
+				2B7F47491708365200A106A9 /* BlobIOSystem.h in Headers */,
+				2B7F474E1708365200A106A9 /* foreach.hpp in Headers */,
+				2B7F47531708365200A106A9 /* format.hpp in Headers */,
+				2B7F47581708365200A106A9 /* lexical_cast.hpp in Headers */,
+				2B7F475D1708365200A106A9 /* make_shared.hpp in Headers */,
+				2B7F47621708365200A106A9 /* common_factor_rt.hpp in Headers */,
+				2B7F47671708365200A106A9 /* noncopyable.hpp in Headers */,
+				2B7F476C1708365200A106A9 /* pointer_cast.hpp in Headers */,
+				2B7F47711708365200A106A9 /* scoped_array.hpp in Headers */,
+				2B7F47761708365200A106A9 /* scoped_ptr.hpp in Headers */,
+				2B7F477B1708365200A106A9 /* shared_array.hpp in Headers */,
+				2B7F47801708365200A106A9 /* shared_ptr.hpp in Headers */,
+				2B7F47851708365200A106A9 /* static_assert.hpp in Headers */,
+				2B7F478A1708365200A106A9 /* timer.hpp in Headers */,
+				2B7F478F1708365200A106A9 /* tuple.hpp in Headers */,
+				2B7F479E1708365200A106A9 /* ByteSwap.h in Headers */,
+				2B7F47A81708365200A106A9 /* CalcTangentsProcess.h in Headers */,
+				2B7F47AD1708365200A106A9 /* CInterfaceIOWrapper.h in Headers */,
+				2B7F47C61708365200A106A9 /* ColladaExporter.h in Headers */,
+				2B7F47CB1708365200A106A9 /* ColladaHelper.h in Headers */,
+				2B7F47D51708365200A106A9 /* ColladaLoader.h in Headers */,
+				2B7F47DF1708365200A106A9 /* ColladaParser.h in Headers */,
+				2B7F47E91708365200A106A9 /* ComputeUVMappingProcess.h in Headers */,
+				2B7F47F31708365200A106A9 /* ConvertToLHProcess.h in Headers */,
+				2B7F48071708365200A106A9 /* DeboneProcess.h in Headers */,
+				2B7F48111708365200A106A9 /* DefaultIOStream.h in Headers */,
+				2B7F481B1708365200A106A9 /* DefaultIOSystem.h in Headers */,
+				2B7F48251708365200A106A9 /* DefaultProgressHandler.h in Headers */,
+				2B7F48391708365200A106A9 /* Exceptional.h in Headers */,
+				2B7F48431708365200A106A9 /* fast_atof.h in Headers */,
+				2B7F48521708365200A106A9 /* FBXCompileConfig.h in Headers */,
+				2B7F485C1708365200A106A9 /* FBXConverter.h in Headers */,
+				2B7F486B1708365200A106A9 /* FBXDocument.h in Headers */,
+				2B7F48751708365200A106A9 /* FBXDocumentUtil.h in Headers */,
+				2B7F487F1708365200A106A9 /* FBXImporter.h in Headers */,
+				2B7F48841708365200A106A9 /* FBXImportSettings.h in Headers */,
+				2B7F48A21708365200A106A9 /* FBXParser.h in Headers */,
+				2B7F48AC1708365200A106A9 /* FBXProperties.h in Headers */,
+				2B7F48B61708365200A106A9 /* FBXTokenizer.h in Headers */,
+				2B7F48C01708365200A106A9 /* FBXUtil.h in Headers */,
+				2B7F48C51708365200A106A9 /* FileLogStream.h in Headers */,
+				2B7F48CA1708365200A106A9 /* FileSystemFilter.h in Headers */,
+				2B7F48D41708365200A106A9 /* FindDegenerates.h in Headers */,
+				2B7F48DE1708365200A106A9 /* FindInstancesProcess.h in Headers */,
+				2B7F48E81708365200A106A9 /* FindInvalidDataProcess.h in Headers */,
+				2B7F48F21708365200A106A9 /* FixNormalsStep.h in Headers */,
+				2B7F48F71708365200A106A9 /* GenericProperty.h in Headers */,
+				2B7F49011708365200A106A9 /* GenFaceNormalsProcess.h in Headers */,
+				2B7F490B1708365200A106A9 /* GenVertexNormalsProcess.h in Headers */,
+				2B7F49151708365200A106A9 /* Hash.h in Headers */,
+				2B7F493D1708365200A106A9 /* IFCLoader.h in Headers */,
+				2B7F49561708365200A106A9 /* IFCReaderGen.h in Headers */,
+				2B7F49601708365200A106A9 /* IFCUtil.h in Headers */,
+				2B7F49651708365200A106A9 /* IFF.h in Headers */,
+				2B7F496F1708365200A106A9 /* Importer.h in Headers */,
+				2B7F497E1708365200A106A9 /* ImproveCacheLocality.h in Headers */,
+				2B7F49AB1708365200A106A9 /* JoinVerticesProcess.h in Headers */,
+				2B7F49B51708365200A106A9 /* LimitBoneWeightsProcess.h in Headers */,
+				2B7F49BA1708365200A106A9 /* LineSplitter.h in Headers */,
+				2B7F49BF1708365200A106A9 /* LogAux.h in Headers */,
+				2B7F4A001708365200A106A9 /* MakeVerboseFormat.h in Headers */,
+				2B7F4A0A1708365200A106A9 /* MaterialSystem.h in Headers */,
+				2B7F4A321708365200A106A9 /* MD4FileData.h in Headers */,
+				2B7F4A781708365200A106A9 /* MemoryIOWrapper.h in Headers */,
+				2B7F4AA01708365200A106A9 /* ObjExporter.h in Headers */,
+				2B7F4AA51708365200A106A9 /* ObjFileData.h in Headers */,
+				2B7F4AAF1708365200A106A9 /* ObjFileImporter.h in Headers */,
+				2B7F4AB91708365200A106A9 /* ObjFileMtlImporter.h in Headers */,
+				2B7F4AC31708365200A106A9 /* ObjFileParser.h in Headers */,
+				2B7F4AC81708365200A106A9 /* ObjTools.h in Headers */,
+				2B7F4AFA1708365200A106A9 /* OptimizeGraph.h in Headers */,
+				2B7F4B041708365200A106A9 /* OptimizeMeshes.h in Headers */,
+				2B7F4B091708365200A106A9 /* ParsingUtils.h in Headers */,
+				2B7F4B2C1708365200A106A9 /* PolyTools.h in Headers */,
+				2B7F4B3B1708365200A106A9 /* PretransformVertices.h in Headers */,
+				2B7F4B451708365200A106A9 /* ProcessHelper.h in Headers */,
+				2B7F4B4A1708365200A106A9 /* Profiler.h in Headers */,
+				2B7F4B4F1708365200A106A9 /* pstdint.h in Headers */,
+				2B7F4B811708365200A106A9 /* qnan.h in Headers */,
+				2B7F4B951708365200A106A9 /* RemoveComments.h in Headers */,
+				2B7F4B9F1708365200A106A9 /* RemoveRedundantMaterials.h in Headers */,
+				2B7F4BA91708365200A106A9 /* RemoveVCProcess.h in Headers */,
+				2B7F4BB81708365200A106A9 /* SceneCombiner.h in Headers */,
+				2B7F4BC21708365200A106A9 /* ScenePreprocessor.h in Headers */,
+				2B7F4BC71708365200A106A9 /* ScenePrivate.h in Headers */,
+				2B7F4BD11708365200A106A9 /* SGSpatialSort.h in Headers */,
+				2B7F4BDB1708365200A106A9 /* SkeletonMeshBuilder.h in Headers */,
+				2B7F4BEA1708365200A106A9 /* SmoothingGroups.h in Headers */,
+				2B7F4BF41708365200A106A9 /* SortByPTypeProcess.h in Headers */,
+				2B7F4BFE1708365200A106A9 /* SpatialSort.h in Headers */,
+				2B7F4C081708365200A106A9 /* SplitByBoneCountProcess.h in Headers */,
+				2B7F4C121708365200A106A9 /* SplitLargeMeshes.h in Headers */,
+				2B7F4C1C1708365200A106A9 /* StandardShapes.h in Headers */,
+				2B7F4C211708365200A106A9 /* StdOStreamLogStream.h in Headers */,
+				2B7F4C261708365200A106A9 /* STEPFile.h in Headers */,
+				2B7F4C301708365200A106A9 /* STEPFileEncoding.h in Headers */,
+				2B7F4C3A1708365200A106A9 /* STEPFileReader.h in Headers */,
+				2B7F4C441708365200A106A9 /* STLExporter.h in Headers */,
+				2B7F4C4E1708365200A106A9 /* STLLoader.h in Headers */,
+				2B7F4C531708365200A106A9 /* StreamReader.h in Headers */,
+				2B7F4C581708365200A106A9 /* StringComparison.h in Headers */,
+				2B7F4C621708365200A106A9 /* Subdivision.h in Headers */,
+				2B7F4C6C1708365200A106A9 /* TargetAnimation.h in Headers */,
+				2B7F4C801708365200A106A9 /* TextureTransform.h in Headers */,
+				2B7F4C851708365200A106A9 /* TinyFormatter.h in Headers */,
+				2B7F4C8F1708365200A106A9 /* TriangulateProcess.h in Headers */,
+				2B7F4CA31708365200A106A9 /* ValidateDataStructure.h in Headers */,
+				2B7F4CA81708365200A106A9 /* Vertex.h in Headers */,
+				2B7F4CB21708365200A106A9 /* VertexTriangleAdjacency.h in Headers */,
+				2B7F4CB71708365200A106A9 /* Win32DebugLogStream.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B91974D0163AEA54009C397B /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B91974D1163AEA54009C397B /* 3DSHelper.h in Headers */,
+				B91974D2163AEA54009C397B /* 3DSLoader.h in Headers */,
+				B91974D3163AEA54009C397B /* ASELoader.h in Headers */,
+				B91974D4163AEA54009C397B /* ASEParser.h in Headers */,
+				B91974E0163AEA54009C397B /* HalfLifeFileData.h in Headers */,
+				B91974E1163AEA54009C397B /* HMPLoader.h in Headers */,
+				B91974E6163AEA54009C397B /* MD2FileData.h in Headers */,
+				B91974E7163AEA54009C397B /* MD2Loader.h in Headers */,
+				B91974E8163AEA54009C397B /* MD2NormalTable.h in Headers */,
+				B91974E9163AEA54009C397B /* MD3FileData.h in Headers */,
+				B91974EA163AEA54009C397B /* MD3Loader.h in Headers */,
+				B91974EB163AEA54009C397B /* MD5Loader.h in Headers */,
+				B91974EC163AEA54009C397B /* MD5Parser.h in Headers */,
+				B91974ED163AEA54009C397B /* MDLDefaultColorMap.h in Headers */,
+				B91974EE163AEA54009C397B /* MDLFileData.h in Headers */,
+				B91974EF163AEA54009C397B /* MDLLoader.h in Headers */,
+				B91974F6163AEA54009C397B /* PlyLoader.h in Headers */,
+				B91974F7163AEA54009C397B /* PlyParser.h in Headers */,
+				B91974FC163AEA54009C397B /* SMDLoader.h in Headers */,
+				B9197506163AEA54009C397B /* XFileHelper.h in Headers */,
+				B9197507163AEA54009C397B /* XFileImporter.h in Headers */,
+				B9197508163AEA54009C397B /* XFileParser.h in Headers */,
+				B9197509163AEA54009C397B /* MDCFileData.h in Headers */,
+				B919750A163AEA54009C397B /* MDCLoader.h in Headers */,
+				B919750B163AEA54009C397B /* MDCNormalTable.h in Headers */,
+				B919750D163AEA54009C397B /* LWOFileData.h in Headers */,
+				B919750E163AEA54009C397B /* LWOLoader.h in Headers */,
+				B919750F163AEA54009C397B /* HMPFileData.h in Headers */,
+				B9197512163AEA54009C397B /* ACLoader.h in Headers */,
+				B9197513163AEA54009C397B /* IRRLoader.h in Headers */,
+				B9197514163AEA54009C397B /* IRRMeshLoader.h in Headers */,
+				B9197515163AEA54009C397B /* IRRShared.h in Headers */,
+				B9197519163AEA54009C397B /* NFFLoader.h in Headers */,
+				B919751B163AEA54009C397B /* Q3DLoader.h in Headers */,
+				B919751C163AEA54009C397B /* BVHLoader.h in Headers */,
+				B919751D163AEA54009C397B /* OFFLoader.h in Headers */,
+				B919751E163AEA54009C397B /* RawLoader.h in Headers */,
+				B919751F163AEA54009C397B /* DXFLoader.h in Headers */,
+				B9197520163AEA54009C397B /* TerragenLoader.h in Headers */,
+				B9197521163AEA54009C397B /* irrXMLWrapper.h in Headers */,
+				B919752D163AEA54009C397B /* B3DImporter.h in Headers */,
+				B9197535163AEA54009C397B /* CSMLoader.h in Headers */,
+				B9197536163AEA54009C397B /* LWSLoader.h in Headers */,
+				B9197537163AEA54009C397B /* LWOAnimation.h in Headers */,
+				B9197538163AEA54009C397B /* MS3DLoader.h in Headers */,
+				B9197539163AEA54009C397B /* UnrealLoader.h in Headers */,
+				B9197545163AEA54009C397B /* BlenderDNA.h in Headers */,
+				B9197546163AEA54009C397B /* BlenderLoader.h in Headers */,
+				B9197547163AEA54009C397B /* BlenderScene.h in Headers */,
+				B9197548163AEA54009C397B /* BlenderSceneGen.h in Headers */,
+				B919754D163AEA54009C397B /* AssimpPCH.h in Headers */,
+				B919754E163AEA54009C397B /* COBLoader.h in Headers */,
+				B919754F163AEA54009C397B /* COBScene.h in Headers */,
+				B9197550163AEA54009C397B /* revision.h in Headers */,
+				B9197555163AEA54009C397B /* Q3BSPFileData.h in Headers */,
+				B9197556163AEA54009C397B /* Q3BSPFileImporter.h in Headers */,
+				B9197557163AEA54009C397B /* Q3BSPFileParser.h in Headers */,
+				B9197558163AEA54009C397B /* Q3BSPZipArchive.h in Headers */,
+				B9197559163AEA54009C397B /* NDOLoader.h in Headers */,
+				B919755A163AEA54009C397B /* BlenderIntermediate.h in Headers */,
+				B919755B163AEA54009C397B /* BlenderModifier.h in Headers */,
+				B9197560163AEA54009C397B /* ConvertUTF.h in Headers */,
+				B9197561163AEA54009C397B /* CXMLReaderImpl.h in Headers */,
+				B9197562163AEA54009C397B /* heapsort.h in Headers */,
+				B9197563163AEA54009C397B /* irrArray.h in Headers */,
+				B9197564163AEA54009C397B /* irrString.h in Headers */,
+				B9197565163AEA54009C397B /* irrTypes.h in Headers */,
+				B9197566163AEA54009C397B /* irrXML.h in Headers */,
+				B9197567163AEA54009C397B /* crypt.h in Headers */,
+				B9197568163AEA54009C397B /* ioapi.h in Headers */,
+				B9197569163AEA54009C397B /* unzip.h in Headers */,
+				B919756A163AEA54009C397B /* anim.h in Headers */,
+				B919756B163AEA54009C397B /* camera.h in Headers */,
+				B919756C163AEA54009C397B /* cexport.h in Headers */,
+				B919756D163AEA54009C397B /* cfileio.h in Headers */,
+				B919756E163AEA54009C397B /* cimport.h in Headers */,
+				B919756F163AEA54009C397B /* color4.h in Headers */,
+				B9197570163AEA54009C397B /* poppack1.h in Headers */,
+				B9197571163AEA54009C397B /* pushpack1.h in Headers */,
+				B9197572163AEA54009C397B /* config.h in Headers */,
+				B9197573163AEA54009C397B /* DefaultLogger.hpp in Headers */,
+				B9197574163AEA54009C397B /* defs.h in Headers */,
+				B9197575163AEA54009C397B /* Exporter.hpp in Headers */,
+				B9197576163AEA54009C397B /* Importer.hpp in Headers */,
+				B9197577163AEA54009C397B /* importerdesc.h in Headers */,
+				B9197578163AEA54009C397B /* IOStream.hpp in Headers */,
+				B9197579163AEA54009C397B /* IOSystem.hpp in Headers */,
+				B919757A163AEA54009C397B /* light.h in Headers */,
+				B919757B163AEA54009C397B /* Logger.hpp in Headers */,
+				B919757C163AEA54009C397B /* LogStream.hpp in Headers */,
+				B919757D163AEA54009C397B /* material.h in Headers */,
+				B919757E163AEA54009C397B /* matrix3x3.h in Headers */,
+				B919757F163AEA54009C397B /* matrix4x4.h in Headers */,
+				B9197580163AEA54009C397B /* mesh.h in Headers */,
+				B9197581163AEA54009C397B /* NullLogger.hpp in Headers */,
+				B9197582163AEA54009C397B /* postprocess.h in Headers */,
+				B9197583163AEA54009C397B /* ProgressHandler.hpp in Headers */,
+				B9197584163AEA54009C397B /* quaternion.h in Headers */,
+				B9197585163AEA54009C397B /* scene.h in Headers */,
+				B9197586163AEA54009C397B /* texture.h in Headers */,
+				B9197587163AEA54009C397B /* types.h in Headers */,
+				B9197588163AEA54009C397B /* vector2.h in Headers */,
+				B9197589163AEA54009C397B /* vector3.h in Headers */,
+				B919758A163AEA54009C397B /* version.h in Headers */,
+				B919758B163AEA54009C397B /* OgreImporter.hpp in Headers */,
+				B919758C163AEA54009C397B /* OgreXmlHelper.hpp in Headers */,
+				B9197595163AEA54009C397B /* M3Importer.h in Headers */,
+				B9197596163AEA54009C397B /* PlyExporter.h in Headers */,
+				B919759C163AEA54009C397B /* crc32.h in Headers */,
+				B919759D163AEA54009C397B /* deflate.h in Headers */,
+				B919759E163AEA54009C397B /* inffast.h in Headers */,
+				B919759F163AEA54009C397B /* inffixed.h in Headers */,
+				B91975A0163AEA54009C397B /* inflate.h in Headers */,
+				B91975A1163AEA54009C397B /* inftrees.h in Headers */,
+				B91975A2163AEA54009C397B /* trees.h in Headers */,
+				B91975A3163AEA54009C397B /* zconf.h in Headers */,
+				B91975A4163AEA54009C397B /* zconf.in.h in Headers */,
+				B91975A5163AEA54009C397B /* zlib.h in Headers */,
+				B91975A6163AEA54009C397B /* zutil.h in Headers */,
+				B91975A7163AEA54009C397B /* XGLLoader.h in Headers */,
+				B91975A8163AEA54009C397B /* clipper.hpp in Headers */,
+				B91975A9163AEA54009C397B /* shapes.h in Headers */,
+				B91975AA163AEA54009C397B /* utils.h in Headers */,
+				B91975AB163AEA54009C397B /* poly2tri.h in Headers */,
+				B91975AC163AEA54009C397B /* advancing_front.h in Headers */,
+				B91975AD163AEA54009C397B /* cdt.h in Headers */,
+				B91975AE163AEA54009C397B /* sweep.h in Headers */,
+				B91975AF163AEA54009C397B /* sweep_context.h in Headers */,
+				B91975B0163AEA54009C397B /* ai_assert.h in Headers */,
+				2B7F46E11708365200A106A9 /* assbin_chunks.h in Headers */,
+				2B7F47091708365200A106A9 /* BaseImporter.h in Headers */,
+				2B7F47131708365200A106A9 /* BaseProcess.h in Headers */,
+				2B7F474A1708365200A106A9 /* BlobIOSystem.h in Headers */,
+				2B7F474F1708365200A106A9 /* foreach.hpp in Headers */,
+				2B7F47541708365200A106A9 /* format.hpp in Headers */,
+				2B7F47591708365200A106A9 /* lexical_cast.hpp in Headers */,
+				2B7F475E1708365200A106A9 /* make_shared.hpp in Headers */,
+				2B7F47631708365200A106A9 /* common_factor_rt.hpp in Headers */,
+				2B7F47681708365200A106A9 /* noncopyable.hpp in Headers */,
+				2B7F476D1708365200A106A9 /* pointer_cast.hpp in Headers */,
+				2B7F47721708365200A106A9 /* scoped_array.hpp in Headers */,
+				2B7F47771708365200A106A9 /* scoped_ptr.hpp in Headers */,
+				2B7F477C1708365200A106A9 /* shared_array.hpp in Headers */,
+				2B7F47811708365200A106A9 /* shared_ptr.hpp in Headers */,
+				2B7F47861708365200A106A9 /* static_assert.hpp in Headers */,
+				2B7F478B1708365200A106A9 /* timer.hpp in Headers */,
+				2B7F47901708365200A106A9 /* tuple.hpp in Headers */,
+				2B7F479F1708365200A106A9 /* ByteSwap.h in Headers */,
+				2B7F47A91708365200A106A9 /* CalcTangentsProcess.h in Headers */,
+				2B7F47AE1708365200A106A9 /* CInterfaceIOWrapper.h in Headers */,
+				2B7F47C71708365200A106A9 /* ColladaExporter.h in Headers */,
+				2B7F47CC1708365200A106A9 /* ColladaHelper.h in Headers */,
+				2B7F47D61708365200A106A9 /* ColladaLoader.h in Headers */,
+				2B7F47E01708365200A106A9 /* ColladaParser.h in Headers */,
+				2B7F47EA1708365200A106A9 /* ComputeUVMappingProcess.h in Headers */,
+				2B7F47F41708365200A106A9 /* ConvertToLHProcess.h in Headers */,
+				2B7F48081708365200A106A9 /* DeboneProcess.h in Headers */,
+				2B7F48121708365200A106A9 /* DefaultIOStream.h in Headers */,
+				2B7F481C1708365200A106A9 /* DefaultIOSystem.h in Headers */,
+				2B7F48261708365200A106A9 /* DefaultProgressHandler.h in Headers */,
+				2B7F483A1708365200A106A9 /* Exceptional.h in Headers */,
+				2B7F48441708365200A106A9 /* fast_atof.h in Headers */,
+				2B7F48531708365200A106A9 /* FBXCompileConfig.h in Headers */,
+				2B7F485D1708365200A106A9 /* FBXConverter.h in Headers */,
+				2B7F486C1708365200A106A9 /* FBXDocument.h in Headers */,
+				2B7F48761708365200A106A9 /* FBXDocumentUtil.h in Headers */,
+				2B7F48801708365200A106A9 /* FBXImporter.h in Headers */,
+				2B7F48851708365200A106A9 /* FBXImportSettings.h in Headers */,
+				2B7F48A31708365200A106A9 /* FBXParser.h in Headers */,
+				2B7F48AD1708365200A106A9 /* FBXProperties.h in Headers */,
+				2B7F48B71708365200A106A9 /* FBXTokenizer.h in Headers */,
+				2B7F48C11708365200A106A9 /* FBXUtil.h in Headers */,
+				2B7F48C61708365200A106A9 /* FileLogStream.h in Headers */,
+				2B7F48CB1708365200A106A9 /* FileSystemFilter.h in Headers */,
+				2B7F48D51708365200A106A9 /* FindDegenerates.h in Headers */,
+				2B7F48DF1708365200A106A9 /* FindInstancesProcess.h in Headers */,
+				2B7F48E91708365200A106A9 /* FindInvalidDataProcess.h in Headers */,
+				2B7F48F31708365200A106A9 /* FixNormalsStep.h in Headers */,
+				2B7F48F81708365200A106A9 /* GenericProperty.h in Headers */,
+				2B7F49021708365200A106A9 /* GenFaceNormalsProcess.h in Headers */,
+				2B7F490C1708365200A106A9 /* GenVertexNormalsProcess.h in Headers */,
+				2B7F49161708365200A106A9 /* Hash.h in Headers */,
+				2B7F493E1708365200A106A9 /* IFCLoader.h in Headers */,
+				2B7F49571708365200A106A9 /* IFCReaderGen.h in Headers */,
+				2B7F49611708365200A106A9 /* IFCUtil.h in Headers */,
+				2B7F49661708365200A106A9 /* IFF.h in Headers */,
+				2B7F49701708365200A106A9 /* Importer.h in Headers */,
+				2B7F497F1708365200A106A9 /* ImproveCacheLocality.h in Headers */,
+				2B7F49AC1708365200A106A9 /* JoinVerticesProcess.h in Headers */,
+				2B7F49B61708365200A106A9 /* LimitBoneWeightsProcess.h in Headers */,
+				2B7F49BB1708365200A106A9 /* LineSplitter.h in Headers */,
+				2B7F49C01708365200A106A9 /* LogAux.h in Headers */,
+				2B7F4A011708365200A106A9 /* MakeVerboseFormat.h in Headers */,
+				2B7F4A0B1708365200A106A9 /* MaterialSystem.h in Headers */,
+				2B7F4A331708365200A106A9 /* MD4FileData.h in Headers */,
+				2B7F4A791708365200A106A9 /* MemoryIOWrapper.h in Headers */,
+				2B7F4AA11708365200A106A9 /* ObjExporter.h in Headers */,
+				2B7F4AA61708365200A106A9 /* ObjFileData.h in Headers */,
+				2B7F4AB01708365200A106A9 /* ObjFileImporter.h in Headers */,
+				2B7F4ABA1708365200A106A9 /* ObjFileMtlImporter.h in Headers */,
+				2B7F4AC41708365200A106A9 /* ObjFileParser.h in Headers */,
+				2B7F4AC91708365200A106A9 /* ObjTools.h in Headers */,
+				2B7F4AFB1708365200A106A9 /* OptimizeGraph.h in Headers */,
+				2B7F4B051708365200A106A9 /* OptimizeMeshes.h in Headers */,
+				2B7F4B0A1708365200A106A9 /* ParsingUtils.h in Headers */,
+				2B7F4B2D1708365200A106A9 /* PolyTools.h in Headers */,
+				2B7F4B3C1708365200A106A9 /* PretransformVertices.h in Headers */,
+				2B7F4B461708365200A106A9 /* ProcessHelper.h in Headers */,
+				2B7F4B4B1708365200A106A9 /* Profiler.h in Headers */,
+				2B7F4B501708365200A106A9 /* pstdint.h in Headers */,
+				2B7F4B821708365200A106A9 /* qnan.h in Headers */,
+				2B7F4B961708365200A106A9 /* RemoveComments.h in Headers */,
+				2B7F4BA01708365200A106A9 /* RemoveRedundantMaterials.h in Headers */,
+				2B7F4BAA1708365200A106A9 /* RemoveVCProcess.h in Headers */,
+				2B7F4BB91708365200A106A9 /* SceneCombiner.h in Headers */,
+				2B7F4BC31708365200A106A9 /* ScenePreprocessor.h in Headers */,
+				2B7F4BC81708365200A106A9 /* ScenePrivate.h in Headers */,
+				2B7F4BD21708365200A106A9 /* SGSpatialSort.h in Headers */,
+				2B7F4BDC1708365200A106A9 /* SkeletonMeshBuilder.h in Headers */,
+				2B7F4BEB1708365200A106A9 /* SmoothingGroups.h in Headers */,
+				2B7F4BF51708365200A106A9 /* SortByPTypeProcess.h in Headers */,
+				2B7F4BFF1708365200A106A9 /* SpatialSort.h in Headers */,
+				2B7F4C091708365200A106A9 /* SplitByBoneCountProcess.h in Headers */,
+				2B7F4C131708365200A106A9 /* SplitLargeMeshes.h in Headers */,
+				2B7F4C1D1708365200A106A9 /* StandardShapes.h in Headers */,
+				2B7F4C221708365200A106A9 /* StdOStreamLogStream.h in Headers */,
+				2B7F4C271708365200A106A9 /* STEPFile.h in Headers */,
+				2B7F4C311708365200A106A9 /* STEPFileEncoding.h in Headers */,
+				2B7F4C3B1708365200A106A9 /* STEPFileReader.h in Headers */,
+				2B7F4C451708365200A106A9 /* STLExporter.h in Headers */,
+				2B7F4C4F1708365200A106A9 /* STLLoader.h in Headers */,
+				2B7F4C541708365200A106A9 /* StreamReader.h in Headers */,
+				2B7F4C591708365200A106A9 /* StringComparison.h in Headers */,
+				2B7F4C631708365200A106A9 /* Subdivision.h in Headers */,
+				2B7F4C6D1708365200A106A9 /* TargetAnimation.h in Headers */,
+				2B7F4C811708365200A106A9 /* TextureTransform.h in Headers */,
+				2B7F4C861708365200A106A9 /* TinyFormatter.h in Headers */,
+				2B7F4C901708365200A106A9 /* TriangulateProcess.h in Headers */,
+				2B7F4CA41708365200A106A9 /* ValidateDataStructure.h in Headers */,
+				2B7F4CA91708365200A106A9 /* Vertex.h in Headers */,
+				2B7F4CB31708365200A106A9 /* VertexTriangleAdjacency.h in Headers */,
+				2B7F4CB81708365200A106A9 /* Win32DebugLogStream.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3222,23 +4144,8 @@
 				3AF45AFD0E4B716800207D74 /* 3DSLoader.h in Headers */,
 				3AF45B020E4B716800207D74 /* ASELoader.h in Headers */,
 				3AF45B040E4B716800207D74 /* ASEParser.h in Headers */,
-				3AF45B070E4B716800207D74 /* BaseImporter.h in Headers */,
-				3AF45B080E4B716800207D74 /* BaseProcess.h in Headers */,
-				3AF45B090E4B716800207D74 /* ByteSwap.h in Headers */,
-				3AF45B0B0E4B716800207D74 /* CalcTangentsProcess.h in Headers */,
-				3AF45B0D0E4B716800207D74 /* ConvertToLHProcess.h in Headers */,
-				3AF45B0F0E4B716800207D74 /* DefaultIOStream.h in Headers */,
-				3AF45B110E4B716800207D74 /* DefaultIOSystem.h in Headers */,
-				3AF45B150E4B716800207D74 /* fast_atof.h in Headers */,
-				3AF45B160E4B716800207D74 /* FileLogStream.h in Headers */,
-				3AF45B180E4B716800207D74 /* GenFaceNormalsProcess.h in Headers */,
-				3AF45B1A0E4B716800207D74 /* GenVertexNormalsProcess.h in Headers */,
 				3AF45B1B0E4B716800207D74 /* HalfLifeFileData.h in Headers */,
 				3AF45B1E0E4B716800207D74 /* HMPLoader.h in Headers */,
-				3AF45B210E4B716800207D74 /* ImproveCacheLocality.h in Headers */,
-				3AF45B230E4B716800207D74 /* JoinVerticesProcess.h in Headers */,
-				3AF45B270E4B716800207D74 /* LimitBoneWeightsProcess.h in Headers */,
-				3AF45B290E4B716800207D74 /* MaterialSystem.h in Headers */,
 				3AF45B2A0E4B716800207D74 /* MD2FileData.h in Headers */,
 				3AF45B2C0E4B716800207D74 /* MD2Loader.h in Headers */,
 				3AF45B2D0E4B716800207D74 /* MD2NormalTable.h in Headers */,
@@ -3249,49 +4156,23 @@
 				3AF45B380E4B716800207D74 /* MDLDefaultColorMap.h in Headers */,
 				3AF45B390E4B716800207D74 /* MDLFileData.h in Headers */,
 				3AF45B3B0E4B716800207D74 /* MDLLoader.h in Headers */,
-				3AF45B3D0E4B716800207D74 /* ObjFileData.h in Headers */,
-				3AF45B3F0E4B716800207D74 /* ObjFileImporter.h in Headers */,
-				3AF45B410E4B716800207D74 /* ObjFileMtlImporter.h in Headers */,
-				3AF45B430E4B716800207D74 /* ObjFileParser.h in Headers */,
-				3AF45B440E4B716800207D74 /* ObjTools.h in Headers */,
-				3AF45B450E4B716800207D74 /* ParsingUtils.h in Headers */,
 				3AF45B470E4B716800207D74 /* PlyLoader.h in Headers */,
 				3AF45B490E4B716800207D74 /* PlyParser.h in Headers */,
-				3AF45B4B0E4B716800207D74 /* PretransformVertices.h in Headers */,
-				3AF45B4C0E4B716800207D74 /* qnan.h in Headers */,
-				3AF45B4E0E4B716800207D74 /* RemoveComments.h in Headers */,
-				3AF45B500E4B716800207D74 /* RemoveRedundantMaterials.h in Headers */,
 				3AF45B530E4B716800207D74 /* SMDLoader.h in Headers */,
-				3AF45B550E4B716800207D74 /* SpatialSort.h in Headers */,
-				3AF45B570E4B716800207D74 /* SplitLargeMeshes.h in Headers */,
-				3AF45B590E4B716800207D74 /* STLLoader.h in Headers */,
-				3AF45B5A0E4B716800207D74 /* StringComparison.h in Headers */,
-				3AF45B5C0E4B716800207D74 /* TextureTransform.h in Headers */,
-				3AF45B5E0E4B716800207D74 /* TriangulateProcess.h in Headers */,
-				3AF45B600E4B716800207D74 /* ValidateDataStructure.h in Headers */,
-				3AF45B620E4B716800207D74 /* VertexTriangleAdjacency.h in Headers */,
-				3AF45B630E4B716800207D74 /* Win32DebugLogStream.h in Headers */,
 				3AF45B640E4B716800207D74 /* XFileHelper.h in Headers */,
 				3AF45B660E4B716800207D74 /* XFileImporter.h in Headers */,
 				3AF45B680E4B716800207D74 /* XFileParser.h in Headers */,
 				3AB8A3AF0E50D67A00606590 /* MDCFileData.h in Headers */,
 				3AB8A3B10E50D67A00606590 /* MDCLoader.h in Headers */,
 				3AB8A3B20E50D67A00606590 /* MDCNormalTable.h in Headers */,
-				3AB8A3B60E50D69D00606590 /* FixNormalsStep.h in Headers */,
 				3AB8A3BA0E50D6DB00606590 /* LWOFileData.h in Headers */,
 				3AB8A3BC0E50D6DB00606590 /* LWOLoader.h in Headers */,
 				3AB8A3C60E50D77900606590 /* HMPFileData.h in Headers */,
-				3AB8A3CA0E50D7CC00606590 /* IFF.h in Headers */,
-				3AB8A3CD0E50D7FF00606590 /* Hash.h in Headers */,
 				F90BAFD30F5DD87000124155 /* ACLoader.h in Headers */,
 				F90BAFE00F5DD90800124155 /* IRRLoader.h in Headers */,
 				F90BAFE20F5DD90800124155 /* IRRMeshLoader.h in Headers */,
 				F90BAFE40F5DD90800124155 /* IRRShared.h in Headers */,
-				F90BAFED0F5DD93600124155 /* ColladaHelper.h in Headers */,
-				F90BAFEF0F5DD93600124155 /* ColladaLoader.h in Headers */,
-				F90BAFF10F5DD93600124155 /* ColladaParser.h in Headers */,
 				F90BAFF70F5DD96100124155 /* NFFLoader.h in Headers */,
-				F90BAFFD0F5DD9A000124155 /* SGSpatialSort.h in Headers */,
 				F90BB0090F5DD9DD00124155 /* Q3DLoader.h in Headers */,
 				F90BB00E0F5DD9F400124155 /* BVHLoader.h in Headers */,
 				F90BB0150F5DDA1400124155 /* OFFLoader.h in Headers */,
@@ -3299,47 +4180,20 @@
 				F90BB0230F5DDA5700124155 /* DXFLoader.h in Headers */,
 				F90BB0310F5DDAB500124155 /* TerragenLoader.h in Headers */,
 				F90BB0370F5DDB1B00124155 /* irrXMLWrapper.h in Headers */,
-				F90BB03D0F5DDB3200124155 /* ScenePreprocessor.h in Headers */,
-				F90BB03F0F5DDB3200124155 /* SceneCombiner.h in Headers */,
-				F90BB0440F5DDB4600124155 /* SortByPTypeProcess.h in Headers */,
-				F90BB0490F5DDB6100124155 /* FindDegenerates.h in Headers */,
-				F90BB04E0F5DDB8D00124155 /* ComputeUVMappingProcess.h in Headers */,
-				F90BB0530F5DDBA800124155 /* StandardShapes.h in Headers */,
-				F90BB0580F5DDBBF00124155 /* FindInstancesProcess.h in Headers */,
-				F90BB05C0F5DDBCB00124155 /* RemoveVCProcess.h in Headers */,
-				F90BB0620F5DDBE600124155 /* FindInvalidDataProcess.h in Headers */,
-				F90BB0660F5DDC0700124155 /* SkeletonMeshBuilder.h in Headers */,
-				F90BB06B0F5DDC1E00124155 /* SmoothingGroups.h in Headers */,
 				F90BB0890F5DDE0700124155 /* B3DImporter.h in Headers */,
 				7411B15511416D5E00BCD793 /* CSMLoader.h in Headers */,
 				7411B16011416DDD00BCD793 /* LWSLoader.h in Headers */,
 				7411B16A11416DF400BCD793 /* LWOAnimation.h in Headers */,
 				7411B17711416E2500BCD793 /* MS3DLoader.h in Headers */,
 				7411B19211416EBC00BCD793 /* UnrealLoader.h in Headers */,
-				7411B1C411416EF400BCD793 /* FileSystemFilter.h in Headers */,
-				7411B1C511416EF400BCD793 /* GenericProperty.h in Headers */,
-				7411B1C611416EF400BCD793 /* MemoryIOWrapper.h in Headers */,
-				7411B1C811416EF400BCD793 /* OptimizeGraph.h in Headers */,
-				7411B1CA11416EF400BCD793 /* OptimizeMeshes.h in Headers */,
-				7411B1CB11416EF400BCD793 /* ProcessHelper.h in Headers */,
-				7411B1CC11416EF400BCD793 /* StdOStreamLogStream.h in Headers */,
-				7411B1CD11416EF400BCD793 /* StreamReader.h in Headers */,
-				7411B1CF11416EF400BCD793 /* Subdivision.h in Headers */,
-				7411B1D111416EF400BCD793 /* TargetAnimation.h in Headers */,
-				7411B1D211416EF400BCD793 /* Vertex.h in Headers */,
 				74C9BB5211ACBB1000AF885C /* BlenderDNA.h in Headers */,
 				74C9BB5411ACBB1000AF885C /* BlenderLoader.h in Headers */,
 				74C9BB5611ACBB1000AF885C /* BlenderScene.h in Headers */,
 				74C9BB5711ACBB1000AF885C /* BlenderSceneGen.h in Headers */,
-				74C9BB8311ACBB7800AF885C /* MakeVerboseFormat.h in Headers */,
 				74C9BB8D11ACBB9900AF885C /* AssimpPCH.h in Headers */,
 				74C9BB9D11ACBBBC00AF885C /* COBLoader.h in Headers */,
 				74C9BB9E11ACBBBC00AF885C /* COBScene.h in Headers */,
 				74C9BBB611ACBC2600AF885C /* revision.h in Headers */,
-				74C9BBC711ACBC6C00AF885C /* Exceptional.h in Headers */,
-				74C9BBC811ACBC6C00AF885C /* LineSplitter.h in Headers */,
-				74C9BBC911ACBC6C00AF885C /* MD4FileData.h in Headers */,
-				74C9BBCA11ACBC6C00AF885C /* TinyFormatter.h in Headers */,
 				8E7ABBAF127E0F1A00512ED1 /* Q3BSPFileData.h in Headers */,
 				8E7ABBB1127E0F1A00512ED1 /* Q3BSPFileImporter.h in Headers */,
 				8E7ABBB3127E0F1A00512ED1 /* Q3BSPFileParser.h in Headers */,
@@ -3347,10 +4201,6 @@
 				8E7ABBC9127E0F2A00512ED1 /* NDOLoader.h in Headers */,
 				8E7ABBD4127E0F3800512ED1 /* BlenderIntermediate.h in Headers */,
 				8E7ABBD6127E0F3800512ED1 /* BlenderModifier.h in Headers */,
-				8E7ABBE7127E0FA400512ED1 /* assbin_chunks.h in Headers */,
-				8E7ABBE8127E0FA400512ED1 /* DefaultProgressHandler.h in Headers */,
-				8E7ABBE9127E0FA400512ED1 /* Profiler.h in Headers */,
-				8E7ABBEA127E0FA400512ED1 /* pstdint.h in Headers */,
 				8E8DEE6B127E2B78005EF64D /* ConvertUTF.h in Headers */,
 				8E8DEE6C127E2B78005EF64D /* CXMLReaderImpl.h in Headers */,
 				8E8DEE6D127E2B78005EF64D /* heapsort.h in Headers */,
@@ -3396,21 +4246,8 @@
 				F9BA8BC01543268400E63FFE /* version.h in Headers */,
 				F9BA8C3C154328B600E63FFE /* OgreImporter.hpp in Headers */,
 				F9BA8C40154328B600E63FFE /* OgreXmlHelper.hpp in Headers */,
-				F99A9EB415436077000682F3 /* BlobIOSystem.h in Headers */,
-				F99A9EB915436098000682F3 /* lexical_cast.hpp in Headers */,
-				F99A9EBE154360A0000682F3 /* make_shared.hpp in Headers */,
-				F99A9EC3154360A5000682F3 /* noncopyable.hpp in Headers */,
-				F99A9EC8154360B5000682F3 /* timer.hpp in Headers */,
-				F99A9ECD154360E2000682F3 /* CInterfaceIOWrapper.h in Headers */,
-				F99A9ED415436125000682F3 /* DeboneProcess.h in Headers */,
-				F99A9F1D154361D4000682F3 /* LogAux.h in Headers */,
 				F99A9F2915436207000682F3 /* M3Importer.h in Headers */,
 				F99A9F3315436269000682F3 /* PlyExporter.h in Headers */,
-				F99A9F3B15436286000682F3 /* PolyTools.h in Headers */,
-				F99A9F45154362DE000682F3 /* ScenePrivate.h in Headers */,
-				F99A9F4C15436304000682F3 /* SplitByBoneCountProcess.h in Headers */,
-				F99A9F5C15436323000682F3 /* STEPFile.h in Headers */,
-				F99A9F5E15436323000682F3 /* STEPFileReader.h in Headers */,
 				F9607060154366AB004D91DD /* crc32.h in Headers */,
 				F9607062154366AB004D91DD /* deflate.h in Headers */,
 				F9607064154366AB004D91DD /* inffast.h in Headers */,
@@ -3432,9 +4269,119 @@
 				F96070E81543675E004D91DD /* sweep.h in Headers */,
 				F96070EA1543675E004D91DD /* sweep_context.h in Headers */,
 				F97BA03615439DB3009EB9DD /* ai_assert.h in Headers */,
-				F97BA07315439FC3009EB9DD /* IFCLoader.h in Headers */,
-				F97BA07715439FC3009EB9DD /* IFCReaderGen.h in Headers */,
-				F97BA07915439FC3009EB9DD /* IFCUtil.h in Headers */,
+				2B7F46DD1708365200A106A9 /* assbin_chunks.h in Headers */,
+				2B7F47051708365200A106A9 /* BaseImporter.h in Headers */,
+				2B7F470F1708365200A106A9 /* BaseProcess.h in Headers */,
+				2B7F47461708365200A106A9 /* BlobIOSystem.h in Headers */,
+				2B7F474B1708365200A106A9 /* foreach.hpp in Headers */,
+				2B7F47501708365200A106A9 /* format.hpp in Headers */,
+				2B7F47551708365200A106A9 /* lexical_cast.hpp in Headers */,
+				2B7F475A1708365200A106A9 /* make_shared.hpp in Headers */,
+				2B7F475F1708365200A106A9 /* common_factor_rt.hpp in Headers */,
+				2B7F47641708365200A106A9 /* noncopyable.hpp in Headers */,
+				2B7F47691708365200A106A9 /* pointer_cast.hpp in Headers */,
+				2B7F476E1708365200A106A9 /* scoped_array.hpp in Headers */,
+				2B7F47731708365200A106A9 /* scoped_ptr.hpp in Headers */,
+				2B7F47781708365200A106A9 /* shared_array.hpp in Headers */,
+				2B7F477D1708365200A106A9 /* shared_ptr.hpp in Headers */,
+				2B7F47821708365200A106A9 /* static_assert.hpp in Headers */,
+				2B7F47871708365200A106A9 /* timer.hpp in Headers */,
+				2B7F478C1708365200A106A9 /* tuple.hpp in Headers */,
+				2B7F479B1708365200A106A9 /* ByteSwap.h in Headers */,
+				2B7F47A51708365200A106A9 /* CalcTangentsProcess.h in Headers */,
+				2B7F47AA1708365200A106A9 /* CInterfaceIOWrapper.h in Headers */,
+				2B7F47C31708365200A106A9 /* ColladaExporter.h in Headers */,
+				2B7F47C81708365200A106A9 /* ColladaHelper.h in Headers */,
+				2B7F47D21708365200A106A9 /* ColladaLoader.h in Headers */,
+				2B7F47DC1708365200A106A9 /* ColladaParser.h in Headers */,
+				2B7F47E61708365200A106A9 /* ComputeUVMappingProcess.h in Headers */,
+				2B7F47F01708365200A106A9 /* ConvertToLHProcess.h in Headers */,
+				2B7F48041708365200A106A9 /* DeboneProcess.h in Headers */,
+				2B7F480E1708365200A106A9 /* DefaultIOStream.h in Headers */,
+				2B7F48181708365200A106A9 /* DefaultIOSystem.h in Headers */,
+				2B7F48221708365200A106A9 /* DefaultProgressHandler.h in Headers */,
+				2B7F48361708365200A106A9 /* Exceptional.h in Headers */,
+				2B7F48401708365200A106A9 /* fast_atof.h in Headers */,
+				2B7F484F1708365200A106A9 /* FBXCompileConfig.h in Headers */,
+				2B7F48591708365200A106A9 /* FBXConverter.h in Headers */,
+				2B7F48681708365200A106A9 /* FBXDocument.h in Headers */,
+				2B7F48721708365200A106A9 /* FBXDocumentUtil.h in Headers */,
+				2B7F487C1708365200A106A9 /* FBXImporter.h in Headers */,
+				2B7F48811708365200A106A9 /* FBXImportSettings.h in Headers */,
+				2B7F489F1708365200A106A9 /* FBXParser.h in Headers */,
+				2B7F48A91708365200A106A9 /* FBXProperties.h in Headers */,
+				2B7F48B31708365200A106A9 /* FBXTokenizer.h in Headers */,
+				2B7F48BD1708365200A106A9 /* FBXUtil.h in Headers */,
+				2B7F48C21708365200A106A9 /* FileLogStream.h in Headers */,
+				2B7F48C71708365200A106A9 /* FileSystemFilter.h in Headers */,
+				2B7F48D11708365200A106A9 /* FindDegenerates.h in Headers */,
+				2B7F48DB1708365200A106A9 /* FindInstancesProcess.h in Headers */,
+				2B7F48E51708365200A106A9 /* FindInvalidDataProcess.h in Headers */,
+				2B7F48EF1708365200A106A9 /* FixNormalsStep.h in Headers */,
+				2B7F48F41708365200A106A9 /* GenericProperty.h in Headers */,
+				2B7F48FE1708365200A106A9 /* GenFaceNormalsProcess.h in Headers */,
+				2B7F49081708365200A106A9 /* GenVertexNormalsProcess.h in Headers */,
+				2B7F49121708365200A106A9 /* Hash.h in Headers */,
+				2B7F493A1708365200A106A9 /* IFCLoader.h in Headers */,
+				2B7F49531708365200A106A9 /* IFCReaderGen.h in Headers */,
+				2B7F495D1708365200A106A9 /* IFCUtil.h in Headers */,
+				2B7F49621708365200A106A9 /* IFF.h in Headers */,
+				2B7F496C1708365200A106A9 /* Importer.h in Headers */,
+				2B7F497B1708365200A106A9 /* ImproveCacheLocality.h in Headers */,
+				2B7F49A81708365200A106A9 /* JoinVerticesProcess.h in Headers */,
+				2B7F49B21708365200A106A9 /* LimitBoneWeightsProcess.h in Headers */,
+				2B7F49B71708365200A106A9 /* LineSplitter.h in Headers */,
+				2B7F49BC1708365200A106A9 /* LogAux.h in Headers */,
+				2B7F49FD1708365200A106A9 /* MakeVerboseFormat.h in Headers */,
+				2B7F4A071708365200A106A9 /* MaterialSystem.h in Headers */,
+				2B7F4A2F1708365200A106A9 /* MD4FileData.h in Headers */,
+				2B7F4A751708365200A106A9 /* MemoryIOWrapper.h in Headers */,
+				2B7F4A9D1708365200A106A9 /* ObjExporter.h in Headers */,
+				2B7F4AA21708365200A106A9 /* ObjFileData.h in Headers */,
+				2B7F4AAC1708365200A106A9 /* ObjFileImporter.h in Headers */,
+				2B7F4AB61708365200A106A9 /* ObjFileMtlImporter.h in Headers */,
+				2B7F4AC01708365200A106A9 /* ObjFileParser.h in Headers */,
+				2B7F4AC51708365200A106A9 /* ObjTools.h in Headers */,
+				2B7F4AF71708365200A106A9 /* OptimizeGraph.h in Headers */,
+				2B7F4B011708365200A106A9 /* OptimizeMeshes.h in Headers */,
+				2B7F4B061708365200A106A9 /* ParsingUtils.h in Headers */,
+				2B7F4B291708365200A106A9 /* PolyTools.h in Headers */,
+				2B7F4B381708365200A106A9 /* PretransformVertices.h in Headers */,
+				2B7F4B421708365200A106A9 /* ProcessHelper.h in Headers */,
+				2B7F4B471708365200A106A9 /* Profiler.h in Headers */,
+				2B7F4B4C1708365200A106A9 /* pstdint.h in Headers */,
+				2B7F4B7E1708365200A106A9 /* qnan.h in Headers */,
+				2B7F4B921708365200A106A9 /* RemoveComments.h in Headers */,
+				2B7F4B9C1708365200A106A9 /* RemoveRedundantMaterials.h in Headers */,
+				2B7F4BA61708365200A106A9 /* RemoveVCProcess.h in Headers */,
+				2B7F4BB51708365200A106A9 /* SceneCombiner.h in Headers */,
+				2B7F4BBF1708365200A106A9 /* ScenePreprocessor.h in Headers */,
+				2B7F4BC41708365200A106A9 /* ScenePrivate.h in Headers */,
+				2B7F4BCE1708365200A106A9 /* SGSpatialSort.h in Headers */,
+				2B7F4BD81708365200A106A9 /* SkeletonMeshBuilder.h in Headers */,
+				2B7F4BE71708365200A106A9 /* SmoothingGroups.h in Headers */,
+				2B7F4BF11708365200A106A9 /* SortByPTypeProcess.h in Headers */,
+				2B7F4BFB1708365200A106A9 /* SpatialSort.h in Headers */,
+				2B7F4C051708365200A106A9 /* SplitByBoneCountProcess.h in Headers */,
+				2B7F4C0F1708365200A106A9 /* SplitLargeMeshes.h in Headers */,
+				2B7F4C191708365200A106A9 /* StandardShapes.h in Headers */,
+				2B7F4C1E1708365200A106A9 /* StdOStreamLogStream.h in Headers */,
+				2B7F4C231708365200A106A9 /* STEPFile.h in Headers */,
+				2B7F4C2D1708365200A106A9 /* STEPFileEncoding.h in Headers */,
+				2B7F4C371708365200A106A9 /* STEPFileReader.h in Headers */,
+				2B7F4C411708365200A106A9 /* STLExporter.h in Headers */,
+				2B7F4C4B1708365200A106A9 /* STLLoader.h in Headers */,
+				2B7F4C501708365200A106A9 /* StreamReader.h in Headers */,
+				2B7F4C551708365200A106A9 /* StringComparison.h in Headers */,
+				2B7F4C5F1708365200A106A9 /* Subdivision.h in Headers */,
+				2B7F4C691708365200A106A9 /* TargetAnimation.h in Headers */,
+				2B7F4C7D1708365200A106A9 /* TextureTransform.h in Headers */,
+				2B7F4C821708365200A106A9 /* TinyFormatter.h in Headers */,
+				2B7F4C8C1708365200A106A9 /* TriangulateProcess.h in Headers */,
+				2B7F4CA01708365200A106A9 /* ValidateDataStructure.h in Headers */,
+				2B7F4CA51708365200A106A9 /* Vertex.h in Headers */,
+				2B7F4CAF1708365200A106A9 /* VertexTriangleAdjacency.h in Headers */,
+				2B7F4CB41708365200A106A9 /* Win32DebugLogStream.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3446,23 +4393,8 @@
 				F962E8EE0F5DE6E2009A5495 /* 3DSLoader.h in Headers */,
 				F962E8EF0F5DE6E2009A5495 /* ASELoader.h in Headers */,
 				F962E8F00F5DE6E2009A5495 /* ASEParser.h in Headers */,
-				F962E8F10F5DE6E2009A5495 /* BaseImporter.h in Headers */,
-				F962E8F20F5DE6E2009A5495 /* BaseProcess.h in Headers */,
-				F962E8F30F5DE6E2009A5495 /* ByteSwap.h in Headers */,
-				F962E8F40F5DE6E2009A5495 /* CalcTangentsProcess.h in Headers */,
-				F962E8F50F5DE6E2009A5495 /* ConvertToLHProcess.h in Headers */,
-				F962E8F60F5DE6E2009A5495 /* DefaultIOStream.h in Headers */,
-				F962E8F70F5DE6E2009A5495 /* DefaultIOSystem.h in Headers */,
-				F962E8F90F5DE6E2009A5495 /* fast_atof.h in Headers */,
-				F962E8FA0F5DE6E2009A5495 /* FileLogStream.h in Headers */,
-				F962E8FB0F5DE6E2009A5495 /* GenFaceNormalsProcess.h in Headers */,
-				F962E8FC0F5DE6E2009A5495 /* GenVertexNormalsProcess.h in Headers */,
 				F962E8FD0F5DE6E2009A5495 /* HalfLifeFileData.h in Headers */,
 				F962E8FE0F5DE6E2009A5495 /* HMPLoader.h in Headers */,
-				F962E8FF0F5DE6E2009A5495 /* ImproveCacheLocality.h in Headers */,
-				F962E9000F5DE6E2009A5495 /* JoinVerticesProcess.h in Headers */,
-				F962E9010F5DE6E2009A5495 /* LimitBoneWeightsProcess.h in Headers */,
-				F962E9020F5DE6E2009A5495 /* MaterialSystem.h in Headers */,
 				F962E9030F5DE6E2009A5495 /* MD2FileData.h in Headers */,
 				F962E9040F5DE6E2009A5495 /* MD2Loader.h in Headers */,
 				F962E9050F5DE6E2009A5495 /* MD2NormalTable.h in Headers */,
@@ -3473,49 +4405,23 @@
 				F962E90A0F5DE6E2009A5495 /* MDLDefaultColorMap.h in Headers */,
 				F962E90B0F5DE6E2009A5495 /* MDLFileData.h in Headers */,
 				F962E90C0F5DE6E2009A5495 /* MDLLoader.h in Headers */,
-				F962E90D0F5DE6E2009A5495 /* ObjFileData.h in Headers */,
-				F962E90E0F5DE6E2009A5495 /* ObjFileImporter.h in Headers */,
-				F962E90F0F5DE6E2009A5495 /* ObjFileMtlImporter.h in Headers */,
-				F962E9100F5DE6E2009A5495 /* ObjFileParser.h in Headers */,
-				F962E9110F5DE6E2009A5495 /* ObjTools.h in Headers */,
-				F962E9120F5DE6E2009A5495 /* ParsingUtils.h in Headers */,
 				F962E9130F5DE6E2009A5495 /* PlyLoader.h in Headers */,
 				F962E9140F5DE6E2009A5495 /* PlyParser.h in Headers */,
-				F962E9150F5DE6E2009A5495 /* PretransformVertices.h in Headers */,
-				F962E9160F5DE6E2009A5495 /* qnan.h in Headers */,
-				F962E9170F5DE6E2009A5495 /* RemoveComments.h in Headers */,
-				F962E9180F5DE6E2009A5495 /* RemoveRedundantMaterials.h in Headers */,
 				F962E9190F5DE6E2009A5495 /* SMDLoader.h in Headers */,
-				F962E91A0F5DE6E2009A5495 /* SpatialSort.h in Headers */,
-				F962E91B0F5DE6E2009A5495 /* SplitLargeMeshes.h in Headers */,
-				F962E91C0F5DE6E2009A5495 /* STLLoader.h in Headers */,
-				F962E91D0F5DE6E2009A5495 /* StringComparison.h in Headers */,
-				F962E91E0F5DE6E2009A5495 /* TextureTransform.h in Headers */,
-				F962E91F0F5DE6E2009A5495 /* TriangulateProcess.h in Headers */,
-				F962E9200F5DE6E2009A5495 /* ValidateDataStructure.h in Headers */,
-				F962E9210F5DE6E2009A5495 /* VertexTriangleAdjacency.h in Headers */,
-				F962E9220F5DE6E2009A5495 /* Win32DebugLogStream.h in Headers */,
 				F962E9230F5DE6E2009A5495 /* XFileHelper.h in Headers */,
 				F962E9240F5DE6E2009A5495 /* XFileImporter.h in Headers */,
 				F962E9250F5DE6E2009A5495 /* XFileParser.h in Headers */,
 				F962E9280F5DE6E2009A5495 /* MDCFileData.h in Headers */,
 				F962E9290F5DE6E2009A5495 /* MDCLoader.h in Headers */,
 				F962E92A0F5DE6E2009A5495 /* MDCNormalTable.h in Headers */,
-				F962E92B0F5DE6E2009A5495 /* FixNormalsStep.h in Headers */,
 				F962E92C0F5DE6E2009A5495 /* LWOFileData.h in Headers */,
 				F962E92D0F5DE6E2009A5495 /* LWOLoader.h in Headers */,
 				F962E92E0F5DE6E2009A5495 /* HMPFileData.h in Headers */,
-				F962E9300F5DE6E2009A5495 /* IFF.h in Headers */,
-				F962E9310F5DE6E2009A5495 /* Hash.h in Headers */,
 				F962E9360F5DE6E2009A5495 /* ACLoader.h in Headers */,
 				F962E9370F5DE6E2009A5495 /* IRRLoader.h in Headers */,
 				F962E9380F5DE6E2009A5495 /* IRRMeshLoader.h in Headers */,
 				F962E9390F5DE6E2009A5495 /* IRRShared.h in Headers */,
-				F962E93A0F5DE6E2009A5495 /* ColladaHelper.h in Headers */,
-				F962E93B0F5DE6E2009A5495 /* ColladaLoader.h in Headers */,
-				F962E93C0F5DE6E2009A5495 /* ColladaParser.h in Headers */,
 				F962E93D0F5DE6E2009A5495 /* NFFLoader.h in Headers */,
-				F962E93E0F5DE6E2009A5495 /* SGSpatialSort.h in Headers */,
 				F962E93F0F5DE6E2009A5495 /* Q3DLoader.h in Headers */,
 				F962E9400F5DE6E2009A5495 /* BVHLoader.h in Headers */,
 				F962E9410F5DE6E2009A5495 /* OFFLoader.h in Headers */,
@@ -3523,47 +4429,20 @@
 				F962E9430F5DE6E2009A5495 /* DXFLoader.h in Headers */,
 				F962E9440F5DE6E2009A5495 /* TerragenLoader.h in Headers */,
 				F962E9450F5DE6E2009A5495 /* irrXMLWrapper.h in Headers */,
-				F962E9460F5DE6E2009A5495 /* ScenePreprocessor.h in Headers */,
-				F962E9470F5DE6E2009A5495 /* SceneCombiner.h in Headers */,
-				F962E9480F5DE6E2009A5495 /* SortByPTypeProcess.h in Headers */,
-				F962E9490F5DE6E2009A5495 /* FindDegenerates.h in Headers */,
-				F962E94A0F5DE6E2009A5495 /* ComputeUVMappingProcess.h in Headers */,
-				F962E94B0F5DE6E2009A5495 /* StandardShapes.h in Headers */,
-				F962E94C0F5DE6E2009A5495 /* FindInstancesProcess.h in Headers */,
-				F962E94D0F5DE6E2009A5495 /* RemoveVCProcess.h in Headers */,
-				F962E94E0F5DE6E2009A5495 /* FindInvalidDataProcess.h in Headers */,
-				F962E94F0F5DE6E2009A5495 /* SkeletonMeshBuilder.h in Headers */,
-				F962E9500F5DE6E2009A5495 /* SmoothingGroups.h in Headers */,
 				F962E9570F5DE6E2009A5495 /* B3DImporter.h in Headers */,
 				7411B15711416D5E00BCD793 /* CSMLoader.h in Headers */,
 				7411B16211416DDD00BCD793 /* LWSLoader.h in Headers */,
 				7411B16C11416DF400BCD793 /* LWOAnimation.h in Headers */,
 				7411B17911416E2500BCD793 /* MS3DLoader.h in Headers */,
 				7411B19411416EBC00BCD793 /* UnrealLoader.h in Headers */,
-				7411B1D311416EF400BCD793 /* FileSystemFilter.h in Headers */,
-				7411B1D411416EF400BCD793 /* GenericProperty.h in Headers */,
-				7411B1D511416EF400BCD793 /* MemoryIOWrapper.h in Headers */,
-				7411B1D711416EF400BCD793 /* OptimizeGraph.h in Headers */,
-				7411B1D911416EF400BCD793 /* OptimizeMeshes.h in Headers */,
-				7411B1DA11416EF400BCD793 /* ProcessHelper.h in Headers */,
-				7411B1DB11416EF400BCD793 /* StdOStreamLogStream.h in Headers */,
-				7411B1DC11416EF400BCD793 /* StreamReader.h in Headers */,
-				7411B1DE11416EF400BCD793 /* Subdivision.h in Headers */,
-				7411B1E011416EF400BCD793 /* TargetAnimation.h in Headers */,
-				7411B1E111416EF400BCD793 /* Vertex.h in Headers */,
 				74C9BB5911ACBB1000AF885C /* BlenderDNA.h in Headers */,
 				74C9BB5B11ACBB1000AF885C /* BlenderLoader.h in Headers */,
 				74C9BB5D11ACBB1000AF885C /* BlenderScene.h in Headers */,
 				74C9BB5E11ACBB1000AF885C /* BlenderSceneGen.h in Headers */,
-				74C9BB8511ACBB7800AF885C /* MakeVerboseFormat.h in Headers */,
 				74C9BB8F11ACBB9900AF885C /* AssimpPCH.h in Headers */,
 				74C9BBA011ACBBBC00AF885C /* COBLoader.h in Headers */,
 				74C9BBA111ACBBBC00AF885C /* COBScene.h in Headers */,
 				74C9BBB711ACBC2600AF885C /* revision.h in Headers */,
-				74C9BBCB11ACBC6C00AF885C /* Exceptional.h in Headers */,
-				74C9BBCC11ACBC6C00AF885C /* LineSplitter.h in Headers */,
-				74C9BBCD11ACBC6C00AF885C /* MD4FileData.h in Headers */,
-				74C9BBCE11ACBC6C00AF885C /* TinyFormatter.h in Headers */,
 				8E7ABBB6127E0F1A00512ED1 /* Q3BSPFileData.h in Headers */,
 				8E7ABBB8127E0F1A00512ED1 /* Q3BSPFileImporter.h in Headers */,
 				8E7ABBBA127E0F1A00512ED1 /* Q3BSPFileParser.h in Headers */,
@@ -3571,10 +4450,6 @@
 				8E7ABBCB127E0F2A00512ED1 /* NDOLoader.h in Headers */,
 				8E7ABBD7127E0F3800512ED1 /* BlenderIntermediate.h in Headers */,
 				8E7ABBD9127E0F3800512ED1 /* BlenderModifier.h in Headers */,
-				8E7ABBEB127E0FA400512ED1 /* assbin_chunks.h in Headers */,
-				8E7ABBEC127E0FA400512ED1 /* DefaultProgressHandler.h in Headers */,
-				8E7ABBED127E0FA400512ED1 /* Profiler.h in Headers */,
-				8E7ABBEE127E0FA400512ED1 /* pstdint.h in Headers */,
 				8E8DEE79127E2B78005EF64D /* ConvertUTF.h in Headers */,
 				8E8DEE7A127E2B78005EF64D /* CXMLReaderImpl.h in Headers */,
 				8E8DEE7B127E2B78005EF64D /* heapsort.h in Headers */,
@@ -3620,21 +4495,8 @@
 				F9BA8BE21543268400E63FFE /* version.h in Headers */,
 				F9BA8C42154328B600E63FFE /* OgreImporter.hpp in Headers */,
 				F9BA8C46154328B600E63FFE /* OgreXmlHelper.hpp in Headers */,
-				F99A9EB515436077000682F3 /* BlobIOSystem.h in Headers */,
-				F99A9EBA15436098000682F3 /* lexical_cast.hpp in Headers */,
-				F99A9EBF154360A0000682F3 /* make_shared.hpp in Headers */,
-				F99A9EC4154360A5000682F3 /* noncopyable.hpp in Headers */,
-				F99A9EC9154360B5000682F3 /* timer.hpp in Headers */,
-				F99A9ECE154360E2000682F3 /* CInterfaceIOWrapper.h in Headers */,
-				F99A9ED615436125000682F3 /* DeboneProcess.h in Headers */,
-				F99A9F1E154361D4000682F3 /* LogAux.h in Headers */,
 				F99A9F2B15436207000682F3 /* M3Importer.h in Headers */,
 				F99A9F3515436269000682F3 /* PlyExporter.h in Headers */,
-				F99A9F3C15436286000682F3 /* PolyTools.h in Headers */,
-				F99A9F46154362DE000682F3 /* ScenePrivate.h in Headers */,
-				F99A9F4E15436304000682F3 /* SplitByBoneCountProcess.h in Headers */,
-				F99A9F5F15436323000682F3 /* STEPFile.h in Headers */,
-				F99A9F6115436323000682F3 /* STEPFileReader.h in Headers */,
 				F9607074154366AB004D91DD /* crc32.h in Headers */,
 				F9607076154366AB004D91DD /* deflate.h in Headers */,
 				F9607078154366AB004D91DD /* inffast.h in Headers */,
@@ -3656,9 +4518,119 @@
 				F96070F41543675E004D91DD /* sweep.h in Headers */,
 				F96070F61543675E004D91DD /* sweep_context.h in Headers */,
 				F97BA03715439DB3009EB9DD /* ai_assert.h in Headers */,
-				F97BA07D15439FC3009EB9DD /* IFCLoader.h in Headers */,
-				F97BA08115439FC3009EB9DD /* IFCReaderGen.h in Headers */,
-				F97BA08315439FC3009EB9DD /* IFCUtil.h in Headers */,
+				2B7F46DE1708365200A106A9 /* assbin_chunks.h in Headers */,
+				2B7F47061708365200A106A9 /* BaseImporter.h in Headers */,
+				2B7F47101708365200A106A9 /* BaseProcess.h in Headers */,
+				2B7F47471708365200A106A9 /* BlobIOSystem.h in Headers */,
+				2B7F474C1708365200A106A9 /* foreach.hpp in Headers */,
+				2B7F47511708365200A106A9 /* format.hpp in Headers */,
+				2B7F47561708365200A106A9 /* lexical_cast.hpp in Headers */,
+				2B7F475B1708365200A106A9 /* make_shared.hpp in Headers */,
+				2B7F47601708365200A106A9 /* common_factor_rt.hpp in Headers */,
+				2B7F47651708365200A106A9 /* noncopyable.hpp in Headers */,
+				2B7F476A1708365200A106A9 /* pointer_cast.hpp in Headers */,
+				2B7F476F1708365200A106A9 /* scoped_array.hpp in Headers */,
+				2B7F47741708365200A106A9 /* scoped_ptr.hpp in Headers */,
+				2B7F47791708365200A106A9 /* shared_array.hpp in Headers */,
+				2B7F477E1708365200A106A9 /* shared_ptr.hpp in Headers */,
+				2B7F47831708365200A106A9 /* static_assert.hpp in Headers */,
+				2B7F47881708365200A106A9 /* timer.hpp in Headers */,
+				2B7F478D1708365200A106A9 /* tuple.hpp in Headers */,
+				2B7F479C1708365200A106A9 /* ByteSwap.h in Headers */,
+				2B7F47A61708365200A106A9 /* CalcTangentsProcess.h in Headers */,
+				2B7F47AB1708365200A106A9 /* CInterfaceIOWrapper.h in Headers */,
+				2B7F47C41708365200A106A9 /* ColladaExporter.h in Headers */,
+				2B7F47C91708365200A106A9 /* ColladaHelper.h in Headers */,
+				2B7F47D31708365200A106A9 /* ColladaLoader.h in Headers */,
+				2B7F47DD1708365200A106A9 /* ColladaParser.h in Headers */,
+				2B7F47E71708365200A106A9 /* ComputeUVMappingProcess.h in Headers */,
+				2B7F47F11708365200A106A9 /* ConvertToLHProcess.h in Headers */,
+				2B7F48051708365200A106A9 /* DeboneProcess.h in Headers */,
+				2B7F480F1708365200A106A9 /* DefaultIOStream.h in Headers */,
+				2B7F48191708365200A106A9 /* DefaultIOSystem.h in Headers */,
+				2B7F48231708365200A106A9 /* DefaultProgressHandler.h in Headers */,
+				2B7F48371708365200A106A9 /* Exceptional.h in Headers */,
+				2B7F48411708365200A106A9 /* fast_atof.h in Headers */,
+				2B7F48501708365200A106A9 /* FBXCompileConfig.h in Headers */,
+				2B7F485A1708365200A106A9 /* FBXConverter.h in Headers */,
+				2B7F48691708365200A106A9 /* FBXDocument.h in Headers */,
+				2B7F48731708365200A106A9 /* FBXDocumentUtil.h in Headers */,
+				2B7F487D1708365200A106A9 /* FBXImporter.h in Headers */,
+				2B7F48821708365200A106A9 /* FBXImportSettings.h in Headers */,
+				2B7F48A01708365200A106A9 /* FBXParser.h in Headers */,
+				2B7F48AA1708365200A106A9 /* FBXProperties.h in Headers */,
+				2B7F48B41708365200A106A9 /* FBXTokenizer.h in Headers */,
+				2B7F48BE1708365200A106A9 /* FBXUtil.h in Headers */,
+				2B7F48C31708365200A106A9 /* FileLogStream.h in Headers */,
+				2B7F48C81708365200A106A9 /* FileSystemFilter.h in Headers */,
+				2B7F48D21708365200A106A9 /* FindDegenerates.h in Headers */,
+				2B7F48DC1708365200A106A9 /* FindInstancesProcess.h in Headers */,
+				2B7F48E61708365200A106A9 /* FindInvalidDataProcess.h in Headers */,
+				2B7F48F01708365200A106A9 /* FixNormalsStep.h in Headers */,
+				2B7F48F51708365200A106A9 /* GenericProperty.h in Headers */,
+				2B7F48FF1708365200A106A9 /* GenFaceNormalsProcess.h in Headers */,
+				2B7F49091708365200A106A9 /* GenVertexNormalsProcess.h in Headers */,
+				2B7F49131708365200A106A9 /* Hash.h in Headers */,
+				2B7F493B1708365200A106A9 /* IFCLoader.h in Headers */,
+				2B7F49541708365200A106A9 /* IFCReaderGen.h in Headers */,
+				2B7F495E1708365200A106A9 /* IFCUtil.h in Headers */,
+				2B7F49631708365200A106A9 /* IFF.h in Headers */,
+				2B7F496D1708365200A106A9 /* Importer.h in Headers */,
+				2B7F497C1708365200A106A9 /* ImproveCacheLocality.h in Headers */,
+				2B7F49A91708365200A106A9 /* JoinVerticesProcess.h in Headers */,
+				2B7F49B31708365200A106A9 /* LimitBoneWeightsProcess.h in Headers */,
+				2B7F49B81708365200A106A9 /* LineSplitter.h in Headers */,
+				2B7F49BD1708365200A106A9 /* LogAux.h in Headers */,
+				2B7F49FE1708365200A106A9 /* MakeVerboseFormat.h in Headers */,
+				2B7F4A081708365200A106A9 /* MaterialSystem.h in Headers */,
+				2B7F4A301708365200A106A9 /* MD4FileData.h in Headers */,
+				2B7F4A761708365200A106A9 /* MemoryIOWrapper.h in Headers */,
+				2B7F4A9E1708365200A106A9 /* ObjExporter.h in Headers */,
+				2B7F4AA31708365200A106A9 /* ObjFileData.h in Headers */,
+				2B7F4AAD1708365200A106A9 /* ObjFileImporter.h in Headers */,
+				2B7F4AB71708365200A106A9 /* ObjFileMtlImporter.h in Headers */,
+				2B7F4AC11708365200A106A9 /* ObjFileParser.h in Headers */,
+				2B7F4AC61708365200A106A9 /* ObjTools.h in Headers */,
+				2B7F4AF81708365200A106A9 /* OptimizeGraph.h in Headers */,
+				2B7F4B021708365200A106A9 /* OptimizeMeshes.h in Headers */,
+				2B7F4B071708365200A106A9 /* ParsingUtils.h in Headers */,
+				2B7F4B2A1708365200A106A9 /* PolyTools.h in Headers */,
+				2B7F4B391708365200A106A9 /* PretransformVertices.h in Headers */,
+				2B7F4B431708365200A106A9 /* ProcessHelper.h in Headers */,
+				2B7F4B481708365200A106A9 /* Profiler.h in Headers */,
+				2B7F4B4D1708365200A106A9 /* pstdint.h in Headers */,
+				2B7F4B7F1708365200A106A9 /* qnan.h in Headers */,
+				2B7F4B931708365200A106A9 /* RemoveComments.h in Headers */,
+				2B7F4B9D1708365200A106A9 /* RemoveRedundantMaterials.h in Headers */,
+				2B7F4BA71708365200A106A9 /* RemoveVCProcess.h in Headers */,
+				2B7F4BB61708365200A106A9 /* SceneCombiner.h in Headers */,
+				2B7F4BC01708365200A106A9 /* ScenePreprocessor.h in Headers */,
+				2B7F4BC51708365200A106A9 /* ScenePrivate.h in Headers */,
+				2B7F4BCF1708365200A106A9 /* SGSpatialSort.h in Headers */,
+				2B7F4BD91708365200A106A9 /* SkeletonMeshBuilder.h in Headers */,
+				2B7F4BE81708365200A106A9 /* SmoothingGroups.h in Headers */,
+				2B7F4BF21708365200A106A9 /* SortByPTypeProcess.h in Headers */,
+				2B7F4BFC1708365200A106A9 /* SpatialSort.h in Headers */,
+				2B7F4C061708365200A106A9 /* SplitByBoneCountProcess.h in Headers */,
+				2B7F4C101708365200A106A9 /* SplitLargeMeshes.h in Headers */,
+				2B7F4C1A1708365200A106A9 /* StandardShapes.h in Headers */,
+				2B7F4C1F1708365200A106A9 /* StdOStreamLogStream.h in Headers */,
+				2B7F4C241708365200A106A9 /* STEPFile.h in Headers */,
+				2B7F4C2E1708365200A106A9 /* STEPFileEncoding.h in Headers */,
+				2B7F4C381708365200A106A9 /* STEPFileReader.h in Headers */,
+				2B7F4C421708365200A106A9 /* STLExporter.h in Headers */,
+				2B7F4C4C1708365200A106A9 /* STLLoader.h in Headers */,
+				2B7F4C511708365200A106A9 /* StreamReader.h in Headers */,
+				2B7F4C561708365200A106A9 /* StringComparison.h in Headers */,
+				2B7F4C601708365200A106A9 /* Subdivision.h in Headers */,
+				2B7F4C6A1708365200A106A9 /* TargetAnimation.h in Headers */,
+				2B7F4C7E1708365200A106A9 /* TextureTransform.h in Headers */,
+				2B7F4C831708365200A106A9 /* TinyFormatter.h in Headers */,
+				2B7F4C8D1708365200A106A9 /* TriangulateProcess.h in Headers */,
+				2B7F4CA11708365200A106A9 /* ValidateDataStructure.h in Headers */,
+				2B7F4CA61708365200A106A9 /* Vertex.h in Headers */,
+				2B7F4CB01708365200A106A9 /* VertexTriangleAdjacency.h in Headers */,
+				2B7F4CB51708365200A106A9 /* Win32DebugLogStream.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3679,7 +4651,7 @@
 			);
 			name = "assimp-no-boost";
 			productName = libassimp;
-			productReference = 8E8DEEA5127E2D59005EF64D /* libassimp.dylib */;
+			productReference = 8E8DEEA5127E2D59005EF64D /* libassimpd.dylib */;
 			productType = "com.apple.product-type.library.dynamic";
 		};
 		745FF90C113ECC660020C31B /* assimp-static-no-boost */ = {
@@ -3696,7 +4668,24 @@
 			);
 			name = "assimp-static-no-boost";
 			productName = "assimp-static";
-			productReference = 8E8DEEA6127E2D59005EF64D /* libassimp.a */;
+			productReference = 8E8DEEA6127E2D59005EF64D /* libassimpd.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		B91974CF163AEA54009C397B /* assimp-ios-static-no-boost */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B919763C163AEA54009C397B /* Build configuration list for PBXNativeTarget "assimp-ios-static-no-boost" */;
+			buildPhases = (
+				B91974D0163AEA54009C397B /* Headers */,
+				B91975B4163AEA54009C397B /* Frameworks */,
+				B91975B6163AEA54009C397B /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "assimp-ios-static-no-boost";
+			productName = "assimp-static";
+			productReference = B919763F163AEA54009C397B /* libassimp-ios.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 		D2AAC09C05546B4700DB518D /* assimp */ = {
@@ -3713,7 +4702,7 @@
 			);
 			name = assimp;
 			productName = libassimp;
-			productReference = 8E8DEEA3127E2D59005EF64D /* libassimp.dylib */;
+			productReference = 8E8DEEA3127E2D59005EF64D /* libassimpd.dylib */;
 			productType = "com.apple.product-type.library.dynamic";
 		};
 		F962E8830F5DE66A009A5495 /* assimp-static */ = {
@@ -3730,7 +4719,7 @@
 			);
 			name = "assimp-static";
 			productName = "assimp-static";
-			productReference = 8E8DEEA4127E2D59005EF64D /* libassimp.a */;
+			productReference = 8E8DEEA4127E2D59005EF64D /* libassimpd.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 /* End PBXNativeTarget section */
@@ -3740,9 +4729,10 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
+				LastUpgradeCheck = 0460;
 			};
 			buildConfigurationList = 1DEB916408733D950010E9CD /* Build configuration list for PBXProject "assimp" */;
-			compatibilityVersion = "Xcode 3.0";
+			compatibilityVersion = "Xcode 3.2";
 			developmentRegion = English;
 			hasScannedForEncodings = 1;
 			knownRegions = (
@@ -3760,6 +4750,7 @@
 				F962E8830F5DE66A009A5495 /* assimp-static */,
 				745FF829113ECB080020C31B /* assimp-no-boost */,
 				745FF90C113ECC660020C31B /* assimp-static-no-boost */,
+				B91974CF163AEA54009C397B /* assimp-ios-static-no-boost */,
 			);
 		};
 /* End PBXProject section */
@@ -3773,58 +4764,26 @@
 				745FF8B1113ECB080020C31B /* 3DSLoader.cpp in Sources */,
 				745FF8B3113ECB080020C31B /* ASELoader.cpp in Sources */,
 				745FF8B4113ECB080020C31B /* ASEParser.cpp in Sources */,
-				745FF8B5113ECB080020C31B /* Assimp.cpp in Sources */,
-				745FF8B6113ECB080020C31B /* BaseImporter.cpp in Sources */,
-				745FF8B7113ECB080020C31B /* CalcTangentsProcess.cpp in Sources */,
-				745FF8B8113ECB080020C31B /* ConvertToLHProcess.cpp in Sources */,
-				745FF8B9113ECB080020C31B /* DefaultIOStream.cpp in Sources */,
-				745FF8BA113ECB080020C31B /* DefaultIOSystem.cpp in Sources */,
-				745FF8BB113ECB080020C31B /* DefaultLogger.cpp in Sources */,
-				745FF8BD113ECB080020C31B /* GenFaceNormalsProcess.cpp in Sources */,
-				745FF8BE113ECB080020C31B /* GenVertexNormalsProcess.cpp in Sources */,
 				745FF8BF113ECB080020C31B /* HMPLoader.cpp in Sources */,
-				745FF8C0113ECB080020C31B /* Importer.cpp in Sources */,
-				745FF8C1113ECB080020C31B /* ImproveCacheLocality.cpp in Sources */,
-				745FF8C2113ECB080020C31B /* JoinVerticesProcess.cpp in Sources */,
-				745FF8C3113ECB080020C31B /* LimitBoneWeightsProcess.cpp in Sources */,
-				745FF8C4113ECB080020C31B /* MaterialSystem.cpp in Sources */,
 				745FF8C5113ECB080020C31B /* MD2Loader.cpp in Sources */,
 				745FF8C6113ECB080020C31B /* MD3Loader.cpp in Sources */,
 				745FF8C7113ECB080020C31B /* MD5Loader.cpp in Sources */,
 				745FF8C8113ECB080020C31B /* MD5Parser.cpp in Sources */,
 				745FF8C9113ECB080020C31B /* MDLLoader.cpp in Sources */,
 				745FF8CA113ECB080020C31B /* MDLMaterialLoader.cpp in Sources */,
-				745FF8CB113ECB080020C31B /* ObjFileImporter.cpp in Sources */,
-				745FF8CC113ECB080020C31B /* ObjFileMtlImporter.cpp in Sources */,
-				745FF8CD113ECB080020C31B /* ObjFileParser.cpp in Sources */,
 				745FF8CE113ECB080020C31B /* PlyLoader.cpp in Sources */,
 				745FF8CF113ECB080020C31B /* PlyParser.cpp in Sources */,
-				745FF8D0113ECB080020C31B /* PretransformVertices.cpp in Sources */,
-				745FF8D1113ECB080020C31B /* RemoveComments.cpp in Sources */,
-				745FF8D2113ECB080020C31B /* RemoveRedundantMaterials.cpp in Sources */,
 				745FF8D3113ECB080020C31B /* SMDLoader.cpp in Sources */,
-				745FF8D4113ECB080020C31B /* SpatialSort.cpp in Sources */,
-				745FF8D5113ECB080020C31B /* SplitLargeMeshes.cpp in Sources */,
-				745FF8D6113ECB080020C31B /* STLLoader.cpp in Sources */,
-				745FF8D7113ECB080020C31B /* TextureTransform.cpp in Sources */,
-				745FF8D8113ECB080020C31B /* TriangulateProcess.cpp in Sources */,
-				745FF8D9113ECB080020C31B /* ValidateDataStructure.cpp in Sources */,
-				745FF8DA113ECB080020C31B /* VertexTriangleAdjacency.cpp in Sources */,
 				745FF8DB113ECB080020C31B /* XFileImporter.cpp in Sources */,
 				745FF8DC113ECB080020C31B /* XFileParser.cpp in Sources */,
 				745FF8DD113ECB080020C31B /* MDCLoader.cpp in Sources */,
-				745FF8DE113ECB080020C31B /* FixNormalsStep.cpp in Sources */,
 				745FF8DF113ECB080020C31B /* LWOLoader.cpp in Sources */,
-				745FF8E0113ECB080020C31B /* BaseProcess.cpp in Sources */,
 				745FF8E1113ECB080020C31B /* LWOMaterial.cpp in Sources */,
 				745FF8E2113ECB080020C31B /* ACLoader.cpp in Sources */,
 				745FF8E3113ECB080020C31B /* IRRLoader.cpp in Sources */,
 				745FF8E4113ECB080020C31B /* IRRMeshLoader.cpp in Sources */,
 				745FF8E5113ECB080020C31B /* IRRShared.cpp in Sources */,
-				745FF8E6113ECB080020C31B /* ColladaLoader.cpp in Sources */,
-				745FF8E7113ECB080020C31B /* ColladaParser.cpp in Sources */,
 				745FF8E8113ECB080020C31B /* NFFLoader.cpp in Sources */,
-				745FF8E9113ECB080020C31B /* SGSpatialSort.cpp in Sources */,
 				745FF8EA113ECB080020C31B /* Q3DLoader.cpp in Sources */,
 				745FF8EB113ECB080020C31B /* BVHLoader.cpp in Sources */,
 				745FF8EC113ECB080020C31B /* OFFLoader.cpp in Sources */,
@@ -3832,30 +4791,15 @@
 				745FF8EE113ECB080020C31B /* DXFLoader.cpp in Sources */,
 				745FF8EF113ECB080020C31B /* LWOBLoader.cpp in Sources */,
 				745FF8F0113ECB080020C31B /* TerragenLoader.cpp in Sources */,
-				745FF8F1113ECB080020C31B /* SceneCombiner.cpp in Sources */,
-				745FF8F2113ECB080020C31B /* ScenePreprocessor.cpp in Sources */,
-				745FF8F3113ECB080020C31B /* SortByPTypeProcess.cpp in Sources */,
-				745FF8F4113ECB080020C31B /* FindDegenerates.cpp in Sources */,
-				745FF8F5113ECB080020C31B /* ComputeUVMappingProcess.cpp in Sources */,
-				745FF8F6113ECB080020C31B /* StandardShapes.cpp in Sources */,
-				745FF8F7113ECB080020C31B /* FindInstancesProcess.cpp in Sources */,
-				745FF8F8113ECB080020C31B /* RemoveVCProcess.cpp in Sources */,
-				745FF8F9113ECB080020C31B /* FindInvalidDataProcess.cpp in Sources */,
-				745FF8FA113ECB080020C31B /* SkeletonMeshBuilder.cpp in Sources */,
 				745FF8FC113ECB080020C31B /* B3DImporter.cpp in Sources */,
 				7411B15211416D5E00BCD793 /* CSMLoader.cpp in Sources */,
 				7411B15D11416DDD00BCD793 /* LWSLoader.cpp in Sources */,
 				7411B16711416DF400BCD793 /* LWOAnimation.cpp in Sources */,
 				7411B17411416E2500BCD793 /* MS3DLoader.cpp in Sources */,
 				7411B18F11416EBC00BCD793 /* UnrealLoader.cpp in Sources */,
-				7411B1B811416EF400BCD793 /* OptimizeGraph.cpp in Sources */,
-				7411B1BA11416EF400BCD793 /* OptimizeMeshes.cpp in Sources */,
-				7411B1BF11416EF400BCD793 /* Subdivision.cpp in Sources */,
-				7411B1C111416EF400BCD793 /* TargetAnimation.cpp in Sources */,
 				74C9BB5F11ACBB1000AF885C /* BlenderDNA.cpp in Sources */,
 				74C9BB6111ACBB1000AF885C /* BlenderLoader.cpp in Sources */,
 				74C9BB6311ACBB1000AF885C /* BlenderScene.cpp in Sources */,
-				74C9BB7E11ACBB7800AF885C /* MakeVerboseFormat.cpp in Sources */,
 				74C9BB8811ACBB9900AF885C /* AssimpPCH.cpp in Sources */,
 				74C9BB9611ACBBBC00AF885C /* COBLoader.cpp in Sources */,
 				8E7ABBA9127E0F1A00512ED1 /* Q3BSPFileImporter.cpp in Sources */,
@@ -3871,14 +4815,8 @@
 				F9BA8C49154328B600E63FFE /* OgreMaterial.cpp in Sources */,
 				F9BA8C4A154328B600E63FFE /* OgreMesh.cpp in Sources */,
 				F9BA8C4B154328B600E63FFE /* OgreSkeleton.cpp in Sources */,
-				F99A9ED715436125000682F3 /* DeboneProcess.cpp in Sources */,
-				F99A9F1A154361AD000682F3 /* ImporterRegistry.cpp in Sources */,
 				F99A9F2C15436207000682F3 /* M3Importer.cpp in Sources */,
 				F99A9F3615436269000682F3 /* PlyExporter.cpp in Sources */,
-				F99A9F421543629F000682F3 /* PostStepRegistry.cpp in Sources */,
-				F99A9F4F15436304000682F3 /* SplitByBoneCountProcess.cpp in Sources */,
-				F99A9F6315436323000682F3 /* STEPFileReader.cpp in Sources */,
-				F9606FF5154364E5004D91DD /* ProcessHelper.cpp in Sources */,
 				F9607085154366AB004D91DD /* adler32.c in Sources */,
 				F9607086154366AB004D91DD /* compress.c in Sources */,
 				F9607087154366AB004D91DD /* crc32.c in Sources */,
@@ -3895,13 +4833,89 @@
 				F96070FD1543675E004D91DD /* cdt.cc in Sources */,
 				F96070FF1543675E004D91DD /* sweep.cc in Sources */,
 				F96071011543675E004D91DD /* sweep_context.cc in Sources */,
-				F97BA08415439FC3009EB9DD /* IFCCurve.cpp in Sources */,
-				F97BA08515439FC3009EB9DD /* IFCGeometry.cpp in Sources */,
-				F97BA08615439FC3009EB9DD /* IFCLoader.cpp in Sources */,
-				F97BA08815439FC3009EB9DD /* IFCMaterial.cpp in Sources */,
-				F97BA08915439FC3009EB9DD /* IFCProfile.cpp in Sources */,
-				F97BA08A15439FC3009EB9DD /* IFCReaderGen.cpp in Sources */,
-				F97BA08C15439FC3009EB9DD /* IFCUtil.cpp in Sources */,
+				2B7F46E41708365200A106A9 /* Assimp.cpp in Sources */,
+				2B7F46E91708365200A106A9 /* AssimpCExport.cpp in Sources */,
+				2B7F47021708365200A106A9 /* BaseImporter.cpp in Sources */,
+				2B7F470C1708365200A106A9 /* BaseProcess.cpp in Sources */,
+				2B7F47A21708365200A106A9 /* CalcTangentsProcess.cpp in Sources */,
+				2B7F47C01708365200A106A9 /* ColladaExporter.cpp in Sources */,
+				2B7F47CF1708365200A106A9 /* ColladaLoader.cpp in Sources */,
+				2B7F47D91708365200A106A9 /* ColladaParser.cpp in Sources */,
+				2B7F47E31708365200A106A9 /* ComputeUVMappingProcess.cpp in Sources */,
+				2B7F47ED1708365200A106A9 /* ConvertToLHProcess.cpp in Sources */,
+				2B7F48011708365200A106A9 /* DeboneProcess.cpp in Sources */,
+				2B7F480B1708365200A106A9 /* DefaultIOStream.cpp in Sources */,
+				2B7F48151708365200A106A9 /* DefaultIOSystem.cpp in Sources */,
+				2B7F481F1708365200A106A9 /* DefaultLogger.cpp in Sources */,
+				2B7F483D1708365200A106A9 /* Exporter.cpp in Sources */,
+				2B7F48471708365200A106A9 /* FBXAnimation.cpp in Sources */,
+				2B7F484C1708365200A106A9 /* FBXBinaryTokenizer.cpp in Sources */,
+				2B7F48561708365200A106A9 /* FBXConverter.cpp in Sources */,
+				2B7F48601708365200A106A9 /* FBXDeformer.cpp in Sources */,
+				2B7F48651708365200A106A9 /* FBXDocument.cpp in Sources */,
+				2B7F486F1708365200A106A9 /* FBXDocumentUtil.cpp in Sources */,
+				2B7F48791708365200A106A9 /* FBXImporter.cpp in Sources */,
+				2B7F48881708365200A106A9 /* FBXMaterial.cpp in Sources */,
+				2B7F488D1708365200A106A9 /* FBXMeshGeometry.cpp in Sources */,
+				2B7F48921708365200A106A9 /* FBXModel.cpp in Sources */,
+				2B7F48971708365200A106A9 /* FBXNodeAttribute.cpp in Sources */,
+				2B7F489C1708365200A106A9 /* FBXParser.cpp in Sources */,
+				2B7F48A61708365200A106A9 /* FBXProperties.cpp in Sources */,
+				2B7F48B01708365200A106A9 /* FBXTokenizer.cpp in Sources */,
+				2B7F48BA1708365200A106A9 /* FBXUtil.cpp in Sources */,
+				2B7F48CE1708365200A106A9 /* FindDegenerates.cpp in Sources */,
+				2B7F48D81708365200A106A9 /* FindInstancesProcess.cpp in Sources */,
+				2B7F48E21708365200A106A9 /* FindInvalidDataProcess.cpp in Sources */,
+				2B7F48EC1708365200A106A9 /* FixNormalsStep.cpp in Sources */,
+				2B7F48FB1708365200A106A9 /* GenFaceNormalsProcess.cpp in Sources */,
+				2B7F49051708365200A106A9 /* GenVertexNormalsProcess.cpp in Sources */,
+				2B7F49281708365200A106A9 /* IFCBoolean.cpp in Sources */,
+				2B7F492D1708365200A106A9 /* IFCCurve.cpp in Sources */,
+				2B7F49321708365200A106A9 /* IFCGeometry.cpp in Sources */,
+				2B7F49371708365200A106A9 /* IFCLoader.cpp in Sources */,
+				2B7F49411708365200A106A9 /* IFCMaterial.cpp in Sources */,
+				2B7F49461708365200A106A9 /* IFCOpenings.cpp in Sources */,
+				2B7F494B1708365200A106A9 /* IFCProfile.cpp in Sources */,
+				2B7F49501708365200A106A9 /* IFCReaderGen.cpp in Sources */,
+				2B7F495A1708365200A106A9 /* IFCUtil.cpp in Sources */,
+				2B7F49691708365200A106A9 /* Importer.cpp in Sources */,
+				2B7F49731708365200A106A9 /* ImporterRegistry.cpp in Sources */,
+				2B7F49781708365200A106A9 /* ImproveCacheLocality.cpp in Sources */,
+				2B7F49A51708365200A106A9 /* JoinVerticesProcess.cpp in Sources */,
+				2B7F49AF1708365200A106A9 /* LimitBoneWeightsProcess.cpp in Sources */,
+				2B7F49FA1708365200A106A9 /* MakeVerboseFormat.cpp in Sources */,
+				2B7F4A041708365200A106A9 /* MaterialSystem.cpp in Sources */,
+				2B7F4A9A1708365200A106A9 /* ObjExporter.cpp in Sources */,
+				2B7F4AA91708365200A106A9 /* ObjFileImporter.cpp in Sources */,
+				2B7F4AB31708365200A106A9 /* ObjFileMtlImporter.cpp in Sources */,
+				2B7F4ABD1708365200A106A9 /* ObjFileParser.cpp in Sources */,
+				2B7F4AF41708365200A106A9 /* OptimizeGraph.cpp in Sources */,
+				2B7F4AFE1708365200A106A9 /* OptimizeMeshes.cpp in Sources */,
+				2B7F4B301708365200A106A9 /* PostStepRegistry.cpp in Sources */,
+				2B7F4B351708365200A106A9 /* PretransformVertices.cpp in Sources */,
+				2B7F4B3F1708365200A106A9 /* ProcessHelper.cpp in Sources */,
+				2B7F4B8F1708365200A106A9 /* RemoveComments.cpp in Sources */,
+				2B7F4B991708365200A106A9 /* RemoveRedundantMaterials.cpp in Sources */,
+				2B7F4BA31708365200A106A9 /* RemoveVCProcess.cpp in Sources */,
+				2B7F4BB21708365200A106A9 /* SceneCombiner.cpp in Sources */,
+				2B7F4BBC1708365200A106A9 /* ScenePreprocessor.cpp in Sources */,
+				2B7F4BCB1708365200A106A9 /* SGSpatialSort.cpp in Sources */,
+				2B7F4BD51708365200A106A9 /* SkeletonMeshBuilder.cpp in Sources */,
+				2B7F4BEE1708365200A106A9 /* SortByPTypeProcess.cpp in Sources */,
+				2B7F4BF81708365200A106A9 /* SpatialSort.cpp in Sources */,
+				2B7F4C021708365200A106A9 /* SplitByBoneCountProcess.cpp in Sources */,
+				2B7F4C0C1708365200A106A9 /* SplitLargeMeshes.cpp in Sources */,
+				2B7F4C161708365200A106A9 /* StandardShapes.cpp in Sources */,
+				2B7F4C2A1708365200A106A9 /* STEPFileEncoding.cpp in Sources */,
+				2B7F4C341708365200A106A9 /* STEPFileReader.cpp in Sources */,
+				2B7F4C3E1708365200A106A9 /* STLExporter.cpp in Sources */,
+				2B7F4C481708365200A106A9 /* STLLoader.cpp in Sources */,
+				2B7F4C5C1708365200A106A9 /* Subdivision.cpp in Sources */,
+				2B7F4C661708365200A106A9 /* TargetAnimation.cpp in Sources */,
+				2B7F4C7A1708365200A106A9 /* TextureTransform.cpp in Sources */,
+				2B7F4C891708365200A106A9 /* TriangulateProcess.cpp in Sources */,
+				2B7F4C9D1708365200A106A9 /* ValidateDataStructure.cpp in Sources */,
+				2B7F4CAC1708365200A106A9 /* VertexTriangleAdjacency.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3913,58 +4927,26 @@
 				745FF994113ECC660020C31B /* 3DSLoader.cpp in Sources */,
 				745FF996113ECC660020C31B /* ASELoader.cpp in Sources */,
 				745FF997113ECC660020C31B /* ASEParser.cpp in Sources */,
-				745FF998113ECC660020C31B /* Assimp.cpp in Sources */,
-				745FF999113ECC660020C31B /* BaseImporter.cpp in Sources */,
-				745FF99A113ECC660020C31B /* CalcTangentsProcess.cpp in Sources */,
-				745FF99B113ECC660020C31B /* ConvertToLHProcess.cpp in Sources */,
-				745FF99C113ECC660020C31B /* DefaultIOStream.cpp in Sources */,
-				745FF99D113ECC660020C31B /* DefaultIOSystem.cpp in Sources */,
-				745FF99E113ECC660020C31B /* DefaultLogger.cpp in Sources */,
-				745FF9A0113ECC660020C31B /* GenFaceNormalsProcess.cpp in Sources */,
-				745FF9A1113ECC660020C31B /* GenVertexNormalsProcess.cpp in Sources */,
 				745FF9A2113ECC660020C31B /* HMPLoader.cpp in Sources */,
-				745FF9A3113ECC660020C31B /* Importer.cpp in Sources */,
-				745FF9A4113ECC660020C31B /* ImproveCacheLocality.cpp in Sources */,
-				745FF9A5113ECC660020C31B /* JoinVerticesProcess.cpp in Sources */,
-				745FF9A6113ECC660020C31B /* LimitBoneWeightsProcess.cpp in Sources */,
-				745FF9A7113ECC660020C31B /* MaterialSystem.cpp in Sources */,
 				745FF9A8113ECC660020C31B /* MD2Loader.cpp in Sources */,
 				745FF9A9113ECC660020C31B /* MD3Loader.cpp in Sources */,
 				745FF9AA113ECC660020C31B /* MD5Loader.cpp in Sources */,
 				745FF9AB113ECC660020C31B /* MD5Parser.cpp in Sources */,
 				745FF9AC113ECC660020C31B /* MDLLoader.cpp in Sources */,
 				745FF9AD113ECC660020C31B /* MDLMaterialLoader.cpp in Sources */,
-				745FF9AE113ECC660020C31B /* ObjFileImporter.cpp in Sources */,
-				745FF9AF113ECC660020C31B /* ObjFileMtlImporter.cpp in Sources */,
-				745FF9B0113ECC660020C31B /* ObjFileParser.cpp in Sources */,
 				745FF9B1113ECC660020C31B /* PlyLoader.cpp in Sources */,
 				745FF9B2113ECC660020C31B /* PlyParser.cpp in Sources */,
-				745FF9B3113ECC660020C31B /* PretransformVertices.cpp in Sources */,
-				745FF9B4113ECC660020C31B /* RemoveComments.cpp in Sources */,
-				745FF9B5113ECC660020C31B /* RemoveRedundantMaterials.cpp in Sources */,
 				745FF9B6113ECC660020C31B /* SMDLoader.cpp in Sources */,
-				745FF9B7113ECC660020C31B /* SpatialSort.cpp in Sources */,
-				745FF9B8113ECC660020C31B /* SplitLargeMeshes.cpp in Sources */,
-				745FF9B9113ECC660020C31B /* STLLoader.cpp in Sources */,
-				745FF9BA113ECC660020C31B /* TextureTransform.cpp in Sources */,
-				745FF9BB113ECC660020C31B /* TriangulateProcess.cpp in Sources */,
-				745FF9BC113ECC660020C31B /* ValidateDataStructure.cpp in Sources */,
-				745FF9BD113ECC660020C31B /* VertexTriangleAdjacency.cpp in Sources */,
 				745FF9BE113ECC660020C31B /* XFileImporter.cpp in Sources */,
 				745FF9BF113ECC660020C31B /* XFileParser.cpp in Sources */,
 				745FF9C0113ECC660020C31B /* MDCLoader.cpp in Sources */,
-				745FF9C1113ECC660020C31B /* FixNormalsStep.cpp in Sources */,
 				745FF9C2113ECC660020C31B /* LWOLoader.cpp in Sources */,
-				745FF9C3113ECC660020C31B /* BaseProcess.cpp in Sources */,
 				745FF9C4113ECC660020C31B /* LWOMaterial.cpp in Sources */,
 				745FF9C5113ECC660020C31B /* ACLoader.cpp in Sources */,
 				745FF9C6113ECC660020C31B /* IRRLoader.cpp in Sources */,
 				745FF9C7113ECC660020C31B /* IRRMeshLoader.cpp in Sources */,
 				745FF9C8113ECC660020C31B /* IRRShared.cpp in Sources */,
-				745FF9C9113ECC660020C31B /* ColladaLoader.cpp in Sources */,
-				745FF9CA113ECC660020C31B /* ColladaParser.cpp in Sources */,
 				745FF9CB113ECC660020C31B /* NFFLoader.cpp in Sources */,
-				745FF9CC113ECC660020C31B /* SGSpatialSort.cpp in Sources */,
 				745FF9CD113ECC660020C31B /* Q3DLoader.cpp in Sources */,
 				745FF9CE113ECC660020C31B /* BVHLoader.cpp in Sources */,
 				745FF9CF113ECC660020C31B /* OFFLoader.cpp in Sources */,
@@ -3972,30 +4954,15 @@
 				745FF9D1113ECC660020C31B /* DXFLoader.cpp in Sources */,
 				745FF9D2113ECC660020C31B /* LWOBLoader.cpp in Sources */,
 				745FF9D3113ECC660020C31B /* TerragenLoader.cpp in Sources */,
-				745FF9D4113ECC660020C31B /* SceneCombiner.cpp in Sources */,
-				745FF9D5113ECC660020C31B /* ScenePreprocessor.cpp in Sources */,
-				745FF9D6113ECC660020C31B /* SortByPTypeProcess.cpp in Sources */,
-				745FF9D7113ECC660020C31B /* FindDegenerates.cpp in Sources */,
-				745FF9D8113ECC660020C31B /* ComputeUVMappingProcess.cpp in Sources */,
-				745FF9D9113ECC660020C31B /* StandardShapes.cpp in Sources */,
-				745FF9DA113ECC660020C31B /* FindInstancesProcess.cpp in Sources */,
-				745FF9DB113ECC660020C31B /* RemoveVCProcess.cpp in Sources */,
-				745FF9DC113ECC660020C31B /* FindInvalidDataProcess.cpp in Sources */,
-				745FF9DD113ECC660020C31B /* SkeletonMeshBuilder.cpp in Sources */,
 				745FF9DF113ECC660020C31B /* B3DImporter.cpp in Sources */,
 				7411B15011416D5E00BCD793 /* CSMLoader.cpp in Sources */,
 				7411B15B11416DDD00BCD793 /* LWSLoader.cpp in Sources */,
 				7411B16511416DF400BCD793 /* LWOAnimation.cpp in Sources */,
 				7411B17211416E2500BCD793 /* MS3DLoader.cpp in Sources */,
 				7411B18D11416EBC00BCD793 /* UnrealLoader.cpp in Sources */,
-				7411B1A911416EF400BCD793 /* OptimizeGraph.cpp in Sources */,
-				7411B1AB11416EF400BCD793 /* OptimizeMeshes.cpp in Sources */,
-				7411B1B011416EF400BCD793 /* Subdivision.cpp in Sources */,
-				7411B1B211416EF400BCD793 /* TargetAnimation.cpp in Sources */,
 				74C9BB6611ACBB1000AF885C /* BlenderDNA.cpp in Sources */,
 				74C9BB6811ACBB1000AF885C /* BlenderLoader.cpp in Sources */,
 				74C9BB6A11ACBB1000AF885C /* BlenderScene.cpp in Sources */,
-				74C9BB8011ACBB7800AF885C /* MakeVerboseFormat.cpp in Sources */,
 				74C9BB8A11ACBB9900AF885C /* AssimpPCH.cpp in Sources */,
 				74C9BB9911ACBBBC00AF885C /* COBLoader.cpp in Sources */,
 				8E7ABBBE127E0F1A00512ED1 /* Q3BSPFileImporter.cpp in Sources */,
@@ -4011,14 +4978,8 @@
 				F9BA8C4F154328B600E63FFE /* OgreMaterial.cpp in Sources */,
 				F9BA8C50154328B600E63FFE /* OgreMesh.cpp in Sources */,
 				F9BA8C51154328B600E63FFE /* OgreSkeleton.cpp in Sources */,
-				F99A9ED915436125000682F3 /* DeboneProcess.cpp in Sources */,
-				F99A9F1B154361AD000682F3 /* ImporterRegistry.cpp in Sources */,
 				F99A9F2E15436207000682F3 /* M3Importer.cpp in Sources */,
 				F99A9F3815436269000682F3 /* PlyExporter.cpp in Sources */,
-				F99A9F431543629F000682F3 /* PostStepRegistry.cpp in Sources */,
-				F99A9F5115436304000682F3 /* SplitByBoneCountProcess.cpp in Sources */,
-				F99A9F6615436323000682F3 /* STEPFileReader.cpp in Sources */,
-				F9606FF6154364E5004D91DD /* ProcessHelper.cpp in Sources */,
 				F9607099154366AB004D91DD /* adler32.c in Sources */,
 				F960709A154366AB004D91DD /* compress.c in Sources */,
 				F960709B154366AB004D91DD /* crc32.c in Sources */,
@@ -4035,13 +4996,252 @@
 				F96071091543675E004D91DD /* cdt.cc in Sources */,
 				F960710B1543675E004D91DD /* sweep.cc in Sources */,
 				F960710D1543675E004D91DD /* sweep_context.cc in Sources */,
-				F97BA08E15439FC3009EB9DD /* IFCCurve.cpp in Sources */,
-				F97BA08F15439FC3009EB9DD /* IFCGeometry.cpp in Sources */,
-				F97BA09015439FC3009EB9DD /* IFCLoader.cpp in Sources */,
-				F97BA09215439FC3009EB9DD /* IFCMaterial.cpp in Sources */,
-				F97BA09315439FC3009EB9DD /* IFCProfile.cpp in Sources */,
-				F97BA09415439FC3009EB9DD /* IFCReaderGen.cpp in Sources */,
-				F97BA09615439FC3009EB9DD /* IFCUtil.cpp in Sources */,
+				2B7F46E51708365200A106A9 /* Assimp.cpp in Sources */,
+				2B7F46EA1708365200A106A9 /* AssimpCExport.cpp in Sources */,
+				2B7F47031708365200A106A9 /* BaseImporter.cpp in Sources */,
+				2B7F470D1708365200A106A9 /* BaseProcess.cpp in Sources */,
+				2B7F47A31708365200A106A9 /* CalcTangentsProcess.cpp in Sources */,
+				2B7F47C11708365200A106A9 /* ColladaExporter.cpp in Sources */,
+				2B7F47D01708365200A106A9 /* ColladaLoader.cpp in Sources */,
+				2B7F47DA1708365200A106A9 /* ColladaParser.cpp in Sources */,
+				2B7F47E41708365200A106A9 /* ComputeUVMappingProcess.cpp in Sources */,
+				2B7F47EE1708365200A106A9 /* ConvertToLHProcess.cpp in Sources */,
+				2B7F48021708365200A106A9 /* DeboneProcess.cpp in Sources */,
+				2B7F480C1708365200A106A9 /* DefaultIOStream.cpp in Sources */,
+				2B7F48161708365200A106A9 /* DefaultIOSystem.cpp in Sources */,
+				2B7F48201708365200A106A9 /* DefaultLogger.cpp in Sources */,
+				2B7F483E1708365200A106A9 /* Exporter.cpp in Sources */,
+				2B7F48481708365200A106A9 /* FBXAnimation.cpp in Sources */,
+				2B7F484D1708365200A106A9 /* FBXBinaryTokenizer.cpp in Sources */,
+				2B7F48571708365200A106A9 /* FBXConverter.cpp in Sources */,
+				2B7F48611708365200A106A9 /* FBXDeformer.cpp in Sources */,
+				2B7F48661708365200A106A9 /* FBXDocument.cpp in Sources */,
+				2B7F48701708365200A106A9 /* FBXDocumentUtil.cpp in Sources */,
+				2B7F487A1708365200A106A9 /* FBXImporter.cpp in Sources */,
+				2B7F48891708365200A106A9 /* FBXMaterial.cpp in Sources */,
+				2B7F488E1708365200A106A9 /* FBXMeshGeometry.cpp in Sources */,
+				2B7F48931708365200A106A9 /* FBXModel.cpp in Sources */,
+				2B7F48981708365200A106A9 /* FBXNodeAttribute.cpp in Sources */,
+				2B7F489D1708365200A106A9 /* FBXParser.cpp in Sources */,
+				2B7F48A71708365200A106A9 /* FBXProperties.cpp in Sources */,
+				2B7F48B11708365200A106A9 /* FBXTokenizer.cpp in Sources */,
+				2B7F48BB1708365200A106A9 /* FBXUtil.cpp in Sources */,
+				2B7F48CF1708365200A106A9 /* FindDegenerates.cpp in Sources */,
+				2B7F48D91708365200A106A9 /* FindInstancesProcess.cpp in Sources */,
+				2B7F48E31708365200A106A9 /* FindInvalidDataProcess.cpp in Sources */,
+				2B7F48ED1708365200A106A9 /* FixNormalsStep.cpp in Sources */,
+				2B7F48FC1708365200A106A9 /* GenFaceNormalsProcess.cpp in Sources */,
+				2B7F49061708365200A106A9 /* GenVertexNormalsProcess.cpp in Sources */,
+				2B7F49291708365200A106A9 /* IFCBoolean.cpp in Sources */,
+				2B7F492E1708365200A106A9 /* IFCCurve.cpp in Sources */,
+				2B7F49331708365200A106A9 /* IFCGeometry.cpp in Sources */,
+				2B7F49381708365200A106A9 /* IFCLoader.cpp in Sources */,
+				2B7F49421708365200A106A9 /* IFCMaterial.cpp in Sources */,
+				2B7F49471708365200A106A9 /* IFCOpenings.cpp in Sources */,
+				2B7F494C1708365200A106A9 /* IFCProfile.cpp in Sources */,
+				2B7F49511708365200A106A9 /* IFCReaderGen.cpp in Sources */,
+				2B7F495B1708365200A106A9 /* IFCUtil.cpp in Sources */,
+				2B7F496A1708365200A106A9 /* Importer.cpp in Sources */,
+				2B7F49741708365200A106A9 /* ImporterRegistry.cpp in Sources */,
+				2B7F49791708365200A106A9 /* ImproveCacheLocality.cpp in Sources */,
+				2B7F49A61708365200A106A9 /* JoinVerticesProcess.cpp in Sources */,
+				2B7F49B01708365200A106A9 /* LimitBoneWeightsProcess.cpp in Sources */,
+				2B7F49FB1708365200A106A9 /* MakeVerboseFormat.cpp in Sources */,
+				2B7F4A051708365200A106A9 /* MaterialSystem.cpp in Sources */,
+				2B7F4A9B1708365200A106A9 /* ObjExporter.cpp in Sources */,
+				2B7F4AAA1708365200A106A9 /* ObjFileImporter.cpp in Sources */,
+				2B7F4AB41708365200A106A9 /* ObjFileMtlImporter.cpp in Sources */,
+				2B7F4ABE1708365200A106A9 /* ObjFileParser.cpp in Sources */,
+				2B7F4AF51708365200A106A9 /* OptimizeGraph.cpp in Sources */,
+				2B7F4AFF1708365200A106A9 /* OptimizeMeshes.cpp in Sources */,
+				2B7F4B311708365200A106A9 /* PostStepRegistry.cpp in Sources */,
+				2B7F4B361708365200A106A9 /* PretransformVertices.cpp in Sources */,
+				2B7F4B401708365200A106A9 /* ProcessHelper.cpp in Sources */,
+				2B7F4B901708365200A106A9 /* RemoveComments.cpp in Sources */,
+				2B7F4B9A1708365200A106A9 /* RemoveRedundantMaterials.cpp in Sources */,
+				2B7F4BA41708365200A106A9 /* RemoveVCProcess.cpp in Sources */,
+				2B7F4BB31708365200A106A9 /* SceneCombiner.cpp in Sources */,
+				2B7F4BBD1708365200A106A9 /* ScenePreprocessor.cpp in Sources */,
+				2B7F4BCC1708365200A106A9 /* SGSpatialSort.cpp in Sources */,
+				2B7F4BD61708365200A106A9 /* SkeletonMeshBuilder.cpp in Sources */,
+				2B7F4BEF1708365200A106A9 /* SortByPTypeProcess.cpp in Sources */,
+				2B7F4BF91708365200A106A9 /* SpatialSort.cpp in Sources */,
+				2B7F4C031708365200A106A9 /* SplitByBoneCountProcess.cpp in Sources */,
+				2B7F4C0D1708365200A106A9 /* SplitLargeMeshes.cpp in Sources */,
+				2B7F4C171708365200A106A9 /* StandardShapes.cpp in Sources */,
+				2B7F4C2B1708365200A106A9 /* STEPFileEncoding.cpp in Sources */,
+				2B7F4C351708365200A106A9 /* STEPFileReader.cpp in Sources */,
+				2B7F4C3F1708365200A106A9 /* STLExporter.cpp in Sources */,
+				2B7F4C491708365200A106A9 /* STLLoader.cpp in Sources */,
+				2B7F4C5D1708365200A106A9 /* Subdivision.cpp in Sources */,
+				2B7F4C671708365200A106A9 /* TargetAnimation.cpp in Sources */,
+				2B7F4C7B1708365200A106A9 /* TextureTransform.cpp in Sources */,
+				2B7F4C8A1708365200A106A9 /* TriangulateProcess.cpp in Sources */,
+				2B7F4C9E1708365200A106A9 /* ValidateDataStructure.cpp in Sources */,
+				2B7F4CAD1708365200A106A9 /* VertexTriangleAdjacency.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B91975B6163AEA54009C397B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B91975B7163AEA54009C397B /* 3DSConverter.cpp in Sources */,
+				B91975B8163AEA54009C397B /* 3DSLoader.cpp in Sources */,
+				B91975B9163AEA54009C397B /* ASELoader.cpp in Sources */,
+				B91975BA163AEA54009C397B /* ASEParser.cpp in Sources */,
+				B91975C4163AEA54009C397B /* HMPLoader.cpp in Sources */,
+				B91975CA163AEA54009C397B /* MD2Loader.cpp in Sources */,
+				B91975CB163AEA54009C397B /* MD3Loader.cpp in Sources */,
+				B91975CC163AEA54009C397B /* MD5Loader.cpp in Sources */,
+				B91975CD163AEA54009C397B /* MD5Parser.cpp in Sources */,
+				B91975CE163AEA54009C397B /* MDLLoader.cpp in Sources */,
+				B91975CF163AEA54009C397B /* MDLMaterialLoader.cpp in Sources */,
+				B91975D3163AEA54009C397B /* PlyLoader.cpp in Sources */,
+				B91975D4163AEA54009C397B /* PlyParser.cpp in Sources */,
+				B91975D8163AEA54009C397B /* SMDLoader.cpp in Sources */,
+				B91975E0163AEA54009C397B /* XFileImporter.cpp in Sources */,
+				B91975E1163AEA54009C397B /* XFileParser.cpp in Sources */,
+				B91975E2163AEA54009C397B /* MDCLoader.cpp in Sources */,
+				B91975E4163AEA54009C397B /* LWOLoader.cpp in Sources */,
+				B91975E6163AEA54009C397B /* LWOMaterial.cpp in Sources */,
+				B91975E7163AEA54009C397B /* ACLoader.cpp in Sources */,
+				B91975E8163AEA54009C397B /* IRRLoader.cpp in Sources */,
+				B91975E9163AEA54009C397B /* IRRMeshLoader.cpp in Sources */,
+				B91975EA163AEA54009C397B /* IRRShared.cpp in Sources */,
+				B91975ED163AEA54009C397B /* NFFLoader.cpp in Sources */,
+				B91975EF163AEA54009C397B /* Q3DLoader.cpp in Sources */,
+				B91975F0163AEA54009C397B /* BVHLoader.cpp in Sources */,
+				B91975F1163AEA54009C397B /* OFFLoader.cpp in Sources */,
+				B91975F2163AEA54009C397B /* RawLoader.cpp in Sources */,
+				B91975F3163AEA54009C397B /* DXFLoader.cpp in Sources */,
+				B91975F4163AEA54009C397B /* LWOBLoader.cpp in Sources */,
+				B91975F5163AEA54009C397B /* TerragenLoader.cpp in Sources */,
+				B9197600163AEA54009C397B /* B3DImporter.cpp in Sources */,
+				B9197601163AEA54009C397B /* CSMLoader.cpp in Sources */,
+				B9197602163AEA54009C397B /* LWSLoader.cpp in Sources */,
+				B9197603163AEA54009C397B /* LWOAnimation.cpp in Sources */,
+				B9197604163AEA54009C397B /* MS3DLoader.cpp in Sources */,
+				B9197605163AEA54009C397B /* UnrealLoader.cpp in Sources */,
+				B919760A163AEA54009C397B /* BlenderDNA.cpp in Sources */,
+				B919760B163AEA54009C397B /* BlenderLoader.cpp in Sources */,
+				B919760C163AEA54009C397B /* BlenderScene.cpp in Sources */,
+				B919760E163AEA54009C397B /* AssimpPCH.cpp in Sources */,
+				B919760F163AEA54009C397B /* COBLoader.cpp in Sources */,
+				B9197610163AEA54009C397B /* Q3BSPFileImporter.cpp in Sources */,
+				B9197611163AEA54009C397B /* Q3BSPFileParser.cpp in Sources */,
+				B9197612163AEA54009C397B /* Q3BSPZipArchive.cpp in Sources */,
+				B9197613163AEA54009C397B /* NDOLoader.cpp in Sources */,
+				B9197614163AEA54009C397B /* BlenderModifier.cpp in Sources */,
+				B9197615163AEA54009C397B /* ConvertUTF.c in Sources */,
+				B9197616163AEA54009C397B /* irrXML.cpp in Sources */,
+				B9197617163AEA54009C397B /* ioapi.c in Sources */,
+				B9197618163AEA54009C397B /* unzip.c in Sources */,
+				B9197619163AEA54009C397B /* OgreImporter.cpp in Sources */,
+				B919761A163AEA54009C397B /* OgreMaterial.cpp in Sources */,
+				B919761B163AEA54009C397B /* OgreMesh.cpp in Sources */,
+				B919761C163AEA54009C397B /* OgreSkeleton.cpp in Sources */,
+				B919761F163AEA54009C397B /* M3Importer.cpp in Sources */,
+				B9197620163AEA54009C397B /* PlyExporter.cpp in Sources */,
+				B9197625163AEA54009C397B /* adler32.c in Sources */,
+				B9197626163AEA54009C397B /* compress.c in Sources */,
+				B9197627163AEA54009C397B /* crc32.c in Sources */,
+				B9197628163AEA54009C397B /* deflate.c in Sources */,
+				B9197629163AEA54009C397B /* inffast.c in Sources */,
+				B919762A163AEA54009C397B /* inflate.c in Sources */,
+				B919762B163AEA54009C397B /* inftrees.c in Sources */,
+				B919762C163AEA54009C397B /* trees.c in Sources */,
+				B919762D163AEA54009C397B /* zutil.c in Sources */,
+				B919762E163AEA54009C397B /* XGLLoader.cpp in Sources */,
+				B919762F163AEA54009C397B /* clipper.cpp in Sources */,
+				B9197630163AEA54009C397B /* shapes.cc in Sources */,
+				B9197631163AEA54009C397B /* advancing_front.cc in Sources */,
+				B9197632163AEA54009C397B /* cdt.cc in Sources */,
+				B9197633163AEA54009C397B /* sweep.cc in Sources */,
+				B9197634163AEA54009C397B /* sweep_context.cc in Sources */,
+				2B7F46E61708365200A106A9 /* Assimp.cpp in Sources */,
+				2B7F46EB1708365200A106A9 /* AssimpCExport.cpp in Sources */,
+				2B7F47041708365200A106A9 /* BaseImporter.cpp in Sources */,
+				2B7F470E1708365200A106A9 /* BaseProcess.cpp in Sources */,
+				2B7F47A41708365200A106A9 /* CalcTangentsProcess.cpp in Sources */,
+				2B7F47C21708365200A106A9 /* ColladaExporter.cpp in Sources */,
+				2B7F47D11708365200A106A9 /* ColladaLoader.cpp in Sources */,
+				2B7F47DB1708365200A106A9 /* ColladaParser.cpp in Sources */,
+				2B7F47E51708365200A106A9 /* ComputeUVMappingProcess.cpp in Sources */,
+				2B7F47EF1708365200A106A9 /* ConvertToLHProcess.cpp in Sources */,
+				2B7F48031708365200A106A9 /* DeboneProcess.cpp in Sources */,
+				2B7F480D1708365200A106A9 /* DefaultIOStream.cpp in Sources */,
+				2B7F48171708365200A106A9 /* DefaultIOSystem.cpp in Sources */,
+				2B7F48211708365200A106A9 /* DefaultLogger.cpp in Sources */,
+				2B7F483F1708365200A106A9 /* Exporter.cpp in Sources */,
+				2B7F48491708365200A106A9 /* FBXAnimation.cpp in Sources */,
+				2B7F484E1708365200A106A9 /* FBXBinaryTokenizer.cpp in Sources */,
+				2B7F48581708365200A106A9 /* FBXConverter.cpp in Sources */,
+				2B7F48621708365200A106A9 /* FBXDeformer.cpp in Sources */,
+				2B7F48671708365200A106A9 /* FBXDocument.cpp in Sources */,
+				2B7F48711708365200A106A9 /* FBXDocumentUtil.cpp in Sources */,
+				2B7F487B1708365200A106A9 /* FBXImporter.cpp in Sources */,
+				2B7F488A1708365200A106A9 /* FBXMaterial.cpp in Sources */,
+				2B7F488F1708365200A106A9 /* FBXMeshGeometry.cpp in Sources */,
+				2B7F48941708365200A106A9 /* FBXModel.cpp in Sources */,
+				2B7F48991708365200A106A9 /* FBXNodeAttribute.cpp in Sources */,
+				2B7F489E1708365200A106A9 /* FBXParser.cpp in Sources */,
+				2B7F48A81708365200A106A9 /* FBXProperties.cpp in Sources */,
+				2B7F48B21708365200A106A9 /* FBXTokenizer.cpp in Sources */,
+				2B7F48BC1708365200A106A9 /* FBXUtil.cpp in Sources */,
+				2B7F48D01708365200A106A9 /* FindDegenerates.cpp in Sources */,
+				2B7F48DA1708365200A106A9 /* FindInstancesProcess.cpp in Sources */,
+				2B7F48E41708365200A106A9 /* FindInvalidDataProcess.cpp in Sources */,
+				2B7F48EE1708365200A106A9 /* FixNormalsStep.cpp in Sources */,
+				2B7F48FD1708365200A106A9 /* GenFaceNormalsProcess.cpp in Sources */,
+				2B7F49071708365200A106A9 /* GenVertexNormalsProcess.cpp in Sources */,
+				2B7F492A1708365200A106A9 /* IFCBoolean.cpp in Sources */,
+				2B7F492F1708365200A106A9 /* IFCCurve.cpp in Sources */,
+				2B7F49341708365200A106A9 /* IFCGeometry.cpp in Sources */,
+				2B7F49391708365200A106A9 /* IFCLoader.cpp in Sources */,
+				2B7F49431708365200A106A9 /* IFCMaterial.cpp in Sources */,
+				2B7F49481708365200A106A9 /* IFCOpenings.cpp in Sources */,
+				2B7F494D1708365200A106A9 /* IFCProfile.cpp in Sources */,
+				2B7F49521708365200A106A9 /* IFCReaderGen.cpp in Sources */,
+				2B7F495C1708365200A106A9 /* IFCUtil.cpp in Sources */,
+				2B7F496B1708365200A106A9 /* Importer.cpp in Sources */,
+				2B7F49751708365200A106A9 /* ImporterRegistry.cpp in Sources */,
+				2B7F497A1708365200A106A9 /* ImproveCacheLocality.cpp in Sources */,
+				2B7F49A71708365200A106A9 /* JoinVerticesProcess.cpp in Sources */,
+				2B7F49B11708365200A106A9 /* LimitBoneWeightsProcess.cpp in Sources */,
+				2B7F49FC1708365200A106A9 /* MakeVerboseFormat.cpp in Sources */,
+				2B7F4A061708365200A106A9 /* MaterialSystem.cpp in Sources */,
+				2B7F4A9C1708365200A106A9 /* ObjExporter.cpp in Sources */,
+				2B7F4AAB1708365200A106A9 /* ObjFileImporter.cpp in Sources */,
+				2B7F4AB51708365200A106A9 /* ObjFileMtlImporter.cpp in Sources */,
+				2B7F4ABF1708365200A106A9 /* ObjFileParser.cpp in Sources */,
+				2B7F4AF61708365200A106A9 /* OptimizeGraph.cpp in Sources */,
+				2B7F4B001708365200A106A9 /* OptimizeMeshes.cpp in Sources */,
+				2B7F4B321708365200A106A9 /* PostStepRegistry.cpp in Sources */,
+				2B7F4B371708365200A106A9 /* PretransformVertices.cpp in Sources */,
+				2B7F4B411708365200A106A9 /* ProcessHelper.cpp in Sources */,
+				2B7F4B911708365200A106A9 /* RemoveComments.cpp in Sources */,
+				2B7F4B9B1708365200A106A9 /* RemoveRedundantMaterials.cpp in Sources */,
+				2B7F4BA51708365200A106A9 /* RemoveVCProcess.cpp in Sources */,
+				2B7F4BB41708365200A106A9 /* SceneCombiner.cpp in Sources */,
+				2B7F4BBE1708365200A106A9 /* ScenePreprocessor.cpp in Sources */,
+				2B7F4BCD1708365200A106A9 /* SGSpatialSort.cpp in Sources */,
+				2B7F4BD71708365200A106A9 /* SkeletonMeshBuilder.cpp in Sources */,
+				2B7F4BF01708365200A106A9 /* SortByPTypeProcess.cpp in Sources */,
+				2B7F4BFA1708365200A106A9 /* SpatialSort.cpp in Sources */,
+				2B7F4C041708365200A106A9 /* SplitByBoneCountProcess.cpp in Sources */,
+				2B7F4C0E1708365200A106A9 /* SplitLargeMeshes.cpp in Sources */,
+				2B7F4C181708365200A106A9 /* StandardShapes.cpp in Sources */,
+				2B7F4C2C1708365200A106A9 /* STEPFileEncoding.cpp in Sources */,
+				2B7F4C361708365200A106A9 /* STEPFileReader.cpp in Sources */,
+				2B7F4C401708365200A106A9 /* STLExporter.cpp in Sources */,
+				2B7F4C4A1708365200A106A9 /* STLLoader.cpp in Sources */,
+				2B7F4C5E1708365200A106A9 /* Subdivision.cpp in Sources */,
+				2B7F4C681708365200A106A9 /* TargetAnimation.cpp in Sources */,
+				2B7F4C7C1708365200A106A9 /* TextureTransform.cpp in Sources */,
+				2B7F4C8B1708365200A106A9 /* TriangulateProcess.cpp in Sources */,
+				2B7F4C9F1708365200A106A9 /* ValidateDataStructure.cpp in Sources */,
+				2B7F4CAE1708365200A106A9 /* VertexTriangleAdjacency.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4053,58 +5253,26 @@
 				3AF45AFC0E4B716800207D74 /* 3DSLoader.cpp in Sources */,
 				3AF45B010E4B716800207D74 /* ASELoader.cpp in Sources */,
 				3AF45B030E4B716800207D74 /* ASEParser.cpp in Sources */,
-				3AF45B050E4B716800207D74 /* Assimp.cpp in Sources */,
-				3AF45B060E4B716800207D74 /* BaseImporter.cpp in Sources */,
-				3AF45B0A0E4B716800207D74 /* CalcTangentsProcess.cpp in Sources */,
-				3AF45B0C0E4B716800207D74 /* ConvertToLHProcess.cpp in Sources */,
-				3AF45B0E0E4B716800207D74 /* DefaultIOStream.cpp in Sources */,
-				3AF45B100E4B716800207D74 /* DefaultIOSystem.cpp in Sources */,
-				3AF45B120E4B716800207D74 /* DefaultLogger.cpp in Sources */,
-				3AF45B170E4B716800207D74 /* GenFaceNormalsProcess.cpp in Sources */,
-				3AF45B190E4B716800207D74 /* GenVertexNormalsProcess.cpp in Sources */,
 				3AF45B1D0E4B716800207D74 /* HMPLoader.cpp in Sources */,
-				3AF45B1F0E4B716800207D74 /* Importer.cpp in Sources */,
-				3AF45B200E4B716800207D74 /* ImproveCacheLocality.cpp in Sources */,
-				3AF45B220E4B716800207D74 /* JoinVerticesProcess.cpp in Sources */,
-				3AF45B260E4B716800207D74 /* LimitBoneWeightsProcess.cpp in Sources */,
-				3AF45B280E4B716800207D74 /* MaterialSystem.cpp in Sources */,
 				3AF45B2B0E4B716800207D74 /* MD2Loader.cpp in Sources */,
 				3AF45B2F0E4B716800207D74 /* MD3Loader.cpp in Sources */,
 				3AF45B340E4B716800207D74 /* MD5Loader.cpp in Sources */,
 				3AF45B360E4B716800207D74 /* MD5Parser.cpp in Sources */,
 				3AF45B3A0E4B716800207D74 /* MDLLoader.cpp in Sources */,
 				3AF45B3C0E4B716800207D74 /* MDLMaterialLoader.cpp in Sources */,
-				3AF45B3E0E4B716800207D74 /* ObjFileImporter.cpp in Sources */,
-				3AF45B400E4B716800207D74 /* ObjFileMtlImporter.cpp in Sources */,
-				3AF45B420E4B716800207D74 /* ObjFileParser.cpp in Sources */,
 				3AF45B460E4B716800207D74 /* PlyLoader.cpp in Sources */,
 				3AF45B480E4B716800207D74 /* PlyParser.cpp in Sources */,
-				3AF45B4A0E4B716800207D74 /* PretransformVertices.cpp in Sources */,
-				3AF45B4D0E4B716800207D74 /* RemoveComments.cpp in Sources */,
-				3AF45B4F0E4B716800207D74 /* RemoveRedundantMaterials.cpp in Sources */,
 				3AF45B520E4B716800207D74 /* SMDLoader.cpp in Sources */,
-				3AF45B540E4B716800207D74 /* SpatialSort.cpp in Sources */,
-				3AF45B560E4B716800207D74 /* SplitLargeMeshes.cpp in Sources */,
-				3AF45B580E4B716800207D74 /* STLLoader.cpp in Sources */,
-				3AF45B5B0E4B716800207D74 /* TextureTransform.cpp in Sources */,
-				3AF45B5D0E4B716800207D74 /* TriangulateProcess.cpp in Sources */,
-				3AF45B5F0E4B716800207D74 /* ValidateDataStructure.cpp in Sources */,
-				3AF45B610E4B716800207D74 /* VertexTriangleAdjacency.cpp in Sources */,
 				3AF45B650E4B716800207D74 /* XFileImporter.cpp in Sources */,
 				3AF45B670E4B716800207D74 /* XFileParser.cpp in Sources */,
 				3AB8A3B00E50D67A00606590 /* MDCLoader.cpp in Sources */,
-				3AB8A3B50E50D69D00606590 /* FixNormalsStep.cpp in Sources */,
 				3AB8A3BB0E50D6DB00606590 /* LWOLoader.cpp in Sources */,
-				3AB8A3C40E50D74500606590 /* BaseProcess.cpp in Sources */,
 				3AB8A7DD0E53715F00606590 /* LWOMaterial.cpp in Sources */,
 				F90BAFD20F5DD87000124155 /* ACLoader.cpp in Sources */,
 				F90BAFDF0F5DD90800124155 /* IRRLoader.cpp in Sources */,
 				F90BAFE10F5DD90800124155 /* IRRMeshLoader.cpp in Sources */,
 				F90BAFE30F5DD90800124155 /* IRRShared.cpp in Sources */,
-				F90BAFEE0F5DD93600124155 /* ColladaLoader.cpp in Sources */,
-				F90BAFF00F5DD93600124155 /* ColladaParser.cpp in Sources */,
 				F90BAFF80F5DD96100124155 /* NFFLoader.cpp in Sources */,
-				F90BAFFE0F5DD9A000124155 /* SGSpatialSort.cpp in Sources */,
 				F90BB0080F5DD9DD00124155 /* Q3DLoader.cpp in Sources */,
 				F90BB00F0F5DD9F400124155 /* BVHLoader.cpp in Sources */,
 				F90BB0160F5DDA1400124155 /* OFFLoader.cpp in Sources */,
@@ -4112,30 +5280,15 @@
 				F90BB0240F5DDA5700124155 /* DXFLoader.cpp in Sources */,
 				F90BB0280F5DDA9200124155 /* LWOBLoader.cpp in Sources */,
 				F90BB0320F5DDAB500124155 /* TerragenLoader.cpp in Sources */,
-				F90BB03E0F5DDB3200124155 /* SceneCombiner.cpp in Sources */,
-				F90BB0400F5DDB3200124155 /* ScenePreprocessor.cpp in Sources */,
-				F90BB0450F5DDB4600124155 /* SortByPTypeProcess.cpp in Sources */,
-				F90BB04A0F5DDB6100124155 /* FindDegenerates.cpp in Sources */,
-				F90BB04F0F5DDB8D00124155 /* ComputeUVMappingProcess.cpp in Sources */,
-				F90BB0540F5DDBA800124155 /* StandardShapes.cpp in Sources */,
-				F90BB0590F5DDBBF00124155 /* FindInstancesProcess.cpp in Sources */,
-				F90BB05D0F5DDBCB00124155 /* RemoveVCProcess.cpp in Sources */,
-				F90BB0610F5DDBE600124155 /* FindInvalidDataProcess.cpp in Sources */,
-				F90BB0670F5DDC0700124155 /* SkeletonMeshBuilder.cpp in Sources */,
 				F90BB08A0F5DDE0700124155 /* B3DImporter.cpp in Sources */,
 				7411B15411416D5E00BCD793 /* CSMLoader.cpp in Sources */,
 				7411B15F11416DDD00BCD793 /* LWSLoader.cpp in Sources */,
 				7411B16911416DF400BCD793 /* LWOAnimation.cpp in Sources */,
 				7411B17611416E2500BCD793 /* MS3DLoader.cpp in Sources */,
 				7411B19111416EBC00BCD793 /* UnrealLoader.cpp in Sources */,
-				7411B1C711416EF400BCD793 /* OptimizeGraph.cpp in Sources */,
-				7411B1C911416EF400BCD793 /* OptimizeMeshes.cpp in Sources */,
-				7411B1CE11416EF400BCD793 /* Subdivision.cpp in Sources */,
-				7411B1D011416EF400BCD793 /* TargetAnimation.cpp in Sources */,
 				74C9BB5111ACBB1000AF885C /* BlenderDNA.cpp in Sources */,
 				74C9BB5311ACBB1000AF885C /* BlenderLoader.cpp in Sources */,
 				74C9BB5511ACBB1000AF885C /* BlenderScene.cpp in Sources */,
-				74C9BB8211ACBB7800AF885C /* MakeVerboseFormat.cpp in Sources */,
 				74C9BB8C11ACBB9900AF885C /* AssimpPCH.cpp in Sources */,
 				74C9BB9C11ACBBBC00AF885C /* COBLoader.cpp in Sources */,
 				8E7ABBB0127E0F1A00512ED1 /* Q3BSPFileImporter.cpp in Sources */,
@@ -4151,14 +5304,8 @@
 				F9BA8C3D154328B600E63FFE /* OgreMaterial.cpp in Sources */,
 				F9BA8C3E154328B600E63FFE /* OgreMesh.cpp in Sources */,
 				F9BA8C3F154328B600E63FFE /* OgreSkeleton.cpp in Sources */,
-				F99A9ED315436125000682F3 /* DeboneProcess.cpp in Sources */,
-				F99A9F18154361AD000682F3 /* ImporterRegistry.cpp in Sources */,
 				F99A9F2815436207000682F3 /* M3Importer.cpp in Sources */,
 				F99A9F3215436269000682F3 /* PlyExporter.cpp in Sources */,
-				F99A9F401543629F000682F3 /* PostStepRegistry.cpp in Sources */,
-				F99A9F4B15436304000682F3 /* SplitByBoneCountProcess.cpp in Sources */,
-				F99A9F5D15436323000682F3 /* STEPFileReader.cpp in Sources */,
-				F9606FF3154364E5004D91DD /* ProcessHelper.cpp in Sources */,
 				F960705D154366AB004D91DD /* adler32.c in Sources */,
 				F960705E154366AB004D91DD /* compress.c in Sources */,
 				F960705F154366AB004D91DD /* crc32.c in Sources */,
@@ -4175,13 +5322,89 @@
 				F96070E51543675E004D91DD /* cdt.cc in Sources */,
 				F96070E71543675E004D91DD /* sweep.cc in Sources */,
 				F96070E91543675E004D91DD /* sweep_context.cc in Sources */,
-				F97BA07015439FC3009EB9DD /* IFCCurve.cpp in Sources */,
-				F97BA07115439FC3009EB9DD /* IFCGeometry.cpp in Sources */,
-				F97BA07215439FC3009EB9DD /* IFCLoader.cpp in Sources */,
-				F97BA07415439FC3009EB9DD /* IFCMaterial.cpp in Sources */,
-				F97BA07515439FC3009EB9DD /* IFCProfile.cpp in Sources */,
-				F97BA07615439FC3009EB9DD /* IFCReaderGen.cpp in Sources */,
-				F97BA07815439FC3009EB9DD /* IFCUtil.cpp in Sources */,
+				2B7F46E21708365200A106A9 /* Assimp.cpp in Sources */,
+				2B7F46E71708365200A106A9 /* AssimpCExport.cpp in Sources */,
+				2B7F47001708365200A106A9 /* BaseImporter.cpp in Sources */,
+				2B7F470A1708365200A106A9 /* BaseProcess.cpp in Sources */,
+				2B7F47A01708365200A106A9 /* CalcTangentsProcess.cpp in Sources */,
+				2B7F47BE1708365200A106A9 /* ColladaExporter.cpp in Sources */,
+				2B7F47CD1708365200A106A9 /* ColladaLoader.cpp in Sources */,
+				2B7F47D71708365200A106A9 /* ColladaParser.cpp in Sources */,
+				2B7F47E11708365200A106A9 /* ComputeUVMappingProcess.cpp in Sources */,
+				2B7F47EB1708365200A106A9 /* ConvertToLHProcess.cpp in Sources */,
+				2B7F47FF1708365200A106A9 /* DeboneProcess.cpp in Sources */,
+				2B7F48091708365200A106A9 /* DefaultIOStream.cpp in Sources */,
+				2B7F48131708365200A106A9 /* DefaultIOSystem.cpp in Sources */,
+				2B7F481D1708365200A106A9 /* DefaultLogger.cpp in Sources */,
+				2B7F483B1708365200A106A9 /* Exporter.cpp in Sources */,
+				2B7F48451708365200A106A9 /* FBXAnimation.cpp in Sources */,
+				2B7F484A1708365200A106A9 /* FBXBinaryTokenizer.cpp in Sources */,
+				2B7F48541708365200A106A9 /* FBXConverter.cpp in Sources */,
+				2B7F485E1708365200A106A9 /* FBXDeformer.cpp in Sources */,
+				2B7F48631708365200A106A9 /* FBXDocument.cpp in Sources */,
+				2B7F486D1708365200A106A9 /* FBXDocumentUtil.cpp in Sources */,
+				2B7F48771708365200A106A9 /* FBXImporter.cpp in Sources */,
+				2B7F48861708365200A106A9 /* FBXMaterial.cpp in Sources */,
+				2B7F488B1708365200A106A9 /* FBXMeshGeometry.cpp in Sources */,
+				2B7F48901708365200A106A9 /* FBXModel.cpp in Sources */,
+				2B7F48951708365200A106A9 /* FBXNodeAttribute.cpp in Sources */,
+				2B7F489A1708365200A106A9 /* FBXParser.cpp in Sources */,
+				2B7F48A41708365200A106A9 /* FBXProperties.cpp in Sources */,
+				2B7F48AE1708365200A106A9 /* FBXTokenizer.cpp in Sources */,
+				2B7F48B81708365200A106A9 /* FBXUtil.cpp in Sources */,
+				2B7F48CC1708365200A106A9 /* FindDegenerates.cpp in Sources */,
+				2B7F48D61708365200A106A9 /* FindInstancesProcess.cpp in Sources */,
+				2B7F48E01708365200A106A9 /* FindInvalidDataProcess.cpp in Sources */,
+				2B7F48EA1708365200A106A9 /* FixNormalsStep.cpp in Sources */,
+				2B7F48F91708365200A106A9 /* GenFaceNormalsProcess.cpp in Sources */,
+				2B7F49031708365200A106A9 /* GenVertexNormalsProcess.cpp in Sources */,
+				2B7F49261708365200A106A9 /* IFCBoolean.cpp in Sources */,
+				2B7F492B1708365200A106A9 /* IFCCurve.cpp in Sources */,
+				2B7F49301708365200A106A9 /* IFCGeometry.cpp in Sources */,
+				2B7F49351708365200A106A9 /* IFCLoader.cpp in Sources */,
+				2B7F493F1708365200A106A9 /* IFCMaterial.cpp in Sources */,
+				2B7F49441708365200A106A9 /* IFCOpenings.cpp in Sources */,
+				2B7F49491708365200A106A9 /* IFCProfile.cpp in Sources */,
+				2B7F494E1708365200A106A9 /* IFCReaderGen.cpp in Sources */,
+				2B7F49581708365200A106A9 /* IFCUtil.cpp in Sources */,
+				2B7F49671708365200A106A9 /* Importer.cpp in Sources */,
+				2B7F49711708365200A106A9 /* ImporterRegistry.cpp in Sources */,
+				2B7F49761708365200A106A9 /* ImproveCacheLocality.cpp in Sources */,
+				2B7F49A31708365200A106A9 /* JoinVerticesProcess.cpp in Sources */,
+				2B7F49AD1708365200A106A9 /* LimitBoneWeightsProcess.cpp in Sources */,
+				2B7F49F81708365200A106A9 /* MakeVerboseFormat.cpp in Sources */,
+				2B7F4A021708365200A106A9 /* MaterialSystem.cpp in Sources */,
+				2B7F4A981708365200A106A9 /* ObjExporter.cpp in Sources */,
+				2B7F4AA71708365200A106A9 /* ObjFileImporter.cpp in Sources */,
+				2B7F4AB11708365200A106A9 /* ObjFileMtlImporter.cpp in Sources */,
+				2B7F4ABB1708365200A106A9 /* ObjFileParser.cpp in Sources */,
+				2B7F4AF21708365200A106A9 /* OptimizeGraph.cpp in Sources */,
+				2B7F4AFC1708365200A106A9 /* OptimizeMeshes.cpp in Sources */,
+				2B7F4B2E1708365200A106A9 /* PostStepRegistry.cpp in Sources */,
+				2B7F4B331708365200A106A9 /* PretransformVertices.cpp in Sources */,
+				2B7F4B3D1708365200A106A9 /* ProcessHelper.cpp in Sources */,
+				2B7F4B8D1708365200A106A9 /* RemoveComments.cpp in Sources */,
+				2B7F4B971708365200A106A9 /* RemoveRedundantMaterials.cpp in Sources */,
+				2B7F4BA11708365200A106A9 /* RemoveVCProcess.cpp in Sources */,
+				2B7F4BB01708365200A106A9 /* SceneCombiner.cpp in Sources */,
+				2B7F4BBA1708365200A106A9 /* ScenePreprocessor.cpp in Sources */,
+				2B7F4BC91708365200A106A9 /* SGSpatialSort.cpp in Sources */,
+				2B7F4BD31708365200A106A9 /* SkeletonMeshBuilder.cpp in Sources */,
+				2B7F4BEC1708365200A106A9 /* SortByPTypeProcess.cpp in Sources */,
+				2B7F4BF61708365200A106A9 /* SpatialSort.cpp in Sources */,
+				2B7F4C001708365200A106A9 /* SplitByBoneCountProcess.cpp in Sources */,
+				2B7F4C0A1708365200A106A9 /* SplitLargeMeshes.cpp in Sources */,
+				2B7F4C141708365200A106A9 /* StandardShapes.cpp in Sources */,
+				2B7F4C281708365200A106A9 /* STEPFileEncoding.cpp in Sources */,
+				2B7F4C321708365200A106A9 /* STEPFileReader.cpp in Sources */,
+				2B7F4C3C1708365200A106A9 /* STLExporter.cpp in Sources */,
+				2B7F4C461708365200A106A9 /* STLLoader.cpp in Sources */,
+				2B7F4C5A1708365200A106A9 /* Subdivision.cpp in Sources */,
+				2B7F4C641708365200A106A9 /* TargetAnimation.cpp in Sources */,
+				2B7F4C781708365200A106A9 /* TextureTransform.cpp in Sources */,
+				2B7F4C871708365200A106A9 /* TriangulateProcess.cpp in Sources */,
+				2B7F4C9B1708365200A106A9 /* ValidateDataStructure.cpp in Sources */,
+				2B7F4CAA1708365200A106A9 /* VertexTriangleAdjacency.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4193,58 +5416,26 @@
 				F962E88C0F5DE6C8009A5495 /* 3DSLoader.cpp in Sources */,
 				F962E88E0F5DE6C8009A5495 /* ASELoader.cpp in Sources */,
 				F962E88F0F5DE6C8009A5495 /* ASEParser.cpp in Sources */,
-				F962E8900F5DE6C8009A5495 /* Assimp.cpp in Sources */,
-				F962E8910F5DE6C8009A5495 /* BaseImporter.cpp in Sources */,
-				F962E8920F5DE6C8009A5495 /* CalcTangentsProcess.cpp in Sources */,
-				F962E8930F5DE6C8009A5495 /* ConvertToLHProcess.cpp in Sources */,
-				F962E8940F5DE6C8009A5495 /* DefaultIOStream.cpp in Sources */,
-				F962E8950F5DE6C8009A5495 /* DefaultIOSystem.cpp in Sources */,
-				F962E8960F5DE6C8009A5495 /* DefaultLogger.cpp in Sources */,
-				F962E8980F5DE6C8009A5495 /* GenFaceNormalsProcess.cpp in Sources */,
-				F962E8990F5DE6C8009A5495 /* GenVertexNormalsProcess.cpp in Sources */,
 				F962E89A0F5DE6C8009A5495 /* HMPLoader.cpp in Sources */,
-				F962E89B0F5DE6C8009A5495 /* Importer.cpp in Sources */,
-				F962E89C0F5DE6C8009A5495 /* ImproveCacheLocality.cpp in Sources */,
-				F962E89D0F5DE6C8009A5495 /* JoinVerticesProcess.cpp in Sources */,
-				F962E89E0F5DE6C8009A5495 /* LimitBoneWeightsProcess.cpp in Sources */,
-				F962E89F0F5DE6C8009A5495 /* MaterialSystem.cpp in Sources */,
 				F962E8A00F5DE6C8009A5495 /* MD2Loader.cpp in Sources */,
 				F962E8A10F5DE6C8009A5495 /* MD3Loader.cpp in Sources */,
 				F962E8A20F5DE6C8009A5495 /* MD5Loader.cpp in Sources */,
 				F962E8A30F5DE6C8009A5495 /* MD5Parser.cpp in Sources */,
 				F962E8A40F5DE6C8009A5495 /* MDLLoader.cpp in Sources */,
 				F962E8A50F5DE6C8009A5495 /* MDLMaterialLoader.cpp in Sources */,
-				F962E8A60F5DE6C8009A5495 /* ObjFileImporter.cpp in Sources */,
-				F962E8A70F5DE6C8009A5495 /* ObjFileMtlImporter.cpp in Sources */,
-				F962E8A80F5DE6C8009A5495 /* ObjFileParser.cpp in Sources */,
 				F962E8A90F5DE6C8009A5495 /* PlyLoader.cpp in Sources */,
 				F962E8AA0F5DE6C8009A5495 /* PlyParser.cpp in Sources */,
-				F962E8AB0F5DE6C8009A5495 /* PretransformVertices.cpp in Sources */,
-				F962E8AC0F5DE6C8009A5495 /* RemoveComments.cpp in Sources */,
-				F962E8AD0F5DE6C8009A5495 /* RemoveRedundantMaterials.cpp in Sources */,
 				F962E8AE0F5DE6C8009A5495 /* SMDLoader.cpp in Sources */,
-				F962E8AF0F5DE6C8009A5495 /* SpatialSort.cpp in Sources */,
-				F962E8B00F5DE6C8009A5495 /* SplitLargeMeshes.cpp in Sources */,
-				F962E8B10F5DE6C8009A5495 /* STLLoader.cpp in Sources */,
-				F962E8B20F5DE6C8009A5495 /* TextureTransform.cpp in Sources */,
-				F962E8B30F5DE6C8009A5495 /* TriangulateProcess.cpp in Sources */,
-				F962E8B40F5DE6C8009A5495 /* ValidateDataStructure.cpp in Sources */,
-				F962E8B50F5DE6C8009A5495 /* VertexTriangleAdjacency.cpp in Sources */,
 				F962E8B60F5DE6C8009A5495 /* XFileImporter.cpp in Sources */,
 				F962E8B70F5DE6C8009A5495 /* XFileParser.cpp in Sources */,
 				F962E8B80F5DE6C8009A5495 /* MDCLoader.cpp in Sources */,
-				F962E8B90F5DE6C8009A5495 /* FixNormalsStep.cpp in Sources */,
 				F962E8BA0F5DE6C8009A5495 /* LWOLoader.cpp in Sources */,
-				F962E8BB0F5DE6C8009A5495 /* BaseProcess.cpp in Sources */,
 				F962E8BC0F5DE6C8009A5495 /* LWOMaterial.cpp in Sources */,
 				F962E8BD0F5DE6C8009A5495 /* ACLoader.cpp in Sources */,
 				F962E8BE0F5DE6C8009A5495 /* IRRLoader.cpp in Sources */,
 				F962E8BF0F5DE6C8009A5495 /* IRRMeshLoader.cpp in Sources */,
 				F962E8C00F5DE6C8009A5495 /* IRRShared.cpp in Sources */,
-				F962E8C10F5DE6C8009A5495 /* ColladaLoader.cpp in Sources */,
-				F962E8C20F5DE6C8009A5495 /* ColladaParser.cpp in Sources */,
 				F962E8C30F5DE6C8009A5495 /* NFFLoader.cpp in Sources */,
-				F962E8C40F5DE6C8009A5495 /* SGSpatialSort.cpp in Sources */,
 				F962E8C50F5DE6C8009A5495 /* Q3DLoader.cpp in Sources */,
 				F962E8C60F5DE6C8009A5495 /* BVHLoader.cpp in Sources */,
 				F962E8C70F5DE6C8009A5495 /* OFFLoader.cpp in Sources */,
@@ -4252,30 +5443,15 @@
 				F962E8C90F5DE6C8009A5495 /* DXFLoader.cpp in Sources */,
 				F962E8CA0F5DE6C8009A5495 /* LWOBLoader.cpp in Sources */,
 				F962E8CB0F5DE6C8009A5495 /* TerragenLoader.cpp in Sources */,
-				F962E8CC0F5DE6C8009A5495 /* SceneCombiner.cpp in Sources */,
-				F962E8CD0F5DE6C8009A5495 /* ScenePreprocessor.cpp in Sources */,
-				F962E8CE0F5DE6C8009A5495 /* SortByPTypeProcess.cpp in Sources */,
-				F962E8CF0F5DE6C8009A5495 /* FindDegenerates.cpp in Sources */,
-				F962E8D00F5DE6C8009A5495 /* ComputeUVMappingProcess.cpp in Sources */,
-				F962E8D10F5DE6C8009A5495 /* StandardShapes.cpp in Sources */,
-				F962E8D20F5DE6C8009A5495 /* FindInstancesProcess.cpp in Sources */,
-				F962E8D30F5DE6C8009A5495 /* RemoveVCProcess.cpp in Sources */,
-				F962E8D40F5DE6C8009A5495 /* FindInvalidDataProcess.cpp in Sources */,
-				F962E8D50F5DE6C8009A5495 /* SkeletonMeshBuilder.cpp in Sources */,
 				F962E8D70F5DE6C8009A5495 /* B3DImporter.cpp in Sources */,
 				7411B15611416D5E00BCD793 /* CSMLoader.cpp in Sources */,
 				7411B16111416DDD00BCD793 /* LWSLoader.cpp in Sources */,
 				7411B16B11416DF400BCD793 /* LWOAnimation.cpp in Sources */,
 				7411B17811416E2500BCD793 /* MS3DLoader.cpp in Sources */,
 				7411B19311416EBC00BCD793 /* UnrealLoader.cpp in Sources */,
-				7411B1D611416EF400BCD793 /* OptimizeGraph.cpp in Sources */,
-				7411B1D811416EF400BCD793 /* OptimizeMeshes.cpp in Sources */,
-				7411B1DD11416EF400BCD793 /* Subdivision.cpp in Sources */,
-				7411B1DF11416EF400BCD793 /* TargetAnimation.cpp in Sources */,
 				74C9BB5811ACBB1000AF885C /* BlenderDNA.cpp in Sources */,
 				74C9BB5A11ACBB1000AF885C /* BlenderLoader.cpp in Sources */,
 				74C9BB5C11ACBB1000AF885C /* BlenderScene.cpp in Sources */,
-				74C9BB8411ACBB7800AF885C /* MakeVerboseFormat.cpp in Sources */,
 				74C9BB8E11ACBB9900AF885C /* AssimpPCH.cpp in Sources */,
 				74C9BB9F11ACBBBC00AF885C /* COBLoader.cpp in Sources */,
 				8E7ABBB7127E0F1A00512ED1 /* Q3BSPFileImporter.cpp in Sources */,
@@ -4291,14 +5467,8 @@
 				F9BA8C43154328B600E63FFE /* OgreMaterial.cpp in Sources */,
 				F9BA8C44154328B600E63FFE /* OgreMesh.cpp in Sources */,
 				F9BA8C45154328B600E63FFE /* OgreSkeleton.cpp in Sources */,
-				F99A9ED515436125000682F3 /* DeboneProcess.cpp in Sources */,
-				F99A9F19154361AD000682F3 /* ImporterRegistry.cpp in Sources */,
 				F99A9F2A15436207000682F3 /* M3Importer.cpp in Sources */,
 				F99A9F3415436269000682F3 /* PlyExporter.cpp in Sources */,
-				F99A9F411543629F000682F3 /* PostStepRegistry.cpp in Sources */,
-				F99A9F4D15436304000682F3 /* SplitByBoneCountProcess.cpp in Sources */,
-				F99A9F6015436323000682F3 /* STEPFileReader.cpp in Sources */,
-				F9606FF4154364E5004D91DD /* ProcessHelper.cpp in Sources */,
 				F9607071154366AB004D91DD /* adler32.c in Sources */,
 				F9607072154366AB004D91DD /* compress.c in Sources */,
 				F9607073154366AB004D91DD /* crc32.c in Sources */,
@@ -4315,13 +5485,89 @@
 				F96070F11543675E004D91DD /* cdt.cc in Sources */,
 				F96070F31543675E004D91DD /* sweep.cc in Sources */,
 				F96070F51543675E004D91DD /* sweep_context.cc in Sources */,
-				F97BA07A15439FC3009EB9DD /* IFCCurve.cpp in Sources */,
-				F97BA07B15439FC3009EB9DD /* IFCGeometry.cpp in Sources */,
-				F97BA07C15439FC3009EB9DD /* IFCLoader.cpp in Sources */,
-				F97BA07E15439FC3009EB9DD /* IFCMaterial.cpp in Sources */,
-				F97BA07F15439FC3009EB9DD /* IFCProfile.cpp in Sources */,
-				F97BA08015439FC3009EB9DD /* IFCReaderGen.cpp in Sources */,
-				F97BA08215439FC3009EB9DD /* IFCUtil.cpp in Sources */,
+				2B7F46E31708365200A106A9 /* Assimp.cpp in Sources */,
+				2B7F46E81708365200A106A9 /* AssimpCExport.cpp in Sources */,
+				2B7F47011708365200A106A9 /* BaseImporter.cpp in Sources */,
+				2B7F470B1708365200A106A9 /* BaseProcess.cpp in Sources */,
+				2B7F47A11708365200A106A9 /* CalcTangentsProcess.cpp in Sources */,
+				2B7F47BF1708365200A106A9 /* ColladaExporter.cpp in Sources */,
+				2B7F47CE1708365200A106A9 /* ColladaLoader.cpp in Sources */,
+				2B7F47D81708365200A106A9 /* ColladaParser.cpp in Sources */,
+				2B7F47E21708365200A106A9 /* ComputeUVMappingProcess.cpp in Sources */,
+				2B7F47EC1708365200A106A9 /* ConvertToLHProcess.cpp in Sources */,
+				2B7F48001708365200A106A9 /* DeboneProcess.cpp in Sources */,
+				2B7F480A1708365200A106A9 /* DefaultIOStream.cpp in Sources */,
+				2B7F48141708365200A106A9 /* DefaultIOSystem.cpp in Sources */,
+				2B7F481E1708365200A106A9 /* DefaultLogger.cpp in Sources */,
+				2B7F483C1708365200A106A9 /* Exporter.cpp in Sources */,
+				2B7F48461708365200A106A9 /* FBXAnimation.cpp in Sources */,
+				2B7F484B1708365200A106A9 /* FBXBinaryTokenizer.cpp in Sources */,
+				2B7F48551708365200A106A9 /* FBXConverter.cpp in Sources */,
+				2B7F485F1708365200A106A9 /* FBXDeformer.cpp in Sources */,
+				2B7F48641708365200A106A9 /* FBXDocument.cpp in Sources */,
+				2B7F486E1708365200A106A9 /* FBXDocumentUtil.cpp in Sources */,
+				2B7F48781708365200A106A9 /* FBXImporter.cpp in Sources */,
+				2B7F48871708365200A106A9 /* FBXMaterial.cpp in Sources */,
+				2B7F488C1708365200A106A9 /* FBXMeshGeometry.cpp in Sources */,
+				2B7F48911708365200A106A9 /* FBXModel.cpp in Sources */,
+				2B7F48961708365200A106A9 /* FBXNodeAttribute.cpp in Sources */,
+				2B7F489B1708365200A106A9 /* FBXParser.cpp in Sources */,
+				2B7F48A51708365200A106A9 /* FBXProperties.cpp in Sources */,
+				2B7F48AF1708365200A106A9 /* FBXTokenizer.cpp in Sources */,
+				2B7F48B91708365200A106A9 /* FBXUtil.cpp in Sources */,
+				2B7F48CD1708365200A106A9 /* FindDegenerates.cpp in Sources */,
+				2B7F48D71708365200A106A9 /* FindInstancesProcess.cpp in Sources */,
+				2B7F48E11708365200A106A9 /* FindInvalidDataProcess.cpp in Sources */,
+				2B7F48EB1708365200A106A9 /* FixNormalsStep.cpp in Sources */,
+				2B7F48FA1708365200A106A9 /* GenFaceNormalsProcess.cpp in Sources */,
+				2B7F49041708365200A106A9 /* GenVertexNormalsProcess.cpp in Sources */,
+				2B7F49271708365200A106A9 /* IFCBoolean.cpp in Sources */,
+				2B7F492C1708365200A106A9 /* IFCCurve.cpp in Sources */,
+				2B7F49311708365200A106A9 /* IFCGeometry.cpp in Sources */,
+				2B7F49361708365200A106A9 /* IFCLoader.cpp in Sources */,
+				2B7F49401708365200A106A9 /* IFCMaterial.cpp in Sources */,
+				2B7F49451708365200A106A9 /* IFCOpenings.cpp in Sources */,
+				2B7F494A1708365200A106A9 /* IFCProfile.cpp in Sources */,
+				2B7F494F1708365200A106A9 /* IFCReaderGen.cpp in Sources */,
+				2B7F49591708365200A106A9 /* IFCUtil.cpp in Sources */,
+				2B7F49681708365200A106A9 /* Importer.cpp in Sources */,
+				2B7F49721708365200A106A9 /* ImporterRegistry.cpp in Sources */,
+				2B7F49771708365200A106A9 /* ImproveCacheLocality.cpp in Sources */,
+				2B7F49A41708365200A106A9 /* JoinVerticesProcess.cpp in Sources */,
+				2B7F49AE1708365200A106A9 /* LimitBoneWeightsProcess.cpp in Sources */,
+				2B7F49F91708365200A106A9 /* MakeVerboseFormat.cpp in Sources */,
+				2B7F4A031708365200A106A9 /* MaterialSystem.cpp in Sources */,
+				2B7F4A991708365200A106A9 /* ObjExporter.cpp in Sources */,
+				2B7F4AA81708365200A106A9 /* ObjFileImporter.cpp in Sources */,
+				2B7F4AB21708365200A106A9 /* ObjFileMtlImporter.cpp in Sources */,
+				2B7F4ABC1708365200A106A9 /* ObjFileParser.cpp in Sources */,
+				2B7F4AF31708365200A106A9 /* OptimizeGraph.cpp in Sources */,
+				2B7F4AFD1708365200A106A9 /* OptimizeMeshes.cpp in Sources */,
+				2B7F4B2F1708365200A106A9 /* PostStepRegistry.cpp in Sources */,
+				2B7F4B341708365200A106A9 /* PretransformVertices.cpp in Sources */,
+				2B7F4B3E1708365200A106A9 /* ProcessHelper.cpp in Sources */,
+				2B7F4B8E1708365200A106A9 /* RemoveComments.cpp in Sources */,
+				2B7F4B981708365200A106A9 /* RemoveRedundantMaterials.cpp in Sources */,
+				2B7F4BA21708365200A106A9 /* RemoveVCProcess.cpp in Sources */,
+				2B7F4BB11708365200A106A9 /* SceneCombiner.cpp in Sources */,
+				2B7F4BBB1708365200A106A9 /* ScenePreprocessor.cpp in Sources */,
+				2B7F4BCA1708365200A106A9 /* SGSpatialSort.cpp in Sources */,
+				2B7F4BD41708365200A106A9 /* SkeletonMeshBuilder.cpp in Sources */,
+				2B7F4BED1708365200A106A9 /* SortByPTypeProcess.cpp in Sources */,
+				2B7F4BF71708365200A106A9 /* SpatialSort.cpp in Sources */,
+				2B7F4C011708365200A106A9 /* SplitByBoneCountProcess.cpp in Sources */,
+				2B7F4C0B1708365200A106A9 /* SplitLargeMeshes.cpp in Sources */,
+				2B7F4C151708365200A106A9 /* StandardShapes.cpp in Sources */,
+				2B7F4C291708365200A106A9 /* STEPFileEncoding.cpp in Sources */,
+				2B7F4C331708365200A106A9 /* STEPFileReader.cpp in Sources */,
+				2B7F4C3D1708365200A106A9 /* STLExporter.cpp in Sources */,
+				2B7F4C471708365200A106A9 /* STLLoader.cpp in Sources */,
+				2B7F4C5B1708365200A106A9 /* Subdivision.cpp in Sources */,
+				2B7F4C651708365200A106A9 /* TargetAnimation.cpp in Sources */,
+				2B7F4C791708365200A106A9 /* TextureTransform.cpp in Sources */,
+				2B7F4C881708365200A106A9 /* TriangulateProcess.cpp in Sources */,
+				2B7F4C9C1708365200A106A9 /* ValidateDataStructure.cpp in Sources */,
+				2B7F4CAB1708365200A106A9 /* VertexTriangleAdjacency.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -4331,21 +5577,21 @@
 		1DEB916108733D950010E9CD /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = stabs;
 				EXECUTABLE_PREFIX = lib;
 				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_ENABLE_FIX_AND_CONTINUE = YES;
 				GCC_MODEL_TUNING = G5;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = "";
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				HEADER_SEARCH_PATHS = /usr/local/include;
 				LD_DYLIB_INSTALL_NAME = libassimpd.dylib;
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"\"$(SRCROOT)/../../../boost_1_35_0/bin.v2/libs/date_time/build/darwin/release/architecture-combined/macosx-version-10.4/threading-multi\"",
-					"\"$(SRCROOT)/../../../boost_1_35_0/bin.v2/libs/thread/build/darwin/release/architecture-combined/macosx-version-10.4/threading-multi\"",
-				);
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = assimpd;
+				SDKROOT = macosx;
+				VALID_ARCHS = "i386 x86_64 armv7 armv6";
 				ZERO_LINK = YES;
 			};
 			name = Debug;
@@ -4353,17 +5599,18 @@
 		1DEB916208733D950010E9CD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = stabs;
 				EXECUTABLE_PREFIX = lib;
 				GCC_MODEL_TUNING = G5;
-				LIBRARY_SEARCH_PATHS = (
-					"$(inherited)",
-					"\"$(SRCROOT)/../../../boost_1_35_0/bin.v2/libs/date_time/build/darwin/release/architecture-combined/macosx-version-10.4/threading-multi\"",
-					"\"$(SRCROOT)/../../../boost_1_35_0/bin.v2/libs/thread/build/darwin/release/architecture-combined/macosx-version-10.4/threading-multi\"",
-				);
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				HEADER_SEARCH_PATHS = /usr/local/include;
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = assimp;
+				SDKROOT = macosx;
 				STRIP_INSTALLED_PRODUCT = YES;
 				STRIP_STYLE = "non-global";
+				VALID_ARCHS = "i386 x86_64 armv7 armv6";
 			};
 			name = Release;
 		};
@@ -4371,7 +5618,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ONLY_ACTIVE_ARCH_PRE_XCODE_3_1)";
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
 				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
 				GCC_DEBUGGING_SYMBOLS = full;
@@ -4389,12 +5636,10 @@
 				LD_DYLIB_INSTALL_NAME = libassimp.dylib;
 				LIBRARY_SEARCH_PATHS = /usr/local/lib;
 				OBJROOT = "../../obj/$(PROJECT_NAME)_$(CONFIGURATION)_MacOSX";
-				ONLY_ACTIVE_ARCH_PRE_XCODE_3_1 = "$(NATIVE_ARCH)";
+				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "";
-				PREBINDING = NO;
 				SDKROOT = "$(DEVELOPER_SDK_DIR)/MacOSX10.5.sdk";
 				SYMROOT = "../../bin/$(PROJECT_NAME)_$(CONFIGURATION)_MacOSX";
-				VALID_ARCHS = "i386 x86_64";
 			};
 			name = Debug;
 		};
@@ -4402,8 +5647,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT_PRE_XCODE_3_1)";
-				ARCHS_STANDARD_32_BIT_PRE_XCODE_3_1 = "ppc i386";
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
 				CONFIGURATION_BUILD_DIR = "$(SYMROOT)";
 				CONFIGURATION_TEMP_DIR = "$(OBJROOT)";
 				GCC_INCREASE_PRECOMPILED_HEADER_SHARING = YES;
@@ -4420,28 +5664,30 @@
 				LIBRARY_SEARCH_PATHS = /usr/local/lib;
 				OBJROOT = "../../obj/$(PROJECT_NAME)_$(CONFIGURATION)_MacOSX";
 				OTHER_LDFLAGS = "";
-				PREBINDING = NO;
 				SDKROOT = "$(DEVELOPER_SDK_DIR)/MacOSX10.5.sdk";
 				SYMROOT = "../../bin/$(PROJECT_NAME)_$(CONFIGURATION)_MacOSX";
-				VALID_ARCHS = "i386 x86_64";
 			};
 			name = Release;
 		};
 		745FF8FE113ECB080020C31B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = stabs;
 				EXECUTABLE_PREFIX = lib;
 				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_ENABLE_FIX_AND_CONTINUE = YES;
 				GCC_MODEL_TUNING = G5;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = ASSIMP_BUILD_BOOST_WORKAROUND;
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				HEADER_SEARCH_PATHS = "${SRCROOT}/../../code/BoostWorkaround";
 				LD_DYLIB_INSTALL_NAME = libassimpd.dylib;
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = assimpd;
+				SDKROOT = macosx;
+				VALID_ARCHS = "i386 x86_64 armv6 armv7";
 				ZERO_LINK = YES;
 			};
 			name = Debug;
@@ -4449,6 +5695,8 @@
 		745FF8FF113ECB080020C31B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				DEBUG_INFORMATION_FORMAT = stabs;
 				EXECUTABLE_PREFIX = lib;
 				GCC_MODEL_TUNING = G5;
@@ -4456,11 +5704,14 @@
 					NDEBUG,
 					ASSIMP_BUILD_BOOST_WORKAROUND,
 				);
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				HEADER_SEARCH_PATHS = "${SRCROOT}/../../code/BoostWorkaround";
 				LIBRARY_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = assimp;
+				SDKROOT = macosx;
 				STRIP_INSTALLED_PRODUCT = YES;
 				STRIP_STYLE = "non-global";
+				VALID_ARCHS = "i386 x86_64 armv6 armv7";
 			};
 			name = Release;
 		};
@@ -4468,23 +5719,26 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = stabs;
 				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_ENABLE_FIX_AND_CONTINUE = YES;
 				GCC_ENABLE_SYMBOL_SEPARATION = NO;
 				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
 				GCC_MODEL_TUNING = G5;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = ASSIMP_BUILD_BOOST_WORKAROUND;
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				HEADER_SEARCH_PATHS = "${SRCROOT}/../../code/BoostWorkaround";
 				INSTALL_PATH = /usr/local/lib;
 				LD_DYLIB_INSTALL_NAME = "";
-				PREBINDING = NO;
+				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_NAME = assimpd;
+				SDKROOT = macosx;
 				SEPARATE_STRIP = NO;
 				SKIP_INSTALL = YES;
 				STRIP_INSTALLED_PRODUCT = NO;
+				VALID_ARCHS = "x86_64 i386";
 			};
 			name = Debug;
 		};
@@ -4492,9 +5746,9 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				GCC_ENABLE_FIX_AND_CONTINUE = NO;
 				GCC_ENABLE_SYMBOL_SEPARATION = NO;
 				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
 				GCC_MODEL_TUNING = G5;
@@ -4502,13 +5756,76 @@
 					NDEBUG,
 					ASSIMP_BUILD_BOOST_WORKAROUND,
 				);
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
 				HEADER_SEARCH_PATHS = "${SRCROOT}/../../code/BoostWorkaround";
 				INSTALL_PATH = /usr/local/lib;
-				PREBINDING = NO;
 				PRODUCT_NAME = assimp;
+				SDKROOT = macosx;
 				SEPARATE_STRIP = NO;
 				SKIP_INSTALL = YES;
 				STRIP_INSTALLED_PRODUCT = NO;
+				VALID_ARCHS = "x86_64 i386";
+				ZERO_LINK = NO;
+			};
+			name = Release;
+		};
+		B919763D163AEA54009C397B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = NO;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_ENABLE_SYMBOL_SEPARATION = NO;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
+				GCC_MODEL_TUNING = G5;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = ASSIMP_BUILD_BOOST_WORKAROUND;
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				HEADER_SEARCH_PATHS = "${SRCROOT}/../../code/BoostWorkaround";
+				INSTALL_PATH = /usr/local/lib;
+				LD_DYLIB_INSTALL_NAME = "";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SYSTEM_APPS_DIR)/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.8.sdk/usr/lib\"",
+				);
+				OBJROOT = "../../obj/$(PROJECT_NAME)_$(CONFIGURATION)_iOS";
+				ONLY_ACTIVE_ARCH = NO;
+				PRODUCT_NAME = "assimp-ios";
+				SDKROOT = iphoneos;
+				SEPARATE_STRIP = NO;
+				SKIP_INSTALL = YES;
+				STRIP_INSTALLED_PRODUCT = NO;
+				SYMROOT = "../../bin/$(PROJECT_NAME)_$(CONFIGURATION)_iOS";
+			};
+			name = Debug;
+		};
+		B919763E163AEA54009C397B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COPY_PHASE_STRIP = YES;
+				GCC_ENABLE_SYMBOL_SEPARATION = NO;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
+				GCC_MODEL_TUNING = G5;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					NDEBUG,
+					ASSIMP_BUILD_BOOST_WORKAROUND,
+				);
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				HEADER_SEARCH_PATHS = "${SRCROOT}/../../code/BoostWorkaround";
+				INSTALL_PATH = /usr/local/lib;
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SYSTEM_APPS_DIR)/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.8.sdk/usr/lib\"",
+				);
+				OBJROOT = "../../obj/$(PROJECT_NAME)_$(CONFIGURATION)_iOS";
+				ONLY_ACTIVE_ARCH = NO;
+				PRODUCT_NAME = "assimp-ios";
+				SDKROOT = iphoneos;
+				SEPARATE_STRIP = NO;
+				SKIP_INSTALL = YES;
+				STRIP_INSTALLED_PRODUCT = NO;
+				SYMROOT = "../../bin/$(PROJECT_NAME)_$(CONFIGURATION)_iOS";
 				ZERO_LINK = NO;
 			};
 			name = Release;
@@ -4517,22 +5834,26 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = stabs;
 				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_ENABLE_FIX_AND_CONTINUE = YES;
 				GCC_ENABLE_SYMBOL_SEPARATION = NO;
 				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
 				GCC_MODEL_TUNING = G5;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = "";
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				HEADER_SEARCH_PATHS = /usr/local/include;
 				INSTALL_PATH = /usr/local/lib;
 				LD_DYLIB_INSTALL_NAME = "";
-				PREBINDING = NO;
 				PRODUCT_NAME = assimpd;
+				SDKROOT = macosx;
 				SEPARATE_STRIP = NO;
 				SKIP_INSTALL = YES;
 				STRIP_INSTALLED_PRODUCT = NO;
+				VALID_ARCHS = "i386 x86_64 armv7 armv6";
 			};
 			name = Debug;
 		};
@@ -4540,18 +5861,22 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_32_64_BIT)";
+				COMBINE_HIDPI_IMAGES = YES;
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				GCC_ENABLE_FIX_AND_CONTINUE = NO;
 				GCC_ENABLE_SYMBOL_SEPARATION = NO;
 				GCC_INLINES_ARE_PRIVATE_EXTERN = YES;
 				GCC_MODEL_TUNING = G5;
+				GCC_VERSION = com.apple.compilers.llvm.clang.1_0;
+				HEADER_SEARCH_PATHS = /usr/local/include;
 				INSTALL_PATH = /usr/local/lib;
-				PREBINDING = NO;
 				PRODUCT_NAME = assimp;
+				SDKROOT = macosx;
 				SEPARATE_STRIP = NO;
 				SKIP_INSTALL = YES;
 				STRIP_INSTALLED_PRODUCT = NO;
+				VALID_ARCHS = "i386 x86_64 armv7 armv6";
 				ZERO_LINK = NO;
 			};
 			name = Release;
@@ -4591,6 +5916,15 @@
 			buildConfigurations = (
 				745FF9E1113ECC660020C31B /* Debug */,
 				745FF9E2113ECC660020C31B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B919763C163AEA54009C397B /* Build configuration list for PBXNativeTarget "assimp-ios-static-no-boost" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B919763D163AEA54009C397B /* Debug */,
+				B919763E163AEA54009C397B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;


### PR DESCRIPTION
Hi,

I fixed the 4 build configurations in workspaces/xcode and added a 5th one for iOS.

Notable changes:
- All builds now use Apple LLVM compiler (Clang)
- Builds using boost require boost to be in /usr/local (e.g. `brew install boost`)
