### PR TITLE
Python 3 compatibility fix for xrange in PyAssimp

### DIFF
--- a/port/PyAssimp/pyassimp/core.py
+++ b/port/PyAssimp/pyassimp/core.py
@@ -8,6 +8,11 @@ import sys
 if sys.version_info < (2,6):
     raise 'pyassimp: need python 2.6 or newer'
 
+# xrange was renamed range in Python 3 and the original range from Python 2 was removed.
+# To keep compatibility with both Python 2 and 3, xrange is set to range for version 3.0 and up.
+if sys.version_info >= (3,0):
+    xrange = range
+
 import ctypes
 import os
 


### PR DESCRIPTION
This is a fix that sets xrange to range in Python 3.0 and above. In Python 3 xrange was renamed range and the original range function was removed.