### PR TITLE
Fix gcc warnings. (initialization order)

### DIFF
--- a/code/FBXBinaryTokenizer.cpp
+++ b/code/FBXBinaryTokenizer.cpp
@@ -55,14 +55,15 @@ namespace FBX {
 
 // ------------------------------------------------------------------------------------------------
 Token::Token(const char* sbegin, const char* send, TokenType type, unsigned int offset)
-	: sbegin(sbegin)
+	: 
+	#ifdef DEBUG
+	contents(sbegin, static_cast<size_t>(send-sbegin)),
+	#endif
+	sbegin(sbegin)
 	, send(send)
 	, type(type)
 	, line(offset)
 	, column(BINARY_MARKER)
-#ifdef DEBUG
-	, contents(sbegin, static_cast<size_t>(send-sbegin))
-#endif
 {
 	ai_assert(sbegin);
 	ai_assert(send);

--- a/code/FBXTokenizer.cpp
+++ b/code/FBXTokenizer.cpp
@@ -58,14 +58,15 @@ namespace FBX {
 
 // ------------------------------------------------------------------------------------------------
 Token::Token(const char* sbegin, const char* send, TokenType type, unsigned int line, unsigned int column)
-	: sbegin(sbegin)
+	:
+#ifdef DEBUG
+	contents(sbegin, static_cast<size_t>(send-sbegin)),
+#endif
+	sbegin(sbegin)
 	, send(send)
 	, type(type)
 	, line(line)
 	, column(column)
-#ifdef DEBUG
-	, contents(sbegin, static_cast<size_t>(send-sbegin))
-#endif
 {
 	ai_assert(sbegin);
 	ai_assert(send);


### PR DESCRIPTION
When compiling with -Wall -Werror in debug mode assimp fails to build because of wrong initialization order.
Token::contents must be initialized before any other in constructor.
