### PR TITLE
Fix non-BMesh-containing .blend import

### DIFF
--- a/code/BlenderBMesh.cpp
+++ b/code/BlenderBMesh.cpp
@@ -65,7 +65,6 @@ BlenderBMeshConverter::BlenderBMeshConverter( const Mesh* mesh ):
 	BMesh( mesh ),
 	triMesh( NULL )
 {
-	AssertValidMesh( );
 }
 
 // ------------------------------------------------------------------------------------------------


### PR DESCRIPTION
BlenderBMeshConverter was erroneously asserting that it contained valid
BMesh upon construction. The assertion should only occur when
triangulation is requested, allowing non-BMesh blender meshes to load
properly.

Note that this fixes a number of .blend regression tests that are
currently baselined as failures.
