### PR TITLE
Blender: map texture influence to aiTextureType

### DIFF
--- a/code/BlenderLoader.cpp
+++ b/code/BlenderLoader.cpp
@@ -446,9 +446,43 @@ void BlenderImporter::ResolveImage(aiMaterial* out, const Material* mat, const M
 	else {
 		name = aiString( img->name );
 	}
-	out->AddProperty(&name,AI_MATKEY_TEXTURE_DIFFUSE(
-		conv_data.next_texture[aiTextureType_DIFFUSE]++)
-	);
+
+	aiTextureType texture_type = aiTextureType_UNKNOWN;
+	MTex::MapType map_type = tex->mapto;
+
+	if (map_type & MTex::MapType_COL)
+	    texture_type = aiTextureType_DIFFUSE;
+	else if (map_type & MTex::MapType_NORM) {
+	    if (tex->tex->imaflag & Tex::ImageFlags_NORMALMAP) {
+	        texture_type = aiTextureType_NORMALS;
+	    }
+	    else {
+	        texture_type = aiTextureType_HEIGHT;
+	    }
+	    out->AddProperty(&tex->norfac,1,AI_MATKEY_BUMPSCALING);
+	}
+	else if (map_type & MTex::MapType_COLSPEC)
+		texture_type = aiTextureType_SPECULAR;
+	else if (map_type & MTex::MapType_COLMIR)
+		texture_type = aiTextureType_REFLECTION;
+	//else if (map_type & MTex::MapType_REF)
+	else if (map_type & MTex::MapType_SPEC)
+		texture_type = aiTextureType_SHININESS;
+	else if (map_type & MTex::MapType_EMIT)
+		texture_type = aiTextureType_EMISSIVE;
+	//else if (map_type & MTex::MapType_ALPHA)
+	//else if (map_type & MTex::MapType_HAR)
+	//else if (map_type & MTex::MapType_RAYMIRR)
+	//else if (map_type & MTex::MapType_TRANSLU)
+	else if (map_type & MTex::MapType_AMB)
+		texture_type = aiTextureType_AMBIENT;
+	else if (map_type & MTex::MapType_DISPLACE)
+		texture_type = aiTextureType_DISPLACEMENT;
+	//else if (map_type & MTex::MapType_WARP)
+
+	out->AddProperty(&name,AI_MATKEY_TEXTURE(texture_type,
+	    conv_data.next_texture[texture_type]++));
+
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/code/BlenderScene.cpp
+++ b/code/BlenderScene.cpp
@@ -100,6 +100,7 @@ template <> void Structure :: Convert<MTex> (
     ) const
 { 
 
+    ReadField<ErrorPolicy_Igno>((short&)dest.mapto,"mapto",db);
     ReadField<ErrorPolicy_Igno>((int&)dest.blendtype,"blendtype",db);
     ReadFieldPtr<ErrorPolicy_Igno>(dest.object,"*object",db);
     ReadFieldPtr<ErrorPolicy_Igno>(dest.tex,"*tex",db);
@@ -126,6 +127,7 @@ template <> void Structure :: Convert<MTex> (
     ReadField<ErrorPolicy_Igno>(dest.specfac,"specfac",db);
     ReadField<ErrorPolicy_Igno>(dest.emitfac,"emitfac",db);
     ReadField<ErrorPolicy_Igno>(dest.hardfac,"hardfac",db);
+    ReadField<ErrorPolicy_Igno>(dest.norfac,"norfac",db);
 
 	db.reader->IncPtr(size);
 }
@@ -608,7 +610,7 @@ template <> void Structure :: Convert<Tex> (
     const FileDatabase& db
     ) const
 { 
-
+    ReadField<ErrorPolicy_Igno>((short&)dest.imaflag,"imaflag",db);
     ReadField<ErrorPolicy_Fail>((int&)dest.type,"type",db);
     ReadFieldPtr<ErrorPolicy_Warn>(dest.ima,"*ima",db);
 

--- a/code/BlenderScene.h
+++ b/code/BlenderScene.h
@@ -598,6 +598,18 @@ struct Tex : ElemBase {
 		,Type_VOXELDATA		= 15
 	};
 
+	enum ImageFlags {
+	     ImageFlags_INTERPOL    	 = 1
+	    ,ImageFlags_USEALPHA    	 = 2
+	    ,ImageFlags_MIPMAP      	 = 4
+	    ,ImageFlags_IMAROT      	 = 16
+	    ,ImageFlags_CALCALPHA   	 = 32
+	    ,ImageFlags_NORMALMAP   	 = 2048
+	    ,ImageFlags_GAUSS_MIP   	 = 4096
+	    ,ImageFlags_FILTER_MIN  	 = 8192
+	    ,ImageFlags_DERIVATIVEMAP   = 16384
+	};
+
 	ID id FAIL;
 	// AnimData *adt; 
 
@@ -618,7 +630,8 @@ struct Tex : ElemBase {
 	//short noisedepth, noisetype;
 	//short noisebasis, noisebasis2;
 
-	//short imaflag, flag;
+	//short flag;
+	ImageFlags imaflag;
 	Type type FAIL;
 	//short stype;
 
@@ -685,7 +698,25 @@ struct MTex : ElemBase {
 		,BlendType_BLEND_COLOR		= 13
 	};
 
-	// short texco, mapto, maptoneg;
+	enum MapType {
+	     MapType_COL         = 1
+	    ,MapType_NORM        = 2
+	    ,MapType_COLSPEC     = 4
+	    ,MapType_COLMIR      = 8
+	    ,MapType_REF         = 16
+	    ,MapType_SPEC        = 32
+	    ,MapType_EMIT        = 64
+	    ,MapType_ALPHA       = 128
+	    ,MapType_HAR         = 256
+	    ,MapType_RAYMIRR     = 512
+	    ,MapType_TRANSLU     = 1024
+	    ,MapType_AMB         = 2048
+	    ,MapType_DISPLACE    = 4096
+	    ,MapType_WARP        = 8192
+	};
+
+	// short texco, maptoneg;
+	MapType mapto;
 
 	BlendType blendtype;
 	boost::shared_ptr<Object> object;
@@ -705,7 +736,8 @@ struct MTex : ElemBase {
 
 	//float colfac, varfac;
 
-	//float norfac, dispfac, warpfac;
+	float norfac;
+	//float dispfac, warpfac;
 	float colspecfac, mirrfac, alphafac;
 	float difffac, specfac, emitfac, hardfac;
 	//float raymirrfac, translfac, ambfac;


### PR DESCRIPTION
Previously assimp mapped all blender image textures as aiTextureType_DIFFUSE.  This change interprets the "mapto" property which corresponds to the Blender "Influence" in the properties editor to corresponding aiTextureType. Otherwise the texture type is aiTextureType_UNKNOWN.

Notes:
- Blender's Normal influence with "Normal Map" unchecked maps to aiTextureType_HEIGHT.
- Blender's Normal influence with "Normal Map" checked maps to aiTextureType_NORMAL.
- Normal influence scale maps to AI_MATKEY_BUMPSCALING.

Wasn't sure about the formatting, please let me know, as I can clean it up. This change will break backwards compatibility to code that expected all textures to be mapped to aiTextureType_DIFFUSE.
