### PR TITLE
3DSLoader: Skipped chunks of size 0

### DIFF
--- a/code/3DSLoader.cpp
+++ b/code/3DSLoader.cpp
@@ -79,6 +79,8 @@ static const aiImporterDesc desc = {
 	Discreet3DS::Chunk chunk;                                            \
 	ReadChunk(&chunk);                                                   \
 	int chunkSize = chunk.Size-sizeof(Discreet3DS::Chunk);	             \
+    if(chunkSize <= 0)                                                   \
+        continue;                                                        \
 	const int oldReadLimit = stream->GetReadLimit();                     \
 	stream->SetReadLimit(stream->GetCurrentPos() + chunkSize);           \
 	


### PR DESCRIPTION
3DSLoader now skips chunks of size 0 to make it more fault tolerant.

Note: 
This is a pretty old fix for which we had no detailed description about the issue being solved. I assume the 3DSLoader did either crash or fail for files with 0-size chunks, so that this change just adds a bit fault tolerance for such files.
