### PR TITLE
Clean up some warnings

### DIFF
--- a/code/3DSExporter.cpp
+++ b/code/3DSExporter.cpp
@@ -294,7 +294,7 @@ void Discreet3DSExporter::WriteMaterials()
 			WriteColor(color);
 		}
 
-		aiShadingMode shading_mode;
+		aiShadingMode shading_mode = aiShadingMode_Flat;
 		if (mat.Get(AI_MATKEY_SHADING_MODEL, shading_mode) == AI_SUCCESS) {
 			ChunkWriter chunk(writer, Discreet3DS::CHUNK_MAT_SHADING);
 

--- a/code/ASEParser.cpp
+++ b/code/ASEParser.cpp
@@ -168,7 +168,7 @@ void Parser::LogInfo(const char* szWarn)
 }
 
 // ------------------------------------------------------------------------------------------------
-void Parser::LogError(const char* szWarn)
+AI_WONT_RETURN void Parser::LogError(const char* szWarn)
 {
 	ai_assert(NULL != szWarn);
 

--- a/code/ASEParser.h
+++ b/code/ASEParser.h
@@ -602,7 +602,7 @@ private:
 	// -------------------------------------------------------------------
 	//! Output an error to the logger
 	//! \param szWarn Error message
-	void LogError(const char* szWarn);
+	AI_WONT_RETURN void LogError(const char* szWarn) AI_WONT_RETURN_SUFFIX;
 
 	// -------------------------------------------------------------------
 	//! Parse a string, enclosed in double quotation marks

--- a/code/AssbinExporter.cpp
+++ b/code/AssbinExporter.cpp
@@ -273,13 +273,13 @@ inline size_t WriteArray(IOStream * stream, const T* in, unsigned int size)
 			if (buffer) delete[] buffer;
 		}
 
-		void * GetBufferPointer() { return buffer; };
+		void * GetBufferPointer() { return buffer; }
 
 		// -------------------------------------------------------------------
