### PR TITLE
aiMaterial: use overloads instead of template specializations. This fixe...

### DIFF
--- a/include/assimp/material.h
+++ b/include/assimp/material.h
@@ -691,6 +691,12 @@ public:
     aiReturn Get(const char* pKey,unsigned int type,
 		unsigned int idx, Type* pOut, unsigned int* pMax) const;
 
+	aiReturn Get(const char* pKey,unsigned int type,
+		unsigned int idx, int* pOut, unsigned int* pMax) const;
+
+	aiReturn Get(const char* pKey,unsigned int type,
+		unsigned int idx, float* pOut, unsigned int* pMax) const;
+
     // -------------------------------------------------------------------
     /** @brief Retrieve a Type value with a specific key 
      *  from the material
@@ -704,6 +710,25 @@ public:
 	template <typename Type>
 	aiReturn Get(const char* pKey,unsigned int type,
 		unsigned int idx,Type& pOut) const;
+
+
+	aiReturn Get(const char* pKey,unsigned int type,
+		unsigned int idx, int& pOut) const;
+
+	aiReturn Get(const char* pKey,unsigned int type,
+		unsigned int idx, float& pOut) const;
+
+	aiReturn Get(const char* pKey,unsigned int type,
+		unsigned int idx, aiString& pOut) const;
+
+	aiReturn Get(const char* pKey,unsigned int type,
+		unsigned int idx, aiColor3D& pOut) const;
+
+	aiReturn Get(const char* pKey,unsigned int type,
+		unsigned int idx, aiColor4D& pOut) const;
+
+	aiReturn Get(const char* pKey,unsigned int type,
+		unsigned int idx, aiUVTransform& pOut) const;
 
 	// -------------------------------------------------------------------
 	/** Get the number of textures for a particular texture type.
@@ -792,6 +817,42 @@ public:
 	 *  @param index Set by the AI_MATKEY_XXX macro  */
 	template<class TYPE>
 	aiReturn AddProperty (const TYPE* pInput,
+		unsigned int pNumValues,
+		const char* pKey,
+		unsigned int type  = 0,
+		unsigned int index = 0);
+
+	aiReturn AddProperty (const aiVector3D* pInput,
+		unsigned int pNumValues,
+		const char* pKey,
+		unsigned int type  = 0,
+		unsigned int index = 0);
+
+	aiReturn AddProperty (const aiColor3D* pInput,
+		unsigned int pNumValues,
+		const char* pKey,
+		unsigned int type  = 0,
+		unsigned int index = 0);
+
+	aiReturn AddProperty (const aiColor4D* pInput,
+		unsigned int pNumValues,
+		const char* pKey,
+		unsigned int type  = 0,
+		unsigned int index = 0);
+
+	aiReturn AddProperty (const int* pInput,
+		unsigned int pNumValues,
+		const char* pKey,
+		unsigned int type  = 0,
+		unsigned int index = 0);
+
+	aiReturn AddProperty (const float* pInput,
+		unsigned int pNumValues,
+		const char* pKey,
+		unsigned int type  = 0,
+		unsigned int index = 0);
+
+	aiReturn AddProperty (const aiUVTransform* pInput,
 		unsigned int pNumValues,
 		const char* pKey,
 		unsigned int type  = 0,

--- a/include/assimp/material.inl
+++ b/include/assimp/material.inl
@@ -89,7 +89,7 @@ inline aiReturn aiMaterial::Get(const char* pKey,unsigned int type,
 		}
 
 		iNum = std::min((size_t)iNum,prop->mDataLength / sizeof(Type));
-		memcpy(pOut,prop->mData,iNum * sizeof(Type));
+		::memcpy(pOut,prop->mData,iNum * sizeof(Type));
 		if (pMax) {
 			*pMax = iNum;
 		}
@@ -115,51 +115,45 @@ inline aiReturn aiMaterial::Get(const char* pKey,unsigned int type,
 			return AI_FAILURE;
 		}
 
-		memcpy(&pOut,prop->mData,sizeof(Type));
+		::memcpy(&pOut,prop->mData,sizeof(Type));
 	}
 	return ret;
 }
 
 // ---------------------------------------------------------------------------
