### PR TITLE
Remove std::isnan and std::isinf usage from utFastAtofTest

### DIFF
--- a/code/fast_atof.h
+++ b/code/fast_atof.h
@@ -248,6 +248,9 @@ inline const char* fast_atoreal_move( const char* c, Real& out, bool check_comma
 	if ((c[0] == 'I' || c[0] == 'i') && ASSIMP_strincmp(c, "inf", 3) == 0)
 	{
 		out = std::numeric_limits<Real>::infinity();
+		if (inv) {
+			out = -out;
+		}
 		c += 3;
 		if ((c[0] == 'I' || c[0] == 'i') && ASSIMP_strincmp(c, "inity", 5) == 0)
 		{

--- a/test/unit/utFastAtof.cpp
+++ b/test/unit/utFastAtof.cpp
@@ -2,6 +2,19 @@
 
 #include <fast_atof.h>
 
+namespace {
+
+template <typename Real>
+bool IsNan(Real x) {
+	return x != x;
+}
+
+template <typename Real>
+bool IsInf(Real x) {
+	return std::abs(x) == std::numeric_limits<Real>::infinity();
+}
+
+} // Namespace
 
 class FastAtofTest : public ::testing::Test
 {
@@ -12,8 +25,8 @@ protected:
 		const Real kEps = 1e-5;
 
 #define TEST_CASE(NUM) EXPECT_NEAR(static_cast<Real>(NUM), atof_func(#NUM), kEps)
-#define TEST_CASE_NAN(NUM) EXPECT_TRUE(std::isnan(atof_func(#NUM)))
-#define TEST_CASE_INF(NUM) EXPECT_TRUE(std::isinf(atof_func(#NUM)))
+#define TEST_CASE_NAN(NUM) EXPECT_TRUE(IsNan(atof_func(#NUM)))
+#define TEST_CASE_INF(NUM) EXPECT_TRUE(IsInf(atof_func(#NUM)))
 
 		TEST_CASE(0);
 		TEST_CASE(1.354);


### PR DESCRIPTION
These functions were added in C++11, and should not be used nakedly
in the current code base. Replace them with suitable C++03 constructs.