-		virtual size_t Read(void* /*pvBuffer*/, size_t /*pSize*/, size_t /*pCount*/) { return 0; };
-		virtual aiReturn Seek(size_t /*pOffset*/, aiOrigin /*pOrigin*/) { return aiReturn_FAILURE; };
-		virtual size_t Tell() const { return cursor; };
-		virtual void Flush() { };
+		virtual size_t Read(void* /*pvBuffer*/, size_t /*pSize*/, size_t /*pCount*/) { return 0; }
+		virtual aiReturn Seek(size_t /*pOffset*/, aiOrigin /*pOrigin*/) { return aiReturn_FAILURE; }
+		virtual size_t Tell() const { return cursor; }
+		virtual void Flush() { }
 
 		virtual size_t FileSize() const
 		{

--- a/code/B3DImporter.cpp
+++ b/code/B3DImporter.cpp
@@ -127,12 +127,12 @@ void B3DImporter::InternReadFile( const std::string& pFile, aiScene* pScene, IOS
 }
 
 // ------------------------------------------------------------------------------------------------
-void B3DImporter::Oops(){
+AI_WONT_RETURN void B3DImporter::Oops(){
 	throw DeadlyImportError( "B3D Importer - INTERNAL ERROR" );
 }
 
 // ------------------------------------------------------------------------------------------------
-void B3DImporter::Fail( string str ){
+AI_WONT_RETURN void B3DImporter::Fail( string str ){
 #ifdef DEBUG_B3D
 	cout<<"Error in B3D file data: "<<str<<endl;
 #endif

--- a/code/B3DImporter.h
+++ b/code/B3DImporter.h
@@ -87,8 +87,8 @@ private:
 		float weights[4];
 	};
 
-	void Oops();
-	void Fail( std::string str );
+	AI_WONT_RETURN void Oops() AI_WONT_RETURN_SUFFIX;
+	AI_WONT_RETURN void Fail( std::string str ) AI_WONT_RETURN_SUFFIX;
 
 	void ReadTEXS();
 	void ReadBRUS();

--- a/code/BVHLoader.cpp
+++ b/code/BVHLoader.cpp
@@ -413,7 +413,7 @@ float BVHLoader::GetNextTokenAsFloat()
 
 // ------------------------------------------------------------------------------------------------
 // Aborts the file reading with an exception
-void BVHLoader::ThrowException( const std::string& pError)
+AI_WONT_RETURN void BVHLoader::ThrowException( const std::string& pError)
 {
 	throw DeadlyImportError( boost::str( boost::format( "%s:%d - %s") % mFileName % mLine % pError));
 }

--- a/code/BVHLoader.h
+++ b/code/BVHLoader.h
@@ -134,7 +134,7 @@ protected:
 	float GetNextTokenAsFloat();
 
 	/** Aborts the file reading with an exception */
-	void ThrowException( const std::string& pError);
+	AI_WONT_RETURN void ThrowException( const std::string& pError) AI_WONT_RETURN_SUFFIX;
 
 	/** Constructs an animation for the motion data and stores it in the given scene */
 	void CreateAnimation( aiScene* pScene);

--- a/code/COBLoader.cpp
+++ b/code/COBLoader.cpp
@@ -127,7 +127,7 @@ void COBImporter::SetupProperties(const Importer* /*pImp*/)
 }
 
 // ------------------------------------------------------------------------------------------------
-/*static*/ void COBImporter::ThrowException(const std::string& msg)
+/*static*/ AI_WONT_RETURN void COBImporter::ThrowException(const std::string& msg)
 {
 	throw DeadlyImportError("COB: "+msg);
 }

--- a/code/COBLoader.h
+++ b/code/COBLoader.h
@@ -95,7 +95,7 @@ private:
 
 	// -------------------------------------------------------------------
 	/** Prepend 'COB: ' and throw msg.*/
-	static void ThrowException(const std::string& msg);
+	AI_WONT_RETURN static void ThrowException(const std::string& msg) AI_WONT_RETURN_SUFFIX;
 
 	// -------------------------------------------------------------------
 	/** @brief Read from an ascii scene/object file

--- a/code/ColladaExporter.cpp
+++ b/code/ColladaExporter.cpp
@@ -452,7 +452,7 @@ void ColladaExporter::WriteMaterials()
 	  }
 	}
 
-	aiShadingMode shading;
+	aiShadingMode shading = aiShadingMode_Flat;
 	materials[a].shading_model = "phong";
 	if(mat->Get( AI_MATKEY_SHADING_MODEL, shading) == aiReturn_SUCCESS) {
 		if(shading == aiShadingMode_Phong) {

--- a/code/ColladaParser.cpp
+++ b/code/ColladaParser.cpp
@@ -2659,7 +2659,7 @@ void ColladaParser::ReadScene()
 
 // ------------------------------------------------------------------------------------------------
 // Aborts the file reading with an exception
-void ColladaParser::ThrowException( const std::string& pError) const
+AI_WONT_RETURN void ColladaParser::ThrowException( const std::string& pError) const
 {
 	throw DeadlyImportError( boost::str( boost::format( "Collada: %s - %s") % mFileName % pError));
 }

--- a/code/ColladaParser.h
+++ b/code/ColladaParser.h
@@ -212,7 +212,7 @@ protected:
 
 protected:
 	/** Aborts the file reading with an exception */
-	void ThrowException( const std::string& pError) const;
+	AI_WONT_RETURN void ThrowException( const std::string& pError) const AI_WONT_RETURN_SUFFIX;
 
 	/** Skips all data until the end node of the current element */
 	void SkipElement();

--- a/code/ComputeUVMappingProcess.cpp
+++ b/code/ComputeUVMappingProcess.cpp
@@ -454,7 +454,7 @@ void ComputeUVMappingProcess::Execute( aiScene* pScene)
 						for (unsigned int m = 0; m < pScene->mNumMeshes;++m)
 						{
 							aiMesh* mesh = pScene->mMeshes[m];
-							unsigned int outIdx;
+							unsigned int outIdx = 0;
 							if ( mesh->mMaterialIndex != i || ( outIdx = FindEmptyUVChannel(mesh) ) == UINT_MAX ||
 								!mesh->mNumVertices)
 							{

--- a/code/FBXBinaryTokenizer.cpp
+++ b/code/FBXBinaryTokenizer.cpp
@@ -78,7 +78,8 @@ namespace {
 
 // ------------------------------------------------------------------------------------------------
 // signal tokenization error, this is always unrecoverable. Throws DeadlyImportError.
-void TokenizeError(const std::string& message, unsigned int offset)
+AI_WONT_RETURN void TokenizeError(const std::string& message, unsigned int offset) AI_WONT_RETURN_SUFFIX;
+AI_WONT_RETURN void TokenizeError(const std::string& message, unsigned int offset)
 {
 	throw DeadlyImportError(Util::AddOffset("FBX-Tokenize",message,offset));
 }

--- a/code/FBXConverter.cpp
+++ b/code/FBXConverter.cpp
@@ -1256,8 +1256,11 @@ private:
 				// taking notes so we don't need to do it twice.
 				BOOST_FOREACH(WeightIndexArray::value_type index, indices) {
 
-					unsigned int count;
+					unsigned int count = 0;
 					const unsigned int* const out_idx = geo.ToOutputVertexIndex(index, count);
+					// ToOutputVertexIndex only returns NULL if index is out of bounds
+					// which should never happen
+					ai_assert(out_idx != NULL);
 
 					index_out_indices.push_back(no_index_sentinel);
 					count_out_indices.push_back(0);

--- a/code/FBXDocument.h
+++ b/code/FBXDocument.h
@@ -242,20 +242,20 @@ public:
 
 public:
 
-	fbx_simple_property(Position, aiVector3D, aiVector3D(0,0,0));
-	fbx_simple_property(UpVector, aiVector3D, aiVector3D(0,1,0));
-	fbx_simple_property(InterestPosition, aiVector3D, aiVector3D(0,0,0));
+	fbx_simple_property(Position, aiVector3D, aiVector3D(0,0,0))
+	fbx_simple_property(UpVector, aiVector3D, aiVector3D(0,1,0))
+	fbx_simple_property(InterestPosition, aiVector3D, aiVector3D(0,0,0))
 
-	fbx_simple_property(AspectWidth, float, 1.0f);
-	fbx_simple_property(AspectHeight, float, 1.0f);
-	fbx_simple_property(FilmWidth, float, 1.0f);
-	fbx_simple_property(FilmHeight, float, 1.0f);
+	fbx_simple_property(AspectWidth, float, 1.0f)
+	fbx_simple_property(AspectHeight, float, 1.0f)
+	fbx_simple_property(FilmWidth, float, 1.0f)
+	fbx_simple_property(FilmHeight, float, 1.0f)
 
-	fbx_simple_property(FilmAspectRatio, float, 1.0f);
-	fbx_simple_property(ApertureMode, int, 0);
+	fbx_simple_property(FilmAspectRatio, float, 1.0f)
+	fbx_simple_property(ApertureMode, int, 0)
 
-	fbx_simple_property(FieldOfView, float, 1.0f);
-	fbx_simple_property(FocalLength, float, 1.0f);
+	fbx_simple_property(FieldOfView, float, 1.0f)
+	fbx_simple_property(FocalLength, float, 1.0f)
 
 private:
 };
@@ -314,37 +314,37 @@ public:
 
 public:
 
-	fbx_simple_property(Color, aiVector3D, aiVector3D(1,1,1));
-	fbx_simple_enum_property(LightType, Type, 0);
-	fbx_simple_property(CastLightOnObject, bool, false);
-	fbx_simple_property(DrawVolumetricLight, bool, true);
-	fbx_simple_property(DrawGroundProjection, bool, true);
-	fbx_simple_property(DrawFrontFacingVolumetricLight, bool, false);
-	fbx_simple_property(Intensity, float, 1.0f);
-	fbx_simple_property(InnerAngle, float, 0.0f);
-	fbx_simple_property(OuterAngle, float, 45.0f);
-	fbx_simple_property(Fog, int, 50);
-	fbx_simple_enum_property(DecayType, Decay, 0);
-	fbx_simple_property(DecayStart, int, 0);
-	fbx_simple_property(FileName, std::string, "");
+	fbx_simple_property(Color, aiVector3D, aiVector3D(1,1,1))
+	fbx_simple_enum_property(LightType, Type, 0)
+	fbx_simple_property(CastLightOnObject, bool, false)
+	fbx_simple_property(DrawVolumetricLight, bool, true)
+	fbx_simple_property(DrawGroundProjection, bool, true)
+	fbx_simple_property(DrawFrontFacingVolumetricLight, bool, false)
+	fbx_simple_property(Intensity, float, 1.0f)
+	fbx_simple_property(InnerAngle, float, 0.0f)
+	fbx_simple_property(OuterAngle, float, 45.0f)
+	fbx_simple_property(Fog, int, 50)
+	fbx_simple_enum_property(DecayType, Decay, 0)
+	fbx_simple_property(DecayStart, int, 0)
+	fbx_simple_property(FileName, std::string, "")
 
-	fbx_simple_property(EnableNearAttenuation, bool, false);
-	fbx_simple_property(NearAttenuationStart, float, 0.0f);
-	fbx_simple_property(NearAttenuationEnd, float, 0.0f);
-	fbx_simple_property(EnableFarAttenuation, bool, false);
-	fbx_simple_property(FarAttenuationStart, float, 0.0f);
-	fbx_simple_property(FarAttenuationEnd, float, 0.0f);
+	fbx_simple_property(EnableNearAttenuation, bool, false)
+	fbx_simple_property(NearAttenuationStart, float, 0.0f)
+	fbx_simple_property(NearAttenuationEnd, float, 0.0f)
+	fbx_simple_property(EnableFarAttenuation, bool, false)
+	fbx_simple_property(FarAttenuationStart, float, 0.0f)
+	fbx_simple_property(FarAttenuationEnd, float, 0.0f)
 
-	fbx_simple_property(CastShadows, bool, true);
-	fbx_simple_property(ShadowColor, aiVector3D, aiVector3D(0,0,0));
+	fbx_simple_property(CastShadows, bool, true)
+	fbx_simple_property(ShadowColor, aiVector3D, aiVector3D(0,0,0))
 
-	fbx_simple_property(AreaLightShape, int, 0);
+	fbx_simple_property(AreaLightShape, int, 0)
 
-	fbx_simple_property(LeftBarnDoor, float, 20.0f);
-	fbx_simple_property(RightBarnDoor, float, 20.0f);
-	fbx_simple_property(TopBarnDoor, float, 20.0f);
-	fbx_simple_property(BottomBarnDoor, float, 20.0f);
-	fbx_simple_property(EnableBarnDoor, bool, true);
+	fbx_simple_property(LeftBarnDoor, float, 20.0f)
+	fbx_simple_property(RightBarnDoor, float, 20.0f)
+	fbx_simple_property(TopBarnDoor, float, 20.0f)
+	fbx_simple_property(BottomBarnDoor, float, 20.0f)
+	fbx_simple_property(EnableBarnDoor, bool, true)
 
 
 private:
@@ -387,81 +387,81 @@ public:
 
 public:
 
-	fbx_simple_property(QuaternionInterpolate, int, 0);
+	fbx_simple_property(QuaternionInterpolate, int, 0)
 
-	fbx_simple_property(RotationOffset, aiVector3D, aiVector3D());
-	fbx_simple_property(RotationPivot, aiVector3D, aiVector3D());
-	fbx_simple_property(ScalingOffset, aiVector3D, aiVector3D());
-	fbx_simple_property(ScalingPivot, aiVector3D, aiVector3D());
-	fbx_simple_property(TranslationActive, bool, false);
+	fbx_simple_property(RotationOffset, aiVector3D, aiVector3D())
+	fbx_simple_property(RotationPivot, aiVector3D, aiVector3D())
+	fbx_simple_property(ScalingOffset, aiVector3D, aiVector3D())
+	fbx_simple_property(ScalingPivot, aiVector3D, aiVector3D())
+	fbx_simple_property(TranslationActive, bool, false)
 
-	fbx_simple_property(TranslationMin, aiVector3D, aiVector3D());
-	fbx_simple_property(TranslationMax, aiVector3D, aiVector3D());
+	fbx_simple_property(TranslationMin, aiVector3D, aiVector3D())
+	fbx_simple_property(TranslationMax, aiVector3D, aiVector3D())
 
-	fbx_simple_property(TranslationMinX, bool, false);
-	fbx_simple_property(TranslationMaxX, bool, false);
-	fbx_simple_property(TranslationMinY, bool, false);
-	fbx_simple_property(TranslationMaxY, bool, false);
-	fbx_simple_property(TranslationMinZ, bool, false);
-	fbx_simple_property(TranslationMaxZ, bool, false);
+	fbx_simple_property(TranslationMinX, bool, false)
+	fbx_simple_property(TranslationMaxX, bool, false)
+	fbx_simple_property(TranslationMinY, bool, false)
+	fbx_simple_property(TranslationMaxY, bool, false)
+	fbx_simple_property(TranslationMinZ, bool, false)
+	fbx_simple_property(TranslationMaxZ, bool, false)
 
-	fbx_simple_enum_property(RotationOrder, RotOrder, 0);
-	fbx_simple_property(RotationSpaceForLimitOnly, bool, false);
-	fbx_simple_property(RotationStiffnessX, float, 0.0f);
-	fbx_simple_property(RotationStiffnessY, float, 0.0f);
-	fbx_simple_property(RotationStiffnessZ, float, 0.0f);
-	fbx_simple_property(AxisLen, float, 0.0f);
+	fbx_simple_enum_property(RotationOrder, RotOrder, 0)
+	fbx_simple_property(RotationSpaceForLimitOnly, bool, false)
+	fbx_simple_property(RotationStiffnessX, float, 0.0f)
+	fbx_simple_property(RotationStiffnessY, float, 0.0f)
+	fbx_simple_property(RotationStiffnessZ, float, 0.0f)
+	fbx_simple_property(AxisLen, float, 0.0f)
 
-	fbx_simple_property(PreRotation, aiVector3D, aiVector3D());
-	fbx_simple_property(PostRotation, aiVector3D, aiVector3D());
-	fbx_simple_property(RotationActive, bool, false);
+	fbx_simple_property(PreRotation, aiVector3D, aiVector3D())
+	fbx_simple_property(PostRotation, aiVector3D, aiVector3D())
+	fbx_simple_property(RotationActive, bool, false)
 
-	fbx_simple_property(RotationMin, aiVector3D, aiVector3D());
-	fbx_simple_property(RotationMax, aiVector3D, aiVector3D());
+	fbx_simple_property(RotationMin, aiVector3D, aiVector3D())
+	fbx_simple_property(RotationMax, aiVector3D, aiVector3D())
 
-	fbx_simple_property(RotationMinX, bool, false);
-	fbx_simple_property(RotationMaxX, bool, false);
-	fbx_simple_property(RotationMinY, bool, false);
-	fbx_simple_property(RotationMaxY, bool, false);
-	fbx_simple_property(RotationMinZ, bool, false);
-	fbx_simple_property(RotationMaxZ, bool, false);
-	fbx_simple_enum_property(InheritType, TransformInheritance, 0);
+	fbx_simple_property(RotationMinX, bool, false)
+	fbx_simple_property(RotationMaxX, bool, false)
+	fbx_simple_property(RotationMinY, bool, false)
+	fbx_simple_property(RotationMaxY, bool, false)
+	fbx_simple_property(RotationMinZ, bool, false)
+	fbx_simple_property(RotationMaxZ, bool, false)
+	fbx_simple_enum_property(InheritType, TransformInheritance, 0)
 
-	fbx_simple_property(ScalingActive, bool, false);
-	fbx_simple_property(ScalingMin, aiVector3D, aiVector3D());
-	fbx_simple_property(ScalingMax, aiVector3D, aiVector3D(1.f,1.f,1.f));
-	fbx_simple_property(ScalingMinX, bool, false);
-	fbx_simple_property(ScalingMaxX, bool, false);
-	fbx_simple_property(ScalingMinY, bool, false);
-	fbx_simple_property(ScalingMaxY, bool, false);
-	fbx_simple_property(ScalingMinZ, bool, false);
-	fbx_simple_property(ScalingMaxZ, bool, false);
+	fbx_simple_property(ScalingActive, bool, false)
+	fbx_simple_property(ScalingMin, aiVector3D, aiVector3D())
+	fbx_simple_property(ScalingMax, aiVector3D, aiVector3D(1.f,1.f,1.f))
+	fbx_simple_property(ScalingMinX, bool, false)
+	fbx_simple_property(ScalingMaxX, bool, false)
+	fbx_simple_property(ScalingMinY, bool, false)
+	fbx_simple_property(ScalingMaxY, bool, false)
+	fbx_simple_property(ScalingMinZ, bool, false)
+	fbx_simple_property(ScalingMaxZ, bool, false)
 
-	fbx_simple_property(GeometricTranslation, aiVector3D, aiVector3D());
-	fbx_simple_property(GeometricRotation, aiVector3D, aiVector3D());
-	fbx_simple_property(GeometricScaling, aiVector3D, aiVector3D(1.f, 1.f, 1.f));
+	fbx_simple_property(GeometricTranslation, aiVector3D, aiVector3D())
+	fbx_simple_property(GeometricRotation, aiVector3D, aiVector3D())
+	fbx_simple_property(GeometricScaling, aiVector3D, aiVector3D(1.f, 1.f, 1.f))
 
-	fbx_simple_property(MinDampRangeX, float, 0.0f);
-	fbx_simple_property(MinDampRangeY, float, 0.0f);
-	fbx_simple_property(MinDampRangeZ, float, 0.0f);
-	fbx_simple_property(MaxDampRangeX, float, 0.0f);
-	fbx_simple_property(MaxDampRangeY, float, 0.0f);
-	fbx_simple_property(MaxDampRangeZ, float, 0.0f);
+	fbx_simple_property(MinDampRangeX, float, 0.0f)
+	fbx_simple_property(MinDampRangeY, float, 0.0f)
+	fbx_simple_property(MinDampRangeZ, float, 0.0f)
+	fbx_simple_property(MaxDampRangeX, float, 0.0f)
+	fbx_simple_property(MaxDampRangeY, float, 0.0f)
+	fbx_simple_property(MaxDampRangeZ, float, 0.0f)
 
-	fbx_simple_property(MinDampStrengthX, float, 0.0f);
-	fbx_simple_property(MinDampStrengthY, float, 0.0f);
-	fbx_simple_property(MinDampStrengthZ, float, 0.0f);
-	fbx_simple_property(MaxDampStrengthX, float, 0.0f);
-	fbx_simple_property(MaxDampStrengthY, float, 0.0f);
-	fbx_simple_property(MaxDampStrengthZ, float, 0.0f);
+	fbx_simple_property(MinDampStrengthX, float, 0.0f)
+	fbx_simple_property(MinDampStrengthY, float, 0.0f)
+	fbx_simple_property(MinDampStrengthZ, float, 0.0f)
+	fbx_simple_property(MaxDampStrengthX, float, 0.0f)
+	fbx_simple_property(MaxDampStrengthY, float, 0.0f)
+	fbx_simple_property(MaxDampStrengthZ, float, 0.0f)
 
-	fbx_simple_property(PreferredAngleX, float, 0.0f);
-	fbx_simple_property(PreferredAngleY, float, 0.0f);
-	fbx_simple_property(PreferredAngleZ, float, 0.0f);
+	fbx_simple_property(PreferredAngleX, float, 0.0f)
+	fbx_simple_property(PreferredAngleY, float, 0.0f)
+	fbx_simple_property(PreferredAngleZ, float, 0.0f)
 
-	fbx_simple_property(Show, bool, true);
-	fbx_simple_property(LODBox, bool, false);
-	fbx_simple_property(Freeze, bool, false);
+	fbx_simple_property(Show, bool, true)
+	fbx_simple_property(LODBox, bool, false)
+	fbx_simple_property(Freeze, bool, false)
 
 public:
 
@@ -1015,10 +1015,10 @@ public:
 
 public:
 
-	fbx_simple_property(LocalStart, uint64_t, 0L);
-	fbx_simple_property(LocalStop, uint64_t, 0L);
-	fbx_simple_property(ReferenceStart, uint64_t, 0L);
-	fbx_simple_property(ReferenceStop, uint64_t, 0L);
+	fbx_simple_property(LocalStart, uint64_t, 0L)
+	fbx_simple_property(LocalStop, uint64_t, 0L)
+	fbx_simple_property(ReferenceStart, uint64_t, 0L)
+	fbx_simple_property(ReferenceStop, uint64_t, 0L)
 
 
 
@@ -1227,18 +1227,18 @@ public:
 	}
 
 
-	fbx_simple_property(UpAxis, int, 1);
-	fbx_simple_property(UpAxisSign, int, 1);
-	fbx_simple_property(FrontAxis, int, 2);
-	fbx_simple_property(FrontAxisSign, int, 1);
-	fbx_simple_property(CoordAxis, int, 0);
-	fbx_simple_property(CoordAxisSign, int, 1);
-	fbx_simple_property(OriginalUpAxis, int, 0);
-	fbx_simple_property(OriginalUpAxisSign, int, 1);
-	fbx_simple_property(UnitScaleFactor, double, 1);
-	fbx_simple_property(OriginalUnitScaleFactor, double, 1);
-	fbx_simple_property(AmbientColor, aiVector3D, aiVector3D(0,0,0));
-	fbx_simple_property(DefaultCamera, std::string, "");
+	fbx_simple_property(UpAxis, int, 1)
+	fbx_simple_property(UpAxisSign, int, 1)
+	fbx_simple_property(FrontAxis, int, 2)
+	fbx_simple_property(FrontAxisSign, int, 1)
+	fbx_simple_property(CoordAxis, int, 0)
+	fbx_simple_property(CoordAxisSign, int, 1)
+	fbx_simple_property(OriginalUpAxis, int, 0)
+	fbx_simple_property(OriginalUpAxisSign, int, 1)
+	fbx_simple_property(UnitScaleFactor, double, 1)
+	fbx_simple_property(OriginalUnitScaleFactor, double, 1)
+	fbx_simple_property(AmbientColor, aiVector3D, aiVector3D(0,0,0))
+	fbx_simple_property(DefaultCamera, std::string, "")
 
 
 	enum FrameRate {
@@ -1261,10 +1261,10 @@ public:
 		FrameRate_MAX// end-of-enum sentinel
 	};
 
-	fbx_simple_enum_property(TimeMode, FrameRate, FrameRate_DEFAULT);
-	fbx_simple_property(TimeSpanStart, uint64_t, 0L);
-	fbx_simple_property(TimeSpanStop, uint64_t, 0L);
-	fbx_simple_property(CustomFrameRate, float, -1.0f);
+	fbx_simple_enum_property(TimeMode, FrameRate, FrameRate_DEFAULT)
+	fbx_simple_property(TimeSpanStart, uint64_t, 0L)
+	fbx_simple_property(TimeSpanStop, uint64_t, 0L)
+	fbx_simple_property(CustomFrameRate, float, -1.0f)
 
 
 private:

--- a/code/FBXParser.cpp
+++ b/code/FBXParser.cpp
@@ -68,13 +68,15 @@ namespace {
 
 	// ------------------------------------------------------------------------------------------------
 	// signal parse error, this is always unrecoverable. Throws DeadlyImportError.
-	void ParseError(const std::string& message, const Token& token)
+	AI_WONT_RETURN void ParseError(const std::string& message, const Token& token) AI_WONT_RETURN_SUFFIX;
+	AI_WONT_RETURN void ParseError(const std::string& message, const Token& token)
 	{
 		throw DeadlyImportError(Util::AddTokenText("FBX-Parser",message,&token));
 	}
 
 	// ------------------------------------------------------------------------------------------------
-	void ParseError(const std::string& message, const Element* element = NULL)
+	AI_WONT_RETURN void ParseError(const std::string& message, const Element* element = NULL) AI_WONT_RETURN_SUFFIX;
+	AI_WONT_RETURN void ParseError(const std::string& message, const Element* element)
 	{
 		if(element) {
 			ParseError(message,element->KeyToken());

--- a/code/FBXTokenizer.cpp
+++ b/code/FBXTokenizer.cpp
@@ -86,7 +86,8 @@ namespace {
 
 // ------------------------------------------------------------------------------------------------
 // signal tokenization error, this is always unrecoverable. Throws DeadlyImportError.
-void TokenizeError(const std::string& message, unsigned int line, unsigned int column)
+AI_WONT_RETURN void TokenizeError(const std::string& message, unsigned int line, unsigned int column) AI_WONT_RETURN_SUFFIX;
+AI_WONT_RETURN void TokenizeError(const std::string& message, unsigned int line, unsigned int column)
 {
 	throw DeadlyImportError(Util::AddLineAndColumn("FBX-Tokenize",message,line,column));
 }

--- a/code/MD5Parser.cpp
+++ b/code/MD5Parser.cpp
@@ -88,7 +88,7 @@ MD5Parser::MD5Parser(char* _buffer, unsigned int _fileSize )
 
 // ------------------------------------------------------------------------------------------------
 // Report error to the log stream
-/*static*/ void MD5Parser::ReportError (const char* error, unsigned int line)
+/*static*/ AI_WONT_RETURN void MD5Parser::ReportError (const char* error, unsigned int line)
 {
 	char szBuffer[1024];
 	::sprintf(szBuffer,"[MD5] Line %i: %s",line,error);

--- a/code/MD5Parser.h
+++ b/code/MD5Parser.h
@@ -367,7 +367,7 @@ public:
 	 *  @param error Error message to be reported
 	 *  @param line Index of the line where the error occured
 	 */
-	static void ReportError (const char* error, unsigned int line);
+	AI_WONT_RETURN static void ReportError (const char* error, unsigned int line) AI_WONT_RETURN_SUFFIX;
 
 	// -------------------------------------------------------------------
 	/** Report a specific warning

--- a/code/OgreXmlSerializer.cpp
+++ b/code/OgreXmlSerializer.cpp
@@ -54,7 +54,8 @@ namespace Assimp
 namespace Ogre
 {
 
-void ThrowAttibuteError(const XmlReader* reader, const std::string &name, const std::string &error = "")
+AI_WONT_RETURN void ThrowAttibuteError(const XmlReader* reader, const std::string &name, const std::string &error = "") AI_WONT_RETURN_SUFFIX;
+AI_WONT_RETURN void ThrowAttibuteError(const XmlReader* reader, const std::string &name, const std::string &error)
 {
 	if (!error.empty())
 	{

--- a/code/TextureTransform.cpp
+++ b/code/TextureTransform.cpp
@@ -120,7 +120,7 @@ void TextureTransformStep::PreProcessUVTransform(STransformVecInfo& info)
 	 * offset 2 and 3)
 	 */
 	if ((rounded  = (int)info.mTranslation.x))	{
-		float out;
+		float out = 0.0f;
 		szTemp[0] = 0;
 		if (aiTextureMapMode_Wrap == info.mapU)	{
 			// Wrap - simple take the fraction of the field
@@ -153,7 +153,7 @@ void TextureTransformStep::PreProcessUVTransform(STransformVecInfo& info)
 	 * offset 2 and 3)
 	 */
 	if ((rounded  = (int)info.mTranslation.y))	{
-		float out;
+		float out = 0.0f;
 		szTemp[0] = 0;
 		if (aiTextureMapMode_Wrap == info.mapV)	{
 			// Wrap - simple take the fraction of the field

--- a/code/XFileParser.cpp
+++ b/code/XFileParser.cpp
@@ -1432,7 +1432,7 @@ aiColor3D XFileParser::ReadRGB()
 
 // ------------------------------------------------------------------------------------------------
 // Throws an exception with a line number and the given text.
-void XFileParser::ThrowException( const std::string& pText)
+AI_WONT_RETURN void XFileParser::ThrowException( const std::string& pText)
 {
 	if( mIsBinaryFormat)
 		throw DeadlyImportError( pText);

--- a/code/XFileParser.h
+++ b/code/XFileParser.h
@@ -134,7 +134,7 @@ protected:
 	aiColor4D ReadRGBA();
 
 	/** Throws an exception with a line number and the given text. */
-	void ThrowException( const std::string& pText);
+	AI_WONT_RETURN void ThrowException( const std::string& pText) AI_WONT_RETURN_SUFFIX;
 
 	/** Filters the imported hierarchy for some degenerated cases that some exporters produce.
 	 * @param pData The sub-hierarchy to filter

--- a/code/irrXMLWrapper.h
+++ b/code/irrXMLWrapper.h
@@ -102,7 +102,7 @@ public:
 
 	// ----------------------------------------------------------------------------------
 	//! Virtual destructor
-	virtual ~CIrrXML_IOStreamReader() {};
+	virtual ~CIrrXML_IOStreamReader() {}
 
 	// ----------------------------------------------------------------------------------
 	//!   Reads an amount of bytes from the file.

--- a/include/assimp/Importer.hpp
+++ b/include/assimp/Importer.hpp
@@ -624,8 +624,8 @@ public:
 
 	// -------------------------------------------------------------------
 	/** Private, do not use. */
-	ImporterPimpl* Pimpl() { return pimpl; };
-	const ImporterPimpl* Pimpl() const { return pimpl; };
+	ImporterPimpl* Pimpl() { return pimpl; }
+	const ImporterPimpl* Pimpl() const { return pimpl; }
 
 protected:
 

--- a/include/assimp/ProgressHandler.hpp
+++ b/include/assimp/ProgressHandler.hpp
@@ -99,7 +99,7 @@ public:
 	virtual void UpdateFileRead(int currentStep /*= 0*/, int numberOfSteps /*= 0*/) {
 		float f = numberOfSteps ? currentStep / (float)numberOfSteps : 1.0f;
 		Update( f * 0.5f );
-	};
+	}
 
 	// -------------------------------------------------------------------
 	/** @brief Progress callback for post-processing steps
@@ -113,7 +113,7 @@ public:
 	virtual void UpdatePostProcess(int currentStep /*= 0*/, int numberOfSteps /*= 0*/) {
 		float f = numberOfSteps ? currentStep / (float)numberOfSteps : 1.0f;
 		Update( f * 0.5f + 0.5f );
-	};
+	}
 
 }; // !class ProgressHandler 
 // ------------------------------------------------------------------------------------

--- a/include/assimp/defs.h
+++ b/include/assimp/defs.h
@@ -162,8 +162,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #	define AI_FORCE_INLINE inline
 #endif // (defined _MSC_VER)
 
-#ifdef __clang__
-#	define AI_WONT_RETURN_SUFFIX  __attribute__((analyzer_noreturn))
+#ifdef __GNUC__
+#	define AI_WONT_RETURN_SUFFIX  __attribute__((noreturn))
 #else
 #	define AI_WONT_RETURN_SUFFIX
 #endif // (defined __clang__)

--- a/tools/assimp_cmd/CompareDump.cpp
+++ b/tools/assimp_cmd/CompareDump.cpp
@@ -221,7 +221,7 @@ public:
 private:
 
 	/* Report failure */
-	void failure(const std::string& err, const std::string& name) {
+	AI_WONT_RETURN void failure(const std::string& err, const std::string& name) AI_WONT_RETURN_SUFFIX {
 		std::stringstream ss;
 		throw compare_fails_exception((ss
 			<< "Files are different at " 


### PR DESCRIPTION
Cleans up some compiler warnings. No new regression failures on Linux with GCC. Review and run testsuite on a working config before merging. Also the recent changes to the test suite seem to have made mode cases fail (101 currently vs 96 previous).