### PR TITLE
Fixes assimp/assimp#509

### DIFF
--- a/port/jassimp/jassimp-native/src/jassimp.cpp
+++ b/port/jassimp/jassimp-native/src/jassimp.cpp
@@ -1340,6 +1340,14 @@ static bool loadCameras(JNIEnv *env, const aiScene* cScene, jobject& jScene)
 }
 
 
+JNIEXPORT jint JNICALL Java_jassimp_Jassimp_getVKeysize
+  (JNIEnv *env, jclass jClazz)
+{
+	const int res = sizeof(aiVectorKey);
+
+	return res;
+}
+
 JNIEXPORT jstring JNICALL Java_jassimp_Jassimp_getErrorString
   (JNIEnv *env, jclass jClazz)
 {

--- a/port/jassimp/jassimp-native/src/jassimp.h
+++ b/port/jassimp/jassimp-native/src/jassimp.h
@@ -7,6 +7,9 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+JNIEXPORT jint JNICALL Java_jassimp_Jassimp_getVKeysize
+  (JNIEnv *, jclass);
+
 /*
  * Class:     jassimp_Jassimp
  * Method:    getErrorString

--- a/port/jassimp/jassimp/src/jassimp/AiNodeAnim.java
+++ b/port/jassimp/jassimp/src/jassimp/AiNodeAnim.java
@@ -3,7 +3,7 @@
 Open Asset Import Library - Java Binding (jassimp)
 ---------------------------------------------------------------------------
 
-Copyright (c) 2006-2012, assimp team
+Copyright (c) 2006-2015, assimp team
 
 All rights reserved.
 
@@ -68,9 +68,9 @@ import java.nio.ByteOrder;
  */
 public final class AiNodeAnim {
     /**
-     * Size of one position key entry (includes padding).
+     * Size of one position key entry.
      */
-    private static final int POS_KEY_SIZE = 24;
+    private static final int POS_KEY_SIZE = 20;
     
     /**
      * Size of one rotation key entry.
@@ -78,9 +78,9 @@ public final class AiNodeAnim {
     private static final int ROT_KEY_SIZE = 24;
     
     /**
-     * Size of one scaling key entry (includes padding).
+     * Size of one scaling key entry.
      */
-    private static final int SCALE_KEY_SIZE = 24;
+    private static final int SCALE_KEY_SIZE = 20;
     
     
     /**
@@ -103,14 +103,13 @@ public final class AiNodeAnim {
         m_preState = AiAnimBehavior.fromRawValue(preBehavior);
         m_postState = AiAnimBehavior.fromRawValue(postBehavior);
         
-        /* c data is padded -> 24 bytes with 20 bytes data */
         m_posKeys = ByteBuffer.allocateDirect(numPosKeys * POS_KEY_SIZE);
         m_posKeys.order(ByteOrder.nativeOrder());
         
-        m_rotKeys = ByteBuffer.allocateDirect(numRotKeys * 24);
+        m_rotKeys = ByteBuffer.allocateDirect(numRotKeys * ROT_KEY_SIZE);
         m_rotKeys.order(ByteOrder.nativeOrder());
         
-        m_scaleKeys = ByteBuffer.allocateDirect(numScaleKeys * 24);
+        m_scaleKeys = ByteBuffer.allocateDirect(numScaleKeys * SCALE_KEY_SIZE);
         m_scaleKeys.order(ByteOrder.nativeOrder());
     }
     
@@ -141,7 +140,7 @@ public final class AiNodeAnim {
      * Returns the buffer with position keys of this animation channel.<p>
      * 
      * Position keys consist of a time value (double) and a position (3D vector
-     * of floats), resulting in a total of 24 bytes per entry with padding. 
+     * of floats), resulting in a total of 20 bytes per entry. 
      * The buffer contains {@link #getNumPosKeys()} of these entries.<p>
      *
      * If there are position keys, there will also be at least one
@@ -340,7 +339,7 @@ public final class AiNodeAnim {
      * Returns the buffer with scaling keys of this animation channel.<p>
      * 
      * Scaling keys consist of a time value (double) and a 3D vector of floats,
-     * resulting in a total of 24 bytes per entry with padding. The buffer 
+     * resulting in a total of 20 bytes per entry. The buffer 
      * contains {@link #getNumScaleKeys()} of these entries.<p>
      * 
      * If there are scaling keys, there will also be at least one

--- a/port/jassimp/jassimp/src/jassimp/AiNodeAnim.java
+++ b/port/jassimp/jassimp/src/jassimp/AiNodeAnim.java
@@ -70,7 +70,7 @@ public final class AiNodeAnim {
     /**
      * Size of one position key entry.
      */
-    private static final int POS_KEY_SIZE = 20;
+    private static final int POS_KEY_SIZE = Jassimp.getVKeysize();
     
     /**
      * Size of one rotation key entry.
@@ -80,7 +80,7 @@ public final class AiNodeAnim {
     /**
      * Size of one scaling key entry.
      */
-    private static final int SCALE_KEY_SIZE = 20;
+    private static final int SCALE_KEY_SIZE = Jassimp.getVKeysize();
     
     
     /**

--- a/port/jassimp/jassimp/src/jassimp/Jassimp.java
+++ b/port/jassimp/jassimp/src/jassimp/Jassimp.java
@@ -97,6 +97,13 @@ public final class Jassimp {
     
     
     /**
+     * Returns the size of a struct.<p>
+     * 
+     * @return the result of sizeof call
+     */
+    public static native int getVKeysize();
+
+    /**
      * Returns a human readable error description.<p>
      * 
      * This method can be called when one of the import methods fails, i.e.,


### PR DESCRIPTION
looks like there is no padding on cast a c-struct into jni bytebuffer 