### PR TITLE
Fix read past end of buffer after call to TokenMatch

### DIFF
--- a/code/ParsingUtils.h
+++ b/code/ParsingUtils.h
@@ -202,7 +202,7 @@ AI_FORCE_INLINE bool TokenMatch(char_t*& in, const char* token, unsigned int len
 {
 	if (!::strncmp(token,in,len) && IsSpaceOrNewLine(in[len])) {
 		if (in[len] != '\0') {
-		in += len+1;
+			in += len+1;
 		} else {
 			// If EOF after the token make sure we don't go past end of buffer
 			in += len;

--- a/code/ParsingUtils.h
+++ b/code/ParsingUtils.h
@@ -201,7 +201,12 @@ template <class char_t>
 AI_FORCE_INLINE bool TokenMatch(char_t*& in, const char* token, unsigned int len)
 {
 	if (!::strncmp(token,in,len) && IsSpaceOrNewLine(in[len])) {
+		if (in[len] != '\0') {
 		in += len+1;
+		} else {
+			// If EOF after the token make sure we don't go past end of buffer
+			in += len;
+		}
 		return true;
 	}
 


### PR DESCRIPTION
This one sets "in" to point to terminating 0 character on EOF. Causes no new regression failures.