### PR TITLE
Fixed many doxygen errors

### DIFF
--- a/include/assimp/DefaultLogger.hpp
+++ b/include/assimp/DefaultLogger.hpp
@@ -37,7 +37,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ----------------------------------------------------------------------
 */
-/** @file DefaultLogger.h
+/** @file DefaultLogger.hpp
 */
 
 #ifndef INCLUDED_AI_DEFAULTLOGGER

--- a/include/assimp/Exporter.hpp
+++ b/include/assimp/Exporter.hpp
@@ -39,7 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ---------------------------------------------------------------------------
 */
 
-/** @file  export.hpp
+/** @file  Exporter.hpp
 *  @brief Defines the CPP-API for the Assimp export interface
 */
 #ifndef AI_EXPORT_HPP_INC
@@ -181,7 +181,7 @@ public:
 	 *  about the output data flow of the export process.
 	 * @param pBlob A data blob obtained from a previous call to #aiExportScene. Must not be NULL.
 	 * @param pPath Full target file name. Target must be accessible.
-	 * @param pPreprocessing Accepts any choice of the #aiPostProcessing enumerated
+	 * @param pPreprocessing Accepts any choice of the #aiPostProcessSteps enumerated
 	 *   flags, but in reality only a subset of them makes sense here. Specifying
 	 *   'preprocessing' flags is useful if the input scene does not conform to 
 	 *   Assimp's default conventions as specified in the @link data Data Structures Page @endlink. 

--- a/include/assimp/IOStream.hpp
+++ b/include/assimp/IOStream.hpp
@@ -38,7 +38,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ---------------------------------------------------------------------------
 */
-/** @file IOStream.h
+/** @file IOStream.hpp
  *  @brief File I/O wrappers for C++. 
  */
 

--- a/include/assimp/IOSystem.hpp
+++ b/include/assimp/IOSystem.hpp
@@ -39,7 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ---------------------------------------------------------------------------
 */
 
-/** @file IOSystem.h
+/** @file IOSystem.hpp
  *  @brief File system wrapper for C++. Inherit this class to supply
  *  custom file handling logic to the Import library.
 */

--- a/include/assimp/Importer.hpp
+++ b/include/assimp/Importer.hpp
@@ -39,7 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ---------------------------------------------------------------------------
 */
 
-/** @file  assimp.hpp
+/** @file  Importer.hpp
  *  @brief Defines the C++-API to the Open Asset Import Library.
  */
 #ifndef INCLUDED_AI_ASSIMP_HPP

--- a/include/assimp/LogStream.hpp
+++ b/include/assimp/LogStream.hpp
@@ -38,7 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------
 */
 
-/** @file LogStream.h
+/** @file LogStream.hpp
  *  @brief Abstract base class 'LogStream', representing an output log stream.
  */
 #ifndef INCLUDED_AI_LOGSTREAM_H

--- a/include/assimp/NullLogger.hpp
+++ b/include/assimp/NullLogger.hpp
@@ -38,7 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------
 */
 
-/** @file  NullLogger.h
+/** @file  NullLogger.hpp
  *  @brief Dummy logger
 */
 

--- a/include/assimp/ProgressHandler.hpp
+++ b/include/assimp/ProgressHandler.hpp
@@ -38,7 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------
 */
 
-/** @file ProgressHandler.h
+/** @file ProgressHandler.hpp
  *  @brief Abstract base class 'ProgressHandler'.
  */
 #ifndef INCLUDED_AI_PROGRESSHANDLER_H

--- a/include/assimp/ai_assert.h
+++ b/include/assimp/ai_assert.h
@@ -1,4 +1,4 @@
-/** @file assert.h
+/** @file ai_assert.h
  */
 #ifndef AI_DEBUG_H_INC
 #define AI_DEBUG_H_INC

--- a/include/assimp/cexport.h
+++ b/include/assimp/cexport.h
@@ -122,10 +122,7 @@ ASSIMP_API void aiFreeScene(const C_STRUCT aiScene* pIn);
 * @param pFormatId ID string to specify to which format you want to export to. Use 
 * aiGetExportFormatCount() / aiGetExportFormatDescription() to learn which export formats are available.
 * @param pFileName Output file to write
