### PR TITLE
Fix for FBX Files that do not have a Comma on a new line in a data block

### DIFF
--- a/code/FBXMeshGeometry.cpp
+++ b/code/FBXMeshGeometry.cpp
@@ -347,23 +347,28 @@ void ResolveVertexDataArray(std::vector<T>& data_out, const Scope& source,
     const std::vector<unsigned int>& mapping_offsets,
     const std::vector<unsigned int>& mappings)
 {
-    std::vector<T> tempUV;
-    ParseVectorDataArray(tempUV,GetRequiredElement(source,dataElementName));
+
 
     // handle permutations of Mapping and Reference type - it would be nice to
     // deal with this more elegantly and with less redundancy, but right
     // now it seems unavoidable.
     if (MappingInformationType == "ByVertice" && ReferenceInformationType == "Direct") {
+		std::vector<T> tempData;
+		ParseVectorDataArray(tempData, GetRequiredElement(source, dataElementName));
+
         data_out.resize(vertex_count);
-        for (size_t i = 0, e = tempUV.size(); i < e; ++i) {
+		for (size_t i = 0, e = tempData.size(); i < e; ++i) {
 
             const unsigned int istart = mapping_offsets[i], iend = istart + mapping_counts[i];
             for (unsigned int j = istart; j < iend; ++j) {
-                data_out[mappings[j]] = tempUV[i];
+				data_out[mappings[j]] = tempData[i];
             }
         }
     }
     else if (MappingInformationType == "ByVertice" && ReferenceInformationType == "IndexToDirect") {
+		std::vector<T> tempData;
+		ParseVectorDataArray(tempData, GetRequiredElement(source, dataElementName));
+
         data_out.resize(vertex_count);
 
         std::vector<int> uvIndices;
@@ -373,24 +378,30 @@ void ResolveVertexDataArray(std::vector<T>& data_out, const Scope& source,
 
             const unsigned int istart = mapping_offsets[i], iend = istart + mapping_counts[i];
             for (unsigned int j = istart; j < iend; ++j) {
-                if(static_cast<size_t>(uvIndices[i]) >= tempUV.size()) {
+				if (static_cast<size_t>(uvIndices[i]) >= tempData.size()) {
                     DOMError("index out of range",&GetRequiredElement(source,indexDataElementName));
                 }
-                data_out[mappings[j]] = tempUV[uvIndices[i]];
+				data_out[mappings[j]] = tempData[uvIndices[i]];
             }
         }
     }
     else if (MappingInformationType == "ByPolygonVertex" && ReferenceInformationType == "Direct") {
-        if (tempUV.size() != vertex_count) {
+		std::vector<T> tempData;
+		ParseVectorDataArray(tempData, GetRequiredElement(source, dataElementName));
+
+		if (tempData.size() != vertex_count) {
             FBXImporter::LogError(Formatter::format("length of input data unexpected for ByPolygon mapping: ")
-                << tempUV.size() << ", expected " << vertex_count
+				<< tempData.size() << ", expected " << vertex_count
             );
             return;
         }
 
-        data_out.swap(tempUV);
+		data_out.swap(tempData);
     }
     else if (MappingInformationType == "ByPolygonVertex" && ReferenceInformationType == "IndexToDirect") {
+		std::vector<T> tempData;
+		ParseVectorDataArray(tempData, GetRequiredElement(source, dataElementName));
+
         data_out.resize(vertex_count);
 
         std::vector<int> uvIndices;
@@ -403,11 +414,11 @@ void ResolveVertexDataArray(std::vector<T>& data_out, const Scope& source,
 
         unsigned int next = 0;
         BOOST_FOREACH(int i, uvIndices) {
-            if(static_cast<size_t>(i) >= tempUV.size()) {
+			if (static_cast<size_t>(i) >= tempData.size()) {
                 DOMError("index out of range",&GetRequiredElement(source,indexDataElementName));
             }
 
-            data_out[next++] = tempUV[i];
+			data_out[next++] = tempData[i];
         }
     }
     else {

--- a/code/FBXParser.cpp
+++ b/code/FBXParser.cpp
@@ -125,13 +125,21 @@ Element::Element(const Token& key_token, Parser& parser)
 
         if (n->Type() == TokenType_DATA) {
             tokens.push_back(n);
-
+			TokenPtr prev = n;
             n = parser.AdvanceToNextToken();
             if(!n) {
                 ParseError("unexpected end of file, expected bracket, comma or key",parser.LastToken());
             }
 
             const TokenType ty = n->Type();
+
+			// some exporters are missing a comma on the next line
+			// ignore missing comma and process data
+			if (ty == TokenType_DATA && prev->Type() == TokenType_DATA && (n->Line() == prev->Line() + 1)) {
+				tokens.push_back(n);
+				continue;
+			}
+
             if (ty != TokenType_OPEN_BRACKET && ty != TokenType_CLOSE_BRACKET && ty != TokenType_COMMA && ty != TokenType_KEY) {
                 ParseError("unexpected token; expected bracket, comma or key",n);
             }


### PR DESCRIPTION
Some exporter are missing a Comma on a new line in the Data Block.
This tries to fix it. A Better solution would be that the Tokenizer would generate
missing Comma Tokens when these are missing on a new line.


LayerElementColor: 0 {
			Version: 101
			Name: "colorSet1"
			MappingInformationType: "ByPolygonVertex"
			ReferenceInformationType: "IndexToDirect"
			Colors: *8 {
				a: 0.0,0.0,0.0,1.0
				0.0,0.0,0.0,1.0
                        }
}