### PR TITLE
ColladaLoader: Added unit conversion to meters

### DIFF
--- a/code/ColladaLoader.cpp
+++ b/code/ColladaLoader.cpp
@@ -176,6 +176,15 @@ void ColladaLoader::InternReadFile( const std::string& pFile, aiScene* pScene, I
 				 0, -1,  0,  0,
 				 0,  0,  0,  1);
         }
+
+    // Convert to meter
+    if( parser.mUnitSize != 1.f )
+        pScene->mRootNode->mTransformation *= aiMatrix4x4( 
+            parser.mUnitSize,  0,  0,  0, 
+            0,  parser.mUnitSize,  0,  0,
+            0,  0,  parser.mUnitSize,  0,
+            0,  0,  0,  1               );
+
 	// store all meshes
 	StoreSceneMeshes( pScene);
 


### PR DESCRIPTION
Applied a scale matrix to consider the unitScale value of Collada files. 
This brings the output uniformly to meters.

Note to developers:
I am not fully sure if it is general enough for AssImp code base. At least for our application, it solved some problems to have the output properly scaled with respect to unit size. So I thought it could be useful for others as well. 
