### PR TITLE
Abort early when hitting unexpected EOF in AC3D loader

### DIFF
--- a/code/ACLoader.cpp
+++ b/code/ACLoader.cpp
@@ -349,8 +349,7 @@ void AC3DImporter::LoadObjectSection(std::vector<Object>& objects)
                 {
                     if(!GetNextLine())
                     {
-                        DefaultLogger::get()->error("AC3D: Unexpected EOF: surface is incomplete");
-                        break;
+                        throw DeadlyImportError("AC3D: Unexpected EOF: surface is incomplete");
                     }
                     if (TokenMatch(buffer,"mat",3))
                     {


### PR DESCRIPTION
Without this the code will try to loop through the specified number
of surfaces which could be very large even though none will succeed.

This helps crashes/cb821dbb50a427d2954c6dd12b9132a9 from #454. It was taking excessively long time since it declares 10 million surfaces and then EOFs. The code would loop 10 million times and not do anything useful.

Also someone who can update the test suite might want to turn that one into a real test case.
