### PR TITLE
Fix out-of-bounds write on malformed input

### DIFF
--- a/code/LWOLoader.cpp
+++ b/code/LWOLoader.cpp
@@ -954,6 +954,9 @@ inline void LWOImporter::DoRecursiveVMAPAssignment(VMapEntry* base, unsigned int
     LWO::ReferrerList& refList  = mCurLayer->mPointReferrers;
     unsigned int i;
 
+    if (idx >= base->abAssigned.size()) {
+        throw DeadlyImportError("Bad index");
+    }
     base->abAssigned[idx] = true;
     for (i = 0; i < numRead;++i) {
         base->rawData[idx*base->dims+i]= data[i];


### PR DESCRIPTION
Fixes hangs/14fa1793a3beb6e7db761f7cbfcd3f0c and ef7d28a7282aa3d29fad4fbadba7a29f from #454 . No (new) regression failures on Linux. Please test on windows before merge. @acgessler how's that regression suite fix coming along? Also feel free to change the error message to something more descriptive.