### PR TITLE
Avoid reading past EOF when encountering a malformed STL file

### DIFF
--- a/code/STLLoader.cpp
+++ b/code/STLLoader.cpp
@@ -279,7 +279,7 @@ void STLImporter::LoadASCIIFile()
             break;
         }
         // facet normal -0.13 -0.13 -0.98
-        if (!strncmp(sz,"facet",5) && IsSpaceOrNewLine(*(sz+5)))    {
+        if (!strncmp(sz,"facet",5) && IsSpaceOrNewLine(*(sz+5)) && *(sz + 5) != '\0')    {
 
             if (3 != curVertex) {
                 DefaultLogger::get()->warn("STL: A new facet begins but the old is not yet complete");


### PR DESCRIPTION
Since IsSpaceOrNewLine returns true on '\0' we might try to read past
end of buffer on line 310. Add explicit check to avoid this.

A better fix might be to change IsSpaceOrNewLine to not accept '\0' but that might break other things.

Fixes crashes/9be812f32156c36fc89b4498b5d54ac2 from #454. No new regression failures but STL is one of the tests which always fails on Linux so check on a supported platform before merge.