-* @param pIO custom IO implementation to be used. Use this if you use your own storage methods.
-*   If none is supplied, a default implementation using standard file IO is used. Note that
-*   #aiExportSceneToBlob is provided as convenience function to export to memory buffers.
-* @param pPreprocessing Accepts any choice of the #aiPostProcessing enumerated
+* @param pPreprocessing Accepts any choice of the #aiPostProcessSteps enumerated
 *   flags, but in reality only a subset of them makes sense here. Specifying
 *   'preprocessing' flags is useful if the input scene does not conform to 
 *   Assimp's default conventions as specified in the @link data Data Structures Page @endlink. 
@@ -183,7 +180,7 @@ ASSIMP_API aiReturn aiExportSceneEx( const C_STRUCT aiScene* pScene,
 
 // --------------------------------------------------------------------------------
 /** Describes a blob of exported scene data. Use #aiExportSceneToBlob() to create a blob containing an
-* exported scene. The memory referred by this structure is owned by Assimp. Use #aiReleaseExportedFile()
+* exported scene. The memory referred by this structure is owned by Assimp. 
 * to free its resources. Don't try to free the memory on your side - it will crash for most build configurations
 * due to conflicting heaps.
 *

--- a/include/assimp/cfileio.h
+++ b/include/assimp/cfileio.h
@@ -39,7 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ---------------------------------------------------------------------------
 */
 
-/** @file aiFileIO.h
+/** @file cfileio.h
  *  @brief Defines generic C routines to access memory-mapped files
  */
 #ifndef AI_FILEIO_H_INC

--- a/include/assimp/color4.h
+++ b/include/assimp/color4.h
@@ -38,7 +38,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ---------------------------------------------------------------------------
 */
-/** @file aiColor4D.h
+/** @file color4.h
  *  @brief RGBA color structure, including operators when compiling in C++
  */
 #ifndef AI_COLOR4D_H_INC

--- a/include/assimp/color4.inl
+++ b/include/assimp/color4.inl
@@ -39,7 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ---------------------------------------------------------------------------
 */
 
-/** @file  aiColor4D.inl
+/** @file  color4.inl
  *  @brief Inline implementation of aiColor4t<TReal> operators
  */
 #ifndef AI_COLOR4D_INL_INC

--- a/include/assimp/config.h
+++ b/include/assimp/config.h
@@ -209,7 +209,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	"PP_RRM_EXCLUDE_LIST"
 
 // ---------------------------------------------------------------------------
-/** @brief Configures the #aiProcess_PretransformVertices step to
+/** @brief Configures the #aiProcess_PreTransformVertices step to
  *  keep the scene hierarchy. Meshes are moved to worldspace, but
  *  no optimization is performed (read: meshes with equal materials are not 
  *  joined. The total number of meshes won't change).
@@ -224,7 +224,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	"PP_PTV_KEEP_HIERARCHY"
 
 // ---------------------------------------------------------------------------
-/** @brief Configures the #aiProcess_PretransformVertices step to normalize
+/** @brief Configures the #aiProcess_PreTransformVertices step to normalize
  *  all vertex components into the [-1,1] range. That is, a bounding box
  *  for the whole scene is computed, the maximum component is taken and all
  *  meshes are scaled appropriately (uniformly of course!).
@@ -234,7 +234,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	"PP_PTV_NORMALIZE"
 
 // ---------------------------------------------------------------------------
-/** @brief Configures the #aiProcess_PretransformVertices step to use
+/** @brief Configures the #aiProcess_PreTransformVertices step to use
  *  a users defined matrix as the scene root node transformation before
  *  transforming vertices. 
  *  Property type: bool. Default value: false.
@@ -243,7 +243,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	"PP_PTV_ADD_ROOT_TRANSFORMATION"
 
 // ---------------------------------------------------------------------------
-/** @brief Configures the #aiProcess_PretransformVertices step to use
+/** @brief Configures the #aiProcess_PreTransformVertices step to use
  *  a users defined matrix as the scene root node transformation before
  *  transforming vertices. This property correspond to the 'a1' component
  *  of the transformation matrix.
@@ -376,7 +376,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // ---------------------------------------------------------------------------
 /** @brief Enumerates components of the aiScene and aiMesh data structures
- *  that can be excluded from the import using the #aiPrpcess_RemoveComponent step.
+ *  that can be excluded from the import using the #aiProcess_RemoveComponent step.
  *
  *  See the documentation to #aiProcess_RemoveComponent for more details.
  */
@@ -715,7 +715,7 @@ enum aiComponent
 /** @brief  Tells the MD3 loader which skin files to load.
  *
  * When loading MD3 files, Assimp checks whether a file 
- * <md3_file_name>_<skin_name>.skin is existing. These files are used by
+ * [md3_file_name]_[skin_name].skin is existing. These files are used by
  * Quake III to be able to assign different skins (e.g. red and blue team) 
  * to models. 'default', 'red', 'blue' are typical skin names.
  * Property type: String. Default value: "default".
@@ -728,14 +728,14 @@ enum aiComponent
  *  MD3 file. This can also be a search path.
  *
  * By default Assimp's behaviour is as follows: If a MD3 file 
- * <tt><any_path>/models/<any_q3_subdir>/<model_name>/<file_name>.md3</tt> is 
+ * <tt>any_path/models/any_q3_subdir/model_name/file_name.md3</tt> is 
  * loaded, the library tries to locate the corresponding shader file in
- * <tt><any_path>/scripts/<model_name>.shader</tt>. This property overrides this
+ * <tt>any_path/scripts/model_name.shader</tt>. This property overrides this
  * behaviour. It can either specify a full path to the shader to be loaded
  * or alternatively the path (relative or absolute) to the directory where
  * the shaders for all MD3s to be loaded reside. Assimp attempts to open 
- * <tt><dir>/<model_name>.shader</tt> first, <tt><dir>/<file_name>.shader</tt> 
- * is the fallback file. Note that <dir> should have a terminal (back)slash.
+ * <tt>IMPORT_MD3_SHADER_SRC/model_name.shader</tt> first, <tt>IMPORT_MD3_SHADER_SRC/file_name.shader</tt> 
+ * is the fallback file. Note that IMPORT_MD3_SHADER_SRC should have a terminal (back)slash.
  * Property type: String. Default value: n/a.
  */
 #define AI_CONFIG_IMPORT_MD3_SHADER_SRC \
@@ -818,12 +818,13 @@ enum aiComponent
 /** @brief Ogre Importer detect the texture usage from its filename.
  *
  * Ogre material texture units do not define texture type, the textures usage
- * depends on the used shader or Ogres fixed pipeline. If this config property
+ * depends on the used shader or Ogre's fixed pipeline. If this config property
  * is true Assimp will try to detect the type from the textures filename postfix:
  * _n, _nrm, _nrml, _normal, _normals and _normalmap for normal map, _s, _spec,
  * _specular and _specularmap for specular map, _l, _light, _lightmap, _occ 
  * and _occlusion for light map, _disp and _displacement for displacement map.
- * The matching is case insensitive. Post fix is taken between last "_" and last ".".
+ * The matching is case insensitive. Post fix is taken between the last 
+ * underscore and the last period.
  * Default behavior is to detect type from lower cased texture unit name by 
  * matching against: normalmap, specularmap, lightmap and displacementmap.
  * For both cases if no match is found aiTextureType_DIFFUSE is used.

--- a/include/assimp/defs.h
+++ b/include/assimp/defs.h
@@ -39,7 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ---------------------------------------------------------------------------
 */
 
-/** @file aiDefines.h
+/** @file defs.h
  *  @brief Assimp build configuration setup. See the notes in the comment
  *  blocks to find out how to customize _your_ Assimp build.
  */

--- a/include/assimp/importerdesc.h
+++ b/include/assimp/importerdesc.h
@@ -98,8 +98,7 @@ struct aiImporterDesc
 	/** Implementation comments, i.e. unimplemented features*/
 	const char* mComments;
 
-	/** Any combination of the #aiLoaderFlags enumerated values.
-	    These flags indicate some characteristics common to many
+	/** These flags indicate some characteristics common to many
 		importers. */
 	unsigned int mFlags;
 

--- a/include/assimp/material.h
+++ b/include/assimp/material.h
@@ -95,14 +95,9 @@ enum aiTextureOp
 	aiTextureOp_SignedAdd = 0x5,
 
 
-	/** @cond never 
-	 *  This value is not used. It forces the compiler to use at least
-	 *  32 Bit integers to represent this enum.
-	 */
 #ifndef SWIG
 	_aiTextureOp_Force32Bit = INT_MAX
 #endif
-	//! @endcond
 };
 
 // ---------------------------------------------------------------------------
