### PR TITLE
Fixed half-width from the full-width double quotes.

### DIFF
--- a/port/iOS/IPHONEOS_ARM64_TOOLCHAIN.cmake
+++ b/port/iOS/IPHONEOS_ARM64_TOOLCHAIN.cmake
@@ -2,9 +2,9 @@ INCLUDE(CMakeForceCompiler)
 
 SET (CMAKE_CROSSCOMPILING   TRUE)
 SET (CMAKE_SYSTEM_NAME      "Darwin")
-SET (CMAKE_SYSTEM_PROCESSOR "arm64”)
+SET (CMAKE_SYSTEM_PROCESSOR "arm64")
 
-SET (SDKVER     “7.1”)
+SET (SDKVER     "7.1")
 SET (DEVROOT    "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain")
 SET (SDKROOT    "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS${SDKVER}.sdk")
 SET (CC         "${DEVROOT}/usr/bin/llvm-gcc")

--- a/port/iOS/IPHONEOS_ARMV6_TOOLCHAIN.cmake
+++ b/port/iOS/IPHONEOS_ARMV6_TOOLCHAIN.cmake
@@ -4,10 +4,10 @@ SET (CMAKE_CROSSCOMPILING   TRUE)
 SET (CMAKE_SYSTEM_NAME      "Darwin")
 SET (CMAKE_SYSTEM_PROCESSOR "armv6")
 
-SET (SDKVER     “7.1”)
+SET (SDKVER     "7.1")
 SET (DEVROOT    "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain")
 SET (SDKROOT    "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS${SDKVER}.sdk")
-SET (CC         "${DEVROOT}/usr/bin/clang”)
+SET (CC         "${DEVROOT}/usr/bin/clang")
 SET (CXX        "${DEVROOT}/usr/bin/clang++")
 
 CMAKE_FORCE_C_COMPILER          (${CC} LLVM)

--- a/port/iOS/IPHONEOS_ARMV7S_TOOLCHAIN.cmake
+++ b/port/iOS/IPHONEOS_ARMV7S_TOOLCHAIN.cmake
@@ -2,12 +2,12 @@ INCLUDE(CMakeForceCompiler)
 
 SET (CMAKE_CROSSCOMPILING   TRUE)
 SET (CMAKE_SYSTEM_NAME      "Darwin")
-SET (CMAKE_SYSTEM_PROCESSOR "armv7s”)
+SET (CMAKE_SYSTEM_PROCESSOR "armv7s")
 
-SET (SDKVER     “7.1”)
+SET (SDKVER     "7.1")
 SET (DEVROOT    "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain")
 SET (SDKROOT    "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS${SDKVER}.sdk")
-SET (CC         "${DEVROOT}/usr/bin/clang”)
+SET (CC         "${DEVROOT}/usr/bin/clang")
 SET (CXX        "${DEVROOT}/usr/bin/clang++")
 
 CMAKE_FORCE_C_COMPILER          (${CC} LLVM)

--- a/port/iOS/IPHONEOS_ARMV7_TOOLCHAIN.cmake
+++ b/port/iOS/IPHONEOS_ARMV7_TOOLCHAIN.cmake
@@ -4,10 +4,10 @@ SET (CMAKE_CROSSCOMPILING   TRUE)
 SET (CMAKE_SYSTEM_NAME      "Darwin")
 SET (CMAKE_SYSTEM_PROCESSOR "armv7")
 
-SET (SDKVER     “7.1”)
+SET (SDKVER     "7.1")
 SET (DEVROOT    "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain")
 SET (SDKROOT    "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS${SDKVER}.sdk")
-SET (CC         "${DEVROOT}/usr/bin/clang”)
+SET (CC         "${DEVROOT}/usr/bin/clang")
 SET (CXX        "${DEVROOT}/usr/bin/clang++")
 
 CMAKE_FORCE_C_COMPILER          (${CC} LLVM)

--- a/port/iOS/IPHONEOS_I386_TOOLCHAIN.cmake
+++ b/port/iOS/IPHONEOS_I386_TOOLCHAIN.cmake
@@ -2,13 +2,13 @@ INCLUDE(CMakeForceCompiler)
 
 SET (CMAKE_CROSSCOMPILING   TRUE)
 SET (CMAKE_SYSTEM_NAME      "Darwin")
-SET (CMAKE_SYSTEM_PROCESSOR “i386”)
+SET (CMAKE_SYSTEM_PROCESSOR "i386")
 
-SET (SDKVER     “7.1”)
+SET (SDKVER     "7.1")
 
 SET (DEVROOT    "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain")
 SET (SDKROOT    "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator${SDKVER}.sdk")
-SET (CC         "${DEVROOT}/usr/bin/clang”)
+SET (CC         "${DEVROOT}/usr/bin/clang")
 SET (CXX        "${DEVROOT}/usr/bin/clang++")
 
 CMAKE_FORCE_C_COMPILER          (${CC} LLVM)

--- a/port/iOS/IPHONEOS_X86_64_TOOLCHAIN.cmake
+++ b/port/iOS/IPHONEOS_X86_64_TOOLCHAIN.cmake
@@ -2,13 +2,13 @@ INCLUDE(CMakeForceCompiler)
 
 SET (CMAKE_CROSSCOMPILING   TRUE)
 SET (CMAKE_SYSTEM_NAME      "Darwin")
-SET (CMAKE_SYSTEM_PROCESSOR “x86_64”)
+SET (CMAKE_SYSTEM_PROCESSOR "x86_64")
 
-SET (SDKVER     “7.1”)
+SET (SDKVER     "7.1")
 
 SET (DEVROOT    "/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain")
 SET (SDKROOT    "/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator${SDKVER}.sdk")
-SET (CC         "${DEVROOT}/usr/bin/clang”)
+SET (CC         "${DEVROOT}/usr/bin/clang")
 SET (CXX        "${DEVROOT}/usr/bin/clang++")
 
 CMAKE_FORCE_C_COMPILER          (${CC} LLVM)


### PR DESCRIPTION
Syntax error has occurred while I run the script [build.sh].
I found, some cmake file contains full-width double quotes.
So, please check it and correct.
