### PR TITLE
More crash fixes

### DIFF
--- a/code/ACLoader.cpp
+++ b/code/ACLoader.cpp
@@ -632,6 +632,10 @@ aiNode* AC3DImporter::ConvertObjectSection(Object& object,
 								face.mIndices[1] = cur++;
 
 								// copy vertex positions
+								if (it2 == (*it).entries.end() ) {
+									throw DeadlyImportError("AC3D: Bad line");
+								}
+								ai_assert((*it2).first < object.vertices.size());
 								*vertices++ = object.vertices[(*it2).first];
 								
 								// copy texture coordinates 

--- a/code/ACLoader.cpp
+++ b/code/ACLoader.cpp
@@ -598,6 +598,9 @@ aiNode* AC3DImporter::ConvertObjectSection(Object& object,
 									face.mIndices[i] = cur++;
 
 									// copy vertex positions
+									if ((vertices - mesh->mVertices) >= mesh->mNumVertices) {
+										throw DeadlyImportError("AC3D: Invalid number of vertices");
+									}
 									*vertices = object.vertices[entry.first] + object.translation;
 
 

--- a/code/ACLoader.cpp
+++ b/code/ACLoader.cpp
@@ -274,6 +274,9 @@ void AC3DImporter::LoadObjectSection(std::vector<Object>& objects)
 			SkipSpaces(&buffer);
 
 			unsigned int t = strtoul10(buffer,&buffer);
+			if (t >= std::numeric_limits<int32_t>::max() / sizeof(aiVector3D)) {
+				throw DeadlyImportError("AC3D: Too many vertices, would run out of memory");
+			}
 			obj.vertices.reserve(t);
 			for (unsigned int i = 0; i < t;++i)
 			{

--- a/code/DefaultLogger.cpp
+++ b/code/DefaultLogger.cpp
@@ -165,7 +165,6 @@ void Logger::debug(const char* message)	{
 	// sometimes importers will include data from the input file
 	// (i.e. node names) in their messages.
 	if (strlen(message)>MAX_LOG_MESSAGE_LENGTH) {
-		ai_assert(false);
 		return;
 	}
 	return OnDebug(message);
@@ -176,7 +175,6 @@ void Logger::info(const char* message)	{
 	
 	// SECURITY FIX: see above
 	if (strlen(message)>MAX_LOG_MESSAGE_LENGTH) {
-		ai_assert(false);
 		return;
 	}
 	return OnInfo(message);
@@ -187,7 +185,6 @@ void Logger::warn(const char* message)	{
 	
 	// SECURITY FIX: see above
 	if (strlen(message)>MAX_LOG_MESSAGE_LENGTH) {
-		ai_assert(false);
 		return;
 	}
 	return OnWarn(message);
@@ -198,7 +195,6 @@ void Logger::error(const char* message)	{
 	
 	// SECURITY FIX: see above
 	if (strlen(message)>MAX_LOG_MESSAGE_LENGTH) {
-		ai_assert(false);
 		return;
 	}
 	return OnError(message);

--- a/code/MD3Loader.cpp
+++ b/code/MD3Loader.cpp
@@ -471,6 +471,9 @@ void MD3Importer::ReadSkin(Q3Shader::SkinData& fill) const
 	std::string::size_type s = filename.find_last_of('_');
 	if (s == std::string::npos) {
 		s = filename.find_last_of('.');
+		if (s == std::string::npos) {
+			s = filename.size();
+		}
 	}
 	ai_assert(s != std::string::npos);
 
@@ -532,7 +535,9 @@ bool MD3Importer::ReadMultipartFile()
 {
 	// check whether the file name contains a common postfix, e.g lower_2.md3
 	std::string::size_type s = filename.find_last_of('_'), t = filename.find_last_of('.');
-	ai_assert(t != std::string::npos);
+
+	if (t == std::string::npos)
+		t = filename.size();
 	if (s == std::string::npos)
 		s = t;
 

--- a/code/ObjFileImporter.cpp
+++ b/code/ObjFileImporter.cpp
@@ -424,7 +424,9 @@ void ObjFileImporter::createVertexArray(const ObjFile::Model* pModel,
                 pMesh->mTextureCoords[ 0 ][ newIndex ] = aiVector3D( coord3d.x, coord3d.y, coord3d.z );
             }
 
-            ai_assert( pMesh->mNumVertices > newIndex );
+            if ( pMesh->mNumVertices <= newIndex ) {
+                throw DeadlyImportError("OBJ: bad vertex index");
+            }
 
             // Get destination face
             aiFace *pDestFace = &pMesh->mFaces[ outIndex ];

--- a/code/ObjFileParser.cpp
+++ b/code/ObjFileParser.cpp
@@ -259,7 +259,7 @@ void ObjFileParser::getVector( std::vector<aiVector3D> &point3d_array ) {
         copyNextWord( m_buffer, BUFFERSIZE );
         z = ( float ) fast_atof( m_buffer );
     } else {
-        ai_assert( !"Invalid number of components" );
+        throw DeadlyImportError( "OBJ: Invalid number of components" );
     }
     point3d_array.push_back( aiVector3D( x, y, z ) );
     m_DataIt = skipLine<DataArrayIt>( m_DataIt, m_DataItEnd, m_uiLine );

--- a/code/XFileImporter.cpp
+++ b/code/XFileImporter.cpp
@@ -156,6 +156,10 @@ void XFileImporter::CreateDataRepresentationFromImport( aiScene* pScene, XFile::
 		CreateMeshes( pScene, pScene->mRootNode, pData->mGlobalMeshes);
 	}
 
+	if (!pScene->mRootNode) {
+		throw DeadlyImportError( "No root node" );
+	}
+
 	// Convert everything to OpenGL space... it's the same operation as the conversion back, so we can reuse the step directly
 	MakeLeftHandedProcess convertProcess;
 	convertProcess.Execute( pScene);


### PR DESCRIPTION
Fixes most of the remaining crashes from #454. The only one left after this is the one in #488.

No new regression failures. Please review before merge. Especially the assertion to exception and the last (too many vertices) patches. Also the last patch might require a different limit since it's still sometimes too much for Valgrind.