### PR TITLE
fix typo, BUILD_SHARED_LIBS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ SET( ASSIMP_BIN_INSTALL_DIR "bin" CACHE PATH
 SET(ASSIMP_DEBUG_POSTFIX "d" CACHE STRING "Debug Postfitx for lib, samples and tools")
 
 # Allow the user to build a static library
-option ( BUILD_SHARED_LIB "Build a shared version of the library" ON )
+option ( BUILD_SHARED_LIBS "Build a shared version of the library" ON )
 
 # Generate a pkg-config .pc for the Assimp library.
 CONFIGURE_FILE( "${PROJECT_SOURCE_DIR}/assimp.pc.in" "${PROJECT_BINARY_DIR}/assimp.pc" @ONLY )


### PR DESCRIPTION
BUILD_SHARED_LIB should be BUILD_SHARED_LIBS for building shared library.
