### PR TITLE
Utf8 paths on windows

### DIFF
--- a/code/DefaultIOSystem.cpp
+++ b/code/DefaultIOSystem.cpp
@@ -167,7 +167,13 @@ DefaultIOSystem::~DefaultIOSystem()
 
 // maximum path length
 // XXX http://insanecoding.blogspot.com/2007/11/pathmax-simply-isnt.html 
-#ifdef PATH_MAX
+#ifdef WIN32 
+    // On Windows systems, ignore PATH_MAX. This makes it possible to support long paths
+    // with AssImp just by converting them to extended path form such as "\\?\D:\very long path"
+    // before passing to AssImp.
+    // See: http://msdn.microsoft.com/en-us/library/windows/desktop/aa365247%28v=vs.85%29.aspx
+#   define PATHLIMIT 8192
+#elif defined(PATH_MAX)
 #	define PATHLIMIT PATH_MAX
 #else
 #	define PATHLIMIT 4096


### PR DESCRIPTION
Fixed problems: (windows only). Opening of files failed if..
- they contained non-ansi UTF8 characeters or
- were longer than 256 characters. 

About UTF8 Fix:
To use AssImp in localized products on windows platforms, it is necessary to support files with special characeters. Annoyingly, windows does not support to directly pass UTF8 paths to standard file I/O methods directly, so that existing calls ::fopen failed on windows for paths with special characters.

=> 
On Windows-Platform, we now convert from UTF8 to wstring and use the wstring file methods. This made the file  I/O work for arbitrary UTF8-paths.

About Long-Paths:
By using ExtendedPath notation in Windows (see code comment line 171 for details), it is possible to access paths beyond the 256 character length limitations. However, this was made impossible by the PATHLIMIT restriction in DefaultIOSystem.cpp. 
=> For windows, I increased the PATHLIMIT value to 8192.
