### PR TITLE
Fix issue with CMAKE_CXX_FLAGS initialization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,9 +62,9 @@ if( CMAKE_COMPILER_IS_MINGW )
 endif()
 
 if((CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX) AND NOT CMAKE_COMPILER_IS_MINGW)
-    set(CMAKE_CXX_FLAGS "-fPIC") # this is a very important switch and some libraries seem now to have it....
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC") # this is a very important switch and some libraries seem now to have it....
     # hide all not-exported symbols
-    set(CMAKE_CXX_FLAGS "-fvisibility=hidden -Wall" )
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -Wall" )
 elseif(MSVC)
     # enable multi-core compilation with MSVC
     add_definitions(/MP)


### PR DESCRIPTION
Append the necessary flags to CMAKE_CXX_FLAGS, rather than replacing
the previous values. It's critical that that flags are preserved to
ensure proper and consistent compilation.