### PR TITLE
Fixed a bug returning not all material properties when accessing them.

### DIFF
--- a/port/PyAssimp/pyassimp/core.py
+++ b/port/PyAssimp/pyassimp/core.py
@@ -336,6 +336,23 @@ def _finalize_mesh(mesh, target):
     faces = numpy.array([f.indices for f in target.faces], dtype=numpy.int32)
     setattr(target, 'faces', faces)
 
+
+class PropertyGetter(dict):
+    def __getitem__(self, key, semantic = 0):
+        return dict.__getitem__(self, (key, semantic))
+
+    def keys(self):
+        for k in dict.keys(self):
+            yield k[0]
+
+    def __iter__(self):
+        return self.keys()
+
+    def items(self):
+        for k, v in dict.items(self):
+            yield k[0], v
+
+
 def _get_properties(properties, length): 
     """
     Convenience Function to get the material properties as a dict
@@ -346,7 +363,7 @@ def _get_properties(properties, length):
     for p in [properties[i] for i in range(length)]:
         #the name
         p = p.contents
-        key = str(p.mKey.data.decode("utf-8")).split('.')[1]
+        key = (str(p.mKey.data.decode("utf-8")).split('.')[1], p.mSemantic)
 
         #the data
         from ctypes import POINTER, cast, c_int, c_float, sizeof
@@ -366,7 +383,7 @@ def _get_properties(properties, length):
 
         result[key] = value
 
-    return result
+    return PropertyGetter(result)
 
 def decompose_matrix(matrix):
     if not isinstance(matrix, structs.Matrix4x4):

--- a/port/PyAssimp/scripts/sample.py
+++ b/port/PyAssimp/scripts/sample.py
@@ -10,6 +10,7 @@ import logging
 logging.basicConfig(level=logging.INFO)
 
 import pyassimp
+import pyassimp.postprocess
 
 def recur_node(node,level = 0):
     print("  " + "\t" * level + "- " + str(node))
@@ -19,7 +20,7 @@ def recur_node(node,level = 0):
 
 def main(filename=None):
 
-    scene = pyassimp.load(filename)
+    scene = pyassimp.load(filename, pyassimp.postprocess.aiProcess_Triangulate)
     
     #the model we load
     print("MODEL:" + filename)
@@ -42,7 +43,7 @@ def main(filename=None):
         print("    material id:" + str(mesh.materialindex+1))
         print("    vertices:" + str(len(mesh.vertices)))
         print("    first 3 verts:\n" + str(mesh.vertices[:3]))
-        if mesh.normals.any():
+        if mesh.normals:
                 print("    first 3 normals:\n" + str(mesh.normals[:3]))
         else:
                 print("    no normals")


### PR DESCRIPTION
Also fixed another bug occouring when no normals are provided in sample.py (lists do not have a any() method). And added mesh triangulation to sample.py, otherwise PyAssimp is even not able to load "untriangulated" meshes.

The property solution is not the best way to do it but I don't want to screw the API. A better solution could be a Property class which has the additional semantic attribute stored and queries for attributes where multiple semantics exist should return dicts in the form of {semantic: property}.