-template <>
-inline aiReturn aiMaterial::Get<float>(const char* pKey,unsigned int type,
+inline aiReturn aiMaterial::Get(const char* pKey,unsigned int type,
 	unsigned int idx,float* pOut,
 	unsigned int* pMax) const
 {
 	return ::aiGetMaterialFloatArray(this,pKey,type,idx,pOut,pMax);
 }
 // ---------------------------------------------------------------------------
-template <>
-inline aiReturn aiMaterial::Get<int>(const char* pKey,unsigned int type,
+inline aiReturn aiMaterial::Get(const char* pKey,unsigned int type,
 	unsigned int idx,int* pOut,
 	unsigned int* pMax) const
 {
 	return ::aiGetMaterialIntegerArray(this,pKey,type,idx,pOut,pMax);
 }
 // ---------------------------------------------------------------------------
-template <>
-inline aiReturn aiMaterial::Get<float>(const char* pKey,unsigned int type,
+inline aiReturn aiMaterial::Get(const char* pKey,unsigned int type,
 	unsigned int idx,float& pOut) const
 {
 	return aiGetMaterialFloat(this,pKey,type,idx,&pOut);
 }
 // ---------------------------------------------------------------------------
-template <>
-inline aiReturn aiMaterial::Get<int>(const char* pKey,unsigned int type,
+inline aiReturn aiMaterial::Get(const char* pKey,unsigned int type,
 	unsigned int idx,int& pOut) const
 {
 	return aiGetMaterialInteger(this,pKey,type,idx,&pOut);
 }
 // ---------------------------------------------------------------------------
-template <>
-inline aiReturn aiMaterial::Get<aiColor4D>(const char* pKey,unsigned int type,
+inline aiReturn aiMaterial::Get(const char* pKey,unsigned int type,
 	unsigned int idx,aiColor4D& pOut) const
 {
 	return aiGetMaterialColor(this,pKey,type,idx,&pOut);
 }
 // ---------------------------------------------------------------------------
-template <>
-inline aiReturn aiMaterial::Get<aiColor3D>(const char* pKey,unsigned int type,
+inline aiReturn aiMaterial::Get(const char* pKey,unsigned int type,
 	unsigned int idx,aiColor3D& pOut) const
 {
 	aiColor4D c;
@@ -168,8 +162,7 @@ inline aiReturn aiMaterial::Get<aiColor3D>(const char* pKey,unsigned int type,
 	return ret;
 }
 // ---------------------------------------------------------------------------
-template <>
-inline aiReturn aiMaterial::Get<aiString>(const char* pKey,unsigned int type,
+inline aiReturn aiMaterial::Get(const char* pKey,unsigned int type,
 	unsigned int idx,aiString& pOut) const
 {
 	return aiGetMaterialString(this,pKey,type,idx,&pOut);
@@ -190,8 +183,7 @@ aiReturn aiMaterial::AddProperty (const TYPE* pInput,
 }
 
 // ---------------------------------------------------------------------------
-template<>
-inline aiReturn aiMaterial::AddProperty<float> (const float* pInput,
+inline aiReturn aiMaterial::AddProperty(const float* pInput,
 	const unsigned int pNumValues,
 	const char* pKey,
 	unsigned int type,
@@ -203,8 +195,7 @@ inline aiReturn aiMaterial::AddProperty<float> (const float* pInput,
 }
 
 // ---------------------------------------------------------------------------
-template<>
-inline aiReturn aiMaterial::AddProperty<aiUVTransform> (const aiUVTransform* pInput,
+inline aiReturn aiMaterial::AddProperty(const aiUVTransform* pInput,
 	const unsigned int pNumValues,
 	const char* pKey,
 	unsigned int type,
@@ -216,8 +207,7 @@ inline aiReturn aiMaterial::AddProperty<aiUVTransform> (const aiUVTransform* pIn
 }
 
 // ---------------------------------------------------------------------------
-template<>
-inline aiReturn aiMaterial::AddProperty<aiColor4D> (const aiColor4D* pInput,
+inline aiReturn aiMaterial::AddProperty(const aiColor4D* pInput,
 	const unsigned int pNumValues,
 	const char* pKey,
 	unsigned int type,
@@ -229,8 +219,7 @@ inline aiReturn aiMaterial::AddProperty<aiColor4D> (const aiColor4D* pInput,
 }
 
 // ---------------------------------------------------------------------------
-template<>
-inline aiReturn aiMaterial::AddProperty<aiColor3D> (const aiColor3D* pInput,
+inline aiReturn aiMaterial::AddProperty(const aiColor3D* pInput,
 	const unsigned int pNumValues,
 	const char* pKey,
 	unsigned int type,
@@ -242,8 +231,7 @@ inline aiReturn aiMaterial::AddProperty<aiColor3D> (const aiColor3D* pInput,
 }
 
 // ---------------------------------------------------------------------------
-template<>
-inline aiReturn aiMaterial::AddProperty<aiVector3D> (const aiVector3D* pInput,
+inline aiReturn aiMaterial::AddProperty(const aiVector3D* pInput,
 	const unsigned int pNumValues,
 	const char* pKey,
 	unsigned int type,
@@ -255,8 +243,7 @@ inline aiReturn aiMaterial::AddProperty<aiVector3D> (const aiVector3D* pInput,
 }
 
 // ---------------------------------------------------------------------------
-template<>
-inline aiReturn aiMaterial::AddProperty<int> (const int* pInput,
+inline aiReturn aiMaterial::AddProperty(const int* pInput,
 	const unsigned int pNumValues,
 	const char* pKey,
 	unsigned int type,


### PR DESCRIPTION
...s multiple instances of int material properties being accidentally registered as BINARY because the given type was unsigned int.
