### PR TITLE
Default to latest installed iOS SDK by default

### DIFF
--- a/port/iOS/build.sh
+++ b/port/iOS/build.sh
@@ -6,7 +6,7 @@
 
 BUILD_DIR="./lib/iOS"
 
-IOS_SDK_VERSION=7.1
+IOS_SDK_VERSION=
 IOS_SDK_TARGET=6.0
 #(iPhoneOS iPhoneSimulator) -- determined from arch
 IOS_SDK_DEVICE=


### PR DESCRIPTION
The iOS 7.1 SDK isn't available anymore in the current version of Xcode, so the script doesn't work without modification.
By setting IOS_SDK_VERSION to an empty value, the script will default to a symlink\* which always points to the latest installed SDK.
- /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk
