### PR TITLE
fixed OgreImporter compilation error with boost scoped_ptr

### DIFF
--- a/code/OgreImporter.cpp
+++ b/code/OgreImporter.cpp
@@ -108,10 +108,10 @@ void OgreImporter::InternReadFile(const std::string &pFile, aiScene *pScene, Ass
 		MemoryStreamReader reader(f);
 
 		// Import mesh
-		boost::scoped_ptr<Mesh> mesh = OgreBinarySerializer::ImportMesh(&reader);
+		boost::scoped_ptr<Mesh> mesh(OgreBinarySerializer::ImportMesh(&reader));
 
 		// Import skeleton
-		OgreBinarySerializer::ImportSkeleton(pIOHandler, mesh);
+		OgreBinarySerializer::ImportSkeleton(pIOHandler, mesh.get());
 
 		// Import mesh referenced materials
 		ReadMaterials(pFile, pIOHandler, pScene, mesh.get());
@@ -128,10 +128,10 @@ void OgreImporter::InternReadFile(const std::string &pFile, aiScene *pScene, Ass
 		boost::scoped_ptr<XmlReader> reader(irr::io::createIrrXMLReader(xmlStream.get()));
 
 		// Import mesh
-		boost::scoped_ptr<MeshXml> mesh = OgreXmlSerializer::ImportMesh(reader.get());
+		boost::scoped_ptr<MeshXml> mesh(OgreXmlSerializer::ImportMesh(reader.get()));
 		
 		// Import skeleton
-		OgreXmlSerializer::ImportSkeleton(pIOHandler, mesh);
+		OgreXmlSerializer::ImportSkeleton(pIOHandler, mesh.get());
 
 		// Import mesh referenced materials
 		ReadMaterials(pFile, pIOHandler, pScene, mesh.get());

--- a/code/OgreStructs.cpp
+++ b/code/OgreStructs.cpp
@@ -325,7 +325,7 @@ uint32_t VertexData::VertexSize(uint16_t source) const
 MemoryStream *VertexData::VertexBuffer(uint16_t source)
 {
 	if (vertexBindings.find(source) != vertexBindings.end())
-		return vertexBindings[source];
+		return vertexBindings[source].get();
 	return 0;
 }
 


### PR DESCRIPTION
There is compilation errors when building assimp with actual boost, not workaround. boost::scoped_ptr ctor is explicit and requires get to access pointer :)
