### PR TITLE
Added mesh name importing to .X ascii format.

### DIFF
--- a/code/XFileHelper.h
+++ b/code/XFileHelper.h
@@ -110,6 +110,7 @@ struct Bone
 /** Helper structure to represent an XFile mesh */
 struct Mesh
 {
+	std::string mName;
 	std::vector<aiVector3D> mPositions;
 	std::vector<Face> mPosFaces;
 	std::vector<aiVector3D> mNormals;
@@ -124,7 +125,7 @@ struct Mesh
 
 	std::vector<Bone> mBones;
 
-	Mesh() { mNumTextures = 0; mNumColorSets = 0; }
+	Mesh(const std::string &pName = "") { mName = pName; mNumTextures = 0; mNumColorSets = 0; }
 };
 
 /** Helper structure to represent a XFile frame */

--- a/code/XFileImporter.cpp
+++ b/code/XFileImporter.cpp
@@ -294,6 +294,9 @@ void XFileImporter::CreateMeshes( aiScene* pScene, aiNode* pNode, const std::vec
 			mesh->mNumFaces = (unsigned int)faces.size();
 			mesh->mFaces = new aiFace[mesh->mNumFaces];
 
+			// name
+			mesh->mName.Set(sourceMesh->mName);
+
 			// normals?
 			if( sourceMesh->mNormals.size() > 0)
 				mesh->mNormals = new aiVector3D[numVertices];

--- a/code/XFileParser.cpp
+++ b/code/XFileParser.cpp
@@ -414,7 +414,7 @@ void XFileParser::ParseDataObjectFrame( Node* pParent)
 		else
 		if( objectName == "Mesh")
 		{
-			Mesh* mesh = new Mesh;
+			Mesh* mesh = new Mesh(name);
 			node->mMeshes.push_back( mesh);
 			ParseDataObjectMesh( mesh);
 		} else


### PR DESCRIPTION
assimp doesn't import mesh names from the ascii .X format.

You can verify this by viewing [this model](https://gist.github.com/zippers/c742cff8483e52cc6cc5) in the assimp viewer and observing it contains two meshes named *Mesh 0* and *Mesh 1*.

After applying the patch, you can observe the names *ninja* and *blade* are used instead.