### PR TITLE
Fixed issue in STLLoader that lead to wrong node names.

### DIFF
--- a/code/STLLoader.cpp
+++ b/code/STLLoader.cpp
@@ -206,7 +206,6 @@ void STLImporter::InternReadFile( const std::string& pFile,
     }
 
     // add all created meshes to the single node
-    pScene->mRootNode = new aiNode();
     pScene->mRootNode->mNumMeshes = pScene->mNumMeshes;
     pScene->mRootNode->mMeshes = new unsigned int[pScene->mNumMeshes];
     for (unsigned int i = 0; i < pScene->mNumMeshes; i++)


### PR DESCRIPTION
aiNode was created twice, sorry about that.

This fixes all STL regression errors concerning the node names. There are still some STL regression errors, all of them say something like "Files are different at aiMesh.mFaces. Error is: Expected 4115780318, but actual is 2985128783". Is it possible that the tool is comparing pointers? All models load fine...