### PR TITLE
Collada importer should respect units in file

### DIFF
--- a/code/ColladaLoader.cpp
+++ b/code/ColladaLoader.cpp
@@ -155,7 +155,13 @@ void ColladaLoader::InternReadFile( const std::string& pFile, aiScene* pScene, I
 	// ... then fill the materials with the now adjusted settings
 	FillMaterials(parser, pScene);
 
-	// Convert to Y_UP, if different orientation
+        // Apply unitsize scale calculation
+        pScene->mRootNode->mTransformation *= aiMatrix4x4(parser.mUnitSize, 0,  0,  0, 
+                                                          0,  parser.mUnitSize,  0,  0,
+                                                          0,  0,  parser.mUnitSize,  0,
+                                                          0,  0,  0,  1);
+
+        // Convert to Y_UP, if different orientation
 	if( parser.mUpDirection == ColladaParser::UP_X)
 		pScene->mRootNode->mTransformation *= aiMatrix4x4( 
 			 0, -1,  0,  0, 


### PR DESCRIPTION
The Collada file may (?) have a unit tag in the asset section. This is currently parsed by the ColladaParser but is then ignored. This request will scale the model so that the units returned from a Collada file are consistent with other formats
