### PR TITLE
Added 'const' to () operator on CompareVector

### DIFF
--- a/code/IFCUtil.cpp
+++ b/code/IFCUtil.cpp
@@ -236,7 +236,7 @@ IfcVector3 TempMesh::ComputeLastPolygonNormal(bool normalize) const
 
 struct CompareVector
 {
-	bool operator () (const IfcVector3& a, const IfcVector3& b)
+	bool operator () (const IfcVector3& a, const IfcVector3& b) const
 	{
 		IfcVector3 d = a - b;
 		IfcFloat eps = 1e-6;


### PR DESCRIPTION
This doesn't build on clang as-is. I don't speak C++ but the net said adding "const" is the solution, and it now appears to build fine now for iOS and OS X.