@@ -131,14 +126,9 @@ enum aiTextureMapMode
      */
     aiTextureMapMode_Mirror = 0x2,
 
-	 /** @cond never 
-	  *  This value is not used. It forces the compiler to use at least
-	  *  32 Bit integers to represent this enum.
-	  */
 #ifndef SWIG
 	_aiTextureMapMode_Force32Bit = INT_MAX
 #endif
-	//! @endcond
 };
 
 // ---------------------------------------------------------------------------
@@ -176,14 +166,9 @@ enum aiTextureMapping
     aiTextureMapping_OTHER = 0x5,
 
 
-	 /** @cond never 
-	  *  This value is not used. It forces the compiler to use at least
-	  *  32 Bit integers to represent this enum.
-	  */
 #ifndef SWIG
 	_aiTextureMapping_Force32Bit = INT_MAX
 #endif
-	//! @endcond
 };
 
 // ---------------------------------------------------------------------------
@@ -296,14 +281,9 @@ enum aiTextureType
     aiTextureType_UNKNOWN = 0xC,
 
 
-	 /** @cond never 
-	  *  This value is not used. It forces the compiler to use at least
-	  *  32 Bit integers to represent this enum.
-	  */
 #ifndef SWIG
 	_aiTextureType_Force32Bit = INT_MAX
 #endif
