### PR TITLE
Fix null check in Q3BSPFileImporter

### DIFF
--- a/code/Q3BSPFileImporter.cpp
+++ b/code/Q3BSPFileImporter.cpp
@@ -641,17 +641,17 @@ bool Q3BSPFileImporter::importTextureFromArchive( const Q3BSP::Q3BSPModel *pMode
 	bool res = true;
 	sQ3BSPTexture *pTexture = pModel->m_Textures[ textureId ];
 	if ( !pTexture ) {
-        return false;
-    }
+		return false;
+	}
 
-    std::vector<std::string> supportedExtensions;
-    supportedExtensions.push_back( ".jpg" );
-    supportedExtensions.push_back( ".png" );
-    supportedExtensions.push_back( ".tga" );
+	std::vector<std::string> supportedExtensions;
+	supportedExtensions.push_back( ".jpg" );
+	supportedExtensions.push_back( ".png" );
+	supportedExtensions.push_back( ".tga" );
 	std::string textureName, ext;
 	if ( expandFile( pArchive, pTexture->strName, supportedExtensions, textureName, ext ) ) {
 		IOStream *pTextureStream = pArchive->Open( textureName.c_str() );
-		if ( !pTextureStream ) {
+		if ( pTextureStream ) {
 			size_t texSize = pTextureStream->FileSize();
 			aiTexture *pTexture = new aiTexture;
 			pTexture->mHeight = 0;


### PR DESCRIPTION
Reverse the null condition, preventing invalid texture stream
dereferencing. Fixes #380.
