### PR TITLE
added additional search paths for dll on windows

### DIFF
--- a/port/PyAssimp/pyassimp/helper.py
+++ b/port/PyAssimp/pyassimp/helper.py
@@ -30,7 +30,11 @@ if os.name=='posix':
 
 elif os.name=='nt':
     ext_whitelist.append('.dll')
-
+    path_dirs = os.environ['PATH'].split(';')
+    for dir_candidate in path_dirs:
+        if 'assimp' in dir_candidate.lower():
+            additional_dirs.append(dir_candidate)
+            
 #print(additional_dirs)
 def vec2tuple(x):
     """ Converts a VECTOR3D to a Tuple """


### PR DESCRIPTION
The assimp installer on Windows suggests adding the assimp binary directory to your PATH (in my case C:\Program Files\Assimp\bin\x64). It appeared that (at least on my machine) PyAssimp on Windows was only searching in the current directory for the dll, this change just adds additional search directories from PATH. 
