### PR TITLE
fix for collada parser when importing empty arrays.

### DIFF
--- a/code/ColladaParser.cpp
+++ b/code/ColladaParser.cpp
@@ -1660,7 +1660,6 @@ void ColladaParser::ReadDataArray()
 	std::string id = mReader->getAttributeValue( indexID);
 	int indexCount = GetAttribute( "count");
 	unsigned int count = (unsigned int) mReader->getAttributeValueAsInt( indexCount);
-	if (count == 0) { return; } // some exporters write empty data arrays with count="0"
 	const char* content = TestTextContent();
 
   // read values and store inside an array in the data library


### PR DESCRIPTION
Exiting function so early breaks the parsing procedure, misses node closing and causes improper initialization of element (cannot be referenced later on)
