### PR TITLE
Fixed issue in PlyParser (uint16 values misparsed)

### DIFF
--- a/code/PlyParser.cpp
+++ b/code/PlyParser.cpp
@@ -857,7 +857,7 @@ bool PLY::PropertyInstance::ParseValueBinary(
 
     case EDT_UShort:
         {
-        int16_t i = *((uint16_t*)pCur);
+        uint16_t i = *((uint16_t*)pCur);
 
         // Swap endianess
         if (p_bBE)ByteSwap::Swap(&i);


### PR DESCRIPTION
Yes, I just added a 'u'... It was probably due to a miscopypaste.

The point is; I was working with a binary .ply using uint16 for storing colors and I got a problem for loading it. Every value above (UINT16_MAX/2) was misparsed. After investigating I found the problem was from this fixed line.

If you desire, I could make a sample of a .ply using uint16. Actually a simple triangle using uint16 for colors can be used for demonstrating this. It should be encoded in binary. (but this looks so obvious...)

