### PR TITLE
Add FieldOfView token type (fixes #245)

### DIFF
--- a/code/FBXProperties.cpp
+++ b/code/FBXProperties.cpp
@@ -105,7 +105,7 @@ Property* ReadTypedProperty(const Element& element)
 			ParseTokenAsFloat(*tok[6]))
 		);
 	}
-	else if (!strcmp(cs,"double") || !strcmp(cs,"Number") || !strcmp(cs,"KTime") || !strcmp(cs,"Float")) {
+	else if (!strcmp(cs,"double") || !strcmp(cs,"Number") || !strcmp(cs,"KTime") || !strcmp(cs,"Float") || !strcmp(cs,"FieldOfView")) {
 		return new TypedProperty<float>(ParseTokenAsFloat(*tok[4]));
 	}
 	return NULL;


### PR DESCRIPTION
"FieldOfView" has its own token type (basically just one float), if it's missing the camera will keep reverting to default FOV in ASSIMP.
