### PR TITLE
Fix division by zero

### DIFF
--- a/code/IFCUtil.cpp
+++ b/code/IFCUtil.cpp
@@ -122,7 +122,7 @@ void TempMesh::Transform(const IfcMatrix4& mat)
 // ------------------------------------------------------------------------------
 IfcVector3 TempMesh::Center() const
 {
-	return std::accumulate(verts.begin(),verts.end(),IfcVector3()) / static_cast<IfcFloat>(verts.size());
+	return (verts.size() == 0) ? IfcVector3(0.0f, 0.0f, 0.0f) : (std::accumulate(verts.begin(),verts.end(),IfcVector3()) / static_cast<IfcFloat>(verts.size()));
 }
 
 // ------------------------------------------------------------------------------------------------


### PR DESCRIPTION
There are at least two other places where division by zero happens during processing of test/models/IFC/AC14-FZK-Haus.ifc

In PolyTools.h line 86 function PointInTriangle2D is called from TriangulateProcess.cpp line 392.

It seems that the triangle is almost but not quite degenerate. Dumping the variables I get this:
p0: 0.000000 0.680000
p1: 1.800000 0.679900
p2: 1.800000 0.680000
pp: 0.000000 0.000000
v0: 1.800000 -0.000100
v1: 1.800000 0.000000
v2: 0.000000 -0.680000
dot00: 3.240000
dot01: 3.240000
dot02: 0.000068
dot11: 3.240000
dot12: 0.000000
denom: 0.000000

Is it correct to change PointInTriangle2D to avoid divzero (by always adding FLT_MIN to denominator) or should the conditions in TriangulateProcess be changed?


In vector3.inl line 100 function Normalize() is called from GenVertexNormalsProcess.cpp line 193.
verticesFound.size() = 1
vertex 312
pMesh->mNormals[312] is a zero vector. Normalizing it ends up dividing by zero.

Should this method be changed and/or should the general case of normalizing a zero vector do something sane?

Note that changing Normalize() to either check for 0 or adding FLT_MIN to denominator causes a lot of regression failures.
Dividing by zero is undefined behavior so the compiler is theoretically free to do whatever it pleases. The most common result seems to be NaNs which are not healthy for anything.