### PR TITLE
Free edges map before recursive calls to reduce memory consumption

### DIFF
--- a/code/Subdivision.cpp
+++ b/code/Subdivision.cpp
@@ -290,6 +290,8 @@ void CatmullClarkSubdivider::InternSubdivide (
 		}
 	}
 	
+	{
+	// we want edges to go away before the recursive calls so begin a new scope
 	EdgeMap edges;
 
 	// ---------------------------------------------------------------------
@@ -572,6 +574,7 @@ void CatmullClarkSubdivider::InternSubdivide (
 			}
 		}
 	}
+	}  // end of scope for edges, freeing its memory
 
 	// ---------------------------------------------------------------------
 	// 7. Apply the next subdivision step. 


### PR DESCRIPTION
Reduces peak memory use by about 10 MB during load of SuzanneSubdiv_252.blend.

No new regression failures however this file is one of the cases which fails on Linux to begin with so take it with a grain of salt.

Also should I fix the indentation afterwards?
