### PR TITLE
Fixes random crash when loading fbx files

### DIFF
--- a/code/FBXImporter.cpp
+++ b/code/FBXImporter.cpp
@@ -151,9 +151,9 @@ void FBXImporter::InternReadFile( const std::string& pFile,
 	// streaming for its output data structures so the net win with
 	// streaming input data would be very low.
 	std::vector<char> contents;
-	contents.resize(stream->FileSize());
-
-	stream->Read(&*contents.begin(),contents.size(),1);
+	contents.resize(stream->FileSize()+1);
+    size_t readcnt = stream->Read( &*contents.begin(), 1, contents.size()-1 );
+    contents[ contents.size() - 1 ] = 0;
 	const char* const begin = &*contents.begin();
 
 	// broadphase tokenizing pass in which we identify the core

--- a/code/FBXImporter.cpp
+++ b/code/FBXImporter.cpp
@@ -152,7 +152,7 @@ void FBXImporter::InternReadFile( const std::string& pFile,
 	// streaming input data would be very low.
 	std::vector<char> contents;
 	contents.resize(stream->FileSize()+1);
-    size_t readcnt = stream->Read( &*contents.begin(), 1, contents.size()-1 );
+    stream->Read( &*contents.begin(), 1, contents.size()-1 );
     contents[ contents.size() - 1 ] = 0;
 	const char* const begin = &*contents.begin();
 


### PR DESCRIPTION
We had an issue when loading fbx files without any debugger attached (or `_NO_DEBUG_HEAP=1` set, so memory is not filled with predefined values), because there was no trailing `\0` set when reading the fbx file.
This fixes it.

Without this fix sometimes more tokens where generated than there are actually in this file (depending on what was in the memory before), causing the parser to fail at the last tokens.