### PR TITLE
Valgrin free

### DIFF
--- a/code/3DSHelper.h
+++ b/code/3DSHelper.h
@@ -485,12 +485,12 @@ struct aiFloatKey
 /** Helper structure to represent a 3ds file node */
 struct Node
 {
-    Node()
-        : mParent()
-        , mInstanceNumber()
-        ,   mHierarchyPos       (0)
-        ,   mHierarchyIndex     (0)
-        ,   mInstanceCount      (1)
+    Node():
+    	mParent(NULL)
+		,	mInstanceNumber(0)
+		,	mHierarchyPos		(0)
+		,	mHierarchyIndex		(0)
+		,	mInstanceCount		(1)
     {
         static int iCnt = 0;
 

--- a/code/Assimp.cpp
+++ b/code/Assimp.cpp
@@ -96,6 +96,8 @@ namespace Assimp
     /** will return all registered importers. */
     void GetImporterInstanceList(std::vector< BaseImporter* >& out);
 
+    /** will delete all registered importers. */
+    void DeleteImporterInstanceList(std::vector< BaseImporter* >& out);
 } // namespace assimp
 
 
@@ -647,6 +649,8 @@ ASSIMP_API C_STRUCT const aiImporterDesc* aiGetImporterDesc( const char *extensi
             break;
         }
     }
+
+    DeleteImporterInstanceList(out);
 
     return desc;
 }

--- a/code/Importer.cpp
+++ b/code/Importer.cpp
@@ -90,6 +90,8 @@ using namespace Assimp::Formatter;
 namespace Assimp {
     // ImporterRegistry.cpp
     void GetImporterInstanceList(std::vector< BaseImporter* >& out);
+	void DeleteImporterInstanceList(std::vector< BaseImporter* >& out);
+
     // PostStepRegistry.cpp
     void GetPostProcessingStepInstanceList(std::vector< BaseProcess* >& out);
 }
@@ -173,8 +175,7 @@ Importer::Importer()
 Importer::~Importer()
 {
     // Delete all import plugins
-    for( unsigned int a = 0; a < pimpl->mImporter.size(); a++)
-        delete pimpl->mImporter[a];
+	DeleteImporterInstanceList(pimpl->mImporter);
 
     // Delete all post-processing plug-ins
     for( unsigned int a = 0; a < pimpl->mPostProcessingSteps.size(); a++)
@@ -1113,4 +1114,3 @@ void Importer::GetMemoryRequirements(aiMemoryInfo& in) const
     }
     in.total += in.materials;
 }
-

--- a/code/ImporterRegistry.cpp
+++ b/code/ImporterRegistry.cpp
@@ -321,4 +321,12 @@ void GetImporterInstanceList(std::vector< BaseImporter* >& out)
 #endif
 }
 
+/** will delete all registered importers. */
+void DeleteImporterInstanceList(std::vector< BaseImporter* >& deleteList){
+	for(size_t i= 0; i<deleteList.size();++i){
+		delete deleteList[i];
+		deleteList[i]=NULL;
+	}//for
+}
+
 } // namespace Assimp

--- a/code/MaterialSystem.cpp
+++ b/code/MaterialSystem.cpp
@@ -53,7 +53,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "../include/assimp/DefaultLogger.hpp"
 #include "Macros.h"
 
-
 using namespace Assimp;
 
 // ------------------------------------------------------------------------------------------------
@@ -571,9 +570,11 @@ void aiMaterial::CopyPropertyList(aiMaterial* pcDest,
         for (unsigned int i = 0; i < iOldNum;++i) {
             pcDest->mProperties[i] = pcOld[i];
         }
-
-        delete[] pcOld;
     }
+
+    if(pcOld)
+    	delete[] pcOld;
+
     for (unsigned int i = iOldNum; i< pcDest->mNumProperties;++i)   {
         aiMaterialProperty* propSrc = pcSrc->mProperties[i];
 
@@ -605,4 +606,3 @@ void aiMaterial::CopyPropertyList(aiMaterial* pcDest,
     }
     return;
 }
-

--- a/code/MemoryIOWrapper.h
+++ b/code/MemoryIOWrapper.h
@@ -178,7 +178,8 @@ public:
 
     // -------------------------------------------------------------------
     /** Closes the given file and releases all resources associated with it. */
