### PR TITLE
Fix wrong nesting

### DIFF
--- a/code/3DSLoader.h
+++ b/code/3DSLoader.h
@@ -273,8 +273,8 @@ protected:
 	bool bIsPrj;
 };
 
-#endif // !! ASSIMP_BUILD_NO_3DS_IMPORTER
-
 } // end of namespace Assimp
+
+#endif // !! ASSIMP_BUILD_NO_3DS_IMPORTER
 
 #endif // AI_3DSIMPORTER_H_INC


### PR DESCRIPTION
Otherwise doesn't compile if ASSIMP_BUILD_NO_3DS_IMPORTER is defined because the #endif is inside the namespace block
