### PR TITLE
add strtol10_64 and fix FBX text parsing for int_64 (for animation KTime)

### DIFF
--- a/code/FBXParser.cpp
+++ b/code/FBXParser.cpp
@@ -459,7 +459,7 @@ int64_t ParseTokenAsInt64(const Token& t, const char*& err_out)
 	ai_assert(length > 0);
 
 	const char* out;
-	const int64_t id = strtoul10_64(t.begin(), &out, &length);
+	const int64_t id = strtol10_64(t.begin(), &out, &length);
 	if (out > t.end()) {
 		err_out = "failed to parse Int64 (text)";
 		return 0L;

--- a/code/fast_atof.h
+++ b/code/fast_atof.h
@@ -220,6 +220,23 @@ inline uint64_t strtoul10_64( const char* in, const char** out=0, unsigned int* 
 	return value;
 }
 
+// ------------------------------------------------------------------------------------
+// signed variant of strtoul10_64
+// ------------------------------------------------------------------------------------
+inline int64_t strtol10_64(const char* in, const char** out = 0, unsigned int* max_inout = 0)
+{
+	bool inv = (*in == '-');
+	if (inv || *in == '+')
+		++in;
+
+	int value = strtoul10_64(in, out, max_inout);
+	if (inv) {
+		value = -value;
+	}
+	return value;
+}
+
+
 // Number of relevant decimals for floating-point parsing.
 #define AI_FAST_ATOF_RELAVANT_DECIMALS 15
 


### PR DESCRIPTION
correctly parses a negative int64 value from text