### PR TITLE
PlyParser: fix invalid loading when comment is empty.

### DIFF
--- a/code/PlyParser.cpp
+++ b/code/PlyParser.cpp
@@ -420,7 +420,10 @@ bool PLY::DOM::SkipComments (const char* pCur,
 
     if (TokenMatch(pCur,"comment",7))
     {
-        SkipLine(pCur,&pCur);
+	     if ( !IsLineEnd(pCur[-1]) )
+	     {
+	         SkipLine(pCur,&pCur);
+	     }
         SkipComments(pCur,&pCur);
         *pCurOut = pCur;
         return true;


### PR DESCRIPTION
When the "comment" field of a .ply is empty like "comment\n", assimp field skip all the "comment\n" (call of TokenMatch) with the next line too (call of SkipLine).

By Trying to convert the following .ply file, an error is returned
$ assimp export cube.ply a.obj
assimp export: select file format: 'obj' (Wavefront OBJ format)
Launching asset import ...           OK
Validating postprocessing flags ...  OK
ERROR: Failed to load file: Invalid .ply file: No vertices found. Unable to parse the data format of the PLY file.

"""
ply
format ascii 1.0
comment
element vertex 8
property float x
property float y
property float z
element face 12
property list uchar int vertex_indices
end_header
-1 -1 -1 
-1 1 -1 
0.999999 -1 1 
-1 -1 1 
-1 1 1 
1 0.999999 1 
1 1 -1 
1 -1 -1 
3 7 0 1 
3 4 3 2 
3 5 2 7 
3 2 3 0 
3 0 3 4 
3 6 1 4 
3 6 7 1 
3 5 4 2 
3 6 5 7 
3 7 2 0 
3 1 0 4 
3 5 6 4 
"""

421         if (TokenMatch(pCur,''comment'',7))
(gdb) p pCur
$6 = 0x6361c5 ``comment\nelement vertex 26\nproperty float x\nproperty float y\nproperty float z\nproperty float nx\nproperty float ny\nproperty float nz\nelement face 12\nproperty list uchar uint vertex_indices\nend_header\n1.''...
(gdb) n
423             SkipLine(pCur,&pCur);
(gdb) p pCur
$7 = 0x6361cd ``element vertex 26\nproperty float x\nproperty float y\nproperty float z\nproperty float nx\nproperty float ny\nproperty float nz\nelement face 12\nproperty list uchar uint vertex_indices\nend_header\n1.000000 -''...
(gdb) n
424             SkipComments(pCur,&pCur);
(gdb) p pCur
$8 = 0x6361df "property float x\nproperty float y\nproperty float z\nproperty float nx\nproperty float ny\nproperty float nz\nelement face 12\nproperty list uchar uint vertex_indices\nend_header\n1.000000 -1.000000 -1.000000"...