### PR TITLE
Fix for FBX Files that do not have a Comma on a new line in a data block

### DIFF
--- a/code/FBXParser.cpp
+++ b/code/FBXParser.cpp
@@ -125,13 +125,20 @@ Element::Element(const Token& key_token, Parser& parser)
 
         if (n->Type() == TokenType_DATA) {
             tokens.push_back(n);
-
+			TokenPtr prev = n;
             n = parser.AdvanceToNextToken();
             if(!n) {
                 ParseError("unexpected end of file, expected bracket, comma or key",parser.LastToken());
             }
 
-            const TokenType ty = n->Type();
+			const TokenType ty = n->Type();
+
+			// some exporters are missing a comma on the next line
+			if (ty == TokenType_DATA && prev->Type() == TokenType_DATA && (n->Line() == prev->Line() + 1)) {
+				tokens.push_back(n);
+				continue;
+			}
+
             if (ty != TokenType_OPEN_BRACKET && ty != TokenType_CLOSE_BRACKET && ty != TokenType_COMMA && ty != TokenType_KEY) {
                 ParseError("unexpected token; expected bracket, comma or key",n);
             }


### PR DESCRIPTION
Some FBX Exporters (Cinema4D plugin for example) do not write a Comma between
two Numbers when there is a new Line.

Example:

LayerElementColor: 0 {
			Version: 101
			Name: "colorSet1"
			MappingInformationType: "ByPolygonVertex"
			ReferenceInformationType: "IndexToDirect"
			Colors: *45640 {
				a: 0.0,0.0,0.0,1.0
				0.0,0.0,0.0,1.0
                        }
}

A better fix would be that the Tokenizer would create Comma placeholder tokens.
But this fixes it too.