### PR TITLE
Fixed vertex reference output format in face element for OBJ exporter

### DIFF
--- a/code/ObjExporter.cpp
+++ b/code/ObjExporter.cpp
@@ -243,11 +243,8 @@ void ObjExporter :: WriteGeometryFile()
 					if (fv.vt) {
 						mOutput << fv.vt;
 					}
-					if (f.kind == 'f') {
-						mOutput << '/';
-						if (fv.vn) {
-							mOutput << fv.vn;
-						}
+					if (f.kind == 'f' && fv.vn) {
+						mOutput << '/' << fv.vn;
 					}
 				}
 			}


### PR DESCRIPTION
In the OBJ spec ( http://www.martinreddy.net/gfx/3d/OBJ.spec ), in the section labeled "Referencing groups of vertices", there is no support for allowing a trailing slash with no valid vertex normal reference at the end. This commit modifies the vertex reference output code to prevent this behavior, as it has been causing compatibility issues with other software that parse OBJ files.
