### PR TITLE
Made open method work for UTF8 paths on windows

### DIFF
--- a/code/DefaultIOSystem.cpp
+++ b/code/DefaultIOSystem.cpp
@@ -86,7 +86,14 @@ IOStream* DefaultIOSystem::Open( const char* strFile, const char* strMode)
 	ai_assert(NULL != strFile);
 	ai_assert(NULL != strMode);
 
+#ifdef WIN32
+    wchar_t pFileW[PATHLIMIT];
+    DecodeUTF8(strFile, strlen(strFile), pFileW, PATHLIMIT);
+    
+    FILE* file = ::_wfopen(pFileW, L"rb");
+#else
 	FILE* file = ::fopen( strFile, strMode);
+#endif 
 	if( NULL == file) 
 		return NULL;
 


### PR DESCRIPTION
Fixed: The Open method in DefaultIOSystem did not work for UTF8-Paths in windows

Problem: 
On windows platform, the Open method did only work for ANSI-compatible file paths, e.g. failed for pathnames with german umlauts, chinese characeters etc.

Solution:
srcFile string is now decoded from UTF8 to wstring. For paths that worked before, it makes no difference. But UTF8-paths that failed before will now work as well, because they are called as wstring to _wfopen, so that windows understands them.
