### PR TITLE
Properly parse 'mg' keyword in .obj files

### DIFF
--- a/code/ObjFileParser.cpp
+++ b/code/ObjFileParser.cpp
@@ -149,9 +149,12 @@ void ObjFileParser::parseFile()
 			}
 			break;
 
-		case 'm': // Parse a material library
+		case 'm': // Parse a material library or merging group ('mg')
 			{
-				getMaterialLib();
+				if (*(m_DataIt + 1) == 'g')
+					getGroupNumberAndResolution();
+				else
+					getMaterialLib();
 			}
 			break;
 
@@ -603,6 +606,15 @@ void ObjFileParser::getGroupName()
 // -------------------------------------------------------------------
 //	Not supported
 void ObjFileParser::getGroupNumber()
+{
+	// Not used
+
+	m_DataIt = skipLine<DataArrayIt>( m_DataIt, m_DataItEnd, m_uiLine );
+}
+
+// -------------------------------------------------------------------
+//	Not supported
+void ObjFileParser::getGroupNumberAndResolution()
 {
 	// Not used
 

--- a/code/ObjFileParser.h
+++ b/code/ObjFileParser.h
@@ -102,6 +102,8 @@ private:
 	void getGroupName();
 	/// Gets the group number from file.
 	void getGroupNumber();
+	/// Gets the group number and resolution from file.
+	void getGroupNumberAndResolution();
 	/// Returns the index of the material. Is -1 if not material was found.
 	int getMaterialIndex( const std::string &strMaterialName );
 	/// Parse object name


### PR DESCRIPTION
The 'mg' keyword is currently being interpreted as a material library keyword,
when it really refers to the merging group.  Handle this case, in effect ignoring
the keyword as merging groups are currently unsupported.
