### PR TITLE
for python binding to work on mac '.dylib'  should be added to ext_whitelist

### DIFF
--- a/port/PyAssimp/pyassimp/helper.py
+++ b/port/PyAssimp/pyassimp/helper.py
@@ -27,6 +27,8 @@ if os.name=='posix':
     # currently there's always a symlink called
     # libassimp.so in /usr/local/lib.
     ext_whitelist.append('.so')
+    # libassimp.dylib in /usr/local/lib
+    ext_whitelist.append('.dylib')
 
 elif os.name=='nt':
     ext_whitelist.append('.dll')


### PR DESCRIPTION
add dylib to ext_whitelist for posix system
