### PR TITLE
Support loading the MTL file for an OBJ file when using MemoryIOWrapper

### DIFF
--- a/code/Importer.cpp
+++ b/code/Importer.cpp
@@ -494,7 +494,7 @@ const aiScene* Importer::ReadFileFromMemory( const void* pBuffer,
 	IOSystem* io = pimpl->mIOHandler;
 	pimpl->mIOHandler = NULL;
 
-	SetIOHandler(new MemoryIOSystem((const uint8_t*)pBuffer,pLength));
+	SetIOHandler(new MemoryIOSystem((const uint8_t*)pBuffer,pLength,io));
 
 	// read the file and recover the previous IOSystem
 	char fbuff[128];

--- a/code/MemoryIOWrapper.h
+++ b/code/MemoryIOWrapper.h
@@ -141,8 +141,8 @@ class MemoryIOSystem : public IOSystem
 {
 public:
 	/** Constructor. */
-    MemoryIOSystem (const uint8_t* buff, size_t len) 
-		: buffer (buff), length(len) {
+    MemoryIOSystem (const uint8_t* buff, size_t len, IOSystem* other) 
+		: buffer (buff), length(len), other (other) {
 	}
 
 	/** Destructor. */
@@ -152,19 +152,27 @@ public:
 	// -------------------------------------------------------------------
 	/** Tests for the existence of a file at the given path. */
 	bool Exists( const char* pFile) const {
-		return !strncmp(pFile,AI_MEMORYIO_MAGIC_FILENAME,AI_MEMORYIO_MAGIC_FILENAME_LENGTH);
+		if (!strncmp(pFile,AI_MEMORYIO_MAGIC_FILENAME,AI_MEMORYIO_MAGIC_FILENAME_LENGTH))
+			return true;
+		if (other)
+			return other->Exists(pFile);
+		return false;
 	}
 
 	// -------------------------------------------------------------------
 	/** Returns the directory separator. */
 	char getOsSeparator() const {
+		if (other)
+			return other->getOsSeparator();
 		return '/'; // why not? it doesn't care
 	}
 
 	// -------------------------------------------------------------------
 	/** Open a new file with a given path. */
-	IOStream* Open( const char* pFile, const char* /*pMode*/ = "rb") {
+	IOStream* Open( const char* pFile, const char* pMode = "rb") {
 		if (strncmp(pFile,AI_MEMORYIO_MAGIC_FILENAME,AI_MEMORYIO_MAGIC_FILENAME_LENGTH)) {
+			if (other)
+				return other->Open(pFile,pMode);
 			return NULL;
 		}
 		return new MemoryIOStream(buffer,length);
@@ -172,18 +180,23 @@ public:
 
 	// -------------------------------------------------------------------
 	/** Closes the given file and releases all resources associated with it. */
-	void Close( IOStream* /*pFile*/) {
+	void Close( IOStream* pFile) {
+		if (other)
+			other->Close(pFile);
 	}
 
 	// -------------------------------------------------------------------
 	/** Compare two paths */
-	bool ComparePaths (const char* /*one*/, const char* /*second*/) const {
+	bool ComparePaths (const char* one, const char* second) const {
+		if (other)
+			return other->ComparePaths(one,second);
 		return false;
 	}
 
 private:
 	const uint8_t* buffer;
 	size_t length;
+	IOSystem* other;
 };
 } // end namespace Assimp
 


### PR DESCRIPTION
When using `MemoryIOWrapper` (e.g., by calling `aiImportFileFromMemoryWithProperties()`), the `.mtl` file associated with an `.obj` file is ignored.

This patch (by Christian Van Brussel, posted on [this thread](http://sourceforge.net/p/assimp/mailman/message/30003098/)) enables assimp to load these `.mtl` files.