### PR TITLE
Added alpha texture map to object exporter

### DIFF
--- a/code/ObjExporter.cpp
+++ b/code/ObjExporter.cpp
@@ -182,6 +182,9 @@ void ObjExporter::WriteMaterialFile()
 		if(AI_SUCCESS == mat->Get(AI_MATKEY_TEXTURE_SHININESS(0),s)) {
 			mOutputMat << "map_ns " << s.data << endl;
 		}
+		if(AI_SUCCESS == mat->Get(AI_MATKEY_TEXTURE_OPACITY(0),s)) {
+			mOutputMat << "map_d " << s.data << endl;
+		}
 		if(AI_SUCCESS == mat->Get(AI_MATKEY_TEXTURE_HEIGHT(0),s) || AI_SUCCESS == mat->Get(AI_MATKEY_TEXTURE_NORMALS(0),s)) {
 			// implementations seem to vary here, so write both variants
 			mOutputMat << "bump " << s.data << endl;


### PR DESCRIPTION
The object exporter does not add the map_d value for the alpha texture map. This is required if you have a transparent texture like glass. For example:

newmtl glass
Kd 0.730570 0.928152 1.000000
illum 2
Ns 50.781250
map_Kd glasswall_glass_color.jpg
map_d glasswall_glass_alpha.jpg