-	//! @endcond
 };
 
 #define AI_TEXTURE_TYPE_MAX  aiTextureType_UNKNOWN
@@ -374,14 +354,9 @@ enum aiShadingMode
     aiShadingMode_Fresnel = 0xa,
 
 
-	 /** @cond never 
-	  *  This value is not used. It forces the compiler to use at least
-	  *  32 Bit integers to represent this enum.
-	  */
 #ifndef SWIG
 	_aiShadingMode_Force32Bit = INT_MAX
 #endif
-	//! @endcond
 };
 
 
@@ -420,14 +395,9 @@ enum aiTextureFlags
 	 */
 	aiTextureFlags_IgnoreAlpha = 0x4,
 	
-	 /** @cond never 
-	  *  This value is not used. It forces the compiler to use at least
-	  *  32 Bit integers to represent this enum.
-	  */
 #ifndef SWIG
 	  _aiTextureFlags_Force32Bit = INT_MAX
 #endif
-	//! @endcond
 };
 
 
@@ -442,8 +412,8 @@ enum aiTextureFlags
  *  @code
  *    SourceColor * SourceBlend + DestColor * DestBlend
  *  @endcode
- *  where <DestColor> is the previous color in the framebuffer at this
- *  position and <SourceColor> is the material colro before the transparency
+ *  where DestColor is the previous color in the framebuffer at this
+ *  position and SourceColor is the material colro before the transparency
  *  calculation.<br>
  *  This corresponds to the #AI_MATKEY_BLEND_FUNC property.
 */
@@ -469,14 +439,9 @@ enum aiBlendMode
 	// we don't need more for the moment, but we might need them
 	// in future versions ...
 
-	 /** @cond never 
-	  *  This value is not used. It forces the compiler to use at least
-	  *  32 Bit integers to represent this enum.
-	  */
 #ifndef SWIG
 	_aiBlendMode_Force32Bit = INT_MAX
 #endif
