### PR TITLE
Fix memory leak in OBJ loader when a mesh has no faces.

### DIFF
--- a/code/ObjFileImporter.cpp
+++ b/code/ObjFileImporter.cpp
@@ -308,7 +308,11 @@ aiMesh *ObjFileImporter::createTopology( const ObjFile::Model* pModel, const Obj
     if( !pObjMesh ) {
         return NULL;
     }
-    ai_assert( NULL != pObjMesh );
+
+    if( pObjMesh->m_Faces.empty() ) {
+        return NULL;
+    }
+
     aiMesh* pMesh = new aiMesh;
     if( !pObjMesh->m_name.empty() ) {
         pMesh->mName.Set( pObjMesh->m_name );


### PR DESCRIPTION
Also got rid of an assertion that would never trigger because the same test was already performed two lines above.

The aiMesh object returned by this function leaked if it had zero faces, because the caller doesn't do anything with the returned value in that case (https://github.com/assimp/assimp/blob/master/code/ObjFileImporter.cpp#L261), which means it never gets deleted.

I don't actually have a file with a mesh that has no faces. The root cause of the issue for me seems to be poor handling of the group (g) keyword, since it triggers creation of a new mesh. Something like this:

```
...

mtllib materials.mtl
g everything
usemtl mat01
...
```

The result for me was a mesh named "g everything" with zero faces and a mesh called mat01 with whatever faces defined right after that. I don't have the time to understand how groups work and fix it now, but wanted to point it out anyway.