### PR TITLE
Fix compilation error for Mac OS X and 64-bit architecture

### DIFF
--- a/contrib/rapidjson/include/rapidjson/document.h
+++ b/contrib/rapidjson/include/rapidjson/document.h
@@ -557,12 +557,14 @@ public:
             flags_ |= kIntFlag;
     }
 
+#if !defined(__x86_64__)
     //! Constructor for size_t value.
     explicit GenericValue( size_t u ) RAPIDJSON_NOEXCEPT : data_(), flags_( kNumberUintFlag ) {
         data_.n.u64 = u;
         if ( !( u&0x80000000 ) )
             flags_ |= kIntFlag|kInt64Flag;
     }
+#endif
 #endif
 
     //! Constructor for double value.


### PR DESCRIPTION
For a 64-bit architecture, unsigned long and size_t are the same.
This causes a compilation error due to duplicate constructors in document.h.

Fixed issue https://github.com/assimp/assimp/issues/738