### PR TITLE
Fix overflow in STL header colour reading.

### DIFF
--- a/code/STLLoader.cpp
+++ b/code/STLLoader.cpp
@@ -348,8 +348,8 @@ bool STLImporter::LoadBinaryFile()
 	bool bIsMaterialise = false;
 
 	// search for an occurence of "COLOR=" in the header
-	const char* sz2 = (const char*)mBuffer;
-	const char* const szEnd = sz2+80;
+	const unsigned char* sz2 = (const unsigned char*)mBuffer;
+	const unsigned char* const szEnd = sz2+80;
 	while (sz2 < szEnd)	{
 
 		if ('C' == *sz2++ && 'O' == *sz2++ && 'L' == *sz2++ &&


### PR DESCRIPTION
When reading the STL header for a "COLOR=rgb" part, the bytes were treated as signed chars, when in fact they can range from 0-255. This meant that any value greater than 127 would overflow, leading to an incorrect colour.

This change fixes the issue by treating the header as unsigned chars.
