### PR TITLE
SortByPType Posprocessing crashed for crappy models with degenerated geometry

### DIFF
--- a/code/SortByPTypeProcess.cpp
+++ b/code/SortByPTypeProcess.cpp
@@ -151,7 +151,7 @@ void SortByPTypeProcess::Execute( aiScene* pScene)
 	std::vector<unsigned int>::iterator meshIdx = replaceMeshIndex.begin();
 	for (unsigned int i = 0; i < pScene->mNumMeshes;++i)
 	{
-		aiMesh* mesh = pScene->mMeshes[i];
+		aiMesh* const mesh = pScene->mMeshes[i];
 		ai_assert(0 != mesh->mPrimitiveTypes);
 
 		// if there's just one primitive type in the mesh there's nothing to do for us
@@ -367,6 +367,9 @@ void SortByPTypeProcess::Execute( aiScene* pScene)
 
 		// delete the input mesh
 		delete mesh;
+
+        // avoid invalid pointer
+        pScene->mMeshes[i] = NULL;
 	}
 
 	if (outMeshes.empty())


### PR DESCRIPTION
Which models crashed before the fix?:
The crash was observed for files with the following properties:
1. They contain >=1 meshes
2. They were loaded with SortByPType option
3. They only contained degenerated meshes, so that these were skipped SortByPType

What is improved by the fix?:
Obviously, the affected models were crappy anyway and will still produce empty output after the fix. However, the fix avoids the heap-corruption, which couldn't be solved by try/catch from outside and had the annoying effect that a whole scene with hundreds of individual models could crash due to a single crappy one.

Why did it crash before?
The SortByPType deleted some exluded meshes, but didn't reset the pointers in pScene. After throwing the DeadlyImportException (no remaining meshes), remaining meshes were deleted => Excluded meshes were deleted twice.