-    void Close( IOStream* /*pFile*/) {
+    void Close( IOStream* pFile) {
+    	delete pFile;
     }
 
     // -------------------------------------------------------------------

--- a/code/OpenGEXImporter.cpp
+++ b/code/OpenGEXImporter.cpp
@@ -183,7 +183,9 @@ OpenGEXImporter::VertexContainer::VertexContainer()
 , m_numNormals( 0 )
 , m_normals(NULL)
 , m_numUVComps()
-, m_textureCoords() {
+, m_textureCoords()
+ {
+    // empty
 }
 
 //------------------------------------------------------------------------------------------------
@@ -217,6 +219,7 @@ OpenGEXImporter::OpenGEXImporter()
 , m_ctx( NULL )
 , m_metrics()
 , m_currentNode( NULL )
+, m_currentVertices()
 , m_currentMesh( NULL )
 , m_currentMaterial( NULL )
 , m_tokenType( Grammar::NoneType )
@@ -661,6 +664,7 @@ void OpenGEXImporter::handleVertexArrayNode( ODDLParser::DDLNode *node, aiScene 
         }
 
         const size_t numItems( countDataArrayListItems( vaList ) );
+
         if( Position == attribType ) {
             m_currentVertices.m_numVerts = numItems;
             m_currentVertices.m_vertices = new aiVector3D[ numItems ];

--- a/code/RemoveVCProcess.cpp
+++ b/code/RemoveVCProcess.cpp
@@ -283,7 +283,7 @@ bool RemoveVCProcess::ProcessMesh(aiMesh* pMesh)
         if (!pMesh->mTextureCoords[i])break;
         if (configDeleteFlags & aiComponent_TEXCOORDSn(real) || b)
         {
-            delete pMesh->mTextureCoords[i];
+            delete [] pMesh->mTextureCoords[i];
             pMesh->mTextureCoords[i] = NULL;
             ret = true;
 

--- a/code/SkeletonMeshBuilder.cpp
+++ b/code/SkeletonMeshBuilder.cpp
@@ -73,9 +73,11 @@ SkeletonMeshBuilder::SkeletonMeshBuilder( aiScene* pScene, aiNode* root, bool bK
     root->mMeshes[0] = 0;
 
     // create a dummy material for the mesh
-    pScene->mNumMaterials = 1;
-    pScene->mMaterials = new aiMaterial*[1];
-    pScene->mMaterials[0] = CreateMaterial();
+    if(pScene->mNumMaterials==0){
+		pScene->mNumMaterials = 1;
+		pScene->mMaterials = new aiMaterial*[1];
+		pScene->mMaterials[0] = CreateMaterial();
+    }
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/code/StepExporter.cpp
+++ b/code/StepExporter.cpp
@@ -137,10 +137,12 @@ namespace {
 
 // ------------------------------------------------------------------------------------------------
 // Constructor for a specific scene to export
-StepExporter::StepExporter(const aiScene* pScene, IOSystem* pIOSystem, const std::string& path, const std::string& file, const ExportProperties* pProperties) : mProperties(pProperties), mIOSystem(pIOSystem), mFile(file), mPath(path), mScene(pScene), endstr(";\n")
-{
-    CollectTrafos(pScene->mRootNode, trafos);
-    CollectMeshes(pScene->mRootNode, meshes);
+StepExporter::StepExporter(const aiScene* pScene, IOSystem* pIOSystem, const std::string& path,
+		const std::string& file, const ExportProperties* pProperties):
+				 mProperties(pProperties),mIOSystem(pIOSystem),mFile(file), mPath(path),
+				 mScene(pScene), endstr(";\n") {
+	CollectTrafos(pScene->mRootNode, trafos);
+	CollectMeshes(pScene->mRootNode, meshes);
 
     // make sure that all formatting happens using the standard, C locale and not the user's current locale
     mOutput.imbue( std::locale("C") );

--- a/test/unit/utColladaExportLight.cpp
+++ b/test/unit/utColladaExportLight.cpp
@@ -54,7 +54,6 @@ public:
     {
         ex = new Assimp::Exporter();
         im = new Assimp::Importer();
-
     }
 
     virtual void TearDown()
@@ -73,7 +72,7 @@ protected:
 // ------------------------------------------------------------------------------------------------
 TEST_F(ColladaExportLight, testExportLight)
 {
-    const char* file = "cameraExp.dae";
+    const char* file = "lightsExp.dae";
 
     const aiScene* pTest = im->ReadFile(ASSIMP_TEST_MODELS_DIR "/Collada/lights.dae",0);
     ASSERT_TRUE(pTest!=NULL);
@@ -88,7 +87,6 @@ TEST_F(ColladaExportLight, testExportLight)
     }
 
     EXPECT_EQ(AI_SUCCESS,ex->Export(pTest,"collada",file));
-    EXPECT_EQ(AI_SUCCESS,ex->Export(pTest,"collada","lightsExp.dae"));
 
     const aiScene* imported = im->ReadFile(file,0);
 
@@ -123,7 +121,9 @@ TEST_F(ColladaExportLight, testExportLight)
         EXPECT_NEAR(orig->mAngleInnerCone,read->mAngleInnerCone,0.001);
         EXPECT_NEAR(orig->mAngleOuterCone,read->mAngleOuterCone,0.001);
     }
+
     delete [] origLights;
+
 }
 
 

--- a/test/unit/utNoBoostTest.cpp
+++ b/test/unit/utNoBoostTest.cpp
@@ -76,7 +76,8 @@ TEST(NoBoostTest, Tuple) {
     EXPECT_EQ(4U, first.get<1>());
     EXPECT_EQ(4U, first.get<2>());
 
-    boost::tuple<int, float, double, bool, another> second;
+    boost::tuple<int, float, double, bool, another> second=
+    		boost::make_tuple(1,1.0f,0.0,false,another());
     bool b = second.get<3>();
 
     // check empty tuple

--- a/test/unit/utRemoveRedundantMaterials.cpp
+++ b/test/unit/utRemoveRedundantMaterials.cpp
@@ -60,7 +60,6 @@ protected:
     RemoveRedundantMatsProcess* piProcess;
 
     aiScene* pcScene1;
-    aiScene* pcScene2;
 };
 
 // ------------------------------------------------------------------------------------------------

--- a/test/unit/utSharedPPData.cpp
+++ b/test/unit/utSharedPPData.cpp
@@ -59,28 +59,16 @@ protected:
     SharedPostProcessInfo* shared;
 };
 
-static bool destructed;
-
-struct TestType
-{
-    ~TestType()
-    {
-        destructed = true;
-    }
-};
-
-
 // ------------------------------------------------------------------------------------------------
 void SharedPPDataTest::SetUp()
 {
     shared = new SharedPostProcessInfo();
-    destructed = false;
 }
 
 // ------------------------------------------------------------------------------------------------
 void SharedPPDataTest::TearDown()
 {
-
+	delete shared;
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -112,14 +100,26 @@ TEST_F(SharedPPDataTest, testPropertyPointer)
     EXPECT_FALSE(shared->GetProperty("test16",o));
 }
 
+static bool destructed;
+
+struct TestType
+{
+    ~TestType()
+    {
+        destructed = true;
+    }
+};
 // ------------------------------------------------------------------------------------------------
 TEST_F(SharedPPDataTest, testPropertyDeallocation)
 {
-    TestType *out, * pip = new TestType();
-    shared->AddProperty("quak",pip);
-    EXPECT_TRUE(shared->GetProperty("quak",out));
+	SharedPostProcessInfo* localShared = new SharedPostProcessInfo();
+	destructed = false;
+
+	TestType *out, * pip = new TestType();
+	localShared->AddProperty("quak",pip);
+    EXPECT_TRUE(localShared->GetProperty("quak",out));
     EXPECT_EQ(pip, out);
 
-    delete shared;
+    delete localShared;
     EXPECT_TRUE(destructed);
 }

--- a/test/unit/utSplitLargeMeshes.cpp
+++ b/test/unit/utSplitLargeMeshes.cpp
@@ -58,8 +58,7 @@ protected:
 
     SplitLargeMeshesProcess_Triangle* piProcessTriangle;
     SplitLargeMeshesProcess_Vertex* piProcessVertex;
-    aiMesh* pcMesh1;
-    aiMesh* pcMesh2;
+
 };
 
 // ------------------------------------------------------------------------------------------------
@@ -72,44 +71,6 @@ void SplitLargeMeshesTest::SetUp()
     this->piProcessTriangle->SetLimit(1000);
     this->piProcessVertex->SetLimit(1000);
 
-    this->pcMesh1 = new aiMesh();
-    pcMesh1->mNumVertices = 2100; // quersumme: 3
-    pcMesh1->mVertices = new aiVector3D[pcMesh1->mNumVertices];
-    pcMesh1->mNormals = new aiVector3D[pcMesh1->mNumVertices];
-
-    pcMesh1->mNumFaces = pcMesh1->mNumVertices / 3;
-    pcMesh1->mFaces = new aiFace[pcMesh1->mNumFaces];
-
-    unsigned int qq = 0;
-    for (unsigned int i = 0; i < pcMesh1->mNumFaces;++i)
-    {
-        aiFace& face = pcMesh1->mFaces[i];
-        face.mNumIndices = 3;
-        face.mIndices = new unsigned int[3];
-        face.mIndices[0] = qq++;
-        face.mIndices[1] = qq++;
-        face.mIndices[2] = qq++;
-    }
-
-    // generate many, many faces with randomized indices for
-    // the second mesh
-    this->pcMesh2 = new aiMesh();
-    pcMesh2->mNumVertices = 3000;
-    pcMesh2->mVertices = new aiVector3D[pcMesh2->mNumVertices];
-    pcMesh2->mNormals = new aiVector3D[pcMesh2->mNumVertices];
-
-    pcMesh2->mNumFaces = 10000;
-    pcMesh2->mFaces = new aiFace[pcMesh2->mNumFaces];
-
-    for (unsigned int i = 0; i < pcMesh2->mNumFaces;++i)
-    {
-        aiFace& face = pcMesh2->mFaces[i];
-        face.mNumIndices = 3;
-        face.mIndices = new unsigned int[3];
-        face.mIndices[0] = (unsigned int)((rand() / (float)RAND_MAX) * pcMesh2->mNumVertices);
-        face.mIndices[1] = (unsigned int)((rand() / (float)RAND_MAX) * pcMesh2->mNumVertices);
-        face.mIndices[2] = (unsigned int)((rand() / (float)RAND_MAX) * pcMesh2->mNumVertices);
-    }
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -123,6 +84,26 @@ void SplitLargeMeshesTest::TearDown()
 TEST_F(SplitLargeMeshesTest, testVertexSplit)
 {
     std::vector< std::pair<aiMesh*, unsigned int> > avOut;
+
+     aiMesh *pcMesh1 = new aiMesh();
+     pcMesh1->mNumVertices = 2100; // quersumme: 3
+     pcMesh1->mVertices = new aiVector3D[pcMesh1->mNumVertices];
+     pcMesh1->mNormals = new aiVector3D[pcMesh1->mNumVertices];
+
+     pcMesh1->mNumFaces = pcMesh1->mNumVertices / 3;
+     pcMesh1->mFaces = new aiFace[pcMesh1->mNumFaces];
+
+     unsigned int qq = 0;
+     for (unsigned int i = 0; i < pcMesh1->mNumFaces;++i)
+     {
+         aiFace& face = pcMesh1->mFaces[i];
+         face.mNumIndices = 3;
+         face.mIndices = new unsigned int[3];
+         face.mIndices[0] = qq++;
+         face.mIndices[1] = qq++;
+         face.mIndices[2] = qq++;
+     }
+
 
     int iOldFaceNum = (int)pcMesh1->mNumFaces;
     piProcessVertex->SplitMesh(0,pcMesh1,avOut);
@@ -146,6 +127,26 @@ TEST_F(SplitLargeMeshesTest, testVertexSplit)
 TEST_F(SplitLargeMeshesTest, testTriangleSplit)
 {
     std::vector< std::pair<aiMesh*, unsigned int> > avOut;
+
+    // generate many, many faces with randomized indices for
+    // the second mesh
+    aiMesh *pcMesh2 = new aiMesh();
+    pcMesh2->mNumVertices = 3000;
+    pcMesh2->mVertices = new aiVector3D[pcMesh2->mNumVertices];
+    pcMesh2->mNormals = new aiVector3D[pcMesh2->mNumVertices];
+
+    pcMesh2->mNumFaces = 10000;
+    pcMesh2->mFaces = new aiFace[pcMesh2->mNumFaces];
+
+    for (unsigned int i = 0; i < pcMesh2->mNumFaces;++i)
+    {
+        aiFace& face = pcMesh2->mFaces[i];
+        face.mNumIndices = 3;
+        face.mIndices = new unsigned int[3];
+        face.mIndices[0] = (unsigned int)((rand() / (float)RAND_MAX) * pcMesh2->mNumVertices);
+        face.mIndices[1] = (unsigned int)((rand() / (float)RAND_MAX) * pcMesh2->mNumVertices);
+        face.mIndices[2] = (unsigned int)((rand() / (float)RAND_MAX) * pcMesh2->mNumVertices);
+    }
 
     // the number of faces shouldn't change
     int iOldFaceNum = (int)pcMesh2->mNumFaces;


### PR DESCRIPTION
I run the test using valgrind and remove all the memory leaks that it found.
And fix some compile warnings.
Now there is only one problem with the [here](https://github.com/assimp/assimp/blob/master/test/unit/utSharedPPData.cpp#L106) since you will do a delete instead of delete[].
but I don't know how specialize the class Assimp::SharedPostProcessInfo::THeapData for hendle object pointer and array pointer.