### PR TITLE
Fixed: Remove absolute path from exported file

### DIFF
--- a/test/unit/utColladaExportLight.cpp
+++ b/test/unit/utColladaExportLight.cpp
@@ -49,7 +49,7 @@ TEST_F(ColladaExportLight, testExportLight)
 
 
     EXPECT_EQ(AI_SUCCESS,ex->Export(pTest,"collada",file));
-    EXPECT_EQ(AI_SUCCESS,ex->Export(pTest,"collada","/home/wise/lightsExp.dae"));
+    EXPECT_EQ(AI_SUCCESS,ex->Export(pTest,"collada","lightsExp.dae"));
 
     const aiScene* imported = im->ReadFile(file,0);
 


### PR DESCRIPTION
This fixes the only test that fails for me when I run them.