### PR TITLE
Fix compilation with libc++

### DIFF
--- a/code/ObjFileParser.cpp
+++ b/code/ObjFileParser.cpp
@@ -53,6 +53,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "../include/assimp/DefaultLogger.hpp"
 #include "../include/assimp/material.h"
 #include "../include/assimp/Importer.hpp"
+#include <cstdlib>
 
 
 namespace Assimp {

--- a/code/Q3BSPZipArchive.cpp
+++ b/code/Q3BSPZipArchive.cpp
@@ -45,6 +45,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "Q3BSPZipArchive.h"
 #include <algorithm>
 #include <cassert>
+#include <cstdlib>
 #include "../include/assimp/ai_assert.h"
 
 


### PR DESCRIPTION
Compilation errors when using libc++:

```
 assimp/code/ObjFileParser.cpp:360:30: error: use of
      undeclared identifier 'atoi'
            const int iVal = atoi( pPtr );
```

```
assimp/code/Q3BSPZipArchive.cpp:143:13: error: use of undeclared identifier 'malloc'
        m_Buffer = malloc(m_Size);
                   ^
assimp/code/Q3BSPZipArchive.cpp:147:2: error: use of undeclared identifier 'free'
        free(m_Buffer);
```

Steps to reproduce:
* Compile with libc++ library