### PR TITLE
Fix loading of pk3 q3bsp maps

### DIFF
--- a/code/Q3BSPZipArchive.cpp
+++ b/code/Q3BSPZipArchive.cpp
@@ -292,7 +292,7 @@ bool Q3BSPZipArchive::mapArchive() {
                         // The file has EXACTLY the size of uncompressed_size. In C
                         // you need to mark the last character with '\0', so add
                         // another character
-                        if(unzOpenCurrentFile(m_ZipFileHandle) == UNZ_OK) {
+                        if(fileInfo.uncompressed_size != 0 && unzOpenCurrentFile(m_ZipFileHandle) == UNZ_OK) {
                             std::pair<std::map<std::string, ZipFile*>::iterator, bool> result = m_ArchiveMap.insert(std::make_pair(filename, new ZipFile(fileInfo.uncompressed_size)));
 
                             if(unzReadCurrentFile(m_ZipFileHandle, result.first->second->m_Buffer, fileInfo.uncompressed_size) == (long int) fileInfo.uncompressed_size) {


### PR DESCRIPTION
This fixes loading of pk3 maps.  The pk3 files contain directory entries with a size of 0, which triggered the following assertion:

    Q3BSPZipArchive.cpp:142: Assimp::Q3BSP::ZipFile::ZipFile(size_t): Assertion `m_Size != 0' failed.

The fix ignores "files" with size of 0, which seems to work perfectly for me.