### PR TITLE
fixed "<Colors ...> ... </Color>" typo

### DIFF
--- a/tools/assimp_cmd/WriteDumb.cpp
+++ b/tools/assimp_cmd/WriteDumb.cpp
@@ -1258,7 +1258,7 @@ void WriteDump(const aiScene* scene, FILE* out, const char* src, const char* cmd
 							mesh->mColors[a][n].a);
 					}
 				}
-				fprintf(out,"\t\t</Color>\n");
+				fprintf(out,"\t\t</Colors>\n");
 			}
 			fprintf(out,"\t</Mesh>\n");
 		}


### PR DESCRIPTION
The XML tags did not match. Mismatched tags confuse XML parser kits. So I fixed the tags to match.
