### PR TITLE
Now actually fixed the bug with the normals.

### DIFF
--- a/port/PyAssimp/pyassimp/core.py
+++ b/port/PyAssimp/pyassimp/core.py
@@ -58,14 +58,14 @@ def make_tuple(ai_obj, type = None):
     return res
 
 def call_init(obj, caller = None):
-        # init children
-        if helper.hasattr_silent(obj, '_init'):
-            obj._init(parent = caller)
+    # init children
+    if helper.hasattr_silent(obj, '_init'):
+        obj._init(parent = caller)
 
-        # pointers
-        elif helper.hasattr_silent(obj, 'contents'):
-            if helper.hasattr_silent(obj.contents, '_init'):
-                obj.contents._init(target = obj, parent = caller)
+    # pointers
+    elif helper.hasattr_silent(obj, 'contents'):
+        if helper.hasattr_silent(obj.contents, '_init'):
+            obj.contents._init(target = obj, parent = caller)
 
 
 
@@ -313,7 +313,7 @@ def _finalize_mesh(mesh, target):
             data = numpy.array([make_tuple(getattr(mesh, name)[i]) for i in range(nb_vertices)], dtype=numpy.float32)
             setattr(target, name[1:].lower(), data)
         else:
-            setattr(target, name[1:].lower(), [])
+            setattr(target, name[1:].lower(), numpy.array([], dtype="float32"))
 
     def fillarray(name):
         mAttr = getattr(mesh, name)

--- a/port/PyAssimp/scripts/sample.py
+++ b/port/PyAssimp/scripts/sample.py
@@ -43,7 +43,7 @@ def main(filename=None):
         print("    material id:" + str(mesh.materialindex+1))
         print("    vertices:" + str(len(mesh.vertices)))
         print("    first 3 verts:\n" + str(mesh.vertices[:3]))
-        if mesh.normals:
+        if mesh.normals.any():
                 print("    first 3 normals:\n" + str(mesh.normals[:3]))
         else:
                 print("    no normals")


### PR DESCRIPTION
pyassimp returned a list instead of a numpy array when the normals were
empty. This also applies to texture coordinates and other stuff which is
explicitly converted in _finalize_mesh.

There was no reason for this behaviour but it rendered the sample.py crashing on input data without normals (and would so without texture coordinates).
