### PR TITLE
IFC: Don't store temporary values by reference

### DIFF
--- a/code/IFCOpenings.cpp
+++ b/code/IFCOpenings.cpp
@@ -602,12 +602,12 @@ bool IntersectingLineSegments(const IfcVector2& n0, const IfcVector2& n1,
     const IfcVector2& m0, const IfcVector2& m1,
     IfcVector2& out0, IfcVector2& out1)
 {
-    const IfcVector2& n0_to_n1 = n1 - n0;
+    const IfcVector2 n0_to_n1 = n1 - n0;
 
-    const IfcVector2& n0_to_m0 = m0 - n0;
-    const IfcVector2& n1_to_m1 = m1 - n1;
+    const IfcVector2 n0_to_m0 = m0 - n0;
+    const IfcVector2 n1_to_m1 = m1 - n1;
 
-    const IfcVector2& n0_to_m1 = m1 - n0;
+    const IfcVector2 n0_to_m1 = m1 - n0;
 
     const IfcFloat e = 1e-5f;
     const IfcFloat smalle = 1e-9f;
@@ -927,7 +927,7 @@ size_t CloseWindows(ContourVector& contours,
                 IfcFloat best = static_cast<IfcFloat>(1e10);
                 IfcVector3 bestv;
 
-                const IfcVector3& world_point = minv * IfcVector3(proj_point.x,proj_point.y,0.0f);
+                const IfcVector3 world_point = minv * IfcVector3(proj_point.x,proj_point.y,0.0f);
 
                 BOOST_FOREACH(const TempOpening* opening, refs) {
                     BOOST_FOREACH(const IfcVector3& other, opening->wallPoints) {
@@ -1066,7 +1066,7 @@ IfcMatrix4 ProjectOntoPlane(std::vector<IfcVector2>& out_contour, const TempMesh
 
     // Project all points into the new coordinate system, collect min/max verts on the way
     BOOST_FOREACH(const IfcVector3& x, in_verts) {
-        const IfcVector3& vv = m * x;
+        const IfcVector3 vv = m * x;
         // keep Z offset in the plane coordinate system. Ignoring precision issues
         // (which  are present, of course), this should be the same value for
         // all polygon vertices (assuming the polygon is planar).
@@ -1144,7 +1144,7 @@ bool GenerateOpenings(std::vector<TempOpening>& openings,
     std::vector<IfcVector2> contour_flat;
 
     IfcVector3 nor;
-    const IfcMatrix4& m = ProjectOntoPlane(contour_flat, curmesh,  ok, nor);
+    const IfcMatrix4 m = ProjectOntoPlane(contour_flat, curmesh,  ok, nor);
     if(!ok) {
         return false;
     }
@@ -1242,7 +1242,7 @@ bool GenerateOpenings(std::vector<TempOpening>& openings,
             for (unsigned int vi = 0, vend = profile_vertcnts[f]; vi < vend; ++vi, ++vi_total) {
                 const IfcVector3& x = profile_verts[vi_total];
 
-                const IfcVector3& v = m * x;
+                const IfcVector3 v = m * x;
                 IfcVector2 vv(v.x, v.y);
 
                 //if(check_intersection) {
@@ -1322,7 +1322,7 @@ bool GenerateOpenings(std::vector<TempOpening>& openings,
                 MakeDisjunctWindowContours(other, temp_contour, poly);
                 if(poly.size() == 1) {
 
-                    const BoundingBox& newbb = GetBoundingBox(poly[0].outer);
+                    const BoundingBox newbb = GetBoundingBox(poly[0].outer);
                     if (!BoundingBoxesOverlapping(ibb, newbb )) {
                          // Good guy bounding box
                          bb = newbb ;
@@ -1438,7 +1438,7 @@ bool TryAddOpenings_Poly2Tri(const std::vector<TempOpening>& openings,const std:
     // working coordinate system.
     bool ok;
     IfcVector3 nor;
-    const IfcMatrix3& m = DerivePlaneCoordinateSpace(curmesh, ok, nor);
+    const IfcMatrix3 m = DerivePlaneCoordinateSpace(curmesh, ok, nor);
     if (!ok) {
         return false;
     }
@@ -1686,7 +1686,7 @@ bool TryAddOpenings_Poly2Tri(const std::vector<TempOpening>& openings,const std:
             continue;
         }
 
-        const std::vector<p2t::Triangle*>& tris = cdt->GetTriangles();
+        const std::vector<p2t::Triangle*> tris = cdt->GetTriangles();
 
         // Collect the triangles we just produced
         BOOST_FOREACH(p2t::Triangle* tri, tris) {

--- a/code/IFCOpenings.cpp
+++ b/code/IFCOpenings.cpp
@@ -1227,7 +1227,7 @@ bool GenerateOpenings(std::vector<TempOpening>& openings,
 
             bool side_flag = true;
             if (!is_2d_source) {
-                const IfcVector3& face_nor = ((profile_verts[vi_total+2] - profile_verts[vi_total]) ^
+                const IfcVector3 face_nor = ((profile_verts[vi_total+2] - profile_verts[vi_total]) ^
                     (profile_verts[vi_total+1] - profile_verts[vi_total])).Normalize();
 
                 const IfcFloat abs_dot_face_nor = std::abs(nor * face_nor);
@@ -1692,7 +1692,7 @@ bool TryAddOpenings_Poly2Tri(const std::vector<TempOpening>& openings,const std:
         BOOST_FOREACH(p2t::Triangle* tri, tris) {
             for(int i = 0; i < 3; ++i) {
 
-                const IfcVector2& v = IfcVector2(
+                const IfcVector2 v = IfcVector2(
                     static_cast<IfcFloat>( tri->GetPoint(i)->x ),
                     static_cast<IfcFloat>( tri->GetPoint(i)->y )
                 );


### PR DESCRIPTION
This is not legal in any way and should never have worked.

This actually caused GCC to generate bad code when optimization was on. Reduces regression failures on Linux from 54 to 49. You should probably update the regression whitelist too.