### PR TITLE
Prefer Format::operator<< over Format::operator,

### DIFF
--- a/code/FBXUtil.cpp
+++ b/code/FBXUtil.cpp
@@ -84,29 +84,29 @@ const char* TokenTypeString(TokenType t)
 // ------------------------------------------------------------------------------------------------
 std::string AddOffset(const std::string& prefix, const std::string& text, unsigned int offset)
 {
-    return static_cast<std::string>( (Formatter::format(),prefix," (offset 0x",std::hex,offset,") ",text) );
+    return static_cast<std::string>( (Formatter::format() << prefix << " (offset 0x" << std::hex << offset << ") " << text) );
 }
 
 // ------------------------------------------------------------------------------------------------
 std::string AddLineAndColumn(const std::string& prefix, const std::string& text, unsigned int line, unsigned int column)
 {
-    return static_cast<std::string>( (Formatter::format(),prefix," (line ",line,", col ",column,") ",text) );
+    return static_cast<std::string>( (Formatter::format() << prefix << " (line " << line << " <<  col " << column << ") " << text) );
 }
 
 // ------------------------------------------------------------------------------------------------
 std::string AddTokenText(const std::string& prefix, const std::string& text, const Token* tok)
 {
     if(tok->IsBinary()) {
-        return static_cast<std::string>( (Formatter::format(),prefix,
-            " (",TokenTypeString(tok->Type()),
-            ", offset 0x", std::hex, tok->Offset(),") ",
+        return static_cast<std::string>( (Formatter::format() << prefix <<
+            " (" << TokenTypeString(tok->Type()) <<
+            ", offset 0x" << std::hex << tok->Offset() << ") " <<
             text) );
     }
 
-    return static_cast<std::string>( (Formatter::format(),prefix,
-        " (",TokenTypeString(tok->Type()),
-        ", line ",tok->Line(),
-        ", col ",tok->Column(),") ",
+    return static_cast<std::string>( (Formatter::format() << prefix <<
+        " (" << TokenTypeString(tok->Type()) <<
+        ", line " << tok->Line() <<
+        ", col " << tok->Column() << ") " <<
         text) );
 }
 
@@ -115,4 +115,3 @@ std::string AddTokenText(const std::string& prefix, const std::string& text, con
 } // !Assimp
 
 #endif
-


### PR DESCRIPTION
cppcheck gives false positives for use of the comma operator, so use << operator.