### PR TITLE
GenVertexNormalsProcess produces invalid results for specific input

### DIFF
--- a/code/GenVertexNormalsProcess.cpp
+++ b/code/GenVertexNormalsProcess.cpp
@@ -192,7 +192,7 @@ bool GenVertexNormalsProcess::GenMeshVertexNormals (aiMesh* pMesh, unsigned int 
                 const aiVector3D& v = pMesh->mNormals[verticesFound[a]];
                 if (is_not_qnan(v.x))pcNor += v;
             }
-            pcNor.Normalize();
+            pcNor.NormalizeSafe();
 
             // Write the smoothed normal back to all affected normals
             for (unsigned int a = 0; a < verticesFound.size(); ++a)
@@ -225,7 +225,7 @@ bool GenVertexNormalsProcess::GenMeshVertexNormals (aiMesh* pMesh, unsigned int 
                 if (v * vr >= fLimit * vrlen * v.Length())
                     pcNor += v;
             }
-            pcNew[i] = pcNor.Normalize();
+            pcNew[i] = pcNor.NormalizeSafe();
         }
     }
 

--- a/include/assimp/vector3.h
+++ b/include/assimp/vector3.h
@@ -116,6 +116,8 @@ public:
     /** @brief Normalize the vector */
     aiVector3t& Normalize();
 
+    /** @brief Normalize the vector with extra check for zero vectors */
+    aiVector3t& NormalizeSafe();
 
     /** @brief Componentwise multiplication of two vectors
      *

--- a/include/assimp/vector3.inl
+++ b/include/assimp/vector3.inl
@@ -104,7 +104,7 @@ template <typename TReal>
 AI_FORCE_INLINE aiVector3t<TReal>& aiVector3t<TReal>::NormalizeSafe() {
     TReal len = Length();
     if (len > static_cast<TReal>(0))
-        *this /= Length();
+        *this /= len;
     return *this;
 }
 // ------------------------------------------------------------------------------------------------

--- a/include/assimp/vector3.inl
+++ b/include/assimp/vector3.inl
@@ -101,6 +101,14 @@ AI_FORCE_INLINE aiVector3t<TReal>& aiVector3t<TReal>::Normalize() {
 }
 // ------------------------------------------------------------------------------------------------
 template <typename TReal>
+AI_FORCE_INLINE aiVector3t<TReal>& aiVector3t<TReal>::NormalizeSafe() {
+    TReal len = Length();
+    if (len > static_cast<TReal>(0))
+        *this /= Length();
+    return *this;
+}
+// ------------------------------------------------------------------------------------------------
+template <typename TReal>
 AI_FORCE_INLINE const aiVector3t<TReal>& aiVector3t<TReal>::operator += (const aiVector3t<TReal>& o) {
     x += o.x; y += o.y; z += o.z; return *this;
 }


### PR DESCRIPTION
This has been discussed here #485 and as we met the issue again, here is the fix that you were agree to merge in.

Basically, normal generator produces invalid results when it has to normalize a zero vector. Say if you have a look at the test sample `number_formats.obj`:

```
v 0 0 0
v 1 2. 3.0
v +1 +2. +3.0
v -1 -2. -3.0

f 1 2 4
```

So when you ask it to compute normals, it adds 1st, 2nd and 4th vectors and get `(0, 0, 0)` as a result, then it normalizes it by dividing by zero and bad stuff happens.

The proposed fix introduces a "safe" version of the normalization code that takes care about that specific case. Both calls in normalizer have been replaced, it is probably a good idea to review other code and replace some other normalizations, too.