-	//! @endcond
 };
 
 
@@ -862,7 +827,9 @@ public:
 	/** @brief Remove a given key from the list.
 	 *
 	 *  The function fails if the key isn't found
-	 *  @param pKey Key to be deleted */
+	 *  @param pKey Key to be deleted 
+	 *  @param type Set by the AI_MATKEY_XXX macro
+	 *  @param index Set by the AI_MATKEY_XXX macro  */
 	aiReturn RemoveProperty (const char* pKey,
 		unsigned int type  = 0,
 		unsigned int index = 0);
@@ -1330,6 +1297,8 @@ extern "C" {
 #define AI_MATKEY_TEXFLAGS_UNKNOWN(N)	\
 	AI_MATKEY_TEXFLAGS(aiTextureType_UNKNOWN,N)
 
+//! @endcond
+//!
 // ---------------------------------------------------------------------------
 /** @brief Retrieve a material property with a specific key from the material
  *
@@ -1537,6 +1506,7 @@ ASSIMP_API unsigned int aiGetMaterialTextureCount(const C_STRUCT aiMaterial* pMa
  *      Pass NULL if you're not interested in this information. Otherwise,
  *      pass a pointer to an array of two aiTextureMapMode's (one for each
  *      axis, UV order).
+ *  @param[out] flags Receives the the texture flags.
  *  @return AI_SUCCESS on success, otherwise something else. Have fun.*/
 // ---------------------------------------------------------------------------
 #ifdef __cplusplus

--- a/include/assimp/material.inl
+++ b/include/assimp/material.inl
@@ -39,7 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ---------------------------------------------------------------------------
 */
 
-/** @file aiMaterial.inl
+/** @file material.inl
  *  @brief Defines the C++ getters for the material system
  */
 

--- a/include/assimp/matrix3x3.inl
+++ b/include/assimp/matrix3x3.inl
@@ -39,7 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ---------------------------------------------------------------------------
 */
 
-/** @file aiMatrix3x3.inl
+/** @file matrix3x3.inl
  *  @brief Inline implementation of the 3x3 matrix operators
  */
 #ifndef AI_MATRIX3x3_INL_INC

--- a/include/assimp/matrix4x4.inl
+++ b/include/assimp/matrix4x4.inl
@@ -39,7 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ---------------------------------------------------------------------------
 */
 
-/** @file aiMatrix4x4t<TReal>.inl
+/** @file matrix4x4.inl
  *  @brief Inline implementation of the 4x4 matrix operators
  */
 #ifndef AI_MATRIX4x4_INL_INC

--- a/include/assimp/mesh.h
+++ b/include/assimp/mesh.h
@@ -668,8 +668,7 @@ struct aiMesh
 	}
 
 	//! Check whether the mesh contains positions. Provided no special
-	//! scene flags are set (such as #AI_SCENE_FLAGS_ANIM_SKELETON_ONLY), 
-	//! this will always be true 
+	//! scene flags are set, this will always be true 
 	bool HasPositions() const 
 		{ return mVertices != NULL && mNumVertices > 0; }
 

