### PR TITLE
 Enable support of FBX 2011 (7100)

### DIFF
--- a/code/FBXDocument.cpp
+++ b/code/FBXDocument.cpp
@@ -292,16 +292,16 @@ void Document::ReadHeader()
 
 	// while we maye have some success with newer files, we don't support
 	// the older 6.n fbx format
-	if(fbxVersion < 7200) {
-		DOMError("unsupported, old format version, supported are only FBX 2012 and FBX 2013");
+	if(fbxVersion < 7100) {
+		DOMError("unsupported, old format version, supported are only FBX 2011, FBX 2012 and FBX 2013");
 	}
 	if(fbxVersion > 7300) {
 		if(Settings().strictMode) {
-			DOMError("unsupported, newer format version, supported are only FBX 2012 and FBX 2013"
+			DOMError("unsupported, newer format version, supported are only FBX 2011, FBX 2012 and FBX 2013"
 				" (turn off strict mode to try anyhow) ");
 		}
 		else {
-			DOMWarning("unsupported, newer format version, supported are only FBX 2012 and FBX 2013,"
+			DOMWarning("unsupported, newer format version, supported are only FBX 2011, FBX 2012 and FBX 2013,"
 				" trying to read it nevertheless");
 		}
 	}


### PR DESCRIPTION
Why isn't FBX 2011 (`7100`) supported by assimp?
I want to know reasons why assimp does not support FBX 2011.
Because the FBX version of FBX 2011 is `7100` (`7.1.0`).
(I have read these issues: #45 and #93.)

```
 $ head example2011ascii.fbx
; FBX 7.1.0 project file
; Copyright (C) 1997-2010 Autodesk Inc. and/or its licensors.
; All rights reserved.
; ----------------------------------------------------

FBXHeaderExtension:  {
    FBXHeaderVersion: 1003
    FBXVersion: 7100
    CreationTimeStamp:  {
        Version: 1000
```

In my environment, Ubuntu 12.04.03 LTS and g++ 4.6,  assimp could import 7 FBX 2011 files which exported by Maya 2012 and 3dsMax 2012 with no error.
Please consider this pull request.
