### PR TITLE
remove memory.h dependancy

### DIFF
--- a/include/assimp/types.h
+++ b/include/assimp/types.h
@@ -47,7 +47,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // Some runtime headers
 #include <sys/types.h>
-#include <memory.h>
 #include <math.h>
 #include <stddef.h>
 #include <string.h>


### PR DESCRIPTION
Some embedded (or exotic) systems won't provide this header, and it seems to be unused (since memcpy is in string.h).
Tested on MinGW and VS2015.