### PR TITLE
OBJ Exporter: No "g" lines with empty names

### DIFF
--- a/code/ObjExporter.cpp
+++ b/code/ObjExporter.cpp
@@ -228,7 +228,9 @@ void ObjExporter :: WriteGeometryFile()
 	// now write all mesh instances
 	BOOST_FOREACH(const MeshInstance& m, meshes) {
 		mOutput << "# Mesh \'" << m.name << "\' with " << m.faces.size() << " faces" << endl;
-		mOutput << "g " << m.name << endl;
+		if (!m.name.empty()) {
+			mOutput << "g " << m.name << endl;
+		}
 		mOutput << "usemtl " << m.matname << endl;
 
 		BOOST_FOREACH(const Face& f, m.faces) {


### PR DESCRIPTION
In the OBJ spec ( http://www.martinreddy.net/gfx/3d/OBJ.spec ), in the section labeled "Grouping" -> "Syntax", the structure of the "g" group statement is defined. Though this statement allows multiple names on a single line, it is unclear whether there must be at least one name on the line. However, the examples don't show any "g" group statements with no names. So, let's be conservative and not write out a "g" group statement that doesn't have a name. These empty "g" statements were prompting an error message from the three.js OBJ loader code.
