### PR TITLE
Add an assertion and some debug prints

### DIFF
--- a/code/OFFLoader.cpp
+++ b/code/OFFLoader.cpp
@@ -189,6 +189,7 @@ void OFFImporter::InternReadFile( const std::string& pFile,
 
     // second: now parse all face indices
     buffer = old;faces = mesh->mFaces;
+    printf("numVertices: %u   mesh->mNumVertices: %u\n", numVertices, mesh->mNumVertices);
     for (unsigned int i = 0, p = 0; i< mesh->mNumFaces;)
     {
         if(!GetNextLine(buffer,line))break;
@@ -199,8 +200,10 @@ void OFFImporter::InternReadFile( const std::string& pFile,
             continue;
 
         faces->mIndices = new unsigned int [faces->mNumIndices];
+        printf("mNumIndices: %u\n", faces->mNumIndices);
         for (unsigned int m = 0; m < faces->mNumIndices;++m)
         {
+            printf("m: %u\n", m);
             SkipSpaces(&sz);
             if ((idx = strtoul10(sz,&sz)) >= numVertices)
             {
@@ -208,6 +211,7 @@ void OFFImporter::InternReadFile( const std::string& pFile,
                 idx = numVertices-1;
             }
             faces->mIndices[m] = p++;
+            ai_assert(verts < mesh->mVertices + mesh->mNumVertices);
             *verts++ = tempPositions[idx];
         }
         ++i;


### PR DESCRIPTION
Do not merge. This is not a proper fix, contains debugging code and causes regression failures.

This tries to fix crashes/bee0783c79dd9a27abe2651fc16806c1 from #454. I'm not sure what the proper fix is here. Somehow numVertices is wrong and/or isn't properly checked against mNumIndices. What's the difference between numVertices and mesh->mNumVertices? @acgessler thoughts?

Also is it possible to enable logging with "assimp-cmd info" so I could use logger instead of printfs?