### PR TITLE
use NormalizeSafe to prevent NaN when normalizing zero vectors

### DIFF
--- a/code/SmoothingGroups.inl
+++ b/code/SmoothingGroups.inl
@@ -119,7 +119,7 @@ void ComputeNormalsWithSmoothingsGroups(MeshWithSmoothingGroups<T>& sMesh)
             {
                 vNormals += sMesh.mNormals[(*a)];
             }
-            vNormals.Normalize();
+            vNormals.NormalizeSafe();
 
             // write back into all affected normals
             for (std::vector<unsigned int>::const_iterator


### PR DESCRIPTION
This started here #485 and was partially fixed here #713, but I've just found one more place that needs attention for the same reason: `SmoothingGroups.inl`, which is used by 3DS loader and maybe by some other code, as well.

The problem is absolutely the same: the code computes some normals, sums them up and then normalizes, but in some cases the sum is zero, so normalization a zero vector gives unpredictable results.

That's why we've added `NormalizeSafe` and the one-line patch switches from the unsafe `Normalize` to a safer `NormalizeSafe()`.