### PR TITLE
Windows build improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,8 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/assimp-config.cmake.in"         "${C
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/assimp-config-version.cmake.in" "${CMAKE_CURRENT_BINARY_DIR}/assimp-config-version.cmake" @ONLY IMMEDIATE)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/assimp-config.cmake"             "${CMAKE_CURRENT_BINARY_DIR}/assimp-config-version.cmake" DESTINATION "${ASSIMP_LIB_INSTALL_DIR}/cmake/assimp-${ASSIMP_VERSION_MAJOR}.${ASSIMP_VERSION_MINOR}" COMPONENT ${LIBASSIMP-DEV_COMPONENT})
 
+FIND_PACKAGE( DirectX )
+
 option ( ASSIMP_NO_EXPORT
   "Disable Assimp's export functionality."
   OFF
@@ -242,9 +244,9 @@ option ( ASSIMP_BUILD_ASSIMP_TOOLS
   ON
 )
 IF ( ASSIMP_BUILD_ASSIMP_TOOLS )
-  IF ( WIN32 )
+  IF ( WIN32 AND DirectX_FOUND )
     ADD_SUBDIRECTORY( tools/assimp_view/ )
-  ENDIF ( WIN32 )
+  ENDIF ( WIN32 AND DirectX_FOUND )
   ADD_SUBDIRECTORY( tools/assimp_cmd/ )
 ENDIF ( ASSIMP_BUILD_ASSIMP_TOOLS )
 

--- a/samples/SimpleOpenGL/CMakeLists.txt
+++ b/samples/SimpleOpenGL/CMakeLists.txt
@@ -1,6 +1,10 @@
 FIND_PACKAGE(OpenGL)
 FIND_PACKAGE(GLUT)
-find_library(M_LIB m)
+IF ( MSVC )
+  SET(M_LIB)
+ELSE ( MSVC )
+  find_library(M_LIB m)
+ENDIF ( MSVC )
 
 IF ( NOT GLUT_FOUND )
   IF ( MSVC )


### PR DESCRIPTION
This lets the code build out of the box on my Windows machine, where it cannot find DirectX.  It also fixes a library issue (libm.a) on Visual Studio, where this library is not needed; this lets it build once I turn on ASSIMP_BUILD_SAMPLES and find GLUT.