### PR TITLE
Fix some infinite loops

### DIFF
--- a/code/PlyParser.cpp
+++ b/code/PlyParser.cpp
@@ -436,7 +436,7 @@ bool PLY::DOM::ParseHeader (const char* pCur,const char** pCurOut,bool isBinary)
 	*pCurOut = pCur;
 
 	// parse all elements
-	while (true)
+	while ((*pCur) != '\0')
 	{
 		// skip all comments
 		PLY::DOM::SkipComments(pCur,&pCur);

--- a/code/STLLoader.cpp
+++ b/code/STLLoader.cpp
@@ -326,8 +326,10 @@ void STLImporter::LoadASCIIFile()
 			break;
 		}
 		// else skip the whole identifier
-		else while (!::IsSpaceOrNewLine(*sz)) {
-			++sz;
+		else {
+			do {
+				++sz;
+			} while (!::IsSpaceOrNewLine(*sz));
 		}
 	}
 

--- a/code/STLLoader.cpp
+++ b/code/STLLoader.cpp
@@ -308,6 +308,7 @@ void STLImporter::LoadASCIIFile()
 		{
 			if (3 == curVertex)	{
 				DefaultLogger::get()->error("STL: a facet with more than 3 vertices has been found");
+				++sz;
 			}
 			else
 			{


### PR DESCRIPTION
Fixes some (but nowhere near all) of hanging inputs in #454. No new testsuite regressions on Linux which is not very useful since 81 cases currently fail even without any modifications.

Also you might want to add these testcases to the suite since at least one of them hits an error path that appears to have been completely untested until now.