### PR TITLE
Fix volume calculation

### DIFF
--- a/code/FixNormalsStep.cpp
+++ b/code/FixNormalsStep.cpp
@@ -152,8 +152,8 @@ bool FixInfacingNormalsProcess::ProcessMesh( aiMesh* pcMesh, unsigned int index)
     if (fDelta1_z < 0.05f * sqrtf( fDelta1_y * fDelta1_x ))return false;
 
     // now compare the volumes of the bounding boxes
-    if (std::fabs(fDelta0_x * fDelta1_yz) <
-        std::fabs(fDelta1_x * fDelta1_y * fDelta1_z))
+    if (std::fabs(fDelta0_x * fDelta0_y * fDelta0_z) <
+        std::fabs(fDelta1_x * fDelta1_yz))
     {
         if (!DefaultLogger::isNullLogger())
         {


### PR DESCRIPTION
It includes the same part `fDelta1_y * fDelta1_z` (`fDelta1_yz` defined above as `fDelta1_yz = fDelta1_y * fDelta1_z`) on both sides of comparison, that makes no sense. The comment above shows the original intention to compare volumes. No doubt, the copy-paste issue is here.