### PR TITLE
Resolves #802

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,10 +98,10 @@ SET( ASSIMP_INCLUDE_INSTALL_DIR "include" CACHE PATH
 SET( ASSIMP_BIN_INSTALL_DIR "bin" CACHE PATH
   "Path the tool executables are installed to." )
 
-IF (CMAKE_BUILD_TYPE STREQUAL "Release")
-  SET(CMAKE_DEBUG_POSTFIX "" CACHE STRING "Debug Postfix for lib, samples and tools")
-ELSE()
+IF (CMAKE_BUILD_TYPE STREQUAL "Debug")
   SET(CMAKE_DEBUG_POSTFIX "d" CACHE STRING "Debug Postfix for lib, samples and tools")
+ELSE()
+  SET(CMAKE_DEBUG_POSTFIX "" CACHE STRING "Debug Postfix for lib, samples and tools")
 ENDIF()
 
 # Only generate this target if no higher-level project already has


### PR DESCRIPTION
If CMAKE_BUILD_TYPE equal "" as it is in default it will add "d" to library in cmake config.