### PR TITLE
Added support for empty .MTL files.

### DIFF
--- a/code/BaseImporter.cpp
+++ b/code/BaseImporter.cpp
@@ -435,22 +435,27 @@ void BaseImporter::ConvertUTF8toISO8859_1(std::string& data)
 
 // ------------------------------------------------------------------------------------------------
 void BaseImporter::TextFileToBuffer(IOStream* stream,
-    std::vector<char>& data)
+    std::vector<char>& data,
+    TextFileMode mode)
 {
     ai_assert(NULL != stream);
 
     const size_t fileSize = stream->FileSize();
-    if(!fileSize) {
-        throw DeadlyImportError("File is empty");
+    if (mode == FORBID_EMPTY) {
+        if(!fileSize) {
+            throw DeadlyImportError("File is empty");
+        }
     }
 
     data.reserve(fileSize+1);
     data.resize(fileSize);
-    if(fileSize != stream->Read( &data[0], 1, fileSize)) {
-        throw DeadlyImportError("File read error");
-    }
+    if(fileSize > 0) {
+        if(fileSize != stream->Read( &data[0], 1, fileSize)) {
+            throw DeadlyImportError("File read error");
+        }
 
-    ConvertToUTF8(data);
+        ConvertToUTF8(data);
+    }
 
     // append a binary zero to simplify string parsing
     data.push_back(0);

--- a/code/BaseImporter.h
+++ b/code/BaseImporter.h
@@ -347,6 +347,8 @@ public: // static utilities
     static void ConvertUTF8toISO8859_1(
         std::string& data);
 
+	enum TextFileMode { ALLOW_EMPTY, FORBID_EMPTY };
+
     // -------------------------------------------------------------------
     /** Utility for text file loaders which copies the contents of the
      *  file into a memory buffer and converts it to our UTF8
@@ -354,10 +356,12 @@ public: // static utilities
      *  @param stream Stream to read from.
      *  @param data Output buffer to be resized and filled with the
      *   converted text file data. The buffer is terminated with
-     *   a binary 0. */
+     *   a binary 0.
+     *  @param mode Whether it is OK to load empty text files. */
     static void TextFileToBuffer(
         IOStream* stream,
-        std::vector<char>& data);
+        std::vector<char>& data,
+        TextFileMode mode = FORBID_EMPTY);
 
     // -------------------------------------------------------------------
     /** Utility function to move a std::vector into a aiScene array

--- a/code/ObjFileParser.cpp
+++ b/code/ObjFileParser.cpp
@@ -555,9 +555,12 @@ void ObjFileParser::getMaterialLib()
         return;
     }
 
-    // Import material library data from file
+    // Import material library data from file.
+    // Some exporters (e.g. Silo) will happily write out empty
+    // material files if the model doesn't use any materials, so we
+    // allow that.
     std::vector<char> buffer;
-    BaseImporter::TextFileToBuffer( pFile, buffer );
+    BaseImporter::TextFileToBuffer( pFile, buffer, BaseImporter::ALLOW_EMPTY );
     m_pIO->Close( pFile );
 
     // Importing the material library


### PR DESCRIPTION
Some programs such as Silo export an empty .MTL file if you export a
.OBJ that doesn't use any materials. This patch allows the loading of
such files without error.