### PR TITLE
Replaced 'xrange' by 'range' to maintain Python 3.x compatibility.

### DIFF
--- a/port/PyAssimp/pyassimp/core.py
+++ b/port/PyAssimp/pyassimp/core.py
@@ -50,7 +50,7 @@ def make_tuple(ai_obj, type = None):
 
 # It is faster and more correct to have an init function for each assimp class
 def _init_face(aiFace):
-    aiFace.indices = [aiFace.mIndices[i] for i in xrange(aiFace.mNumIndices)]
+    aiFace.indices = [aiFace.mIndices[i] for i in range(aiFace.mNumIndices)]
     
 assimp_struct_inits =  { structs.Face : _init_face }
     


### PR DESCRIPTION
Hi, I noticed an 'xrange' that slipped into the code. I changed it
to a normal 'range' command to maintain Python 2/3 compatibility.

Thank you for creating the PyAssimp wrapper.

Best, Oli
