### PR TITLE
Removed FORCE attribute from CMake variable LIBRARY_SUFFIX

### DIFF
--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -784,7 +784,7 @@ if( MSVC )
   else()
     set(MSVC_PREFIX "vc130")
   endif()
-  set(LIBRARY_SUFFIX "${ASSIMP_LIBRARY_SUFFIX}-${MSVC_PREFIX}-mt" CACHE STRING "the suffix for the assimp windows library" FORCE)
+  set(LIBRARY_SUFFIX "${ASSIMP_LIBRARY_SUFFIX}-${MSVC_PREFIX}-mt" CACHE STRING "the suffix for the assimp windows library")
 endif()
 
 SET_TARGET_PROPERTIES( assimp PROPERTIES


### PR DESCRIPTION
I don't see a reason for forcing the value of LIBRARY_SUFFIX. 
Removing the force attribute would allow experienced users to specify their own suffix format. The default behavior doesn't change with this patch.