### PR TITLE
Enable aiMaterial::AddProperty template specializations in ASSIMP_NO_EXPORT builds

### DIFF
--- a/include/assimp/material.inl
+++ b/include/assimp/material.inl
@@ -176,8 +176,6 @@ inline aiReturn aiMaterial::Get<aiString>(const char* pKey,unsigned int type,
 }
 
 
-#ifndef ASSIMP_BUILD_NO_EXPORT
-
 // ---------------------------------------------------------------------------
 template<class TYPE>
 aiReturn aiMaterial::AddProperty (const TYPE* pInput,
@@ -268,8 +266,6 @@ inline aiReturn aiMaterial::AddProperty<int> (const int* pInput,
 		pNumValues * sizeof(int),
 		pKey,type,index,aiPTI_Integer);
 }
-
-#endif
 
 //! @endcond
 


### PR DESCRIPTION
aiMaterial::AddProperty template specializations are used by import methods in B3DImporter and SceneProcessor; they should be defined accordingly even when ASSIMP_BUILD_NO_EXPORT is defined.
