### PR TITLE
Load and save Ke-Value of mtl-Files

### DIFF
--- a/code/ObjExporter.cpp
+++ b/code/ObjExporter.cpp
@@ -152,6 +152,9 @@ void ObjExporter :: WriteMaterialFile()
 		if(AI_SUCCESS == mat->Get(AI_MATKEY_COLOR_SPECULAR,c)) {
 			mOutputMat << "ks " << c.r << " " << c.g << " " << c.b << endl;
 		}
+		if(AI_SUCCESS == mat->Get(AI_MATKEY_COLOR_EMISSIVE,c)) {
+			mOutputMat << "ke " << c.r << " " << c.g << " " << c.b << endl;
+		}
 
 		float o;
 		if(AI_SUCCESS == mat->Get(AI_MATKEY_OPACITY,o)) {

--- a/code/ObjFileData.h
+++ b/code/ObjFileData.h
@@ -183,6 +183,8 @@ struct Material
 	aiColor3D diffuse;
 	//!	Specular color
 	aiColor3D specular;
+	//!	Emissive color
+	aiColor3D emissive;
 	//!	Alpha value
 	float alpha;
 	//!	Shineness factor

--- a/code/ObjFileImporter.cpp
+++ b/code/ObjFileImporter.cpp
@@ -550,6 +550,7 @@ void ObjFileImporter::createMaterials(const ObjFile::Model* pModel, aiScene* pSc
 		mat->AddProperty( &pCurrentMaterial->ambient, 1, AI_MATKEY_COLOR_AMBIENT );
 		mat->AddProperty( &pCurrentMaterial->diffuse, 1, AI_MATKEY_COLOR_DIFFUSE );
 		mat->AddProperty( &pCurrentMaterial->specular, 1, AI_MATKEY_COLOR_SPECULAR );
+		mat->AddProperty( &pCurrentMaterial->emissive, 1, AI_MATKEY_COLOR_EMISSIVE );
 		mat->AddProperty( &pCurrentMaterial->shineness, 1, AI_MATKEY_SHININESS );
 		mat->AddProperty( &pCurrentMaterial->alpha, 1, AI_MATKEY_OPACITY );
 

--- a/code/ObjFileMtlImporter.cpp
+++ b/code/ObjFileMtlImporter.cpp
@@ -146,6 +146,11 @@ void ObjFileMtlImporter::load()
 					++m_DataIt;
 					getColorRGBA( &m_pModel->m_pCurrentMaterial->specular );
 				}
+				else if (*m_DataIt == 'e')
+				{
+					++m_DataIt;
+					getColorRGBA( &m_pModel->m_pCurrentMaterial->emissive );
+				}
 				m_DataIt = skipLine<DataArrayIt>( m_DataIt, m_DataItEnd, m_uiLine );
 			}
 			break;


### PR DESCRIPTION
The ke-Value (the emissive color http://cgkit.sourceforge.net/doc2/objmaterial.html) is stored in AI_MATKEY_COLOR_EMISSIVE.

The exporter exports it the same way.
