### PR TITLE
Update IfcLoader to use numeric_limits<uint32_t> instead of UINT32_MAX, ...

### DIFF
--- a/code/IFCLoader.cpp
+++ b/code/IFCLoader.cpp
@@ -46,6 +46,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef ASSIMP_BUILD_NO_IFC_IMPORTER
 
 #include <iterator>
+#include <limits>
 #include <boost/tuple/tuple.hpp>
 
 #ifndef ASSIMP_BUILD_NO_COMPRESSED_IFC
@@ -560,7 +561,7 @@ void ProcessProductRepresentation(const IfcProduct& el, aiNode* nd, std::vector<
 	}
 
 	// extract Color from metadata, if present
-	unsigned int matid = ProcessMaterials( el.GetID(), UINT32_MAX, conv, false);
+	unsigned int matid = ProcessMaterials( el.GetID(), std::numeric_limits<uint32_t>::max(), conv, false);
 	std::vector<unsigned int> meshes;
 
 	// we want only one representation type, so bring them in a suitable order (i.e try those

--- a/code/IFCMaterial.cpp
+++ b/code/IFCMaterial.cpp
@@ -46,6 +46,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef ASSIMP_BUILD_NO_IFC_IMPORTER
 #include "IFCUtil.h"
+#include <limits>
 
 namespace Assimp {
 	namespace IFC {
@@ -167,12 +168,12 @@ unsigned int ProcessMaterials(uint64_t id, unsigned int prevMatId, ConversionDat
 	}
 
 	// no local material defined. If there's global one, use that instead
-	if( prevMatId != UINT32_MAX )
+	if( prevMatId != std::numeric_limits<uint32_t>::max() )
 		return prevMatId;
 
 	// we're still here - create an default material if required, or simply fail otherwise
 	if( !forceDefaultMat )
-		return UINT32_MAX;
+		return std::numeric_limits<uint32_t>::max();
 
 	aiString name;
 	name.Set("<IFCDefault>");


### PR DESCRIPTION
...fixes gcc build and is more consistent with the rest of the codebase. Fixes #471.