### PR TITLE
Use correct header for INT_MAX

### DIFF
--- a/include/assimp/metadata.h
+++ b/include/assimp/metadata.h
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #if defined(_MSC_VER) && (_MSC_VER <= 1500)
 #include "Compiler/pstdint.h"
 #else
-#include <stdint.h>
+#include <limits.h>
 #endif
 
 

--- a/include/assimp/metadata.h
+++ b/include/assimp/metadata.h
@@ -51,6 +51,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "Compiler/pstdint.h"
 #else
 #include <limits.h>
+#include <stdint.h>
 #endif
 
 


### PR DESCRIPTION
INT_MAX is defined in limits.h, not stdint.h