### PR TITLE
ObjImporter: Removed unnecessary removal of '\' chars.

### DIFF
--- a/code/ObjFileImporter.cpp
+++ b/code/ObjFileImporter.cpp
@@ -145,38 +145,6 @@ void ObjFileImporter::InternReadFile( const std::string& pFile, aiScene* pScene,
         modelName = pFile;
     }
 
-    // This next stage takes ~ 1/3th of the total readFile task
-    // so should amount for 1/3th of the progress
-    // only update every 100KB or it'll be too slow
-    unsigned int progress = 0;
-    unsigned int progressCounter = 0;
-    const unsigned int updateProgressEveryBytes = 100 * 1024;
-    const unsigned int progressTotal = (3*m_Buffer.size()/updateProgressEveryBytes);
-    // process all '\'
-    std::vector<char> ::iterator iter = m_Buffer.begin();
-    while (iter != m_Buffer.end())
-    {
-        if (*iter == '\\')
-        {
-            // remove '\'
-            iter = m_Buffer.erase(iter);
-            // remove next character
-            while (*iter == '\r' || *iter == '\n')
-                iter = m_Buffer.erase(iter);
-        }
-        else
-            ++iter;
-
-        if (++progressCounter >= updateProgressEveryBytes)
-        {
-            m_progress->UpdateFileRead(++progress, progressTotal);
-            progressCounter = 0;
-        }
-    }
-
-    // 1/3rd progress
-    m_progress->UpdateFileRead(1, 3);
-
     // parse the file into a temporary representation
     ObjFileParser parser(m_Buffer, modelName, pIOHandler, m_progress);
 

--- a/code/ObjFileParser.cpp
+++ b/code/ObjFileParser.cpp
@@ -111,8 +111,7 @@ void ObjFileParser::parseFile()
     const unsigned int updateProgressEveryBytes = 100 * 1024;
     unsigned int progressCounter = 0;
     const unsigned int bytesToProcess = std::distance(m_DataIt, m_DataItEnd);
-    const unsigned int progressTotal = 3 * bytesToProcess;
-    const unsigned int progressOffset = bytesToProcess;
+    const unsigned int progressTotal = bytesToProcess;
     unsigned int processed = 0;
 
     DataArrayIt lastDataIt = m_DataIt;
@@ -125,7 +124,7 @@ void ObjFileParser::parseFile()
         if (processed > (progressCounter * updateProgressEveryBytes))
         {
             progressCounter++;
-            m_progress->UpdateFileRead(progressOffset + processed*2, progressTotal);
+            m_progress->UpdateFileRead(processed, progressTotal);
         }
 
         // parse line


### PR DESCRIPTION
std::vector::erase() has complexity O(n) which for a large buffer is very
slow.

Additionally in ObjFileParser we have a copyNextLine() function which
takes line continuation with backslashes into account. This is used only
for faces ATM. I'm not sure when a '\' can occur in a .obj file, but I've
only ever seen it on face lines that have more than 3 vertices.

We could use copyNextLine() for other types of lines too if needed. This
would slow down parsing of lines a little bit, but that is probably
mitigated by not scanning through removing backslashes first (that took
1/3rd of the import time in my file that has no backslashes).

Finally I've updated the progress reporting to take into account this
change.