### PR TITLE
Vcs 1030/obj mtl filename fallback

### DIFF
--- a/code/ObjFileImporter.cpp
+++ b/code/ObjFileImporter.cpp
@@ -177,7 +177,7 @@ void ObjFileImporter::InternReadFile( const std::string &file, aiScene* pScene, 
     m_progress->UpdateFileRead(1, 3);
 
     // parse the file into a temporary representation
-    ObjFileParser parser(m_Buffer, modelName, pIOHandler, m_progress);
+    ObjFileParser parser(m_Buffer, modelName, pIOHandler, m_progress, file);
 
     // And create the proper return structures out of it
     CreateDataFromImport(parser.GetModel(), pScene);

--- a/code/ObjFileParser.cpp
+++ b/code/ObjFileParser.cpp
@@ -61,13 +61,14 @@ const std::string ObjFileParser::DEFAULT_MATERIAL = AI_DEFAULT_MATERIAL_NAME;
 
 // -------------------------------------------------------------------
 //  Constructor with loaded data and directories.
-ObjFileParser::ObjFileParser(std::vector<char> &data,const std::string &modelName, IOSystem *io, ProgressHandler* progress ) :
+ObjFileParser::ObjFileParser(std::vector<char> &data, const std::string &modelName, IOSystem *io, ProgressHandler* progress, const std::string &originalObjFileName) :
     m_DataIt(data.begin()),
     m_DataItEnd(data.end()),
     m_pModel(NULL),
     m_uiLine(0),
     m_pIO( io ),
-    m_progress(progress)
+    m_progress(progress),
+    m_originalObjFileName(originalObjFileName)
 {
     std::fill_n(m_buffer,Buffersize,0);
 
@@ -573,9 +574,14 @@ void ObjFileParser::getMaterialLib()
     IOStream *pFile = m_pIO->Open( absName );
 
     if (!pFile ) {
-        DefaultLogger::get()->error( "OBJ: Unable to locate material file " + strMatName );
-        m_DataIt = skipLine<DataArrayIt>( m_DataIt, m_DataItEnd, m_uiLine );
-        return;
+        DefaultLogger::get()->error("OBJ: Unable to locate material file " + strMatName);
+        std::string strMatFallbackName = m_originalObjFileName.substr(0, m_originalObjFileName.length() - 3) + "mtl";
+        pFile = m_pIO->Open(strMatFallbackName);
+        if (!pFile) {
+            DefaultLogger::get()->error("OBJ: Unable to locate material fallback file " + strMatName);
+            m_DataIt = skipLine<DataArrayIt>(m_DataIt, m_DataItEnd, m_uiLine);
+            return;
+        }
     }
 
     // Import material library data from file.

--- a/code/ObjFileParser.cpp
+++ b/code/ObjFileParser.cpp
@@ -576,9 +576,10 @@ void ObjFileParser::getMaterialLib()
     if (!pFile ) {
         DefaultLogger::get()->error("OBJ: Unable to locate material file " + strMatName);
         std::string strMatFallbackName = m_originalObjFileName.substr(0, m_originalObjFileName.length() - 3) + "mtl";
+        DefaultLogger::get()->info("OBJ: Opening fallback material file " + strMatFallbackName);
         pFile = m_pIO->Open(strMatFallbackName);
         if (!pFile) {
-            DefaultLogger::get()->error("OBJ: Unable to locate material fallback file " + strMatName);
+            DefaultLogger::get()->error("OBJ: Unable to locate fallback material file " + strMatName);
             m_DataIt = skipLine<DataArrayIt>(m_DataIt, m_DataItEnd, m_uiLine);
             return;
         }

--- a/code/ObjFileParser.h
+++ b/code/ObjFileParser.h
@@ -72,7 +72,7 @@ public:
 
 public:
     /// \brief  Constructor with data array.
-    ObjFileParser(std::vector<char> &Data,const std::string &strModelName, IOSystem* io, ProgressHandler* progress);
+    ObjFileParser(std::vector<char> &Data, const std::string &strModelName, IOSystem* io, ProgressHandler* progress, const std::string &originalObjFileName);
     /// \brief  Destructor
     ~ObjFileParser();
     /// \brief  Model getter.
@@ -143,6 +143,8 @@ private:
     //! Pointer to progress handler
     ProgressHandler* m_progress;
     /// Path to the current model
+    // name of the obj file where the buffer comes from
+    const std::string& m_originalObjFileName;
 };
 
 }   // Namespace Assimp


### PR DESCRIPTION
* this fallback strategy for cases when a .mtl file is not found serves two use cases:
 * 1.): workaround for a common user mistake: we occasionally get renamed .obj/.mtl files where the creator didn't know that this breaks the reference in the .obj file to the .mtl file
 * 2.): workaround for file name encoding issue: on a debian system that we use, a "Köln.obj" refering to "Köln.mtl" is within assimp processed as "KÃ¶ln.obj" (file open works with this badly encoded file name containing "Ã¶", but not with the correct "ö"). but opening the refered .mtl file also only works when m_pIO->Open() is called with "KÃ¶ln.mtl"