### PR TITLE
Remove WINDOWS builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install cmake python3
-  - if [ $WINDOWS ]; then sudo apt-get install -qq gcc-mingw-w64-x86-64 g++-mingw-w64-x86-64 binutils-mingw-w64-x86-64 wine ; fi
   - if [ $LINUX ]; then sudo apt-get install -qq freeglut3-dev libxmu-dev libxi-dev ; fi
   - echo -e "#ifndef A_R_H_INC\n#define A_R_H_INC\n#define GitVersion ${TRAVIS_JOB_ID}\n#define GitBranch \"${TRAVIS_BRANCH}\"\n#endif // A_R_H_INC" > revision.h
 
@@ -17,10 +16,6 @@ env:
     - LINUX=1 TRAVIS_NO_EXPORT=NO
     - LINUX=1 SHARED_BUILD=ON
     - LINUX=1 SHARED_BUILD=OFF
-    - WINDOWS=1 TRAVIS_NO_EXPORT=YES
-    - WINDOWS=1 TRAVIS_NO_EXPORT=NO
-    - WINDOWS=1 SHARED_BUILD=ON
-    - WINDOWS=1 SHARED_BUILD=OFF
     - ANDROID=1
 
 language: cpp
@@ -34,17 +29,7 @@ install:
 
 script:
   - if [ $ANDROID ]; then 
-    ant -v -Dmy.dir=${TRAVIS_BUILD_DIR} -f ${TRAVIS_BUILD_DIR}/port/jassimp/build.xml ndk-jni ; 
-    elif [ $WINDOWS -a $CC = "gcc" ]; then
-    sudo sh -c "wget http://source.winehq.org/git/wine.git/commitdiff_plain/86781a6a524fa336f893ffd0a87373ffd306913c?hp=076edfe9d4b6cd39b6cf41b9f1d3e18688cc8673 -O - | patch -p 1 -d /usr/x86_64-w64-mingw32" ;
-    sudo sh -c "wget https://www.winehq.org/pipermail/wine-patches/2012-February/111438.html -O - | patch -p 1 -d /usr/x86_64-w64-mingw32" ;
-    cmake -G "Unix Makefiles" -DASSIMP_NO_EXPORT=$TRAVIS_NO_EXPORT -DBUILD_SHARED_LIBS=$SHARED_BUILD -DCMAKE_TOOLCHAIN_FILE=cmake-modules/MinGW_x86_64.cmake ;
-    cmake --build . ;
-    make install ;
-    elif [ $WINDOWS ]; then
-    echo "Skip compile with non-gcc setting." ;
-    elif [ $RESERVED ]; then
-    echo "Reserved condition" ;
+    ant -v -Dmy.dir=${TRAVIS_BUILD_DIR} -f ${TRAVIS_BUILD_DIR}/port/jassimp/build.xml ndk-jni ;
     else
     cmake -G "Unix Makefiles" -DASSIMP_ENABLE_BOOST_WORKAROUND=YES -DASSIMP_NO_EXPORT=$TRAVIS_NO_EXPORT -DBUILD_SHARED_LIBS=$SHARED_BUILD ;
     make ;
@@ -56,6 +41,6 @@ script:
     chmod 755 run.py ;
     ./run.py ;
     echo "==========================================================" ;
-    echo "REGRESSION TEST FAILS (results/run_regression_suite_failures.csv)" ;
+    echo "REGRESSION TEST FAILURES (results/run_regression_suite_failures.csv)" ;
     cat ../results/run_regression_suite_failures.csv;
     fi


### PR DESCRIPTION
- Currently, the mingw linker crashes linking unit.exe, causing failing assimp CI.
- Significant increase in build time for testing an exotic platform - Mingw crosscompile on linux. Assimp does not have many system dependencies so I feel we can omit this.
- Only compiles because MinGW headers are patched before compiling.
- Confusion since 2 build combinations appear in Travis but are disabled.
- Travis file grows overly complex.
- For multiple months this build did nothing and no one noticed.

As a side note, I'd love to run a significantly larger build matrix, but Travis does not currently seem suited for it.

Also, @arris69, @kimkulling 