--- a/include/assimp/postprocess.h
+++ b/include/assimp/postprocess.h
@@ -282,7 +282,7 @@ enum aiPostProcessSteps
 	/** <hr>Searches for redundant/unreferenced materials and removes them.
 	 *
 	 * This is especially useful in combination with the 
-	 * #aiProcess_PretransformVertices and #aiProcess_OptimizeMeshes flags. 
+	 * #aiProcess_PreTransformVertices and #aiProcess_OptimizeMeshes flags. 
 	 * Both join small meshes with equal characteristics, but they can't do 
 	 * their work if two meshes have different materials. Because several
 	 * material settings are lost during Assimp's import filters,
@@ -335,7 +335,7 @@ enum aiPostProcessSteps
 	 * To have the degenerate stuff not only detected and collapsed but
 	 * removed, try one of the following procedures:
 	 * <br><b>1.</b> (if you support lines and points for rendering but don't
-	 *    want the degenerates)</br>
+	 *    want the degenerates)<br>
 	 * <ul>
 	 *   <li>Specify the #aiProcess_FindDegenerates flag.
 	 *   </li>
@@ -345,7 +345,7 @@ enum aiPostProcessSteps
 	 *       pipeline steps.
 	 *   </li>
 	 * </ul>
-	 * <br><b>2.</b>(if you don't support lines and points at all)</br>
+	 * <br><b>2.</b>(if you don't support lines and points at all)<br>
 	 * <ul>
 	 *   <li>Specify the #aiProcess_FindDegenerates flag.
 	 *   </li>
@@ -550,7 +550,7 @@ enum aiPostProcessSteps
 
 
 // ---------------------------------------------------------------------------------------
-/** @def aiProcessPreset_TargetRealtimeUse_Fast
+/** @def aiProcessPreset_TargetRealtime_Fast
  *  @brief Default postprocess configuration optimizing the data for real-time rendering.
  *  
  *  Applications would want to use this preset to load models on end-user PCs,

--- a/include/assimp/quaternion.inl
+++ b/include/assimp/quaternion.inl
@@ -39,7 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ---------------------------------------------------------------------------
 */
 
-/** @file  aiQuaterniont.inl
+/** @file  quaternion.inl
  *  @brief Inline implementation of aiQuaterniont<TReal> operators
  */
 #ifndef AI_QUATERNION_INL_INC

--- a/include/assimp/scene.h
+++ b/include/assimp/scene.h
@@ -39,7 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ---------------------------------------------------------------------------
 */
 
-/** @file aiScene.h
+/** @file scene.h
  *  @brief Defines the data structures in which the imported scene is returned.
  */
 #ifndef __AI_SCENE_H_INC__
@@ -182,8 +182,6 @@ struct aiNode
 	}
 
 
-	/** @override
-	 */
 	inline const aiNode* FindNode(const char* name) const
 	{
 		if (!::strcmp( mName.data,name))return this;
@@ -217,7 +215,7 @@ struct aiNode
 
 
 // -------------------------------------------------------------------------------
-/** @def AI_SCENE_FLAGS_INCOMPLETE
+/**
  * Specifies that the scene data structure that was imported is not complete.
  * This flag bypasses some internal validations and allows the import 
  * of animation skeletons, material libraries or camera animation paths 
@@ -225,14 +223,14 @@ struct aiNode
  */
 #define AI_SCENE_FLAGS_INCOMPLETE	0x1
 
-/** @def AI_SCENE_FLAGS_VALIDATED
+/**
  * This flag is set by the validation postprocess-step (aiPostProcess_ValidateDS)
  * if the validation is successful. In a validated scene you can be sure that
  * any cross references in the data structure (e.g. vertex indices) are valid.
  */
 #define AI_SCENE_FLAGS_VALIDATED	0x2
 
-/** @def AI_SCENE_FLAGS_VALIDATION_WARNING
+/**
  * This flag is set by the validation postprocess-step (aiPostProcess_ValidateDS)
  * if the validation is successful but some issues have been found.
  * This can for example mean that a texture that does not exist is referenced 
@@ -242,7 +240,7 @@ struct aiNode
  */
 #define AI_SCENE_FLAGS_VALIDATION_WARNING  	0x4
 
-/** @def AI_SCENE_FLAGS_NON_VERBOSE_FORMAT
+/**
  * This flag is currently only set by the aiProcess_JoinIdenticalVertices step.
  * It indicates that the vertices of the output meshes aren't in the internal
  * verbose format anymore. In the verbose format all vertices are unique,
@@ -250,7 +248,7 @@ struct aiNode
  */
 #define AI_SCENE_FLAGS_NON_VERBOSE_FORMAT  	0x8
 
- /** @def AI_SCENE_FLAGS_TERRAIN
+ /**
  * Denotes pure height-map terrain data. Pure terrains usually consist of quads, 
  * sometimes triangles, in a regular grid. The x,y coordinates of all vertex 
  * positions refer to the x,y coordinates on the terrain height map, the z-axis

--- a/include/assimp/types.h
+++ b/include/assimp/types.h
@@ -241,7 +241,7 @@ struct aiColor3D
  *  For most applications, it will be absolutely sufficient to interpret the
  *  aiString as ASCII data and work with it as one would work with a plain char*. 
  *  Windows users in need of proper support for i.e asian characters can use the
- *  #MultiByteToWideChar(), #WideCharToMultiByte() WinAPI functionality to convert the
+ *  MultiByteToWideChar(), WideCharToMultiByte() WinAPI functionality to convert the
  *  UTF-8 strings to their working character set (i.e. MBCS, WideChar).
  *
  *  We use this representation instead of std::string to be C-compatible. The 
@@ -388,6 +388,8 @@ typedef enum aiReturn
 	 *  Force 32-bit size enum
 	 */
 	_AI_ENFORCE_ENUM_SIZE = 0x7fffffff 
+
+    /// @endcond
 } aiReturn;  // !enum aiReturn
 
 // just for backwards compatibility, don't use these constants anymore
