### PR TITLE
FBX Import fix

### DIFF
--- a/code/FBXMeshGeometry.cpp
+++ b/code/FBXMeshGeometry.cpp
@@ -347,23 +347,28 @@ void ResolveVertexDataArray(std::vector<T>& data_out, const Scope& source,
     const std::vector<unsigned int>& mapping_offsets,
     const std::vector<unsigned int>& mappings)
 {
-    std::vector<T> tempUV;
-    ParseVectorDataArray(tempUV,GetRequiredElement(source,dataElementName));
+
 
     // handle permutations of Mapping and Reference type - it would be nice to
     // deal with this more elegantly and with less redundancy, but right
     // now it seems unavoidable.
     if (MappingInformationType == "ByVertice" && ReferenceInformationType == "Direct") {
+		std::vector<T> tempData;
+		ParseVectorDataArray(tempData, GetRequiredElement(source, dataElementName));
+
         data_out.resize(vertex_count);
-        for (size_t i = 0, e = tempUV.size(); i < e; ++i) {
+		for (size_t i = 0, e = tempData.size(); i < e; ++i) {
 
             const unsigned int istart = mapping_offsets[i], iend = istart + mapping_counts[i];
             for (unsigned int j = istart; j < iend; ++j) {
-                data_out[mappings[j]] = tempUV[i];
+				data_out[mappings[j]] = tempData[i];
             }
         }
     }
     else if (MappingInformationType == "ByVertice" && ReferenceInformationType == "IndexToDirect") {
+		std::vector<T> tempData;
+		ParseVectorDataArray(tempData, GetRequiredElement(source, dataElementName));
+
         data_out.resize(vertex_count);
 
         std::vector<int> uvIndices;
@@ -373,24 +378,30 @@ void ResolveVertexDataArray(std::vector<T>& data_out, const Scope& source,
 
             const unsigned int istart = mapping_offsets[i], iend = istart + mapping_counts[i];
             for (unsigned int j = istart; j < iend; ++j) {
-                if(static_cast<size_t>(uvIndices[i]) >= tempUV.size()) {
+				if (static_cast<size_t>(uvIndices[i]) >= tempData.size()) {
                     DOMError("index out of range",&GetRequiredElement(source,indexDataElementName));
                 }
-                data_out[mappings[j]] = tempUV[uvIndices[i]];
+				data_out[mappings[j]] = tempData[uvIndices[i]];
             }
         }
     }
     else if (MappingInformationType == "ByPolygonVertex" && ReferenceInformationType == "Direct") {
-        if (tempUV.size() != vertex_count) {
+		std::vector<T> tempData;
+		ParseVectorDataArray(tempData, GetRequiredElement(source, dataElementName));
+
+		if (tempData.size() != vertex_count) {
             FBXImporter::LogError(Formatter::format("length of input data unexpected for ByPolygon mapping: ")
-                << tempUV.size() << ", expected " << vertex_count
+				<< tempData.size() << ", expected " << vertex_count
             );
             return;
         }
 
-        data_out.swap(tempUV);
+		data_out.swap(tempData);
     }
     else if (MappingInformationType == "ByPolygonVertex" && ReferenceInformationType == "IndexToDirect") {
+		std::vector<T> tempData;
+		ParseVectorDataArray(tempData, GetRequiredElement(source, dataElementName));
+
         data_out.resize(vertex_count);
 
         std::vector<int> uvIndices;
@@ -403,11 +414,11 @@ void ResolveVertexDataArray(std::vector<T>& data_out, const Scope& source,
 
         unsigned int next = 0;
         BOOST_FOREACH(int i, uvIndices) {
-            if(static_cast<size_t>(i) >= tempUV.size()) {
+			if (static_cast<size_t>(i) >= tempData.size()) {
                 DOMError("index out of range",&GetRequiredElement(source,indexDataElementName));
             }
 
-            data_out[next++] = tempUV[i];
+			data_out[next++] = tempData[i];
         }
     }
     else {


### PR DESCRIPTION
Fixes an error when an Element has no data.

Example from (Cinema4D export):
		LayerElementNormal: 0 {
			Version: 101
			Name: ""
			MappingInformationType: "NoMappingInformation"
			ReferenceInformationType: "Direct"
		}

What's missing here is the "Normals" data block.
Cinema4D outputs this with NoMappingInformation which does not
export the "Normals" datablock. This can happen for other LayerElement* types.

