### PR TITLE
Fix stdint.h include that broke the build for VC9 and below.

### DIFF
--- a/include/assimp/metadata.h
+++ b/include/assimp/metadata.h
@@ -46,7 +46,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define __AI_METADATA_H_INC__
 
 #include <assert.h>
+
+#if defined(_MSC_VER) && (_MSC_VER <= 1500)
+#include "pstdint.h"
+#else
 #include <stdint.h>
+#endif
 
 
 


### PR DESCRIPTION
Hello, I'm not sure if any of you active devs use VC9 for Assimp. Just thought this might be a good think to have in before the 3.1 release as many people will be building it from sources on various compilers.

Let me know if you have some other preference for the preprocessor checks. Not that familiar with your conventions.