@@ -414,13 +416,14 @@ enum aiOrigin
 	 *   Force 32-bit size enum 
 	 */
 	_AI_ORIGIN_ENFORCE_ENUM_SIZE = 0x7fffffff 
+	
+	/// @endcond
 }; // !enum aiOrigin
 
 // ----------------------------------------------------------------------------------
 /** @brief Enumerates predefined log streaming destinations. 
  *  Logging to these streams can be enabled with a single call to 
- *   #LogStream::createDefaultStream or #aiAttachPredefinedLogStream(),
- *   respectively.
+ *   #LogStream::createDefaultStream.
  */
 enum aiDefaultLogStream	
 {
@@ -442,6 +445,7 @@ enum aiDefaultLogStream
 	 *  Force 32-bit size enum 
 	 */
 	_AI_DLS_ENFORCE_ENUM_SIZE = 0x7fffffff 
+	/// @endcond
 }; // !enum aiDefaultLogStream
 
 // just for backwards compatibility, don't use these constants anymore

--- a/include/assimp/vector2.h
+++ b/include/assimp/vector2.h
@@ -38,7 +38,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ---------------------------------------------------------------------------
 */
-/** @file aiVector2t.h
+/** @file vector2.h
  *  @brief 2D vector structure, including operators when compiling in C++
  */
 #ifndef AI_VECTOR2D_H_INC

--- a/include/assimp/vector2.inl
+++ b/include/assimp/vector2.inl
@@ -39,7 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ---------------------------------------------------------------------------
 */
 
-/** @file  aiVector2D.inl
+/** @file  vector2.inl
  *  @brief Inline implementation of aiVector2t<TReal> operators
  */
 #ifndef AI_VECTOR2D_INL_INC

--- a/include/assimp/vector3.h
+++ b/include/assimp/vector3.h
@@ -38,7 +38,7 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ---------------------------------------------------------------------------
 */
-/** @file aiVector3D.h
+/** @file vector3.h
  *  @brief 3D vector structure, including operators when compiling in C++
  */
 #ifndef AI_VECTOR3D_H_INC

--- a/include/assimp/vector3.inl
+++ b/include/assimp/vector3.inl
@@ -39,7 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ---------------------------------------------------------------------------
 */
 
-/** @file  aiVector3D.inl
+/** @file  vector3.inl
  *  @brief Inline implementation of aiVector3t<TReal> operators
  */
 #ifndef AI_VECTOR3D_INL_INC

--- a/include/assimp/version.h
+++ b/include/assimp/version.h
@@ -39,7 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ---------------------------------------------------------------------------
 */
 
-/** @file  aiVersion.h
+/** @file  version.h
  *  @brief Functions to query the version of the Assimp runtime, check
  *    compile flags, ...
  */


### PR DESCRIPTION
Many doxygen comments were too old (filenames have changed since, for example), so no useable documentation could be generated with doxygen.

After fixes many issues, a more or less usable doc can be generated (at least the aiMaterial help is all there, which wasn't the case before)

Other than doxygen comments I did not change anything (no code change)