### PR TITLE
Fixed error of aiQuaterniont::Rotate()

### DIFF
--- a/include/assimp/quaternion.inl
+++ b/include/assimp/quaternion.inl
@@ -273,11 +273,10 @@ template<typename TReal>
 inline aiVector3t<TReal> aiQuaterniont<TReal>::Rotate (const aiVector3t<TReal>& v)
 {
 	aiQuaterniont q2(0.f,v.x,v.y,v.z), q = *this, qinv = q;
-	q.Conjugate();
+	qinv.Conjugate();
 
 	q = q*q2*qinv;
 	return aiVector3t<TReal>(q.x,q.y,q.z);
-
 }
 
 #endif


### PR DESCRIPTION
The function rotates a point to opposite direction.
Conjugate() should be applied to inverse of the quaternion.