### PR TITLE
Fix warning when compiling using -Wswitch-enum

### DIFF
--- a/include/assimp/metadata.h
+++ b/include/assimp/metadata.h
@@ -177,6 +177,9 @@ struct aiMetadata
                 case AI_AIVECTOR3D:
                     delete static_cast<aiVector3D*>(data);
                     break;
+#ifndef SWIG
+                case FORCE_32BIT:
+#endif
                 default:
                     assert(false);
                     break;


### PR DESCRIPTION
No changes to functionality, only removing a warning due to unhandled value in a switch statement. The missing value is not of any interest there, so let the default block handle it. Found while building an application with assimp static library + headers on Xcode 7.2.1.