### PR TITLE
Null-terminate string

### DIFF
--- a/code/AssbinLoader.cpp
+++ b/code/AssbinLoader.cpp
@@ -138,6 +138,7 @@ aiString Read<aiString>(IOStream * stream)
 	aiString s;
 	stream->Read(&s.length,4,1);
 	stream->Read(s.data,s.length,1);
+	s.data[s.length] = 0;
 	return s;
 }
 


### PR DESCRIPTION
In theory it shouldn't be necessary since the length is specified but there are parts like https://github.com/assimp/assimp/blob/master/code/MaterialSystem.cpp#L74 that depend on it.
