### PR TITLE
DefaultIOStream::FileSize(): Replaced windows-based version to use mFile directly

### DIFF
--- a/code/DefaultIOStream.cpp
+++ b/code/DefaultIOStream.cpp
@@ -112,11 +112,11 @@ size_t DefaultIOStream::FileSize() const
 
 		// TODO: Is that really faster if we're already owning a handle to the file?
 #if defined _WIN32 && !defined __GNUC__
-		struct __stat64 fileStat; 
-		int err = _stat64(  mFilename.c_str(), &fileStat ); 
-		if (0 != err) 
-			return 0; 
-		cachedSize = (size_t) (fileStat.st_size); 
+
+        int current = ::ftell(mFile);
+        ::fseek(mFile, 0, SEEK_END);
+        cachedSize = (size_t)::ftell(mFile);
+        ::fseek(mFile, current, SEEK_SET);
 #else
 		struct stat fileStat; 
 		int err = stat(mFilename.c_str(), &fileStat ); 


### PR DESCRIPTION
DefaultIOStream::FileSize(): Replaced windows-based version to use mFile directly instead of fileStat

Unfortunately, it is not 100% clear anymore what was the main motivation for this change, because it is several years old and I don't have a changelog of the author. 

It might be related to the TODO comment line in 113 in the original AssImp code. Maybe it was faster or it avoided issues in case that file loaders used exclusive open.

All I know is that this change is not the accidental result of a merge: According to SVN blame, this code section had never been touched since revision 1, i.e. the code section was not just an accidental revert to some older state of the assImp repository. 

Therefore, it seems pretty likely that it fixed some relevant problem in our product - maybe related to loaders with exclusive open. Also, it is used and stable working in our product for years now.
