### PR TITLE
ObjFileMtlImporter: Fixed a segfault due to NULL ptr access.

### DIFF
--- a/code/ObjFileMtlImporter.cpp
+++ b/code/ObjFileMtlImporter.cpp
@@ -339,6 +339,7 @@ void ObjFileMtlImporter::getTexture() {
     } else if(!ASSIMP_strincmp( pPtr, ReflectionTexture.c_str(), ReflectionTexture.size() ) ) {
         // Reflection texture(s)
         //Do nothing here
+        return;
     } else if (!ASSIMP_strincmp( pPtr, DisplacementTexture.c_str(), DisplacementTexture.size() ) ) {
         // Displacement texture
         out = &m_pModel->m_pCurrentMaterial->textureDisp;


### PR DESCRIPTION
We don't handle reflection textures during MTL import. This allowed a NULL
ptr to be used. Simply return in the case of a reflection texture.