### PR TITLE
Fix incorrect abs usage

### DIFF
--- a/code/IFCCurve.cpp
+++ b/code/IFCCurve.cpp
@@ -91,7 +91,7 @@ public:
 		a = std::fmod(a,static_cast<IfcFloat>( AI_MATH_TWO_PI ));
 		b = std::fmod(b,static_cast<IfcFloat>( AI_MATH_TWO_PI ));
 		const IfcFloat setting = static_cast<IfcFloat>( AI_MATH_PI * conv.settings.conicSamplingAngle / 180.0 );
-		return static_cast<size_t>( std::ceil(abs( b-a)) / setting);
+		return static_cast<size_t>( std::ceil(std::abs( b-a)) / setting);
 	}
 
 	// --------------------------------------------------
@@ -276,7 +276,7 @@ public:
 		IfcFloat acc = 0;
 		BOOST_FOREACH(const CurveEntry& entry, curves) {
 			const ParamRange& range = entry.first->GetParametricRange();
-			const IfcFloat delta = abs(range.second-range.first);
+			const IfcFloat delta = std::abs(range.second-range.first);
 			if (u < acc+delta) {
 				return entry.first->Eval( entry.second ? (u-acc) + range.first : range.second-(u-acc));
 			}
@@ -295,7 +295,7 @@ public:
 		IfcFloat acc = 0;
 		BOOST_FOREACH(const CurveEntry& entry, curves) {
 			const ParamRange& range = entry.first->GetParametricRange();
-			const IfcFloat delta = abs(range.second-range.first);
+			const IfcFloat delta = std::abs(range.second-range.first);
 			if (a <= acc+delta && b >= acc) {
 				const IfcFloat at =  std::max(static_cast<IfcFloat>( 0. ),a-acc), bt = std::min(delta,b-acc);
 				cnt += entry.first->EstimateSampleCount( entry.second ? at + range.first : range.second - bt, entry.second ? bt + range.first : range.second - at );
@@ -569,7 +569,7 @@ bool Curve :: InRange(IfcFloat u) const
 IfcFloat Curve :: GetParametricRangeDelta() const
 {
 	const ParamRange& range = GetParametricRange();
-	return abs(range.second - range.first);
+	return std::abs(range.second - range.first);
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/code/IFCGeometry.cpp
+++ b/code/IFCGeometry.cpp
@@ -375,21 +375,21 @@ void ProcessSweptDiskSolid(const IfcSweptDiskSolid solid, TempMesh& result, Conv
 		bool take_any = false;
 
 		for (unsigned int i = 0; i < 2; ++i, take_any = true) {
-			if ((last_dir == 0 || take_any) && abs(d.x) > 1e-6) {
+			if ((last_dir == 0 || take_any) && std::abs(d.x) > 1e-6) {
 				q.y = startvec.y;
 				q.z = startvec.z;
 				q.x = -(d.y * q.y + d.z * q.z) / d.x;
 				last_dir = 0;
 				break;
 			}
-			else if ((last_dir == 1 || take_any) && abs(d.y) > 1e-6) {
+			else if ((last_dir == 1 || take_any) && std::abs(d.y) > 1e-6) {
 				q.x = startvec.x;
 				q.z = startvec.z;
 				q.y = -(d.x * q.x + d.z * q.z) / d.y;
 				last_dir = 1;
 				break;
 			}
-			else if ((last_dir == 2 && abs(d.z) > 1e-6) || take_any) { 
+			else if ((last_dir == 2 && std::abs(d.z) > 1e-6) || take_any) {
 				q.y = startvec.y;
 				q.x = startvec.x;
 				q.z = -(d.y * q.y + d.x * q.x) / d.z;

--- a/code/IFCOpenings.cpp
+++ b/code/IFCOpenings.cpp
@@ -1244,7 +1244,7 @@ bool GenerateOpenings(std::vector<TempOpening>& openings,
 				const IfcVector3& face_nor = ((profile_verts[vi_total+2] - profile_verts[vi_total]) ^
 					(profile_verts[vi_total+1] - profile_verts[vi_total])).Normalize();
 
-				const IfcFloat abs_dot_face_nor = abs(nor * face_nor);
+				const IfcFloat abs_dot_face_nor = std::abs(nor * face_nor);
 				if (abs_dot_face_nor < 0.9) {
 					vi_total += profile_vertcnts[f];
 					continue;


### PR DESCRIPTION
Replace calls to abs with a float to calls to std::abs. Before int abs(int) was being called.