### PR TITLE
fix .3DS error "Chunk is too large" with gcc >=4.7.0 / mingw

### DIFF
--- a/include/assimp/Compiler/pushpack1.h
+++ b/include/assimp/Compiler/pushpack1.h
@@ -25,7 +25,7 @@
 #	pragma pack(push,1)
 #	define PACK_STRUCT
 #elif defined( __GNUC__ )
-#	define PACK_STRUCT	__attribute__((packed))
+#	define PACK_STRUCT	__attribute__((gcc_struct, __packed__))
 #else
 #	error Compiler not supported
 #endif


### PR DESCRIPTION
GCC 4.7.0 breaks **attribute**((packed)):
http://www.bttr-software.de/forum/mix_entry.php?id=11767

see also the gcc 4.7.0 changelog: http://gcc.gnu.org/gcc-4.7/changes.html

"Windows mingw targets are using the -mms-bitfields option by default."

not sure if my fix is the cleanest approach, but it seems to work... gcc_struct seems to exist since gcc 3.4 

backlink to the initial bug report: http://springrts.com/mantis/view.php?id=3972
