### PR TITLE
aiGetExportFormatDescription() no longer uses free'd memory

### DIFF
--- a/code/AssimpCExport.cpp
+++ b/code/AssimpCExport.cpp
@@ -63,7 +63,8 @@ ASSIMP_API const aiExportFormatDesc* aiGetExportFormatDescription( size_t index)
 {
     // Note: this is valid as the index always pertains to a built-in exporter,
     // for which the returned structure is guaranteed to be of static storage duration.
-    const aiExportFormatDesc* orig( Exporter().GetExportFormatDescription( index ) );
+    Exporter exporter;
+    const aiExportFormatDesc* orig( exporter.GetExportFormatDescription( index ) );
     if (NULL == orig) {
         return NULL;
     }


### PR DESCRIPTION
aiGetExportFormatDescription() now creates an Exporter object at the beginning of the function, so that a call to `GetExportFormatDescription()` doesn't access free'd memory.