### PR TITLE
Fix for potential use of unassigned variable compiler warning.

### DIFF
--- a/code/FBXParser.cpp
+++ b/code/FBXParser.cpp
@@ -512,7 +512,7 @@ void ReadBinaryDataArray(char type, uint32_t count, const char*& data, const cha
 	ai_assert(data + comp_len == end);
 
 	// determine the length of the uncompressed data by looking at the type signature
-	uint32_t stride;
+	uint32_t stride = 0;
 	switch(type)
 	{
 	case 'f':


### PR DESCRIPTION
See title.
