### PR TITLE
Replaced boost with c++11 features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,32 +114,7 @@ IF (NOT TARGET uninstall)
   add_custom_target(uninstall "${CMAKE_COMMAND}" -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake")
 ENDIF()
 
-# Globally enable Boost resp. the Boost workaround – it is also needed by the
-# tools which include the Assimp headers.
-option ( ASSIMP_ENABLE_BOOST_WORKAROUND
-  "If a simple implementation of the used Boost functions is used. Slightly reduces functionality, but enables builds without Boost available."
-  ON
-)
-IF ( ASSIMP_ENABLE_BOOST_WORKAROUND )
-  INCLUDE_DIRECTORIES( code/BoostWorkaround )
-  ADD_DEFINITIONS( -DASSIMP_BUILD_BOOST_WORKAROUND )
-  MESSAGE( STATUS "Building a non-boost version of Assimp." )
-ELSE ( ASSIMP_ENABLE_BOOST_WORKAROUND )
-  SET( Boost_DETAILED_FAILURE_MSG ON )
-  IF ( NOT Boost_ADDITIONAL_VERSIONS )
-    SET( Boost_ADDITIONAL_VERSIONS "1.47" "1.47.0" "1.48.0" "1.48" "1.49" "1.49.0" "1.50" "1.50.0" "1.51" "1.51.0" "1.52.0" "1.53.0" "1.54.0" "1.55" "1.55.0" "1.56" "1.56.0" "1.57" "1.57.0" "1.58" "1.58.0" "1.59" "1.59.0")
-  ENDIF ( NOT Boost_ADDITIONAL_VERSIONS )
-  FIND_PACKAGE( Boost )
-  IF ( NOT Boost_FOUND )
-    MESSAGE( FATAL_ERROR
-      "Boost libraries (http://www.boost.org/) not found. "
-      "You can build a non-boost version of Assimp with slightly reduced "
-      "functionality by specifying -DASSIMP_ENABLE_BOOST_WORKAROUND=ON."
-    )
-  ENDIF ( NOT Boost_FOUND )
 
-  INCLUDE_DIRECTORIES( ${Boost_INCLUDE_DIRS} )
-ENDIF ( ASSIMP_ENABLE_BOOST_WORKAROUND )
 
 # cmake configuration files
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/assimp-config.cmake.in"         "${CMAKE_CURRENT_BINARY_DIR}/assimp-config.cmake" @ONLY IMMEDIATE)
@@ -207,7 +182,7 @@ MARK_AS_ADVANCED ( ASSIMP_BUILD_ARCHITECTURE ASSIMP_BUILD_COMPILER )
 
 
 SET ( ASSIMP_BUILD_NONFREE_C4D_IMPORTER OFF CACHE BOOL
-  "Build the C4D importer, which relies on the non-free Melange SDK." 
+  "Build the C4D importer, which relies on the non-free Melange SDK."
 )
 
 IF (ASSIMP_BUILD_NONFREE_C4D_IMPORTER)
@@ -222,26 +197,26 @@ IF (ASSIMP_BUILD_NONFREE_C4D_IMPORTER)
     ELSEIF(MSVC90)
       SET(C4D_LIB_POSTFIX "_2008md")
     ELSE()
-      MESSAGE( FATAL_ERROR 
+      MESSAGE( FATAL_ERROR
         "C4D is currently only supported with MSVC 9, 10, 11"
       )
     ENDIF()
-      
+
     IF(CMAKE_CL_64)
       SET(C4D_LIB_ARCH_POSTFIX "_x64")
     ELSE()
       SET(C4D_LIB_ARCH_POSTFIX "")
     ENDIF()
-    
+
     SET(C4D_LIB_BASE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/contrib/Melange/_melange/lib/WIN")
-    
+
     SET(C4D_DEBUG_LIBRARY "${C4D_LIB_BASE_PATH}/debug/_melange_lib${C4D_LIB_ARCH_POSTFIX}${C4D_LIB_POSTFIX}.lib")
     SET(C4D_RELEASE_LIBRARY "${C4D_LIB_BASE_PATH}/release/_melange_lib${C4D_LIB_ARCH_POSTFIX}${C4D_LIB_POSTFIX}.lib")
-    
+
     # winsock and winmm are necessary dependencies of melange (this is undocumented, but true.)
     SET(C4D_EXTRA_LIBRARIES WSock32.lib Winmm.lib)
   ELSE ()
-    MESSAGE( FATAL_ERROR 
+    MESSAGE( FATAL_ERROR
       "C4D is currently only available on Windows with melange SDK installed in contrib/Melange"
     )
   ENDIF ( MSVC )
@@ -319,7 +294,7 @@ if(CMAKE_CPACK_COMMAND AND UNIX AND ASSIMP_OPT_BUILD_PACKAGES)
   set(CPACK_COMPONENT_${LIBASSIMP-DEV_COMPONENT_UPPER}_DEPENDS $    "{LIBASSIMP_COMPONENT}" )
   set(CPACK_COMPONENT_ASSIMP-DEV_DISPLAY_NAME                       "${CPACK_COMPONENT_${LIBASSIMP-DEV_COMPONENT}_DISPLAY_NAME}" )
   set(CPACK_COMPONENT_ASSIMP-DEV_DEPENDS                            "${LIBASSIMP-DEV_COMPONENT}" )
-  set(CPACK_DEBIAN_BUILD_DEPENDS debhelper cmake libboost-dev libboost-thread-dev libboost-math-dev zlib1g-dev pkg-config)
+  set(CPACK_DEBIAN_BUILD_DEPENDS debhelper cmake zlib1g-dev pkg-config)
 
   # debian
   set(CPACK_DEBIAN_PACKAGE_PRIORITY "optional")
@@ -352,15 +327,15 @@ if(WIN32)
 		set(BIN_DIR "${PROJECT_SOURCE_DIR}/bin32/")
 		set(LIB_DIR "${PROJECT_SOURCE_DIR}/lib32/")
 	endif()
-	
+
 	if(MSVC12)
 		set(ASSIMP_MSVC_VERSION "vc120")
-	elseif(MSVC14)	
+	elseif(MSVC14)
 		set(ASSIMP_MSVC_VERSION "vc140")
 	endif(MSVC12)
 
 	if(MSVC12 OR MSVC14)
-		add_custom_target(UpdateAssimpLibsDebugSymbolsAndDLLs COMMENT "Copying Assimp Libraries ..." VERBATIM)	
+		add_custom_target(UpdateAssimpLibsDebugSymbolsAndDLLs COMMENT "Copying Assimp Libraries ..." VERBATIM)
 		add_custom_command(TARGET UpdateAssimpLibsDebugSymbolsAndDLLs COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/code/Release/assimp-${ASSIMP_MSVC_VERSION}-mt.dll	${BIN_DIR}assimp-${ASSIMP_MSVC_VERSION}-mt.dll VERBATIM)
 		add_custom_command(TARGET UpdateAssimpLibsDebugSymbolsAndDLLs COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/code/Release/assimp-${ASSIMP_MSVC_VERSION}-mt.exp	${LIB_DIR}assimp-${ASSIMP_MSVC_VERSION}-mt.exp VERBATIM)
 		add_custom_command(TARGET UpdateAssimpLibsDebugSymbolsAndDLLs COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/code/Release/assimp-${ASSIMP_MSVC_VERSION}-mt.lib	${LIB_DIR}assimp-${ASSIMP_MSVC_VERSION}-mt.lib VERBATIM)

--- a/code/3DSConverter.cpp
+++ b/code/3DSConverter.cpp
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "../include/assimp/scene.h"
 #include "../include/assimp/DefaultLogger.hpp"
 #include "StringComparison.h"
-#include <boost/scoped_array.hpp>
+#include <memory>
 #include <cctype>
 
 using namespace Assimp;
@@ -359,7 +359,7 @@ void Discreet3DSImporter::ConvertMeshes(aiScene* pcOut)
 
     // we need to split all meshes by their materials
     for (std::vector<D3DS::Mesh>::iterator i =  mScene->mMeshes.begin(); i != mScene->mMeshes.end();++i)    {
-        boost::scoped_array< std::vector<unsigned int> > aiSplit(new std::vector<unsigned int>[mScene->mMaterials.size()]);
+        std::unique_ptr< std::vector<unsigned int>[] > aiSplit(new std::vector<unsigned int>[mScene->mMaterials.size()]);
 
         name.length = ASSIMP_itoa10(name.data,num++);
 

--- a/code/3DSExporter.cpp
+++ b/code/3DSExporter.cpp
@@ -164,7 +164,7 @@ void ExportScene3DS(const char* pFile, IOSystem* pIOSystem, const aiScene* pScen
     // in |Exporter::ExportFormatEntry|.
     aiScene* scenecopy_tmp;
     SceneCombiner::CopyScene(&scenecopy_tmp,pScene);
-    std::auto_ptr<aiScene> scenecopy(scenecopy_tmp);
+    std::unique_ptr<aiScene> scenecopy(scenecopy_tmp);
 
     SplitLargeMeshesProcess_Triangle tri_splitter;
     tri_splitter.SetLimit(0xffff);

--- a/code/3DSExporter.cpp
+++ b/code/3DSExporter.cpp
@@ -150,7 +150,7 @@ namespace {
 // Worker function for exporting a scene to 3DS. Prototyped and registered in Exporter.cpp
 void ExportScene3DS(const char* pFile, IOSystem* pIOSystem, const aiScene* pScene, const ExportProperties* pProperties)
 {
-    boost::shared_ptr<IOStream> outfile (pIOSystem->Open(pFile, "wb"));
+    std::shared_ptr<IOStream> outfile (pIOSystem->Open(pFile, "wb"));
     if(!outfile) {
         throw DeadlyExportError("Could not open output .3ds file: " + std::string(pFile));
     }
@@ -181,7 +181,7 @@ void ExportScene3DS(const char* pFile, IOSystem* pIOSystem, const aiScene* pScen
 } // end of namespace Assimp
 
 // ------------------------------------------------------------------------------------------------
-Discreet3DSExporter:: Discreet3DSExporter(boost::shared_ptr<IOStream> outfile, const aiScene* scene)
+Discreet3DSExporter:: Discreet3DSExporter(std::shared_ptr<IOStream> outfile, const aiScene* scene)
 : scene(scene)
 , writer(outfile)
 {

--- a/code/3DSExporter.h
+++ b/code/3DSExporter.h
@@ -45,7 +45,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define AI_3DSEXPORTER_H_INC
 
 #include <map>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include "StreamWriter.h"
 #include "./../include/assimp/material.h"
@@ -64,7 +64,7 @@ namespace Assimp
 class Discreet3DSExporter
 {
 public:
-    Discreet3DSExporter(boost::shared_ptr<IOStream> outfile, const aiScene* pScene);
+    Discreet3DSExporter(std::shared_ptr<IOStream> outfile, const aiScene* pScene);
 
 private:
 

--- a/code/ACLoader.cpp
+++ b/code/ACLoader.cpp
@@ -60,7 +60,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "../include/assimp/scene.h"
 #include "../include/assimp/config.h"
 #include "../include/assimp/IOSystem.hpp"
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 
 using namespace Assimp;
 
@@ -708,7 +708,7 @@ aiNode* AC3DImporter::ConvertObjectSection(Object& object,
             // collect all meshes using the same material group.
             if (object.subDiv)  {
                 if (configEvalSubdivision) {
-                    boost::scoped_ptr<Subdivider> div(Subdivider::Create(Subdivider::CATMULL_CLARKE));
+                    std::unique_ptr<Subdivider> div(Subdivider::Create(Subdivider::CATMULL_CLARKE));
                     DefaultLogger::get()->info("AC3D: Evaluating subdivision surface: "+object.name);
 
                     std::vector<aiMesh*> cpy(meshes.size()-oldm,NULL);
@@ -787,7 +787,7 @@ void AC3DImporter::SetupProperties(const Importer* pImp)
 void AC3DImporter::InternReadFile( const std::string& pFile,
     aiScene* pScene, IOSystem* pIOHandler)
 {
-    boost::scoped_ptr<IOStream> file( pIOHandler->Open( pFile, "rb"));
+    std::unique_ptr<IOStream> file( pIOHandler->Open( pFile, "rb"));
 
     // Check whether we can read from the file
     if( file.get() == NULL)

--- a/code/ASELoader.cpp
+++ b/code/ASELoader.cpp
@@ -51,7 +51,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "SkeletonMeshBuilder.h"
 #include "TargetAnimation.h"
 #include "../include/assimp/Importer.hpp"
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include "../include/assimp/IOSystem.hpp"
 #include "../include/assimp/DefaultLogger.hpp"
 #include "../include/assimp/scene.h"
@@ -130,7 +130,7 @@ void ASEImporter::SetupProperties(const Importer* pImp)
 void ASEImporter::InternReadFile( const std::string& pFile,
     aiScene* pScene, IOSystem* pIOHandler)
 {
-    boost::scoped_ptr<IOStream> file( pIOHandler->Open( pFile, "rb"));
+    std::unique_ptr<IOStream> file( pIOHandler->Open( pFile, "rb"));
 
     // Check whether we can read from the file
     if( file.get() == NULL) {

--- a/code/Assimp.cpp
+++ b/code/Assimp.cpp
@@ -59,8 +59,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // ------------------------------------------------------------------------------------------------
 #ifndef ASSIMP_BUILD_SINGLETHREADED
-#   include <boost/thread/thread.hpp>
-#   include <boost/thread/mutex.hpp>
+#   include <thread>
+#   include <mutex>
 #endif
 // ------------------------------------------------------------------------------------------------
 using namespace Assimp;
@@ -103,7 +103,7 @@ namespace Assimp
 
 #ifndef ASSIMP_BUILD_SINGLETHREADED
 /** Global mutex to manage the access to the log-stream map */
-static boost::mutex gLogStreamMutex;
+static std::mutex gLogStreamMutex;
 #endif
 
 
@@ -119,7 +119,7 @@ public:
 
     ~LogToCallbackRedirector()  {
 #ifndef ASSIMP_BUILD_SINGLETHREADED
-        boost::mutex::scoped_lock lock(gLogStreamMutex);
+        std::lock_guard<std::mutex> lock(gLogStreamMutex);
 #endif
         // (HACK) Check whether the 'stream.user' pointer points to a
         // custom LogStream allocated by #aiGetPredefinedLogStream.
@@ -321,8 +321,8 @@ ASSIMP_API const aiScene* aiApplyPostProcessing(const aiScene* pScene,
 }
 
 // ------------------------------------------------------------------------------------------------
-ASSIMP_API const aiScene *aiApplyCustomizedPostProcessing( const aiScene *scene, 
-                                                           BaseProcess* process, 
+ASSIMP_API const aiScene *aiApplyCustomizedPostProcessing( const aiScene *scene,
+                                                           BaseProcess* process,
                                                            bool requestValidation ) {
     const aiScene* sc( NULL );
 
@@ -343,7 +343,7 @@ ASSIMP_API const aiScene *aiApplyCustomizedPostProcessing( const aiScene *scene,
     }
 
     ASSIMP_END_EXCEPTION_REGION( const aiScene* );
-    
+
     return sc;
 }
 
@@ -383,7 +383,7 @@ ASSIMP_API void aiAttachLogStream( const aiLogStream* stream )
     ASSIMP_BEGIN_EXCEPTION_REGION();
 
 #ifndef ASSIMP_BUILD_SINGLETHREADED
-    boost::mutex::scoped_lock lock(gLogStreamMutex);
+    std::lock_guard<std::mutex> lock(gLogStreamMutex);
 #endif
 
     LogStream* lg = new LogToCallbackRedirector(*stream);
@@ -402,7 +402,7 @@ ASSIMP_API aiReturn aiDetachLogStream( const aiLogStream* stream)
     ASSIMP_BEGIN_EXCEPTION_REGION();
 
 #ifndef ASSIMP_BUILD_SINGLETHREADED
-    boost::mutex::scoped_lock lock(gLogStreamMutex);
+    std::lock_guard<std::mutex> lock(gLogStreamMutex);
 #endif
     // find the log-stream associated with this data
     LogStreamMap::iterator it = gActiveLogStreams.find( *stream);
@@ -427,7 +427,7 @@ ASSIMP_API void aiDetachAllLogStreams(void)
 {
     ASSIMP_BEGIN_EXCEPTION_REGION();
 #ifndef ASSIMP_BUILD_SINGLETHREADED
-    boost::mutex::scoped_lock lock(gLogStreamMutex);
+    std::lock_guard<std::mutex> lock(gLogStreamMutex);
 #endif
     Logger *logger( DefaultLogger::get() );
     if ( NULL == logger ) {
@@ -440,7 +440,7 @@ ASSIMP_API void aiDetachAllLogStreams(void)
     }
     gActiveLogStreams.clear();
     DefaultLogger::kill();
-    
+
     ASSIMP_END_EXCEPTION_REGION(void);
 }
 

--- a/code/B3DImporter.cpp
+++ b/code/B3DImporter.cpp
@@ -7,8 +7,8 @@ Copyright (c) 2006-2016, assimp team
 
 All rights reserved.
 
-Redistribution and use of this software in source and binary forms, 
-with or without modification, are permitted provided that the following 
+Redistribution and use of this software in source and binary forms,
+with or without modification, are permitted provided that the following
 conditions are met:
 
 * Redistributions of source code must retain the above
@@ -25,16 +25,16 @@ conditions are met:
   derived from this software without specific prior
   written permission of the assimp team.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
 OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
 LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ---------------------------------------------------------------------------
 */
@@ -51,7 +51,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "TextureTransform.h"
 #include "ConvertToLHProcess.h"
 #include "StringUtils.h"
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include "../include/assimp/IOSystem.hpp"
 #include "../include/assimp/anim.h"
 #include "../include/assimp/scene.h"
@@ -71,11 +71,11 @@ static const aiImporterDesc desc = {
     0,
     0,
     0,
-    "b3d" 
+    "b3d"
 };
 
 // (fixme, Aramis) quick workaround to get rid of all those signed to unsigned warnings
-#ifdef _MSC_VER 
+#ifdef _MSC_VER
 #	pragma warning (disable: 4018)
 #endif
 
@@ -114,7 +114,7 @@ void B3DImporter::InternReadFile( const std::string& pFile, aiScene* pScene, IOS
     cout<<"Hello world from the B3DImporter!"<<endl;
 #endif
 
-    boost::scoped_ptr<IOStream> file( pIOHandler->Open( pFile));
+    std::unique_ptr<IOStream> file( pIOHandler->Open( pFile));
 
     // Check whether we can read from the file
     if( file.get() == NULL)
@@ -280,12 +280,12 @@ void B3DImporter::ReadBRUS(){
 
         aiMaterial *mat=new aiMaterial;
         _materials.push_back( mat );
-        
+
         // Name
         aiString ainame( name );
         mat->AddProperty( &ainame,AI_MATKEY_NAME );
-        
-        // Diffuse color 
+
+        // Diffuse color
         mat->AddProperty( &color,1,AI_MATKEY_COLOR_DIFFUSE );
 
         // Opacity
@@ -294,16 +294,16 @@ void B3DImporter::ReadBRUS(){
         // Specular color
         aiColor3D speccolor( shiny,shiny,shiny );
         mat->AddProperty( &speccolor,1,AI_MATKEY_COLOR_SPECULAR );
-        
+
         // Specular power
         float specpow=shiny*128;
         mat->AddProperty( &specpow,1,AI_MATKEY_SHININESS );
-        
+
         // Double sided
         if( fx & 0x10 ){
-            int i=1; 
+            int i=1;
             mat->AddProperty( &i,1,AI_MATKEY_TWOSIDED );
-        } 		
+        }
 
         //Textures
         for( int i=0;i<n_texs;++i ){
@@ -569,7 +569,7 @@ void B3DImporter::ReadBB3D( aiScene *scene ){
     string t=ReadChunk();
     if( t=="BB3D" ){
         int version=ReadInt();
-        
+
         if (!DefaultLogger::isNullLogger()) {
             char dmp[128];
             ai_snprintf(dmp, 128, "B3D file format version: %i",version);
@@ -669,7 +669,7 @@ void B3DImporter::ReadBB3D( aiScene *scene ){
     }
     scene->mNumMaterials=_materials.size();
     scene->mMaterials=to_array( _materials );
-    
+
     //meshes
     scene->mNumMeshes=_meshes.size();
     scene->mMeshes=to_array( _meshes );

--- a/code/BVHLoader.cpp
+++ b/code/BVHLoader.cpp
@@ -47,7 +47,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "fast_atof.h"
 #include "SkeletonMeshBuilder.h"
 #include "../include/assimp/Importer.hpp"
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include <boost/format.hpp>
 #include "../include/assimp/IOSystem.hpp"
 #include "../include/assimp/scene.h"
@@ -118,7 +118,7 @@ void BVHLoader::InternReadFile( const std::string& pFile, aiScene* pScene, IOSys
     mFileName = pFile;
 
     // read file into memory
-    boost::scoped_ptr<IOStream> file( pIOHandler->Open( pFile));
+    std::unique_ptr<IOStream> file( pIOHandler->Open( pFile));
     if( file.get() == NULL)
         throw DeadlyImportError( "Failed to open file " + pFile + ".");
 

--- a/code/BVHLoader.cpp
+++ b/code/BVHLoader.cpp
@@ -48,11 +48,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "SkeletonMeshBuilder.h"
 #include "../include/assimp/Importer.hpp"
 #include <memory>
-#include <boost/format.hpp>
+#include "TinyFormatter.h"
 #include "../include/assimp/IOSystem.hpp"
 #include "../include/assimp/scene.h"
 
 using namespace Assimp;
+using namespace Assimp::Formatter;
 
 static const aiImporterDesc desc = {
     "BVH Importer (MoCap)",
@@ -179,12 +180,12 @@ aiNode* BVHLoader::ReadNode()
     // first token is name
     std::string nodeName = GetNextToken();
     if( nodeName.empty() || nodeName == "{")
-        ThrowException( boost::str( boost::format( "Expected node name, but found \"%s\".") % nodeName));
+        ThrowException( format() << "Expected node name, but found \"" << nodeName << "\"." );
 
     // then an opening brace should follow
     std::string openBrace = GetNextToken();
     if( openBrace != "{")
-        ThrowException( boost::str( boost::format( "Expected opening brace \"{\", but found \"%s\".") % openBrace));
+        ThrowException( format() << "Expected opening brace \"{\", but found \"" << openBrace << "\"." );
 
     // Create a node
     aiNode* node = new aiNode( nodeName);
@@ -216,7 +217,7 @@ aiNode* BVHLoader::ReadNode()
             // The real symbol is "End Site". Second part comes in a separate token
             std::string siteToken = GetNextToken();
             if( siteToken != "Site")
-                ThrowException( boost::str( boost::format( "Expected \"End Site\" keyword, but found \"%s %s\".") % token % siteToken));
+                ThrowException( format() << "Expected \"End Site\" keyword, but found \"" << token << " " << siteToken << "\"." );
 
             aiNode* child = ReadEndSite( nodeName);
             child->mParent = node;
@@ -229,7 +230,7 @@ aiNode* BVHLoader::ReadNode()
         } else
         {
             // everything else is a parse error
-            ThrowException( boost::str( boost::format( "Unknown keyword \"%s\".") % token));
+            ThrowException( format() << "Unknown keyword \"" << token << "\"." );
         }
     }
 
@@ -252,7 +253,7 @@ aiNode* BVHLoader::ReadEndSite( const std::string& pParentName)
     // check opening brace
     std::string openBrace = GetNextToken();
     if( openBrace != "{")
-        ThrowException( boost::str( boost::format( "Expected opening brace \"{\", but found \"%s\".") % openBrace));
+        ThrowException( format() << "Expected opening brace \"{\", but found \"" << openBrace << "\".");
 
     // Create a node
     aiNode* node = new aiNode( "EndSite_" + pParentName);
@@ -274,7 +275,7 @@ aiNode* BVHLoader::ReadEndSite( const std::string& pParentName)
         } else
         {
             // everything else is a parse error
-            ThrowException( boost::str( boost::format( "Unknown keyword \"%s\".") % token));
+            ThrowException( format() << "Unknown keyword \"" << token << "\"." );
         }
     }
 
@@ -321,7 +322,7 @@ void BVHLoader::ReadNodeChannels( BVHLoader::Node& pNode)
         else if( channelToken == "Zrotation")
             pNode.mChannels.push_back( Channel_RotationZ);
         else
-            ThrowException( boost::str( boost::format( "Invalid channel specifier \"%s\".") % channelToken));
+            ThrowException( format() << "Invalid channel specifier \"" << channelToken << "\"." );
     }
 }
 
@@ -332,7 +333,7 @@ void BVHLoader::ReadMotion( aiScene* /*pScene*/)
     // Read number of frames
     std::string tokenFrames = GetNextToken();
     if( tokenFrames != "Frames:")
-        ThrowException( boost::str( boost::format( "Expected frame count \"Frames:\", but found \"%s\".") % tokenFrames));
+        ThrowException( format() << "Expected frame count \"Frames:\", but found \"" << tokenFrames << "\".");
 
     float numFramesFloat = GetNextTokenAsFloat();
     mAnimNumFrames = (unsigned int) numFramesFloat;
@@ -341,7 +342,7 @@ void BVHLoader::ReadMotion( aiScene* /*pScene*/)
     std::string tokenDuration1 = GetNextToken();
     std::string tokenDuration2 = GetNextToken();
     if( tokenDuration1 != "Frame" || tokenDuration2 != "Time:")
-        ThrowException( boost::str( boost::format( "Expected frame duration \"Frame Time:\", but found \"%s %s\".") % tokenDuration1 % tokenDuration2));
+        ThrowException( format() << "Expected frame duration \"Frame Time:\", but found \"" << tokenDuration1 << " " << tokenDuration2 << "\"." );
 
     mAnimTickDuration = GetNextTokenAsFloat();
 
@@ -414,7 +415,7 @@ float BVHLoader::GetNextTokenAsFloat()
     ctoken = fast_atoreal_move<float>( ctoken, result);
 
     if( ctoken != token.c_str() + token.length())
-        ThrowException( boost::str( boost::format( "Expected a floating point number, but found \"%s\".") % token));
+        ThrowException( format() << "Expected a floating point number, but found \"" << token << "\"." );
 
     return result;
 }
@@ -423,7 +424,7 @@ float BVHLoader::GetNextTokenAsFloat()
 // Aborts the file reading with an exception
 AI_WONT_RETURN void BVHLoader::ThrowException( const std::string& pError)
 {
-    throw DeadlyImportError( boost::str( boost::format( "%s:%d - %s") % mFileName % mLine % pError));
+    throw DeadlyImportError( format() << mFileName << ":" << mLine << " - " << pError);
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/code/BaseImporter.cpp
+++ b/code/BaseImporter.cpp
@@ -52,8 +52,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "../include/assimp/postprocess.h"
 #include <ios>
 #include <list>
-#include <boost/scoped_ptr.hpp>
-#include <boost/scoped_array.hpp>
+#include <memory>
 #include <sstream>
 #include <cctype>
 
@@ -149,10 +148,10 @@ void BaseImporter::GetExtensionList(std::set<std::string>& extensions)
     if (!pIOHandler)
         return false;
 
-    boost::scoped_ptr<IOStream> pStream (pIOHandler->Open(pFile));
+    std::unique_ptr<IOStream> pStream (pIOHandler->Open(pFile));
     if (pStream.get() ) {
         // read 200 characters from the file
-        boost::scoped_array<char> _buffer (new char[searchBytes+1 /* for the '\0' */]);
+        std::unique_ptr<char[]> _buffer (new char[searchBytes+1 /* for the '\0' */]);
         char* buffer = _buffer.get();
         if( NULL == buffer ) {
             return false;
@@ -256,7 +255,7 @@ void BaseImporter::GetExtensionList(std::set<std::string>& extensions)
         const uint32_t* magic_u32;
     };
     magic = reinterpret_cast<const char*>(_magic);
-    boost::scoped_ptr<IOStream> pStream (pIOHandler->Open(pFile));
+    std::unique_ptr<IOStream> pStream (pIOHandler->Open(pFile));
     if (pStream.get() ) {
 
         // skip to offset

--- a/code/BlenderDNA.cpp
+++ b/code/BlenderDNA.cpp
@@ -48,13 +48,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "BlenderDNA.h"
 #include "StreamReader.h"
 #include "fast_atof.h"
-#include <boost/foreach.hpp>
 
 using namespace Assimp;
 using namespace Assimp::Blender;
 using namespace Assimp::Formatter;
 
-#define for_each BOOST_FOREACH
 bool match4(StreamReaderAny& stream, const char* string) {
     char tmp[] = {
         (stream).GetI1(),
@@ -86,7 +84,7 @@ void DNAParser :: Parse ()
     }
 
     std::vector<std::string> names (stream.GetI4());
-    for_each(std::string& s, names) {
+    for(std::string& s : names) {
         while (char c = stream.GetI1()) {
             s += c;
         }
@@ -99,7 +97,7 @@ void DNAParser :: Parse ()
     }
 
     std::vector<Type> types (stream.GetI4());
-    for_each(Type& s, types) {
+    for(Type& s : types) {
         while (char c = stream.GetI1()) {
             s.name += c;
         }
@@ -111,7 +109,7 @@ void DNAParser :: Parse ()
         throw DeadlyImportError("BlenderDNA: Expected TLEN field");
     }
 
-    for_each(Type& s, types) {
+    for(Type& s : types) {
         s.size = stream.GetI2();
     }
 
@@ -238,9 +236,9 @@ void DNA :: DumpToFile()
     f << "Field format: type name offset size" << "\n";
     f << "Structure format: name size" << "\n";
 
-    for_each(const Structure& s, structures) {
+    for(const Structure& s : structures) {
         f << s.name << " " << s.size << "\n\n";
-        for_each(const Field& ff, s.fields) {
+        for(const Field& ff : s.fields) {
             f << "\t" << ff.type << " " << ff.name << " " << ff.offset << " " << ff.size << std::endl;
         }
         f << std::endl;

--- a/code/BlenderDNA.cpp
+++ b/code/BlenderDNA.cpp
@@ -268,17 +268,17 @@ void DNA :: DumpToFile()
 }
 
 // ------------------------------------------------------------------------------------------------
-boost::shared_ptr< ElemBase > DNA :: ConvertBlobToStructure(
+std::shared_ptr< ElemBase > DNA :: ConvertBlobToStructure(
     const Structure& structure,
     const FileDatabase& db
 ) const
 {
     std::map<std::string, FactoryPair >::const_iterator it = converters.find(structure.name);
     if (it == converters.end()) {
-        return boost::shared_ptr< ElemBase >();
+        return std::shared_ptr< ElemBase >();
     }
 
-    boost::shared_ptr< ElemBase > ret = (structure.*((*it).second.first))();
+    std::shared_ptr< ElemBase > ret = (structure.*((*it).second.first))();
     (structure.*((*it).second.second))(ret,db);
 
     return ret;

--- a/code/BlenderDNA.h
+++ b/code/BlenderDNA.h
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "StreamReader.h"
 #include "../include/assimp/DefaultLogger.hpp"
 #include <stdint.h>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 
 // enable verbose log output. really verbose, so be careful.
@@ -97,7 +97,7 @@ struct ElemBase
      * string points is the `c_str` of the `name` attribute of the
      * corresponding `Structure`, that is, it is only valid as long
      * as the DNA is not modified. The dna_type is only set if the
-     * data type is not static, i.e. a boost::shared_ptr<ElemBase>
+     * data type is not static, i.e. a std::shared_ptr<ElemBase>
      * in the scene description would have its type resolved
      * at runtime, so this member is always set. */
     const char* dna_type;
@@ -127,7 +127,7 @@ struct FileOffset
 
 // -------------------------------------------------------------------------------
 /** Dummy derivate of std::vector to be able to use it in templates simultaenously
- *  with boost::shared_ptr, which takes only one template argument
+ *  with std::shared_ptr, which takes only one template argument
  *  while std::vector takes three. Also we need to provide some special member
  *  functions of shared_ptr */
 // -------------------------------------------------------------------------------
@@ -260,11 +260,11 @@ public:
     // --------------------------------------------------------
     // generic converter
     template <typename T>
-    void Convert(boost::shared_ptr<ElemBase> in,const FileDatabase& db) const;
+    void Convert(std::shared_ptr<ElemBase> in,const FileDatabase& db) const;
 
     // --------------------------------------------------------
     // generic allocator
-    template <typename T> boost::shared_ptr<ElemBase> Allocate() const;
+    template <typename T> std::shared_ptr<ElemBase> Allocate() const;
 
 
 
@@ -282,7 +282,7 @@ public:
 
     // --------------------------------------------------------
     // field parsing for pointer or dynamic array types
-    // (boost::shared_ptr or boost::shared_array)
+    // (std::shared_ptr)
     // The return value indicates whether the data was already cached.
     template <int error_policy, template <typename> class TOUT, typename T>
     bool ReadFieldPtr(TOUT<T>& out, const char* name,
@@ -291,7 +291,7 @@ public:
 
     // --------------------------------------------------------
     // field parsing for static arrays of pointer or dynamic
-    // array types (boost::shared_ptr[] or boost::shared_array[])
+    // array types (std::shared_ptr[])
     // The return value indicates whether the data was already cached.
     template <int error_policy, template <typename> class TOUT, typename T, size_t N>
     bool ReadFieldPtr(TOUT<T> (&out)[N], const char* name,
@@ -318,7 +318,7 @@ private:
         const FileDatabase& db, const Field& f, bool) const;
 
     // --------------------------------------------------------
-    bool ResolvePointer( boost::shared_ptr< FileOffset >& out, const Pointer & ptrval,
+    bool ResolvePointer( std::shared_ptr< FileOffset >& out, const Pointer & ptrval,
         const FileDatabase& db, const Field& f, bool) const;
 
     // --------------------------------------------------------
@@ -329,8 +329,8 @@ private:
 private:
 
     // ------------------------------------------------------------------------------
-    template <typename T> T* _allocate(boost::shared_ptr<T>& out, size_t& s) const {
-        out = boost::shared_ptr<T>(new T());
+    template <typename T> T* _allocate(std::shared_ptr<T>& out, size_t& s) const {
+        out = std::shared_ptr<T>(new T());
         s = 1;
         return out.get();
     }
@@ -394,7 +394,7 @@ template <> struct Structure :: _defaultInitializer<ErrorPolicy_Fail> {
 };
 
 // -------------------------------------------------------------------------------------------------------
-template <> inline bool Structure :: ResolvePointer<boost::shared_ptr,ElemBase>(boost::shared_ptr<ElemBase>& out,
+template <> inline bool Structure :: ResolvePointer<std::shared_ptr,ElemBase>(std::shared_ptr<ElemBase>& out,
     const Pointer & ptrval,
     const FileDatabase& db,
     const Field& f,
@@ -413,11 +413,11 @@ class DNA
 public:
 
     typedef void (Structure::*ConvertProcPtr) (
-        boost::shared_ptr<ElemBase> in,
+        std::shared_ptr<ElemBase> in,
         const FileDatabase&
     ) const;
 
-    typedef boost::shared_ptr<ElemBase> (
+    typedef std::shared_ptr<ElemBase> (
         Structure::*AllocProcPtr) () const;
 
     typedef std::pair< AllocProcPtr, ConvertProcPtr > FactoryPair;
@@ -464,7 +464,7 @@ public:
      *  @param structure Destination structure definition
      *  @param db File database.
      *  @return A null pointer if no appropriate converter is available.*/
-    boost::shared_ptr< ElemBase > ConvertBlobToStructure(
+    std::shared_ptr< ElemBase > ConvertBlobToStructure(
         const Structure& structure,
         const FileDatabase& db
         ) const;
@@ -724,7 +724,7 @@ public:
     bool little;
 
     DNA dna;
-    boost::shared_ptr< StreamReaderAny > reader;
+    std::shared_ptr< StreamReaderAny > reader;
     vector< FileBlockHead > entries;
 
 public:
@@ -738,7 +738,7 @@ public:
     // arrays of objects are never cached because we can't easily
     // ensure their proper destruction.
     template <typename T>
-    ObjectCache<boost::shared_ptr>& cache(boost::shared_ptr<T>& /*in*/) const {
+    ObjectCache<std::shared_ptr>& cache(std::shared_ptr<T>& /*in*/) const {
         return _cache;
     }
 
@@ -755,7 +755,7 @@ private:
 #endif
 
     mutable ObjectCache<vector> _cacheArrays;
-    mutable ObjectCache<boost::shared_ptr> _cache;
+    mutable ObjectCache<std::shared_ptr> _cache;
 
     mutable size_t next_cache_idx;
 };

--- a/code/BlenderDNA.inl
+++ b/code/BlenderDNA.inl
@@ -5,8 +5,8 @@ Open Asset Import Library (assimp)
 Copyright (c) 2006-2016, assimp team
 All rights reserved.
 
-Redistribution and use of this software in source and binary forms, 
-with or without modification, are permitted provided that the 
+Redistribution and use of this software in source and binary forms,
+with or without modification, are permitted provided that the
 following conditions are met:
 
 * Redistributions of source code must retain the above
@@ -23,29 +23,29 @@ following conditions are met:
   derived from this software without specific prior
   written permission of the assimp team.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
 OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
 LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ----------------------------------------------------------------------
 */
 
 /** @file  BlenderDNA.inl
- *  @brief Blender `DNA` (file format specification embedded in 
+ *  @brief Blender `DNA` (file format specification embedded in
  *    blend file itself) loader.
  */
 #ifndef INCLUDED_AI_BLEND_DNA_INL
 #define INCLUDED_AI_BLEND_DNA_INL
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace Assimp {
     namespace Blender {
@@ -71,7 +71,7 @@ const Field* Structure :: Get (const std::string& ss) const
 }
 
 //--------------------------------------------------------------------------------
-const Field& Structure :: operator [] (const size_t i) const 
+const Field& Structure :: operator [] (const size_t i) const
 {
     if (i >= fields.size()) {
         throw Error((Formatter::format(),
@@ -83,15 +83,15 @@ const Field& Structure :: operator [] (const size_t i) const
 }
 
 //--------------------------------------------------------------------------------
-template <typename T> boost::shared_ptr<ElemBase> Structure :: Allocate() const 
+template <typename T> std::shared_ptr<ElemBase> Structure :: Allocate() const
 {
-    return boost::shared_ptr<T>(new T()); 
+    return std::shared_ptr<T>(new T());
 }
 
 //--------------------------------------------------------------------------------
 template <typename T> void Structure :: Convert(
-    boost::shared_ptr<ElemBase> in,
-    const FileDatabase& db) const 
+    std::shared_ptr<ElemBase> in,
+    const FileDatabase& db) const
 {
     Convert<T> (*static_cast<T*> ( in.get() ),db);
 }
@@ -226,7 +226,7 @@ bool Structure :: ReadFieldPtr(TOUT<T>& out, const char* name, const FileDatabas
 
 //--------------------------------------------------------------------------------
 template <int error_policy, template <typename> class TOUT, typename T, size_t N>
-bool Structure :: ReadFieldPtr(TOUT<T> (&out)[N], const char* name, 
+bool Structure :: ReadFieldPtr(TOUT<T> (&out)[N], const char* name,
     const FileDatabase& db) const
 {
     // XXX see if we can reduce this to call to the 'normal' ReadFieldPtr
@@ -306,12 +306,12 @@ void Structure :: ReadField(T& out, const char* name, const FileDatabase& db) co
 
 //--------------------------------------------------------------------------------
 template <template <typename> class TOUT, typename T>
-bool Structure :: ResolvePointer(TOUT<T>& out, const Pointer & ptrval, const FileDatabase& db, 
-    const Field& f, 
-    bool non_recursive /*= false*/) const 
+bool Structure :: ResolvePointer(TOUT<T>& out, const Pointer & ptrval, const FileDatabase& db,
+    const Field& f,
+    bool non_recursive /*= false*/) const
 {
     out.reset(); // ensure null pointers work
-    if (!ptrval.val) { 
+    if (!ptrval.val) {
         return false;
     }
     const Structure& s = db.dna[f.type];
@@ -328,7 +328,7 @@ bool Structure :: ResolvePointer(TOUT<T>& out, const Pointer & ptrval, const Fil
     }
 
     // try to retrieve the object from the cache
-    db.cache(out).get(s,out,ptrval); 
+    db.cache(out).get(s,out,ptrval);
     if (out) {
         return true;
     }
@@ -340,11 +340,11 @@ bool Structure :: ResolvePointer(TOUT<T>& out, const Pointer & ptrval, const Fil
     // I really ought to improve StreamReader to work with 64 bit indices exclusively.
 
     // continue conversion after allocating the required storage
-    size_t num = block->size / ss.size; 
+    size_t num = block->size / ss.size;
     T* o = _allocate(out,num);
 
     // cache the object before we convert it to avoid cyclic recursion.
-    db.cache(out).set(s,out,ptrval); 
+    db.cache(out).set(s,out,ptrval);
 
     // if the non_recursive flag is set, we don't do anything but leave
     // the cursor at the correct position to resolve the object.
@@ -366,45 +366,45 @@ bool Structure :: ResolvePointer(TOUT<T>& out, const Pointer & ptrval, const Fil
 
 
 //--------------------------------------------------------------------------------
-inline bool Structure :: ResolvePointer( boost::shared_ptr< FileOffset >& out, const Pointer & ptrval, 
-    const FileDatabase& db, 
+inline bool Structure :: ResolvePointer( std::shared_ptr< FileOffset >& out, const Pointer & ptrval,
+    const FileDatabase& db,
     const Field&,
     bool) const
 {
     // Currently used exclusively by PackedFile::data to represent
-    // a simple offset into the mapped BLEND file. 
+    // a simple offset into the mapped BLEND file.
     out.reset();
-    if (!ptrval.val) { 
+    if (!ptrval.val) {
         return false;
     }
 
     // find the file block the pointer is pointing to
     const FileBlockHead* block = LocateFileBlockForAddress(ptrval,db);
 
-    out =  boost::shared_ptr< FileOffset > (new FileOffset());
+    out =  std::shared_ptr< FileOffset > (new FileOffset());
     out->val = block->start+ static_cast<size_t>((ptrval.val - block->address.val) );
     return false;
 }
 
 //--------------------------------------------------------------------------------
 template <template <typename> class TOUT, typename T>
-bool Structure :: ResolvePointer(vector< TOUT<T> >& out, const Pointer & ptrval, 
-    const FileDatabase& db, 
+bool Structure :: ResolvePointer(vector< TOUT<T> >& out, const Pointer & ptrval,
+    const FileDatabase& db,
     const Field& f,
-    bool) const 
+    bool) const
 {
     // This is a function overload, not a template specialization. According to
     // the partial ordering rules, it should be selected by the compiler
     // for array-of-pointer inputs, i.e. Object::mats.
 
     out.reset();
-    if (!ptrval.val) { 
+    if (!ptrval.val) {
         return false;
     }
 
     // find the file block the pointer is pointing to
     const FileBlockHead* block = LocateFileBlockForAddress(ptrval,db);
-    const size_t num = block->size / (db.i64bit?8:4); 
+    const size_t num = block->size / (db.i64bit?8:4);
 
     // keep the old stream position
     const StreamReaderAny::pos pold = db.reader->GetCurrentPos();
@@ -418,7 +418,7 @@ bool Structure :: ResolvePointer(vector< TOUT<T> >& out, const Pointer & ptrval,
         Convert(val,db);
 
         // and resolve the pointees
-        res = ResolvePointer(out[i],val,db,f) && res; 
+        res = ResolvePointer(out[i],val,db,f) && res;
     }
 
     db.reader->SetCurrentPos(pold);
@@ -426,18 +426,18 @@ bool Structure :: ResolvePointer(vector< TOUT<T> >& out, const Pointer & ptrval,
 }
 
 //--------------------------------------------------------------------------------
-template <> bool Structure :: ResolvePointer<boost::shared_ptr,ElemBase>(boost::shared_ptr<ElemBase>& out, 
-    const Pointer & ptrval, 
-    const FileDatabase& db, 
+template <> bool Structure :: ResolvePointer<std::shared_ptr,ElemBase>(std::shared_ptr<ElemBase>& out,
+    const Pointer & ptrval,
+    const FileDatabase& db,
     const Field&,
     bool
-) const 
+) const
 {
     // Special case when the data type needs to be determined at runtime.
     // Less secure than in the `strongly-typed` case.
 
     out.reset();
-    if (!ptrval.val) { 
+    if (!ptrval.val) {
         return false;
     }
 
@@ -448,7 +448,7 @@ template <> bool Structure :: ResolvePointer<boost::shared_ptr,ElemBase>(boost::
     const Structure& s = db.dna[block->dna_index];
 
     // try to retrieve the object from the cache
-    db.cache(out).get(s,out,ptrval); 
+    db.cache(out).get(s,out,ptrval);
     if (out) {
         return true;
     }
@@ -473,15 +473,15 @@ template <> bool Structure :: ResolvePointer<boost::shared_ptr,ElemBase>(boost::
 
     // allocate the object hull
     out = (s.*builders.first)();
-    
-    // cache the object immediately to prevent infinite recursion in a 
+
+    // cache the object immediately to prevent infinite recursion in a
     // circular list with a single element (i.e. a self-referencing element).
     db.cache(out).set(s,out,ptrval);
 
     // and do the actual conversion
     (s.*builders.second)(out,db);
     db.reader->SetCurrentPos(pold);
-    
+
     // store a pointer to the name string of the actual type
     // in the object itself. This allows the conversion code
     // to perform additional type checking.
@@ -495,10 +495,10 @@ template <> bool Structure :: ResolvePointer<boost::shared_ptr,ElemBase>(boost::
 }
 
 //--------------------------------------------------------------------------------
-const FileBlockHead* Structure :: LocateFileBlockForAddress(const Pointer & ptrval, const FileDatabase& db) const 
+const FileBlockHead* Structure :: LocateFileBlockForAddress(const Pointer & ptrval, const FileDatabase& db) const
 {
     // the file blocks appear in list sorted by
-    // with ascending base addresses so we can run a 
+    // with ascending base addresses so we can run a
     // binary search to locate the pointee quickly.
 
     // NOTE: Blender seems to distinguish between side-by-side
@@ -525,7 +525,7 @@ const FileBlockHead* Structure :: LocateFileBlockForAddress(const Pointer & ptrv
 }
 
 // ------------------------------------------------------------------------------------------------
-// NOTE: The MSVC debugger keeps showing up this annoying `a cast to a smaller data type has 
+// NOTE: The MSVC debugger keeps showing up this annoying `a cast to a smaller data type has
 // caused a loss of data`-warning. Avoid this warning by a masking with an appropriate bitmask.
 
 template <typename T> struct signless;
@@ -534,7 +534,7 @@ template <> struct signless<short> {typedef unsigned short type;};
 template <> struct signless<int> {typedef unsigned int type;};
 
 template <typename T>
-struct static_cast_silent { 
+struct static_cast_silent {
     template <typename V>
     T operator()(V in) {
         return static_cast<T>(in & static_cast<typename signless<T>::type>(-1));
@@ -554,7 +554,7 @@ template <> struct static_cast_silent<double> {
 };
 
 // ------------------------------------------------------------------------------------------------
-template <typename T> inline void ConvertDispatcher(T& out, const Structure& in,const FileDatabase& db) 
+template <typename T> inline void ConvertDispatcher(T& out, const Structure& in,const FileDatabase& db)
 {
     if (in.name == "int") {
         out = static_cast_silent<T>()(db.reader->GetU4());
@@ -677,7 +677,7 @@ const Structure* DNA :: Get (const std::string& ss) const
 }
 
 //--------------------------------------------------------------------------------
-const Structure& DNA :: operator [] (const size_t i) const 
+const Structure& DNA :: operator [] (const size_t i) const
 {
     if (i >= structures.size()) {
         throw Error((Formatter::format(),
@@ -690,8 +690,8 @@ const Structure& DNA :: operator [] (const size_t i) const
 
 //--------------------------------------------------------------------------------
 template <template <typename> class TOUT> template <typename T> void ObjectCache<TOUT> :: get (
-    const Structure& s, 
-    TOUT<T>& out, 
+    const Structure& s,
+    TOUT<T>& out,
     const Pointer& ptr
 ) const {
 
@@ -703,7 +703,7 @@ template <template <typename> class TOUT> template <typename T> void ObjectCache
 
     typename StructureCache::const_iterator it = caches[s.cache_idx].find(ptr);
     if (it != caches[s.cache_idx].end()) {
-        out = boost::static_pointer_cast<T>( (*it).second );
+        out = std::static_pointer_cast<T>( (*it).second );
 
 #ifndef ASSIMP_BUILD_BLENDER_NO_STATS
         ++db.stats().cache_hits;
@@ -715,7 +715,7 @@ template <template <typename> class TOUT> template <typename T> void ObjectCache
 
 //--------------------------------------------------------------------------------
 template <template <typename> class TOUT> template <typename T> void ObjectCache<TOUT> :: set (
-    const Structure& s, 
+    const Structure& s,
     const TOUT<T>& out,
     const Pointer& ptr
 ) {
@@ -723,7 +723,7 @@ template <template <typename> class TOUT> template <typename T> void ObjectCache
         s.cache_idx = db.next_cache_idx++;
         caches.resize(db.next_cache_idx);
     }
-    caches[s.cache_idx][ptr] = boost::static_pointer_cast<ElemBase>( out ); 
+    caches[s.cache_idx][ptr] = std::static_pointer_cast<ElemBase>( out );
 
 #ifndef ASSIMP_BUILD_BLENDER_NO_STATS
     ++db.stats().cached_objects;

--- a/code/BlenderIntermediate.h
+++ b/code/BlenderIntermediate.h
@@ -157,7 +157,7 @@ namespace Blender {
         TempArray <std::vector, aiTexture> textures;
 
         // set of all materials referenced by at least one mesh in the scene
-        std::deque< boost::shared_ptr< Material > > materials_raw;
+        std::deque< std::shared_ptr< Material > > materials_raw;
 
         // counter to name sentinel textures inserted as substitutes for procedural textures.
         unsigned int sentinel_cnt;

--- a/code/BlenderIntermediate.h
+++ b/code/BlenderIntermediate.h
@@ -49,13 +49,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "BlenderDNA.h"
 #include "BlenderScene.h"
 #include "BlenderSceneGen.h"
-#include <boost/foreach.hpp>
 #include <deque>
 #include "./../include/assimp/material.h"
 
 struct aiTexture;
-
-#define for_each(x,y) BOOST_FOREACH(x,y)
 
 namespace Assimp {
 namespace Blender {
@@ -71,7 +68,7 @@ namespace Blender {
         }
 
         ~TempArray () {
-            for_each(T* elem, arr) {
+            for(T* elem : arr) {
                 delete elem;
             }
         }

--- a/code/BlenderLoader.cpp
+++ b/code/BlenderLoader.cpp
@@ -164,7 +164,7 @@ void BlenderImporter::InternReadFile( const std::string& pFile,
 #endif
 
     FileDatabase file;
-    boost::shared_ptr<IOStream> stream(pIOHandler->Open(pFile,"rb"));
+    std::shared_ptr<IOStream> stream(pIOHandler->Open(pFile,"rb"));
     if (!stream) {
         ThrowException("Could not open file for reading");
     }
@@ -190,7 +190,7 @@ void BlenderImporter::InternReadFile( const std::string& pFile,
 
         // http://www.gzip.org/zlib/rfc-gzip.html#header-trailer
         stream->Seek(0L,aiOrigin_SET);
-        boost::shared_ptr<StreamReaderLE> reader = boost::shared_ptr<StreamReaderLE>(new StreamReaderLE(stream));
+        std::shared_ptr<StreamReaderLE> reader = std::shared_ptr<StreamReaderLE>(new StreamReaderLE(stream));
 
         // build a zlib stream
         z_stream zstream;
@@ -260,9 +260,9 @@ void BlenderImporter::InternReadFile( const std::string& pFile,
 }
 
 // ------------------------------------------------------------------------------------------------
-void BlenderImporter::ParseBlendFile(FileDatabase& out, boost::shared_ptr<IOStream> stream)
+void BlenderImporter::ParseBlendFile(FileDatabase& out, std::shared_ptr<IOStream> stream)
 {
-    out.reader = boost::shared_ptr<StreamReaderAny>(new StreamReaderAny(stream,out.little));
+    out.reader = std::shared_ptr<StreamReaderAny>(new StreamReaderAny(stream,out.little));
 
     DNAParser dna_reader(out);
     const DNA* dna = NULL;
@@ -342,7 +342,7 @@ void BlenderImporter::ConvertBlendFile(aiScene* out, const Scene& in,const FileD
     // the file. This is terrible. Here, we're first looking for
     // all objects which don't have parent objects at all -
     std::deque<const Object*> no_parents;
-    for (boost::shared_ptr<Base> cur = boost::static_pointer_cast<Base> ( in.base.first ); cur; cur = cur->next) {
+    for (std::shared_ptr<Base> cur = std::static_pointer_cast<Base> ( in.base.first ); cur; cur = cur->next) {
         if (cur->object) {
             if(!cur->object->parent) {
                 no_parents.push_back(cur->object.get());
@@ -350,7 +350,7 @@ void BlenderImporter::ConvertBlendFile(aiScene* out, const Scene& in,const FileD
             else conv.objects.insert(cur->object.get());
         }
     }
-    for (boost::shared_ptr<Base> cur = in.basact; cur; cur = cur->next) {
+    for (std::shared_ptr<Base> cur = in.basact; cur; cur = cur->next) {
         if (cur->object) {
             if(cur->object->parent) {
                 conv.objects.insert(cur->object.get());
@@ -565,7 +565,7 @@ void BlenderImporter::BuildMaterials(ConversionData& conv_data)
 
             if (index == static_cast<unsigned int>( -1 )) {
                 // Setup a default material.
-                boost::shared_ptr<Material> p(new Material());
+                std::shared_ptr<Material> p(new Material());
                 ai_assert(::strlen(AI_DEFAULT_MATERIAL_NAME) < sizeof(p->id.name)-2);
                 strcpy( p->id.name+2, AI_DEFAULT_MATERIAL_NAME );
 
@@ -589,7 +589,7 @@ void BlenderImporter::BuildMaterials(ConversionData& conv_data)
         }
     }
 
-    for(boost::shared_ptr<Material> mat : conv_data.materials_raw) {
+    for(std::shared_ptr<Material> mat : conv_data.materials_raw) {
 
         // reset per material global counters
         for (size_t i = 0; i < sizeof(conv_data.next_texture)/sizeof(conv_data.next_texture[0]);++i) {
@@ -749,8 +749,8 @@ void BlenderImporter::ConvertMesh(const Scene& /*in*/, const Object* /*obj*/, co
                 ThrowException("Material index is out of range");
             }
 
-            boost::shared_ptr<Material> mat = mesh->mat[it.first];
-            const std::deque< boost::shared_ptr<Material> >::iterator has = std::find(
+            std::shared_ptr<Material> mat = mesh->mat[it.first];
+            const std::deque< std::shared_ptr<Material> >::iterator has = std::find(
                     conv_data.materials_raw.begin(),
                     conv_data.materials_raw.end(),mat
             );

--- a/code/BlenderLoader.cpp
+++ b/code/BlenderLoader.cpp
@@ -305,7 +305,7 @@ void BlenderImporter::ExtractScene(Scene& out, const FileDatabase& file)
     const Structure& ss = file.dna.structures[(*it).second];
 
     // we need a scene somewhere to start with.
-    for_each(const FileBlockHead& bl,file.entries) {
+    for(const FileBlockHead& bl :file.entries) {
 
         // Fix: using the DNA index is more reliable to locate scenes
         //if (bl.id == "SC") {
@@ -560,7 +560,7 @@ void BlenderImporter::BuildMaterials(ConversionData& conv_data)
 
     // add a default material if necessary
     unsigned int index = static_cast<unsigned int>( -1 );
-    for_each( aiMesh* mesh, conv_data.meshes.get() ) {
+    for( aiMesh* mesh : conv_data.meshes.get() ) {
         if (mesh->mMaterialIndex == static_cast<unsigned int>( -1 )) {
 
             if (index == static_cast<unsigned int>( -1 )) {
@@ -589,7 +589,7 @@ void BlenderImporter::BuildMaterials(ConversionData& conv_data)
         }
     }
 
-    for_each(boost::shared_ptr<Material> mat, conv_data.materials_raw) {
+    for(boost::shared_ptr<Material> mat : conv_data.materials_raw) {
 
         // reset per material global counters
         for (size_t i = 0; i < sizeof(conv_data.next_texture)/sizeof(conv_data.next_texture[0]);++i) {
@@ -722,7 +722,7 @@ void BlenderImporter::ConvertMesh(const Scene& /*in*/, const Object* /*obj*/, co
     temp->reserve(temp->size() + per_mat.size());
 
     std::map<size_t,size_t> mat_num_to_mesh_idx;
-    for_each(MyPair& it, per_mat) {
+    for(MyPair& it : per_mat) {
 
         mat_num_to_mesh_idx[it.first] = temp->size();
         temp->push_back(new aiMesh());
@@ -1157,7 +1157,7 @@ aiNode* BlenderImporter::ConvertNode(const Scene& in, const Object* obj, Convers
     if (children.size()) {
         node->mNumChildren = static_cast<unsigned int>(children.size());
         aiNode** nd = node->mChildren = new aiNode*[node->mNumChildren]();
-        for_each (const Object* nobj,children) {
+        for (const Object* nobj :children) {
             *nd = ConvertNode(in,nobj,conv_data,node->mTransformation * parentTransform);
             (*nd++)->mParent = node;
         }

--- a/code/BlenderLoader.h
+++ b/code/BlenderLoader.h
@@ -46,7 +46,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "BaseImporter.h"
 #include "LogAux.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 struct aiNode;
 struct aiMesh;
@@ -133,7 +133,7 @@ protected:
 
     // --------------------
     void ParseBlendFile(Blender::FileDatabase& out,
-        boost::shared_ptr<IOStream> stream
+        std::shared_ptr<IOStream> stream
     );
 
     // --------------------

--- a/code/BlenderModifier.cpp
+++ b/code/BlenderModifier.cpp
@@ -48,9 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "SceneCombiner.h"
 #include "Subdivision.h"
 #include "../include/assimp/scene.h"
-#include <boost/scoped_ptr.hpp>
-#include <boost/scoped_array.hpp>
-#include <boost/pointer_cast.hpp>
+#include <memory>
 
 #include <functional>
 
@@ -113,8 +111,8 @@ void BlenderModifierShowcase::ApplyModifiers(aiNode& out, ConversionData& conv_d
     // we're allowed to dereference the pointers without risking to crash. We might still be
     // invoking UB btw - we're assuming that the ModifierData member of the respective modifier
     // structures is at offset sizeof(vftable) with no padding.
-    const SharedModifierData* cur = boost::static_pointer_cast<const SharedModifierData> ( orig_object.modifiers.first.get() );
-    for (; cur; cur =  boost::static_pointer_cast<const SharedModifierData> ( cur->modifier.next.get() ), ++ful) {
+    const SharedModifierData* cur = static_cast<const SharedModifierData *> ( orig_object.modifiers.first.get() );
+    for (; cur; cur =  static_cast<const SharedModifierData *> ( cur->modifier.next.get() ), ++ful) {
         ai_assert(cur->dna_type);
 
         const Structure* s = conv_data.db.dna.Get( cur->dna_type );
@@ -153,7 +151,7 @@ void BlenderModifierShowcase::ApplyModifiers(aiNode& out, ConversionData& conv_d
 
             BlenderModifier* const modifier = *curmod;
             if(modifier->IsActive(dat)) {
-                modifier->DoIt(out,conv_data,*boost::static_pointer_cast<const ElemBase>(cur),in,orig_object);
+                modifier->DoIt(out,conv_data,*static_cast<const ElemBase *>(cur),in,orig_object);
                 cnt++;
 
                 curgod = NULL;
@@ -312,11 +310,11 @@ void  BlenderModifier_Subdivision :: DoIt(aiNode& out, ConversionData& conv_data
         return;
     };
 
-    boost::scoped_ptr<Subdivider> subd(Subdivider::Create(algo));
+    std::unique_ptr<Subdivider> subd(Subdivider::Create(algo));
     ai_assert(subd);
 
     aiMesh** const meshes = &conv_data.meshes[conv_data.meshes->size() - out.mNumMeshes];
-    boost::scoped_array<aiMesh*> tempmeshes(new aiMesh*[out.mNumMeshes]());
+    std::unique_ptr<aiMesh*[]> tempmeshes(new aiMesh*[out.mNumMeshes]());
 
     subd->Subdivide(meshes,out.mNumMeshes,tempmeshes.get(),std::max( mir.renderLevels, mir.levels ),true);
     std::copy(tempmeshes.get(),tempmeshes.get()+out.mNumMeshes,meshes);

--- a/code/BlenderScene.cpp
+++ b/code/BlenderScene.cpp
@@ -64,7 +64,7 @@ template <> void Structure :: Convert<Object> (
     ReadFieldArray2<ErrorPolicy_Warn>(dest.parentinv,"parentinv",db);
     ReadFieldArray<ErrorPolicy_Warn>(dest.parsubstr,"parsubstr",db);
     {
-        boost::shared_ptr<Object> parent;
+        std::shared_ptr<Object> parent;
         ReadFieldPtr<ErrorPolicy_Warn>(parent,"*parent",db);
         dest.parent = parent.get();
     }
@@ -337,7 +337,7 @@ template <> void Structure :: Convert<MTexPoly> (
 {
 
     {
-        boost::shared_ptr<Image> tpage;
+        std::shared_ptr<Image> tpage;
         ReadFieldPtr<ErrorPolicy_Igno>(tpage,"*tpage",db);
         dest.tpage = tpage.get();
     }

--- a/code/BlenderScene.h
+++ b/code/BlenderScene.h
@@ -73,7 +73,7 @@ namespace Blender {
 //
 // * Pointers to other structures or primitive types are allowed.
 //   No references or double pointers or arrays of pointers.
-//   A pointer to a T is normally written as boost::shared_ptr, while a
+//   A pointer to a T is normally written as std::shared_ptr, while a
 //   pointer to an array of elements is written as boost::
 //   shared_array. To avoid cyclic pointers, use raw pointers in
 //   one direction.
@@ -98,6 +98,8 @@ struct Object;
 struct MTex;
 struct Image;
 
+#include <memory>
+
 #define AI_BLEND_MESH_MAX_VERTS 2000000000L
 
 // -------------------------------------------------------------------------------
@@ -110,8 +112,8 @@ struct ID : ElemBase {
 // -------------------------------------------------------------------------------
 struct ListBase : ElemBase {
 
-    boost::shared_ptr<ElemBase> first;
-    boost::shared_ptr<ElemBase> last;
+    std::shared_ptr<ElemBase> first;
+    std::shared_ptr<ElemBase> last;
 };
 
 
@@ -119,14 +121,14 @@ struct ListBase : ElemBase {
 struct PackedFile : ElemBase {
      int size WARN;
      int seek WARN;
-     boost::shared_ptr< FileOffset > data WARN;
+     std::shared_ptr< FileOffset > data WARN;
 };
 
 // -------------------------------------------------------------------------------
 struct GroupObject : ElemBase {
 
-    boost::shared_ptr<GroupObject> prev,next FAIL;
-    boost::shared_ptr<Object> ob;
+    std::shared_ptr<GroupObject> prev,next FAIL;
+    std::shared_ptr<Object> ob;
 };
 
 // -------------------------------------------------------------------------------
@@ -134,7 +136,7 @@ struct Group : ElemBase {
     ID id FAIL;
     int layer;
 
-    boost::shared_ptr<GroupObject> gobject;
+    std::shared_ptr<GroupObject> gobject;
 };
 
 // -------------------------------------------------------------------------------
@@ -222,7 +224,7 @@ struct MTFace : ElemBase {
     short tile;
     short unwrap;
 
-    // boost::shared_ptr<Image> tpage;
+    // std::shared_ptr<Image> tpage;
 };
 
 // -------------------------------------------------------------------------------
@@ -259,12 +261,12 @@ struct Material : ElemBase {
     float darkness;
     float refrac;
 
-    boost::shared_ptr<Group> group;
+    std::shared_ptr<Group> group;
 
     short diff_shader WARN;
     short spec_shader WARN;
 
-    boost::shared_ptr<MTex> mtex[18];
+    std::shared_ptr<MTex> mtex[18];
 };
 
 // -------------------------------------------------------------------------------
@@ -295,7 +297,7 @@ struct Mesh : ElemBase {
     vector<MDeformVert> dvert;
     vector<MCol> mcol;
 
-    vector< boost::shared_ptr<Material> > mat FAIL;
+    vector< std::shared_ptr<Material> > mat FAIL;
 };
 
 // -------------------------------------------------------------------------------
@@ -304,7 +306,7 @@ struct Library : ElemBase {
 
     char name[240] WARN;
     char filename[240] FAIL;
-    boost::shared_ptr<Library> parent WARN;
+    std::shared_ptr<Library> parent WARN;
 };
 
 // -------------------------------------------------------------------------------
@@ -444,8 +446,8 @@ struct ModifierData : ElemBase  {
       eModifierType_ShapeKey
     };
 
-    boost::shared_ptr<ElemBase> next WARN;
-    boost::shared_ptr<ElemBase> prev WARN;
+    std::shared_ptr<ElemBase> next WARN;
+    std::shared_ptr<ElemBase> prev WARN;
 
     int type, mode;
     char name[32];
@@ -489,7 +491,7 @@ struct MirrorModifierData : ElemBase {
 
     short axis, flag;
     float tolerance;
-    boost::shared_ptr<Object> mirror_ob;
+    std::shared_ptr<Object> mirror_ob;
 };
 
 // -------------------------------------------------------------------------------
@@ -517,11 +519,11 @@ struct Object : ElemBase  {
     char parsubstr[32] WARN;
 
     Object* parent WARN;
-    boost::shared_ptr<Object> track WARN;
+    std::shared_ptr<Object> track WARN;
 
-    boost::shared_ptr<Object> proxy,proxy_from,proxy_group WARN;
-    boost::shared_ptr<Group> dup_group WARN;
-    boost::shared_ptr<ElemBase> data FAIL;
+    std::shared_ptr<Object> proxy,proxy_from,proxy_group WARN;
+    std::shared_ptr<Group> dup_group WARN;
+    std::shared_ptr<ElemBase> data FAIL;
 
     ListBase modifiers;
 };
@@ -530,17 +532,17 @@ struct Object : ElemBase  {
 // -------------------------------------------------------------------------------
 struct Base : ElemBase {
     Base* prev WARN;
-    boost::shared_ptr<Base> next WARN;
-    boost::shared_ptr<Object> object WARN;
+    std::shared_ptr<Base> next WARN;
+    std::shared_ptr<Object> object WARN;
 };
 
 // -------------------------------------------------------------------------------
 struct Scene : ElemBase {
     ID id FAIL;
 
-    boost::shared_ptr<Object> camera WARN;
-    boost::shared_ptr<World> world WARN;
-    boost::shared_ptr<Base> basact WARN;
+    std::shared_ptr<Object> camera WARN;
+    std::shared_ptr<World> world WARN;
+    std::shared_ptr<Base> basact WARN;
 
     ListBase base;
 };
@@ -564,7 +566,7 @@ struct Image : ElemBase {
     //unsigned int bindcode;
     //unsigned int *repbind;
 
-    boost::shared_ptr<PackedFile> packedfile;
+    std::shared_ptr<PackedFile> packedfile;
     //struct PreviewImage * preview;
 
     float lastupdate;
@@ -650,7 +652,7 @@ struct Tex : ElemBase {
 
     //bNodeTree *nodetree;
     //Ipo *ipo;
-    boost::shared_ptr<Image> ima WARN;
+    std::shared_ptr<Image> ima WARN;
     //PluginTex *plugin;
     //ColorBand *coba;
     //EnvMap *env;
@@ -717,8 +719,8 @@ struct MTex : ElemBase {
     MapType mapto;
 
     BlendType blendtype;
-    boost::shared_ptr<Object> object;
-    boost::shared_ptr<Tex> tex;
+    std::shared_ptr<Object> object;
+    std::shared_ptr<Tex> tex;
     char uvname[32];
 
     Projection projx,projy,projz;

--- a/code/BlobIOSystem.h
+++ b/code/BlobIOSystem.h
@@ -49,7 +49,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "./../include/assimp/cexport.h"
 #include "./../include/assimp/IOSystem.hpp"
 #include "./../include/assimp/DefaultLogger.hpp"
-#include <boost/foreach.hpp>
 #include <stdint.h>
 #include <set>
 #include <vector>
@@ -224,7 +223,7 @@ public:
 
     virtual ~BlobIOSystem()
     {
-        BOOST_FOREACH(BlobEntry& blobby, blobs) {
+        for(BlobEntry& blobby : blobs) {
             delete blobby.second;
         }
     }
@@ -243,7 +242,7 @@ public:
     {
         // one must be the master
         aiExportDataBlob* master = NULL, *cur;
-        BOOST_FOREACH(const BlobEntry& blobby, blobs) {
+        for(const BlobEntry& blobby : blobs) {
             if (blobby.first == AI_BLOBIO_MAGIC) {
                 master = blobby.second;
                 break;
@@ -257,7 +256,7 @@ public:
         master->name.Set("");
 
         cur = master;
-        BOOST_FOREACH(const BlobEntry& blobby, blobs) {
+        for(const BlobEntry& blobby : blobs) {
             if (blobby.second == master) {
                 continue;
             }

--- a/code/BoostWorkaround/boost/scoped_ptr.hpp
+++ b/code/BoostWorkaround/boost/scoped_ptr.hpp
@@ -6,7 +6,7 @@
 
 namespace boost {
 
-// small replacement for boost::scoped_ptr
+// small replacement for std::unique_ptr
 template <class T>
 class scoped_ptr
 {

--- a/code/BoostWorkaround/boost/shared_ptr.hpp
+++ b/code/BoostWorkaround/boost/shared_ptr.hpp
@@ -67,7 +67,7 @@ namespace boost {
 	}
 
 // ------------------------------
-// Small replacement for boost::shared_ptr, not threadsafe because no
+// Small replacement for std::shared_ptr, not threadsafe because no
 // atomic reference counter is in use.
 // ------------------------------
 template <class T>

--- a/code/C4DImporter.cpp
+++ b/code/C4DImporter.cpp
@@ -131,7 +131,7 @@ void C4DImporter::SetupProperties(const Importer* /*pImp*/)
 void C4DImporter::InternReadFile( const std::string& pFile,
     aiScene* pScene, IOSystem* pIOHandler)
 {
-    boost::scoped_ptr<IOStream> file( pIOHandler->Open( pFile));
+    std::unique_ptr<IOStream> file( pIOHandler->Open( pFile));
 
     if( file.get() == NULL) {
         ThrowException("failed to open file " + pFile);

--- a/code/C4DImporter.cpp
+++ b/code/C4DImporter.cpp
@@ -161,7 +161,7 @@ void C4DImporter::InternReadFile( const std::string& pFile,
         RecurseHierarchy(doc->GetFirstObject(), pScene->mRootNode);
     }
     catch(...) {
-        BOOST_FOREACH(aiMesh* mesh, meshes) {
+        for(aiMesh* mesh : meshes) {
             delete mesh;
         }
         BaseDocument::Free(doc);
@@ -176,7 +176,7 @@ void C4DImporter::InternReadFile( const std::string& pFile,
 
     // copy materials over, adding a default material if necessary
     unsigned int mat_count = static_cast<unsigned int>(materials.size());
-    BOOST_FOREACH(aiMesh* mesh, meshes) {
+    for(aiMesh* mesh : meshes) {
         ai_assert(mesh->mMaterialIndex <= mat_count);
         if(mesh->mMaterialIndex >= mat_count) {
             ++mat_count;

--- a/code/COBLoader.cpp
+++ b/code/COBLoader.cpp
@@ -54,7 +54,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "LineSplitter.h"
 #include "TinyFormatter.h"
 #include <boost/scoped_ptr.hpp>
-#include <boost/foreach.hpp>
 #include "../include/assimp/IOSystem.hpp"
 #include "../include/assimp/DefaultLogger.hpp"
 #include "../include/assimp/scene.h"
@@ -63,8 +62,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using namespace Assimp;
 using namespace Assimp::COB;
 using namespace Assimp::Formatter;
-
-#define for_each BOOST_FOREACH
 
 
 static const float units[] = {
@@ -170,17 +167,17 @@ void COBImporter::InternReadFile( const std::string& pFile,
     }
 
     // sort faces by material indices
-    for_each(boost::shared_ptr< Node >& n,scene.nodes) {
+    for(boost::shared_ptr< Node >& n : scene.nodes) {
         if (n->type == Node::TYPE_MESH) {
             Mesh& mesh = (Mesh&)(*n.get());
-            for_each(Face& f,mesh.faces) {
+            for(Face& f : mesh.faces) {
                 mesh.temp_map[f.material].push_back(&f);
             }
         }
     }
 
     // count meshes
-    for_each(boost::shared_ptr< Node >& n,scene.nodes) {
+    for(boost::shared_ptr< Node >& n : scene.nodes) {
         if (n->type == Node::TYPE_MESH) {
             Mesh& mesh = (Mesh&)(*n.get());
             if (mesh.vertex_positions.size() && mesh.texture_coords.size()) {
@@ -193,7 +190,7 @@ void COBImporter::InternReadFile( const std::string& pFile,
     pScene->mNumMeshes = 0;
 
     // count lights and cameras
-    for_each(boost::shared_ptr< Node >& n,scene.nodes) {
+    for(boost::shared_ptr< Node >& n : scene.nodes) {
         if (n->type == Node::TYPE_LIGHT) {
             ++pScene->mNumLights;
         }
@@ -251,10 +248,10 @@ aiNode* COBImporter::BuildNodes(const Node& root,const Scene& scin,aiScene* fill
         if (ndmesh.vertex_positions.size() && ndmesh.texture_coords.size()) {
 
             typedef std::pair<unsigned int,Mesh::FaceRefList> Entry;
-            for_each(const Entry& reflist,ndmesh.temp_map) {
+            for(const Entry& reflist : ndmesh.temp_map) {
                 {   // create mesh
                     size_t n = 0;
-                    for_each(Face* f, reflist.second) {
+                    for(Face* f : reflist.second) {
                         n += f->indices.size();
                     }
                     if (!n) {
@@ -267,7 +264,7 @@ aiNode* COBImporter::BuildNodes(const Node& root,const Scene& scin,aiScene* fill
                     outmesh->mTextureCoords[0] = new aiVector3D[n];
 
                     outmesh->mFaces = new aiFace[reflist.second.size()]();
-                    for_each(Face* f, reflist.second) {
+                    for(Face* f : reflist.second) {
                         if (f->indices.empty()) {
                             continue;
                         }
@@ -275,7 +272,7 @@ aiNode* COBImporter::BuildNodes(const Node& root,const Scene& scin,aiScene* fill
                         aiFace& fout = outmesh->mFaces[outmesh->mNumFaces++];
                         fout.mIndices = new unsigned int[f->indices.size()];
 
-                        for_each(VertexIndex& v, f->indices) {
+                        for(VertexIndex& v : f->indices) {
                             if (v.pos_idx >= ndmesh.vertex_positions.size()) {
                                 ThrowException("Position index out of range");
                             }
@@ -295,7 +292,7 @@ aiNode* COBImporter::BuildNodes(const Node& root,const Scene& scin,aiScene* fill
                     outmesh->mMaterialIndex = fill->mNumMaterials;
                 }{  // create material
                     const Material* min = NULL;
-                    for_each(const Material& m, scin.materials) {
+                    for(const Material& m : scin.materials) {
                         if (m.parent_id == ndmesh.id && m.matnum == reflist.first) {
                             min = &m;
                             break;
@@ -396,7 +393,7 @@ aiNode* COBImporter::BuildNodes(const Node& root,const Scene& scin,aiScene* fill
 
     // add children recursively
     nd->mChildren = new aiNode*[root.temp_children.size()]();
-    for_each(const Node* n, root.temp_children) {
+    for(const Node* n : root.temp_children) {
         (nd->mChildren[nd->mNumChildren++] = BuildNodes(*n,scin,fill))->mParent = nd;
     }
 
@@ -647,7 +644,7 @@ void COBImporter::ReadUnit_Ascii(Scene& out, LineSplitter& splitter, const Chunk
 
     // parent chunks preceede their childs, so we should have the
     // corresponding chunk already.
-    for_each(boost::shared_ptr< Node >& nd, out.nodes) {
+    for(boost::shared_ptr< Node >& nd : out.nodes) {
         if (nd->id == nfo.parent_id) {
             const unsigned int t=strtoul10(splitter[1]);
 
@@ -903,7 +900,7 @@ void COBImporter::ReadBitM_Ascii(Scene& /*out*/, LineSplitter& splitter, const C
 void COBImporter::ReadString_Binary(std::string& out, StreamReaderLE& reader)
 {
     out.resize( reader.GetI2());
-    for_each(char& c,out) {
+    for(char& c : out) {
         c = reader.GetI1();
     }
 }
@@ -1043,14 +1040,14 @@ void COBImporter::ReadPolH_Binary(COB::Scene& out, StreamReaderLE& reader, const
     ReadBasicNodeInfo_Binary(msh,reader,nfo);
 
     msh.vertex_positions.resize(reader.GetI4());
-    for_each(aiVector3D& v,msh.vertex_positions) {
+    for(aiVector3D& v : msh.vertex_positions) {
         v.x = reader.GetF4();
         v.y = reader.GetF4();
         v.z = reader.GetF4();
     }
 
     msh.texture_coords.resize(reader.GetI4());
-    for_each(aiVector2D& v,msh.texture_coords) {
+    for(aiVector2D& v : msh.texture_coords) {
         v.x = reader.GetF4();
         v.y = reader.GetF4();
     }
@@ -1283,7 +1280,7 @@ void COBImporter::ReadUnit_Binary(COB::Scene& out, StreamReaderLE& reader, const
 
     // parent chunks preceede their childs, so we should have the
     // corresponding chunk already.
-    for_each(boost::shared_ptr< Node >& nd, out.nodes) {
+    for(boost::shared_ptr< Node >& nd : out.nodes) {
         if (nd->id == nfo.parent_id) {
             const unsigned int t=reader.GetI2();
             nd->unit_scale = t>=sizeof(units)/sizeof(units[0])?(

--- a/code/COBScene.h
+++ b/code/COBScene.h
@@ -44,7 +44,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef INCLUDED_AI_COB_SCENE_H
 #define INCLUDED_AI_COB_SCENE_H
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <deque>
 
 #include "BaseImporter.h"
@@ -237,7 +237,7 @@ struct Material : ChunkInfo
     AutoFacet autofacet;
     float autofacet_angle;
 
-    boost::shared_ptr<Texture> tex_env,tex_bump,tex_color;
+    std::shared_ptr<Texture> tex_env,tex_bump,tex_color;
 };
 
 // ------------------
@@ -254,7 +254,7 @@ struct Bitmap : ChunkInfo
     std::vector<char> buff_zipped;
 };
 
-typedef std::deque< boost::shared_ptr<Node> > NodeList;
+typedef std::deque< std::shared_ptr<Node> > NodeList;
 typedef std::vector< Material > MaterialList;
 
 // ------------------

--- a/code/CSMLoader.cpp
+++ b/code/CSMLoader.cpp
@@ -52,7 +52,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "ParsingUtils.h"
 #include "fast_atof.h"
 #include "../include/assimp/Importer.hpp"
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include "../include/assimp/IOSystem.hpp"
 #include "../include/assimp/anim.h"
 #include "../include/assimp/DefaultLogger.hpp"
@@ -122,7 +122,7 @@ void CSMImporter::SetupProperties(const Importer* pImp)
 void CSMImporter::InternReadFile( const std::string& pFile,
     aiScene* pScene, IOSystem* pIOHandler)
 {
-    boost::scoped_ptr<IOStream> file( pIOHandler->Open( pFile, "rb"));
+    std::unique_ptr<IOStream> file( pIOHandler->Open( pFile, "rb"));
 
     // Check whether we can read from the file
     if( file.get() == NULL) {

--- a/code/ColladaExporter.cpp
+++ b/code/ColladaExporter.cpp
@@ -636,7 +636,7 @@ void ColladaExporter::WriteMaterials()
     aiString name;
     if( mat->Get( AI_MATKEY_NAME, name) != aiReturn_SUCCESS )
       name = "mat";
-    materials[a].name = std::string( "m") + boost::lexical_cast<std::string> (a) + name.C_Str();
+    materials[a].name = std::string( "m") + std::to_string(a) + name.C_Str();
     for( std::string::iterator it = materials[a].name.begin(); it != materials[a].name.end(); ++it ) {
       if( !isalnum_C( *it ) ) {
         *it = '_';
@@ -812,7 +812,7 @@ void ColladaExporter::WriteGeometry( size_t pIndex)
     {
         if( mesh->HasTextureCoords( a) )
         {
-            WriteFloatArray( idstr + "-tex" + boost::lexical_cast<std::string> (a), mesh->mNumUVComponents[a] == 3 ? FloatType_TexCoord3 : FloatType_TexCoord2,
+            WriteFloatArray( idstr + "-tex" + std::to_string(a), mesh->mNumUVComponents[a] == 3 ? FloatType_TexCoord3 : FloatType_TexCoord2,
                 (float*) mesh->mTextureCoords[a], mesh->mNumVertices);
         }
     }
@@ -821,7 +821,7 @@ void ColladaExporter::WriteGeometry( size_t pIndex)
     for( size_t a = 0; a < AI_MAX_NUMBER_OF_TEXTURECOORDS; ++a)
     {
         if( mesh->HasVertexColors( a) )
-            WriteFloatArray( idstr + "-color" + boost::lexical_cast<std::string> (a), FloatType_Color, (float*) mesh->mColors[a], mesh->mNumVertices);
+            WriteFloatArray( idstr + "-color" + std::to_string(a), FloatType_Color, (float*) mesh->mColors[a], mesh->mNumVertices);
     }
 
     // assemble vertex structure

--- a/code/ColladaExporter.cpp
+++ b/code/ColladaExporter.cpp
@@ -55,7 +55,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "Exceptional.h"
 
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include <ctime>
 #include <set>
 
@@ -75,7 +75,7 @@ void ExportSceneCollada(const char* pFile, IOSystem* pIOSystem, const aiScene* p
     ColladaExporter iDoTheExportThing( pScene, pIOSystem, path, file);
 
     // we're still here - export successfully completed. Write result to the given IOSYstem
-    boost::scoped_ptr<IOStream> outfile (pIOSystem->Open(pFile,"wt"));
+    std::unique_ptr<IOStream> outfile (pIOSystem->Open(pFile,"wt"));
     if(outfile == NULL) {
         throw DeadlyExportError("could not open output .dae file: " + std::string(pFile));
     }
@@ -268,7 +268,7 @@ void ColladaExporter::WriteTextures() {
 
             std::string name = mFile + "_texture_" + (i < 1000 ? "0" : "") + (i < 100 ? "0" : "") + (i < 10 ? "0" : "") + str + "." + ((const char*) texture->achFormatHint);
 
-            boost::scoped_ptr<IOStream> outfile(mIOSystem->Open(mPath + name, "wb"));
+            std::unique_ptr<IOStream> outfile(mIOSystem->Open(mPath + name, "wb"));
             if(outfile == NULL) {
                 throw DeadlyExportError("could not open output texture file: " + mPath + name);
             }

--- a/code/ColladaExporter.h
+++ b/code/ColladaExporter.h
@@ -52,7 +52,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <sstream>
 #include <vector>
 #include <map>
-#include <boost/lexical_cast.hpp>
 
 struct aiScene;
 struct aiNode;
@@ -123,7 +122,7 @@ protected:
     void PopTag() { ai_assert( startstr.length() > 1); startstr.erase( startstr.length() - 2); }
 
     /// Creates a mesh ID for the given mesh
-    std::string GetMeshId( size_t pIndex) const { return std::string( "meshId" ) + boost::lexical_cast<std::string> (pIndex); }
+    std::string GetMeshId( size_t pIndex) const { return std::string( "meshId" ) + std::to_string(pIndex); }
 
 public:
     /// Stringstream to write all output into

--- a/code/ColladaLoader.cpp
+++ b/code/ColladaLoader.cpp
@@ -56,7 +56,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "time.h"
 #include "math.h"
-#include <boost/foreach.hpp>
 #include "../include/assimp/DefaultLogger.hpp"
 #include "../include/assimp/Importer.hpp"
 #include <numeric>
@@ -317,7 +316,7 @@ void ColladaLoader::ApplyVertexToEffectSemanticMapping(Collada::Sampler& sampler
 // Builds lights for the given node and references them
 void ColladaLoader::BuildLightsForNode( const ColladaParser& pParser, const Collada::Node* pNode, aiNode* pTarget)
 {
-    BOOST_FOREACH( const Collada::LightInstance& lid, pNode->mLights)
+    for( const Collada::LightInstance& lid : pNode->mLights)
     {
         // find the referred light
         ColladaParser::LightLibrary::const_iterator srcLightIt = pParser.mLightLibrary.find( lid.mLight);
@@ -385,7 +384,7 @@ void ColladaLoader::BuildLightsForNode( const ColladaParser& pParser, const Coll
 // Builds cameras for the given node and references them
 void ColladaLoader::BuildCamerasForNode( const ColladaParser& pParser, const Collada::Node* pNode, aiNode* pTarget)
 {
-    BOOST_FOREACH( const Collada::CameraInstance& cid, pNode->mCameras)
+    for( const Collada::CameraInstance& cid : pNode->mCameras)
     {
         // find the referred light
         ColladaParser::CameraLibrary::const_iterator srcCameraIt = pParser.mCameraLibrary.find( cid.mCamera);
@@ -447,7 +446,7 @@ void ColladaLoader::BuildMeshesForNode( const ColladaParser& pParser, const Coll
     newMeshRefs.reserve(pNode->mMeshes.size());
 
     // add a mesh for each subgroup in each collada mesh
-    BOOST_FOREACH( const Collada::MeshInstance& mid, pNode->mMeshes)
+    for( const Collada::MeshInstance& mid : pNode->mMeshes)
     {
         const Collada::Mesh* srcMesh = NULL;
         const Collada::Controller* srcController = NULL;
@@ -1170,7 +1169,7 @@ void ColladaLoader::CreateAnimation( aiScene* pScene, const ColladaParser& pPars
                       }
                       ++pos;
                   }
-				  
+
 				  // https://github.com/assimp/assimp/issues/458
 			  	  // Sub-sample axis-angle channels if the delta between two consecutive
                   // key-frame angles is >= 180 degrees.

--- a/code/ColladaLoader.cpp
+++ b/code/ColladaLoader.cpp
@@ -63,6 +63,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 using namespace Assimp;
+using namespace Assimp::Formatter;
 
 static const aiImporterDesc desc = {
     "Collada Importer",
@@ -467,7 +468,7 @@ void ColladaLoader::BuildMeshesForNode( const ColladaParser& pParser, const Coll
 
             if( !srcMesh)
             {
-                DefaultLogger::get()->warn( boost::str( boost::format( "Collada: Unable to find geometry for ID \"%s\". Skipping.") % mid.mMeshOrController));
+                DefaultLogger::get()->warn( format() << "Collada: Unable to find geometry for ID \"" << mid.mMeshOrController << "\". Skipping." );
                 continue;
             }
         } else
@@ -496,7 +497,7 @@ void ColladaLoader::BuildMeshesForNode( const ColladaParser& pParser, const Coll
             }
             else
             {
-                DefaultLogger::get()->warn( boost::str( boost::format( "Collada: No material specified for subgroup <%s> in geometry <%s>.") % submesh.mMaterial % mid.mMeshOrController));
+                DefaultLogger::get()->warn( format() << "Collada: No material specified for subgroup <" << submesh.mMaterial << "> in geometry <" << mid.mMeshOrController << ">." );
                 if( !mid.mMaterials.empty() )
                     meshMaterial = mid.mMaterials.begin()->second.mMatName;
             }
@@ -784,7 +785,7 @@ aiMesh* ColladaLoader::CreateMesh( const ColladaParser& pParser, const Collada::
             if( bnode)
                 bone->mName.Set( FindNameForNode( bnode));
             else
-                DefaultLogger::get()->warn( boost::str( boost::format( "ColladaLoader::CreateMesh(): could not find corresponding node for joint \"%s\".") % bone->mName.data));
+                DefaultLogger::get()->warn( format() << "ColladaLoader::CreateMesh(): could not find corresponding node for joint \"" << bone->mName.data << "\"." );
 
             // and insert bone
             dstMesh->mBones[boneCount++] = bone;
@@ -1004,7 +1005,7 @@ void ColladaLoader::CreateAnimation( aiScene* pScene, const ColladaParser& pPars
                 else if( subElement == "Z")
                     entry.mSubElement = 2;
                 else
-                    DefaultLogger::get()->warn( boost::str( boost::format( "Unknown anim subelement <%s>. Ignoring") % subElement));
+                    DefaultLogger::get()->warn( format() << "Unknown anim subelement <" << subElement << ">. Ignoring" );
             } else
             {
                 // no subelement following, transformId is remaining string
@@ -1082,7 +1083,7 @@ void ColladaLoader::CreateAnimation( aiScene* pScene, const ColladaParser& pPars
 
             // time count and value count must match
             if( e.mTimeAccessor->mCount != e.mValueAccessor->mCount)
-                throw DeadlyImportError( boost::str( boost::format( "Time count / value count mismatch in animation channel \"%s\".") % e.mChannel->mTarget));
+                throw DeadlyImportError( format() << "Time count / value count mismatch in animation channel \"" << e.mChannel->mTarget << "\"." );
 
       if( e.mTimeAccessor->mCount > 0 )
       {
@@ -1498,8 +1499,8 @@ aiString ColladaLoader::FindFilenameForEffectTexture( const ColladaParser& pPars
     ColladaParser::ImageLibrary::const_iterator imIt = pParser.mImageLibrary.find( name);
     if( imIt == pParser.mImageLibrary.end())
     {
-        throw DeadlyImportError( boost::str( boost::format(
-            "Collada: Unable to resolve effect texture entry \"%s\", ended up at ID \"%s\".") % pName % name));
+        throw DeadlyImportError( format() <<
+            "Collada: Unable to resolve effect texture entry \"" << pName << "\", ended up at ID \"" << name << "\"." );
     }
 
     aiString result;
@@ -1665,7 +1666,7 @@ std::string ColladaLoader::FindNameForNode( const Collada::Node* pNode)
     {
         // No need to worry. Unnamed nodes are no problem at all, except
         // if cameras or lights need to be assigned to them.
-    return boost::str( boost::format( "$ColladaAutoName$_%d") % mNodeNameCounter++);
+    return format() << "$ColladaAutoName$_" << mNodeNameCounter++;
     }
 }
 

--- a/code/ColladaParser.cpp
+++ b/code/ColladaParser.cpp
@@ -55,10 +55,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "../include/assimp/DefaultLogger.hpp"
 #include "../include/assimp/IOSystem.hpp"
 #include "../include/assimp/light.h"
+#include "TinyFormatter.h"
 
 
 using namespace Assimp;
 using namespace Assimp::Collada;
+using namespace Assimp::Formatter;
 
 // ------------------------------------------------------------------------------------------------
 // Constructor to be privately used by Importer
@@ -163,7 +165,7 @@ void ColladaParser::ReadContents()
                 ReadStructure();
             } else
             {
-                DefaultLogger::get()->debug( boost::str( boost::format( "Ignoring global element <%s>.") % mReader->getNodeName()));
+                DefaultLogger::get()->debug( format() << "Ignoring global element <" << mReader->getNodeName() << ">." );
                 SkipElement();
             }
         } else
@@ -724,7 +726,7 @@ void ColladaParser::ReadControllerJoints( Collada::Controller& pController)
 
                 // local URLS always start with a '#'. We don't support global URLs
                 if( attrSource[0] != '#')
-                    ThrowException( boost::str( boost::format( "Unsupported URL format in \"%s\" in source attribute of <joints> data <input> element") % attrSource));
+                    ThrowException( format() << "Unsupported URL format in \"" << attrSource << "\" in source attribute of <joints> data <input> element" );
                 attrSource++;
 
                 // parse source URL to corresponding source
@@ -733,7 +735,7 @@ void ColladaParser::ReadControllerJoints( Collada::Controller& pController)
                 else if( strcmp( attrSemantic, "INV_BIND_MATRIX") == 0)
                     pController.mJointOffsetMatrixSource = attrSource;
                 else
-                    ThrowException( boost::str( boost::format( "Unknown semantic \"%s\" in <joints> data <input> element") % attrSemantic));
+                    ThrowException( format() << "Unknown semantic \"" << attrSemantic << "\" in <joints> data <input> element" );
 
                 // skip inner data, if present
                 if( !mReader->isEmptyElement())
@@ -783,7 +785,7 @@ void ColladaParser::ReadControllerWeights( Collada::Controller& pController)
 
                 // local URLS always start with a '#'. We don't support global URLs
                 if( attrSource[0] != '#')
-                    ThrowException( boost::str( boost::format( "Unsupported URL format in \"%s\" in source attribute of <vertex_weights> data <input> element") % attrSource));
+                    ThrowException( format() << "Unsupported URL format in \"" << attrSource << "\" in source attribute of <vertex_weights> data <input> element" );
                 channel.mAccessor = attrSource + 1;
 
                 // parse source URL to corresponding source
@@ -792,7 +794,7 @@ void ColladaParser::ReadControllerWeights( Collada::Controller& pController)
                 else if( strcmp( attrSemantic, "WEIGHT") == 0)
                     pController.mWeightInputWeights = channel;
                 else
-                    ThrowException( boost::str( boost::format( "Unknown semantic \"%s\" in <vertex_weights> data <input> element") % attrSemantic));
+                    ThrowException( format() << "Unknown semantic \"" << attrSemantic << "\" in <vertex_weights> data <input> element" );
 
                 // skip inner data, if present
                 if( !mReader->isEmptyElement())
@@ -1962,7 +1964,7 @@ void ColladaParser::ReadAccessor( const std::string& pID)
     int attrSource = GetAttribute( "source");
     const char* source = mReader->getAttributeValue( attrSource);
     if( source[0] != '#')
-        ThrowException( boost::str( boost::format( "Unknown reference format in url \"%s\" in source attribute of <accessor> element.") % source));
+        ThrowException( format() << "Unknown reference format in url \"" << source << "\" in source attribute of <accessor> element." );
     int attrCount = GetAttribute( "count");
     unsigned int count = (unsigned int) mReader->getAttributeValueAsInt( attrCount);
     int attrOffset = TestAttribute( "offset");
@@ -2021,7 +2023,7 @@ void ColladaParser::ReadAccessor( const std::string& pID)
                     else if( name == "U") acc.mSubOffset[0] = acc.mParams.size();
                     else if( name == "V") acc.mSubOffset[1] = acc.mParams.size();
                     //else
-                    //  DefaultLogger::get()->warn( boost::str( boost::format( "Unknown accessor parameter \"%s\". Ignoring data channel.") % name));
+                    //  DefaultLogger::get()->warn( format() << "Unknown accessor parameter \"" << name << "\". Ignoring data channel." );
                 }
 
                 // read data type
@@ -2044,7 +2046,7 @@ void ColladaParser::ReadAccessor( const std::string& pID)
                 SkipElement();
             } else
             {
-                ThrowException( boost::str( boost::format( "Unexpected sub element <%s> in tag <accessor>") % mReader->getNodeName()));
+                ThrowException( format() << "Unexpected sub element <" << mReader->getNodeName() << "> in tag <accessor>" );
             }
         }
         else if( mReader->getNodeType() == irr::io::EXN_ELEMENT_END)
@@ -2074,7 +2076,7 @@ void ColladaParser::ReadVertexData( Mesh* pMesh)
                 ReadInputChannel( pMesh->mPerVertexData);
             } else
             {
-                ThrowException( boost::str( boost::format( "Unexpected sub element <%s> in tag <vertices>") % mReader->getNodeName()));
+                ThrowException( format() << "Unexpected sub element <" << mReader->getNodeName() << "> in tag <vertices>" );
             }
         }
         else if( mReader->getNodeType() == irr::io::EXN_ELEMENT_END)
@@ -2172,13 +2174,13 @@ void ColladaParser::ReadIndexData( Mesh* pMesh)
                 SkipElement("extra");
             } else
             {
-                ThrowException( boost::str( boost::format( "Unexpected sub element <%s> in tag <%s>") % mReader->getNodeName() % elementName));
+                ThrowException( format() << "Unexpected sub element <" << mReader->getNodeName() << "> in tag <" << elementName << ">" );
             }
         }
         else if( mReader->getNodeType() == irr::io::EXN_ELEMENT_END)
         {
             if( mReader->getNodeName() != elementName)
-                ThrowException( boost::str( boost::format( "Expected end of <%s> element.") % elementName));
+                ThrowException( format() << "Expected end of <" << elementName << "> element." );
 
             break;
         }
@@ -2211,7 +2213,7 @@ void ColladaParser::ReadInputChannel( std::vector<InputChannel>& poChannels)
     int attrSource = GetAttribute( "source");
     const char* source = mReader->getAttributeValue( attrSource);
     if( source[0] != '#')
-        ThrowException( boost::str( boost::format( "Unknown reference format in url \"%s\" in source attribute of <input> element.") % source));
+        ThrowException( format() << "Unknown reference format in url \"" << source << "\" in source attribute of <input> element." );
     channel.mAccessor = source+1; // skipping the leading #, hopefully the remaining text is the accessor ID only
 
     // read index offset, if per-index <input>
@@ -2225,7 +2227,7 @@ void ColladaParser::ReadInputChannel( std::vector<InputChannel>& poChannels)
         if(attrSet > -1){
             attrSet = mReader->getAttributeValueAsInt( attrSet);
             if(attrSet < 0)
-                ThrowException( boost::str( boost::format( "Invalid index \"%i\" in set attribute of <input> element") % (attrSet)));
+                ThrowException( format() << "Invalid index \"" << (attrSet) << "\" in set attribute of <input> element" );
 
             channel.mIndex = attrSet;
         }
@@ -2449,7 +2451,7 @@ void ColladaParser::ExtractDataObjectFromChannel( const InputChannel& pInput, si
 
     const Accessor& acc = *pInput.mResolved;
     if( pLocalIndex >= acc.mCount)
-        ThrowException( boost::str( boost::format( "Invalid data index (%d/%d) in primitive specification") % pLocalIndex % acc.mCount));
+        ThrowException( format() << "Invalid data index (" << pLocalIndex << "/" << acc.mCount << ") in primitive specification" );
 
     // get a pointer to the start of the data object referred to by the accessor and the local index
     const float* dataObject = &(acc.mData->mValues[0]) + acc.mOffset + pLocalIndex* acc.mStride;
@@ -2904,7 +2906,7 @@ void ColladaParser::ReadScene()
 // Aborts the file reading with an exception
 AI_WONT_RETURN void ColladaParser::ThrowException( const std::string& pError) const
 {
-    throw DeadlyImportError( boost::str( boost::format( "Collada: %s - %s") % mFileName % pError));
+    throw DeadlyImportError( format() << "Collada: " << mFileName << " - " << pError );
 }
 void ColladaParser::ReportWarning(const char* msg,...)
 {
@@ -2955,14 +2957,14 @@ void ColladaParser::TestOpening( const char* pName)
 {
     // read element start
     if( !mReader->read())
-        ThrowException( boost::str( boost::format( "Unexpected end of file while beginning of <%s> element.") % pName));
+        ThrowException( format() << "Unexpected end of file while beginning of <" << pName << "> element." );
     // whitespace in front is ok, just read again if found
     if( mReader->getNodeType() == irr::io::EXN_TEXT)
         if( !mReader->read())
-            ThrowException( boost::str( boost::format( "Unexpected end of file while reading beginning of <%s> element.") % pName));
+            ThrowException( format() << "Unexpected end of file while reading beginning of <" << pName << "> element." );
 
     if( mReader->getNodeType() != irr::io::EXN_ELEMENT || strcmp( mReader->getNodeName(), pName) != 0)
-        ThrowException( boost::str( boost::format( "Expected start of <%s> element.") % pName));
+        ThrowException( format() << "Expected start of <" << pName << "> element." );
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -2975,15 +2977,15 @@ void ColladaParser::TestClosing( const char* pName)
 
     // if not, read some more
     if( !mReader->read())
-        ThrowException( boost::str( boost::format( "Unexpected end of file while reading end of <%s> element.") % pName));
+        ThrowException( format() << "Unexpected end of file while reading end of <" << pName << "> element." );
     // whitespace in front is ok, just read again if found
     if( mReader->getNodeType() == irr::io::EXN_TEXT)
         if( !mReader->read())
-            ThrowException( boost::str( boost::format( "Unexpected end of file while reading end of <%s> element.") % pName));
+            ThrowException( format() << "Unexpected end of file while reading end of <" << pName << "> element." );
 
     // but this has the be the closing tag, or we're lost
     if( mReader->getNodeType() != irr::io::EXN_ELEMENT_END || strcmp( mReader->getNodeName(), pName) != 0)
-        ThrowException( boost::str( boost::format( "Expected end of <%s> element.") % pName));
+        ThrowException( format() << "Expected end of <" << pName << "> element." );
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -2995,7 +2997,7 @@ int ColladaParser::GetAttribute( const char* pAttr) const
         return index;
 
     // attribute not found -> throw an exception
-    ThrowException( boost::str( boost::format( "Expected attribute \"%s\" for element <%s>.") % pAttr % mReader->getNodeName()));
+    ThrowException( format() << "Expected attribute \"" << pAttr << "\" for element <" << mReader->getNodeName() << ">." );
     return -1;
 }
 
@@ -3130,7 +3132,7 @@ Collada::InputType ColladaParser::GetTypeForSemantic( const std::string& pSemant
     else if( pSemantic == "TANGENT" || pSemantic == "TEXTANGENT")
         return IT_Tangent;
 
-    DefaultLogger::get()->warn( boost::str( boost::format( "Unknown vertex input type \"%s\". Ignoring.") % pSemantic));
+    DefaultLogger::get()->warn( format() << "Unknown vertex input type \"" << pSemantic << "\". Ignoring." );
     return IT_Invalid;
 }
 

--- a/code/ColladaParser.cpp
+++ b/code/ColladaParser.cpp
@@ -52,7 +52,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "fast_atof.h"
 #include "ParsingUtils.h"
 #include <boost/scoped_ptr.hpp>
-#include <boost/foreach.hpp>
 #include "../include/assimp/DefaultLogger.hpp"
 #include "../include/assimp/IOSystem.hpp"
 #include "../include/assimp/light.h"
@@ -529,10 +528,10 @@ void ColladaParser::ReadAnimation( Collada::Animation* pParent)
     // it turned out to have channels - add them
     if( !channels.empty())
     {
-		// FIXME: Is this essentially doing the same as "single-anim-node" codepath in 
+		// FIXME: Is this essentially doing the same as "single-anim-node" codepath in
 		//        ColladaLoader::StoreAnimations? For now, this has been deferred to after
-		//        all animations and all clips have been read. Due to handling of 
-		//        <library_animation_clips> this cannot be done here, as the channel owner 
+		//        all animations and all clips have been read. Due to handling of
+		//        <library_animation_clips> this cannot be done here, as the channel owner
 		//        is lost, and some exporters make up animations by referring to multiple
 		//        single-channel animations from an <instance_animation>.
 /*
@@ -1404,7 +1403,7 @@ void ColladaParser::ReadEffectProfileCommon( Collada::Effect& pEffect)
                 pEffect.mHasTransparency = true;
 
                 const char* opaque = mReader->getAttributeValueSafe("opaque");
- 
+
                 if(::strcmp(opaque, "RGB_ZERO") == 0 || ::strcmp(opaque, "RGB_ONE") == 0) {
                     pEffect.mRGBTransparency = true;
                 }
@@ -2249,7 +2248,7 @@ size_t ColladaParser::ReadPrimitives( Mesh* pMesh, std::vector<InputChannel>& pP
     // find the offset index for all per-vertex channels
     size_t numOffsets = 1;
     size_t perVertexOffset = SIZE_MAX; // invalid value
-    BOOST_FOREACH( const InputChannel& channel, pPerIndexChannels)
+    for( const InputChannel& channel : pPerIndexChannels)
     {
         numOffsets = std::max( numOffsets, channel.mOffset+1);
         if( channel.mType == IT_Vertex)
@@ -2262,7 +2261,7 @@ size_t ColladaParser::ReadPrimitives( Mesh* pMesh, std::vector<InputChannel>& pP
     {
         case Prim_Polylist:
         {
-            BOOST_FOREACH( size_t i, pVCount)
+            for( size_t i : pVCount)
                 expectedPointCount += i;
             break;
         }
@@ -2910,14 +2909,14 @@ AI_WONT_RETURN void ColladaParser::ThrowException( const std::string& pError) co
 void ColladaParser::ReportWarning(const char* msg,...)
 {
     ai_assert(NULL != msg);
-    
+
     va_list args;
     va_start(args,msg);
-    
+
     char szBuffer[3000];
     const int iLen = vsprintf(szBuffer,msg,args);
     ai_assert(iLen > 0);
-    
+
     va_end(args);
     DefaultLogger::get()->warn("Validation warning: " + std::string(szBuffer,iLen));
 }

--- a/code/ColladaParser.cpp
+++ b/code/ColladaParser.cpp
@@ -51,7 +51,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "ColladaParser.h"
 #include "fast_atof.h"
 #include "ParsingUtils.h"
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include "../include/assimp/DefaultLogger.hpp"
 #include "../include/assimp/IOSystem.hpp"
 #include "../include/assimp/light.h"
@@ -87,13 +87,13 @@ ColladaParser::ColladaParser( IOSystem* pIOHandler, const std::string& pFile)
     }
 
     // open the file
-    boost::scoped_ptr<IOStream> file( pIOHandler->Open(pFile ) );
+    std::unique_ptr<IOStream> file( pIOHandler->Open(pFile ) );
     if (file.get() == NULL) {
         throw DeadlyImportError( "Failed to open file " + pFile + "." );
     }
 
     // generate a XML reader for it
-    boost::scoped_ptr<CIrrXML_IOStreamReader> mIOWrapper(new CIrrXML_IOStreamReader(file.get()));
+    std::unique_ptr<CIrrXML_IOStreamReader> mIOWrapper(new CIrrXML_IOStreamReader(file.get()));
     mReader = irr::io::createIrrXMLReader( mIOWrapper.get());
     if (!mReader) {
         ThrowException("Collada: Unable to open file.");

--- a/code/ColladaParser.h
+++ b/code/ColladaParser.h
@@ -1,28 +1,28 @@
 /*
  Open Asset Import Library (assimp)
  ----------------------------------------------------------------------
- 
+
  Copyright (c) 2006-2016, assimp team
  All rights reserved.
- 
+
  Redistribution and use of this software in source and binary forms,
  with or without modification, are permitted provided that the
  following conditions are met:
- 
+
  * Redistributions of source code must retain the above
  copyright notice, this list of conditions and the
  following disclaimer.
- 
+
  * Redistributions in binary form must reproduce the above
  copyright notice, this list of conditions and the
  following disclaimer in the documentation and/or other
  materials provided with the distribution.
- 
+
  * Neither the name of the assimp team, nor the names of its
  contributors may be used to endorse or promote products
  derived from this software without specific prior
  written permission of the assimp team.
- 
+
  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
@@ -34,7 +34,7 @@
  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- 
+
  ----------------------------------------------------------------------
  */
 
@@ -49,11 +49,11 @@
 #include "ColladaHelper.h"
 #include "../include/assimp/ai_assert.h"
 #include <boost/format.hpp>
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 
 namespace Assimp
 {
-    
+
     // ------------------------------------------------------------------------------------------
     /** Parser helper class for the Collada loader.
      *
@@ -63,23 +63,23 @@ namespace Assimp
     class ColladaParser
     {
         friend class ColladaLoader;
-        
+
     protected:
         /** Constructor from XML file */
         ColladaParser( IOSystem* pIOHandler, const std::string& pFile);
-        
+
         /** Destructor */
         ~ColladaParser();
-        
+
         /** Reads the contents of the file */
         void ReadContents();
-        
+
         /** Reads the structure of the file */
         void ReadStructure();
-        
+
         /** Reads asset informations such as coordinate system informations and legal blah */
         void ReadAssetInfo();
-        
+
         /** Reads the animation library */
         void ReadAnimationLibrary();
 
@@ -88,137 +88,137 @@ namespace Assimp
 
 		/** Re-build animations from animation clip library, if present, otherwise combine single-channel animations */
 		void PostProcessRootAnimations();
-        
+
         /** Reads an animation into the given parent structure */
         void ReadAnimation( Collada::Animation* pParent);
-        
+
         /** Reads an animation sampler into the given anim channel */
         void ReadAnimationSampler( Collada::AnimationChannel& pChannel);
-        
+
         /** Reads the skeleton controller library */
         void ReadControllerLibrary();
-        
+
         /** Reads a controller into the given mesh structure */
         void ReadController( Collada::Controller& pController);
-        
+
         /** Reads the joint definitions for the given controller */
         void ReadControllerJoints( Collada::Controller& pController);
-        
+
         /** Reads the joint weights for the given controller */
         void ReadControllerWeights( Collada::Controller& pController);
-        
+
         /** Reads the image library contents */
         void ReadImageLibrary();
-        
+
         /** Reads an image entry into the given image */
         void ReadImage( Collada::Image& pImage);
-        
+
         /** Reads the material library */
         void ReadMaterialLibrary();
-        
+
         /** Reads a material entry into the given material */
         void ReadMaterial( Collada::Material& pMaterial);
-        
+
         /** Reads the camera library */
         void ReadCameraLibrary();
-        
+
         /** Reads a camera entry into the given camera */
         void ReadCamera( Collada::Camera& pCamera);
-        
+
         /** Reads the light library */
         void ReadLightLibrary();
-        
+
         /** Reads a light entry into the given light */
         void ReadLight( Collada::Light& pLight);
-        
+
         /** Reads the effect library */
         void ReadEffectLibrary();
-        
+
         /** Reads an effect entry into the given effect*/
         void ReadEffect( Collada::Effect& pEffect);
-        
+
         /** Reads an COMMON effect profile */
         void ReadEffectProfileCommon( Collada::Effect& pEffect);
-        
+
         /** Read sampler properties */
         void ReadSamplerProperties( Collada::Sampler& pSampler);
-        
+
         /** Reads an effect entry containing a color or a texture defining that color */
         void ReadEffectColor( aiColor4D& pColor, Collada::Sampler& pSampler);
-        
+
         /** Reads an effect entry containing a float */
         void ReadEffectFloat( float& pFloat);
-        
+
         /** Reads an effect parameter specification of any kind */
         void ReadEffectParam( Collada::EffectParam& pParam);
-        
+
         /** Reads the geometry library contents */
         void ReadGeometryLibrary();
-        
+
         /** Reads a geometry from the geometry library. */
         void ReadGeometry( Collada::Mesh* pMesh);
-        
+
         /** Reads a mesh from the geometry library */
         void ReadMesh( Collada::Mesh* pMesh);
-        
+
         /** Reads a source element - a combination of raw data and an accessor defining
          * things that should not be redefinable. Yes, that's another rant.
          */
         void ReadSource();
-        
+
         /** Reads a data array holding a number of elements, and stores it in the global library.
          * Currently supported are array of floats and arrays of strings.
          */
         void ReadDataArray();
-        
+
         /** Reads an accessor and stores it in the global library under the given ID -
          * accessors use the ID of the parent <source> element
          */
         void ReadAccessor( const std::string& pID);
-        
+
         /** Reads input declarations of per-vertex mesh data into the given mesh */
         void ReadVertexData( Collada::Mesh* pMesh);
-        
+
         /** Reads input declarations of per-index mesh data into the given mesh */
         void ReadIndexData( Collada::Mesh* pMesh);
-        
+
         /** Reads a single input channel element and stores it in the given array, if valid */
         void ReadInputChannel( std::vector<Collada::InputChannel>& poChannels);
-        
+
         /** Reads a <p> primitive index list and assembles the mesh data into the given mesh */
         size_t ReadPrimitives( Collada::Mesh* pMesh, std::vector<Collada::InputChannel>& pPerIndexChannels,
                               size_t pNumPrimitives, const std::vector<size_t>& pVCount, Collada::PrimitiveType pPrimType);
-        
+
         /** Copies the data for a single primitive into the mesh, based on the InputChannels */
         void CopyVertex(size_t currentVertex, size_t numOffsets, size_t numPoints, size_t perVertexOffset,
                         Collada::Mesh* pMesh, std::vector<Collada::InputChannel>& pPerIndexChannels,
                         size_t currentPrimitive, const std::vector<size_t>& indices);
-        
+
         /** Reads one triangle of a tristrip into the mesh */
         void ReadPrimTriStrips(size_t numOffsets, size_t perVertexOffset, Collada::Mesh* pMesh,
                                std::vector<Collada::InputChannel>& pPerIndexChannels, size_t currentPrimitive, const std::vector<size_t>& indices);
-        
+
         /** Extracts a single object from an input channel and stores it in the appropriate mesh data array */
         void ExtractDataObjectFromChannel( const Collada::InputChannel& pInput, size_t pLocalIndex, Collada::Mesh* pMesh);
-        
+
         /** Reads the library of node hierarchies and scene parts */
         void ReadSceneLibrary();
-        
+
         /** Reads a scene node's contents including children and stores it in the given node */
         void ReadSceneNode( Collada::Node* pNode);
-        
+
         /** Reads a node transformation entry of the given type and adds it to the given node's transformation list. */
         void ReadNodeTransformation( Collada::Node* pNode, Collada::TransformType pType);
-        
+
         /** Reads a mesh reference in a node and adds it to the node's mesh list */
         void ReadNodeGeometry( Collada::Node* pNode);
-        
+
         /** Reads the collada scene */
         void ReadScene();
-        
+
         // Processes bind_vertex_input and bind elements
         void ReadMaterialVertexInputBinding( Collada::SemanticMappingTable& tbl);
-        
+
     protected:
         /** Aborts the file reading with an exception */
         AI_WONT_RETURN void ThrowException( const std::string& pError) const AI_WONT_RETURN_SUFFIX;
@@ -226,95 +226,95 @@ namespace Assimp
 
         /** Skips all data until the end node of the current element */
         void SkipElement();
-        
+
         /** Skips all data until the end node of the given element */
         void SkipElement( const char* pElement);
-        
+
         /** Compares the current xml element name to the given string and returns true if equal */
         bool IsElement( const char* pName) const;
-        
+
         /** Tests for the opening tag of the given element, throws an exception if not found */
         void TestOpening( const char* pName);
-        
+
         /** Tests for the closing tag of the given element, throws an exception if not found */
         void TestClosing( const char* pName);
-        
+
         /** Checks the present element for the presence of the attribute, returns its index
          or throws an exception if not found */
         int GetAttribute( const char* pAttr) const;
-        
+
         /** Returns the index of the named attribute or -1 if not found. Does not throw,
          therefore useful for optional attributes */
         int TestAttribute( const char* pAttr) const;
-        
+
         /** Reads the text contents of an element, throws an exception if not given.
          Skips leading whitespace. */
         const char* GetTextContent();
-        
+
         /** Reads the text contents of an element, returns NULL if not given.
          Skips leading whitespace. */
         const char* TestTextContent();
-        
+
         /** Reads a single bool from current text content */
         bool ReadBoolFromTextContent();
-        
+
         /** Reads a single float from current text content */
         float ReadFloatFromTextContent();
-        
+
         /** Calculates the resulting transformation from all the given transform steps */
         aiMatrix4x4 CalculateResultTransform( const std::vector<Collada::Transform>& pTransforms) const;
-        
+
         /** Determines the input data type for the given semantic string */
         Collada::InputType GetTypeForSemantic( const std::string& pSemantic);
-        
+
         /** Finds the item in the given library by its reference, throws if not found */
         template <typename Type> const Type& ResolveLibraryReference(
                                                                      const std::map<std::string, Type>& pLibrary, const std::string& pURL) const;
-        
+
     protected:
         /** Filename, for a verbose error message */
         std::string mFileName;
-        
+
         /** XML reader, member for everyday use */
         irr::io::IrrXMLReader* mReader;
-        
+
         /** All data arrays found in the file by ID. Might be referred to by actually
          everyone. Collada, you are a steaming pile of indirection. */
         typedef std::map<std::string, Collada::Data> DataLibrary;
         DataLibrary mDataLibrary;
-        
+
         /** Same for accessors which define how the data in a data array is accessed. */
         typedef std::map<std::string, Collada::Accessor> AccessorLibrary;
         AccessorLibrary mAccessorLibrary;
-        
+
         /** Mesh library: mesh by ID */
         typedef std::map<std::string, Collada::Mesh*> MeshLibrary;
         MeshLibrary mMeshLibrary;
-        
+
         /** node library: root node of the hierarchy part by ID */
         typedef std::map<std::string, Collada::Node*> NodeLibrary;
         NodeLibrary mNodeLibrary;
-        
+
         /** Image library: stores texture properties by ID */
         typedef std::map<std::string, Collada::Image> ImageLibrary;
         ImageLibrary mImageLibrary;
-        
+
         /** Effect library: surface attributes by ID */
         typedef std::map<std::string, Collada::Effect> EffectLibrary;
         EffectLibrary mEffectLibrary;
-        
+
         /** Material library: surface material by ID */
         typedef std::map<std::string, Collada::Material> MaterialLibrary;
         MaterialLibrary mMaterialLibrary;
-        
+
         /** Light library: surface light by ID */
         typedef std::map<std::string, Collada::Light> LightLibrary;
         LightLibrary mLightLibrary;
-        
+
         /** Camera library: surface material by ID */
         typedef std::map<std::string, Collada::Camera> CameraLibrary;
         CameraLibrary mCameraLibrary;
-        
+
         /** Controller library: joint controllers by ID */
         typedef std::map<std::string, Collada::Controller> ControllerLibrary;
         ControllerLibrary mControllerLibrary;
@@ -326,24 +326,24 @@ namespace Assimp
 		/** Animation clip library: clip animation references by ID */
 		typedef std::vector<std::pair<std::string, std::vector<std::string> > > AnimationClipLibrary;
 		AnimationClipLibrary mAnimationClipLibrary;
-        
+
         /** Pointer to the root node. Don't delete, it just points to one of
          the nodes in the node library. */
         Collada::Node* mRootNode;
-        
+
         /** Root animation container */
         Collada::Animation mAnims;
-        
+
         /** Size unit: how large compared to a meter */
         float mUnitSize;
-        
+
         /** Which is the up vector */
         enum { UP_X, UP_Y, UP_Z } mUpDirection;
-        
+
         /** Collada file format version */
         Collada::FormatVersion mFormat;
     };
-    
+
     // ------------------------------------------------------------------------------------------------
     // Check for element match
     inline bool ColladaParser::IsElement( const char* pName) const
@@ -351,7 +351,7 @@ namespace Assimp
         ai_assert( mReader->getNodeType() == irr::io::EXN_ELEMENT);
         return ::strcmp( mReader->getNodeName(), pName) == 0;
     }
-    
+
     // ------------------------------------------------------------------------------------------------
     // Finds the item in the given library by its reference, throws if not found
     template <typename Type>
@@ -362,7 +362,7 @@ namespace Assimp
             ThrowException( boost::str( boost::format( "Unable to resolve library reference \"%s\".") % pURL));
         return it->second;
     }
-    
+
 } // end of namespace Assimp
 
 #endif // AI_COLLADAPARSER_H_INC

--- a/code/ColladaParser.h
+++ b/code/ColladaParser.h
@@ -48,7 +48,7 @@
 #include "irrXMLWrapper.h"
 #include "ColladaHelper.h"
 #include "../include/assimp/ai_assert.h"
-#include <boost/format.hpp>
+#include "TinyFormatter.h"
 #include <memory>
 
 namespace Assimp
@@ -359,7 +359,7 @@ namespace Assimp
     {
         typename std::map<std::string, Type>::const_iterator it = pLibrary.find( pURL);
         if( it == pLibrary.end())
-            ThrowException( boost::str( boost::format( "Unable to resolve library reference \"%s\".") % pURL));
+            ThrowException( Formatter::format() << "Unable to resolve library reference \"" << pURL << "\"." );
         return it->second;
     }
 

--- a/code/DXFHelper.h
+++ b/code/DXFHelper.h
@@ -213,7 +213,7 @@ struct InsertBlock
 // keeps track of all geometry in a single BLOCK.
 struct Block
 {
-    std::vector< boost::shared_ptr<PolyLine> > lines;
+    std::vector< std::shared_ptr<PolyLine> > lines;
     std::vector<InsertBlock> insertions;
 
     std::string name;

--- a/code/DXFLoader.cpp
+++ b/code/DXFLoader.cpp
@@ -54,7 +54,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "DXFHelper.h"
 #include "../include/assimp/IOSystem.hpp"
 #include "../include/assimp/scene.h"
-#include <boost/foreach.hpp>
 #include <numeric>
 
 using namespace Assimp;
@@ -222,8 +221,8 @@ void DXFImporter::ConvertMeshes(aiScene* pScene, DXF::FileData& output)
     if (!DefaultLogger::isNullLogger()) {
 
         unsigned int vcount = 0, icount = 0;
-        BOOST_FOREACH (const DXF::Block& bl, output.blocks) {
-            BOOST_FOREACH (boost::shared_ptr<const DXF::PolyLine> pl, bl.lines) {
+        for (const DXF::Block& bl : output.blocks) {
+            for (boost::shared_ptr<const DXF::PolyLine> pl : bl.lines) {
                 vcount += pl->positions.size();
                 icount += pl->counts.size();
             }
@@ -242,7 +241,7 @@ void DXFImporter::ConvertMeshes(aiScene* pScene, DXF::FileData& output)
 
     // index blocks by name
     DXF::BlockMap blocks_by_name;
-    BOOST_FOREACH (DXF::Block& bl, output.blocks) {
+    for (DXF::Block& bl : output.blocks) {
         blocks_by_name[bl.name] = &bl;
         if ( !entities && bl.name == AI_DXF_ENTITIES_MAGIC_BLOCK ) {
             entities = &bl;
@@ -263,7 +262,7 @@ void DXFImporter::ConvertMeshes(aiScene* pScene, DXF::FileData& output)
     ExpandBlockReferences(*entities,blocks_by_name);
 
     unsigned int cur = 0;
-    BOOST_FOREACH (boost::shared_ptr<const DXF::PolyLine> pl, entities->lines) {
+    for (boost::shared_ptr<const DXF::PolyLine> pl : entities->lines) {
         if (pl->positions.size()) {
 
             std::map<std::string, unsigned int>::iterator it = layers.find(pl->layer);
@@ -289,12 +288,12 @@ void DXFImporter::ConvertMeshes(aiScene* pScene, DXF::FileData& output)
 
     pScene->mMeshes = new aiMesh*[ pScene->mNumMeshes ] ();
 
-    BOOST_FOREACH(const LayerMap::value_type& elem, layers){
+    for(const LayerMap::value_type& elem : layers){
         aiMesh* const mesh =  pScene->mMeshes[elem.second] = new aiMesh();
         mesh->mName.Set(elem.first);
 
         unsigned int cvert = 0,cface = 0;
-        BOOST_FOREACH(const DXF::PolyLine* pl, corr[elem.second]){
+        for(const DXF::PolyLine* pl : corr[elem.second]){
             // sum over all faces since we need to 'verbosify' them.
             cvert += std::accumulate(pl->counts.begin(),pl->counts.end(),0);
             cface += pl->counts.size();
@@ -309,10 +308,10 @@ void DXFImporter::ConvertMeshes(aiScene* pScene, DXF::FileData& output)
 
         unsigned int prims = 0;
         unsigned int overall_indices = 0;
-        BOOST_FOREACH(const DXF::PolyLine* pl, corr[elem.second]){
+        for(const DXF::PolyLine* pl : corr[elem.second]){
 
             std::vector<unsigned int>::const_iterator it = pl->indices.begin();
-            BOOST_FOREACH(unsigned int facenumv,pl->counts) {
+            for(unsigned int facenumv : pl->counts) {
                 aiFace& face = *faces++;
                 face.mIndices = new unsigned int[face.mNumIndices = facenumv];
 
@@ -358,7 +357,7 @@ void DXFImporter::ConvertMeshes(aiScene* pScene, DXF::FileData& output)
 // ------------------------------------------------------------------------------------------------
 void DXFImporter::ExpandBlockReferences(DXF::Block& bl,const DXF::BlockMap& blocks_by_name)
 {
-    BOOST_FOREACH (const DXF::InsertBlock& insert, bl.insertions) {
+    for (const DXF::InsertBlock& insert : bl.insertions) {
 
         // first check if the referenced blocks exists ...
         const DXF::BlockMap::const_iterator it = blocks_by_name.find(insert.name);
@@ -372,7 +371,7 @@ void DXFImporter::ExpandBlockReferences(DXF::Block& bl,const DXF::BlockMap& bloc
         // XXX this would be the place to implement recursive expansion if needed.
         const DXF::Block& bl_src = *(*it).second;
 
-        BOOST_FOREACH (boost::shared_ptr<const DXF::PolyLine> pl_in, bl_src.lines) {
+        for (boost::shared_ptr<const DXF::PolyLine> pl_in : bl_src.lines) {
             boost::shared_ptr<DXF::PolyLine> pl_out = boost::shared_ptr<DXF::PolyLine>(new DXF::PolyLine(*pl_in));
 
             if (bl_src.base.Length() || insert.scale.x!=1.f || insert.scale.y!=1.f || insert.scale.z!=1.f || insert.angle || insert.pos.Length()) {
@@ -388,7 +387,7 @@ void DXFImporter::ExpandBlockReferences(DXF::Block& bl,const DXF::BlockMap& bloc
                     DefaultLogger::get()->warn("DXF: BLOCK rotation not currently implemented");
                 }
 
-                BOOST_FOREACH (aiVector3D& v, pl_out->positions) {
+                for (aiVector3D& v : pl_out->positions) {
                     v *= trafo;
                 }
             }

--- a/code/DXFLoader.cpp
+++ b/code/DXFLoader.cpp
@@ -133,7 +133,7 @@ void DXFImporter::InternReadFile( const std::string& pFile,
     aiScene* pScene,
     IOSystem* pIOHandler)
 {
-    boost::shared_ptr<IOStream> file = boost::shared_ptr<IOStream>( pIOHandler->Open( pFile) );
+    std::shared_ptr<IOStream> file = std::shared_ptr<IOStream>( pIOHandler->Open( pFile) );
 
     // Check whether we can read the file
     if( file.get() == NULL) {
@@ -222,7 +222,7 @@ void DXFImporter::ConvertMeshes(aiScene* pScene, DXF::FileData& output)
 
         unsigned int vcount = 0, icount = 0;
         for (const DXF::Block& bl : output.blocks) {
-            for (boost::shared_ptr<const DXF::PolyLine> pl : bl.lines) {
+            for (std::shared_ptr<const DXF::PolyLine> pl : bl.lines) {
                 vcount += pl->positions.size();
                 icount += pl->counts.size();
             }
@@ -262,7 +262,7 @@ void DXFImporter::ConvertMeshes(aiScene* pScene, DXF::FileData& output)
     ExpandBlockReferences(*entities,blocks_by_name);
 
     unsigned int cur = 0;
-    for (boost::shared_ptr<const DXF::PolyLine> pl : entities->lines) {
+    for (std::shared_ptr<const DXF::PolyLine> pl : entities->lines) {
         if (pl->positions.size()) {
 
             std::map<std::string, unsigned int>::iterator it = layers.find(pl->layer);
@@ -371,8 +371,8 @@ void DXFImporter::ExpandBlockReferences(DXF::Block& bl,const DXF::BlockMap& bloc
         // XXX this would be the place to implement recursive expansion if needed.
         const DXF::Block& bl_src = *(*it).second;
 
-        for (boost::shared_ptr<const DXF::PolyLine> pl_in : bl_src.lines) {
-            boost::shared_ptr<DXF::PolyLine> pl_out = boost::shared_ptr<DXF::PolyLine>(new DXF::PolyLine(*pl_in));
+        for (std::shared_ptr<const DXF::PolyLine> pl_in : bl_src.lines) {
+            std::shared_ptr<DXF::PolyLine> pl_out = std::shared_ptr<DXF::PolyLine>(new DXF::PolyLine(*pl_in));
 
             if (bl_src.base.Length() || insert.scale.x!=1.f || insert.scale.y!=1.f || insert.scale.z!=1.f || insert.angle || insert.pos.Length()) {
                 // manual coordinate system transformation
@@ -617,7 +617,7 @@ void DXFImporter::ParseInsertion(DXF::LineReader& reader, DXF::FileData& output)
 // ------------------------------------------------------------------------------------------------
 void DXFImporter::ParsePolyLine(DXF::LineReader& reader, DXF::FileData& output)
 {
-    output.blocks.back().lines.push_back( boost::shared_ptr<DXF::PolyLine>( new DXF::PolyLine() ) );
+    output.blocks.back().lines.push_back( std::shared_ptr<DXF::PolyLine>( new DXF::PolyLine() ) );
     DXF::PolyLine& line = *output.blocks.back().lines.back();
 
     unsigned int iguess = 0, vguess = 0;
@@ -799,7 +799,7 @@ void DXFImporter::Parse3DFace(DXF::LineReader& reader, DXF::FileData& output)
     // (note) this is also used for for parsing line entities, so we
     // must handle the vertex_count == 2 case as well.
 
-    output.blocks.back().lines.push_back( boost::shared_ptr<DXF::PolyLine>( new DXF::PolyLine() )  );
+    output.blocks.back().lines.push_back( std::shared_ptr<DXF::PolyLine>( new DXF::PolyLine() )  );
     DXF::PolyLine& line = *output.blocks.back().lines.back();
 
     aiVector3D vip[4];

--- a/code/DefaultLogger.cpp
+++ b/code/DefaultLogger.cpp
@@ -57,10 +57,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdio.h>
 
 #ifndef ASSIMP_BUILD_SINGLETHREADED
-#   include <boost/thread/thread.hpp>
-#   include <boost/thread/mutex.hpp>
+#   include <thread>
+#   include <mutex>
 
-boost::mutex loggerMutex;
+std::mutex loggerMutex;
 #endif
 
 namespace Assimp    {
@@ -135,7 +135,7 @@ Logger *DefaultLogger::create(const char* name /*= "AssimpLog.txt"*/,
 {
     // enter the mutex here to avoid concurrency problems
 #ifndef ASSIMP_BUILD_SINGLETHREADED
-    boost::mutex::scoped_lock lock(loggerMutex);
+    std::lock_guard<std::mutex> lock(loggerMutex);
 #endif
 
     if (m_pLogger && !isNullLogger() )
@@ -210,7 +210,7 @@ void DefaultLogger::set( Logger *logger )
 {
     // enter the mutex here to avoid concurrency problems
 #ifndef ASSIMP_BUILD_SINGLETHREADED
-    boost::mutex::scoped_lock lock(loggerMutex);
+    std::lock_guard<std::mutex> lock(loggerMutex);
 #endif
 
     if (!logger)logger = &s_pNullLogger;
@@ -237,7 +237,7 @@ void DefaultLogger::kill()
 {
     // enter the mutex here to avoid concurrency problems
 #ifndef ASSIMP_BUILD_SINGLETHREADED
-    boost::mutex::scoped_lock lock(loggerMutex);
+    std::lock_guard<std::mutex> lock(loggerMutex);
 #endif
 
 	if ( m_pLogger == &s_pNullLogger ) {
@@ -413,7 +413,8 @@ void DefaultLogger::WriteToStreams(const char *message, ErrorSeverity ErrorSev )
 //  Returns thread id, if not supported only a zero will be returned.
 unsigned int DefaultLogger::GetThreadID()
 {
-    // fixme: we can get this value via boost::threads
+    // fixme: we can get this value via std::threads
+    // std::this_thread::get_id().hash() returns a (big) size_t, not sure if this is useful in this case.
 #ifdef WIN32
     return (unsigned int)::GetCurrentThreadId();
 #else

--- a/code/Exporter.cpp
+++ b/code/Exporter.cpp
@@ -491,7 +491,7 @@ const aiExportFormatDesc* Exporter :: GetExportFormatDescription( size_t pIndex 
 // ------------------------------------------------------------------------------------------------
 aiReturn Exporter :: RegisterExporter(const ExportFormatEntry& desc)
 {
-    BOOST_FOREACH(const ExportFormatEntry& e, pimpl->mExporters) {
+    for(const ExportFormatEntry& e : pimpl->mExporters) {
         if (!strcmp(e.mDescription.id,desc.mDescription.id)) {
             return aiReturn_FAILURE;
         }

--- a/code/Exporter.cpp
+++ b/code/Exporter.cpp
@@ -324,7 +324,7 @@ aiReturn Exporter :: Export( const aiScene* pScene, const char* pFormatId, const
                 aiScene* scenecopy_tmp;
                 SceneCombiner::CopyScene(&scenecopy_tmp,pScene);
 
-                std::auto_ptr<aiScene> scenecopy(scenecopy_tmp);
+                std::unique_ptr<aiScene> scenecopy(scenecopy_tmp);
                 const ScenePrivateData* const priv = ScenePriv(pScene);
 
                 // steps that are not idempotent, i.e. we might need to run them again, usually to get back to the

--- a/code/Exporter.cpp
+++ b/code/Exporter.cpp
@@ -63,7 +63,7 @@ Here we implement only the C++ interface (Assimp::Exporter).
 #include "ConvertToLHProcess.h"
 #include "Exceptional.h"
 #include "ScenePrivate.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include "../include/assimp/Exporter.hpp"
 #include "../include/assimp/mesh.h"
 #include "../include/assimp/postprocess.h"
@@ -184,7 +184,7 @@ public:
 public:
 
     aiExportDataBlob* blob;
-    boost::shared_ptr< Assimp::IOSystem > mIOSystem;
+    std::shared_ptr< Assimp::IOSystem > mIOSystem;
     bool mIsDefaultIOHandler;
 
     /** Post processing steps we can apply at the imported data. */
@@ -254,10 +254,10 @@ const aiExportDataBlob* Exporter :: ExportToBlob(  const aiScene* pScene, const 
     }
 
 
-    boost::shared_ptr<IOSystem> old = pimpl->mIOSystem;
+    std::shared_ptr<IOSystem> old = pimpl->mIOSystem;
 
     BlobIOSystem* blobio = new BlobIOSystem();
-    pimpl->mIOSystem = boost::shared_ptr<IOSystem>( blobio );
+    pimpl->mIOSystem = std::shared_ptr<IOSystem>( blobio );
 
     if (AI_SUCCESS != Export(pScene,pFormatId,blobio->GetMagicFileName())) {
         pimpl->mIOSystem = old;

--- a/code/FBXAnimation.cpp
+++ b/code/FBXAnimation.cpp
@@ -51,7 +51,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "FBXImportSettings.h"
 #include "FBXDocumentUtil.h"
 #include "FBXProperties.h"
-#include <boost/foreach.hpp>
 
 namespace Assimp {
 namespace FBX {
@@ -110,7 +109,7 @@ AnimationCurveNode::AnimationCurveNode(uint64_t id, const Element& element, cons
     const char* whitelist[] = {"Model","NodeAttribute"};
     const std::vector<const Connection*>& conns = doc.GetConnectionsBySourceSequenced(ID(),whitelist,2);
 
-    BOOST_FOREACH(const Connection* con, conns) {
+    for(const Connection* con : conns) {
 
         // link should go for a property
         if (!con->PropertyName().length()) {
@@ -171,7 +170,7 @@ const AnimationCurveMap& AnimationCurveNode::Curves() const
         // resolve attached animation curves
         const std::vector<const Connection*>& conns = doc.GetConnectionsByDestinationSequenced(ID(),"AnimationCurve");
 
-        BOOST_FOREACH(const Connection* con, conns) {
+        for(const Connection* con : conns) {
 
             // link should go for a property
             if (!con->PropertyName().length()) {
@@ -227,7 +226,7 @@ AnimationCurveNodeList AnimationLayer::Nodes(const char* const * target_prop_whi
     const std::vector<const Connection*>& conns = doc.GetConnectionsByDestinationSequenced(ID(),"AnimationCurveNode");
     nodes.reserve(conns.size());
 
-    BOOST_FOREACH(const Connection* con, conns) {
+    for(const Connection* con : conns) {
 
         // link should not go to a property
         if (con->PropertyName().length()) {
@@ -278,7 +277,7 @@ AnimationStack::AnimationStack(uint64_t id, const Element& element, const std::s
     const std::vector<const Connection*>& conns = doc.GetConnectionsByDestinationSequenced(ID(),"AnimationLayer");
     layers.reserve(conns.size());
 
-    BOOST_FOREACH(const Connection* con, conns) {
+    for(const Connection* con : conns) {
 
         // link should not go to a property
         if (con->PropertyName().length()) {

--- a/code/FBXConverter.cpp
+++ b/code/FBXConverter.cpp
@@ -55,7 +55,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "../include/assimp/scene.h"
 #include <boost/tuple/tuple.hpp>
-#include <boost/scoped_array.hpp>
+#include <memory>
 
 #include <iterator>
 #include <sstream>
@@ -338,7 +338,7 @@ private:
         bool reverse_order = false );
 
     // key (time), value, mapto (component index)
-    typedef boost::tuple<boost::shared_ptr<KeyTimeList>, boost::shared_ptr<KeyValueList>, unsigned int > KeyFrameList;
+    typedef boost::tuple<std::shared_ptr<KeyTimeList>, std::shared_ptr<KeyValueList>, unsigned int > KeyFrameList;
     typedef std::vector<KeyFrameList> KeyFrameListList;
 
 
@@ -2951,8 +2951,8 @@ Converter::KeyFrameListList Converter::GetKeyframeList( const std::vector<const 
             ai_assert( curve->GetKeys().size() == curve->GetValues().size() && curve->GetKeys().size() );
 
             //get values within the start/stop time window
-            boost::shared_ptr<KeyTimeList> Keys( new KeyTimeList() );
-            boost::shared_ptr<KeyValueList> Values( new KeyValueList() );
+            std::shared_ptr<KeyTimeList> Keys( new KeyTimeList() );
+            std::shared_ptr<KeyValueList> Values( new KeyValueList() );
             const int count = curve->GetKeys().size();
             Keys->reserve( count );
             Values->reserve( count );
@@ -3089,7 +3089,7 @@ void Converter::InterpolateKeys( aiQuatKey* valOut, const KeyTimeList& keys, con
     ai_assert( keys.size() );
     ai_assert( valOut );
 
-    boost::scoped_array<aiVectorKey> temp( new aiVectorKey[ keys.size() ] );
+    std::unique_ptr<aiVectorKey[]> temp( new aiVectorKey[ keys.size() ] );
     InterpolateKeys( temp.get(), keys, inputs, def_value, maxTime, minTime );
 
     aiMatrix4x4 m;

--- a/code/FBXConverter.cpp
+++ b/code/FBXConverter.cpp
@@ -55,7 +55,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "../include/assimp/scene.h"
 #include <boost/tuple/tuple.hpp>
-#include <boost/foreach.hpp>
 #include <boost/scoped_array.hpp>
 
 #include <iterator>
@@ -79,8 +78,8 @@ using namespace Util;
 class Converter
 {
 public:
-    /** 
-     *  The different parts that make up the final local transformation of a fbx-node 
+    /**
+     *  The different parts that make up the final local transformation of a fbx-node
      */
     enum TransformationComp
     {
@@ -144,8 +143,8 @@ private:
     // ------------------------------------------------------------------------------------------------
     void GetRotationMatrix( Model::RotOrder mode, const aiVector3D& rotation, aiMatrix4x4& out );
     // ------------------------------------------------------------------------------------------------
-    /** 
-     *  checks if a node has more than just scaling, rotation and translation components 
+    /**
+     *  checks if a node has more than just scaling, rotation and translation components
      */
     bool NeedsComplexTransformationChain( const Model& model );
 
@@ -154,8 +153,8 @@ private:
     std::string NameTransformationChainNode( const std::string& name, TransformationComp comp );
 
     // ------------------------------------------------------------------------------------------------
-    /** 
-     *  note: memory for output_nodes will be managed by the caller 
+    /**
+     *  note: memory for output_nodes will be managed by the caller
      */
     void GenerateTransformationNodeChain( const Model& model, std::vector<aiNode*>& output_nodes );
 
@@ -192,11 +191,11 @@ private:
 
 
     // ------------------------------------------------------------------------------------------------
-    /** 
+    /**
      *  - if materialIndex == NO_MATERIAL_SEPARATION, materials are not taken into
      *    account when determining which weights to include.
      *  - outputVertStartIndices is only used when a material index is specified, it gives for
-     *    each output vertex the DOM index it maps to. 
+     *    each output vertex the DOM index it maps to.
      */
     void ConvertWeights( aiMesh* out, const Model& model, const MeshGeometry& geo,
         const aiMatrix4x4& node_global_transform = aiMatrix4x4(),
@@ -457,7 +456,7 @@ Converter::Converter( aiScene* out, const Document& doc )
 
     if ( doc.Settings().readAllMaterials ) {
         // unfortunately this means we have to evaluate all objects
-        BOOST_FOREACH( const ObjectMap::value_type& v, doc.Objects() ) {
+        for( const ObjectMap::value_type& v : doc.Objects() ) {
 
             const Object* ob = v.second->Get();
             if ( !ob ) {
@@ -515,7 +514,7 @@ void Converter::ConvertNodes( uint64_t id, aiNode& parent, const aiMatrix4x4& pa
     std::vector<aiNode*> nodes_chain;
 
     try {
-        BOOST_FOREACH( const Connection* con, conns ) {
+        for( const Connection* con : conns ) {
 
             // ignore object-property links
             if ( con->PropertyName().length() ) {
@@ -550,7 +549,7 @@ void Converter::ConvertNodes( uint64_t id, aiNode& parent, const aiMatrix4x4& pa
                 // preserve the name - people might have scripts etc. that rely
                 // on specific node names.
                 aiNode* name_carrier = NULL;
-                BOOST_FOREACH( aiNode* prenode, nodes_chain ) {
+                for( aiNode* prenode : nodes_chain ) {
                     if ( !strcmp( prenode->mName.C_Str(), original_name.c_str() ) ) {
                         name_carrier = prenode;
                         break;
@@ -567,7 +566,7 @@ void Converter::ConvertNodes( uint64_t id, aiNode& parent, const aiMatrix4x4& pa
 
                 // link all nodes in a row
                 aiNode* last_parent = &parent;
-                BOOST_FOREACH( aiNode* prenode, nodes_chain ) {
+                for( aiNode* prenode : nodes_chain ) {
                     ai_assert( prenode );
 
                     if ( last_parent != &parent ) {
@@ -619,7 +618,7 @@ void Converter::ConvertNodes( uint64_t id, aiNode& parent, const aiMatrix4x4& pa
 void Converter::ConvertLights( const Model& model )
 {
     const std::vector<const NodeAttribute*>& node_attrs = model.GetAttributes();
-    BOOST_FOREACH( const NodeAttribute* attr, node_attrs ) {
+    for( const NodeAttribute* attr : node_attrs ) {
         const Light* const light = dynamic_cast<const Light*>( attr );
         if ( light ) {
             ConvertLight( model, *light );
@@ -630,7 +629,7 @@ void Converter::ConvertLights( const Model& model )
 void Converter::ConvertCameras( const Model& model )
 {
     const std::vector<const NodeAttribute*>& node_attrs = model.GetAttributes();
-    BOOST_FOREACH( const NodeAttribute* attr, node_attrs ) {
+    for( const NodeAttribute* attr : node_attrs ) {
         const Camera* const cam = dynamic_cast<const Camera*>( attr );
         if ( cam ) {
             ConvertCamera( model, *cam );
@@ -1089,7 +1088,7 @@ void Converter::SetupNodeMetadata( const Model& model, aiNode& nd )
     data->Set( index++, "IsNull", model.IsNull() ? true : false );
 
     // add unparsed properties to the node's metadata
-    BOOST_FOREACH( const DirectPropertyMap::value_type& prop, unparsedProperties ) {
+    for( const DirectPropertyMap::value_type& prop : unparsedProperties ) {
 
         // Interpret the property as a concrete type
         if ( const TypedProperty<bool>* interpreted = prop.second->As<TypedProperty<bool> >() )
@@ -1116,7 +1115,7 @@ void Converter::ConvertModel( const Model& model, aiNode& nd, const aiMatrix4x4&
     std::vector<unsigned int> meshes;
     meshes.reserve( geos.size() );
 
-    BOOST_FOREACH( const Geometry* geo, geos ) {
+    for( const Geometry* geo : geos ) {
 
         const MeshGeometry* const mesh = dynamic_cast< const MeshGeometry* >( geo );
         if ( mesh ) {
@@ -1160,7 +1159,7 @@ std::vector<unsigned int> Converter::ConvertMesh( const MeshGeometry& mesh, cons
     const MatIndexArray& mindices = mesh.GetMaterialIndices();
     if ( doc.Settings().readMaterials && !mindices.empty() ) {
         const MatIndexArray::value_type base = mindices[ 0 ];
-        BOOST_FOREACH( MatIndexArray::value_type index, mindices ) {
+        for( MatIndexArray::value_type index : mindices ) {
             if ( index != base ) {
                 return ConvertMeshMultiMaterial( mesh, model, node_global_transform );
             }
@@ -1212,7 +1211,7 @@ unsigned int Converter::ConvertMeshSingleMaterial( const MeshGeometry& mesh, con
     aiFace* fac = out_mesh->mFaces = new aiFace[ faces.size() ]();
 
     unsigned int cursor = 0;
-    BOOST_FOREACH( unsigned int pcount, faces ) {
+    for( unsigned int pcount : faces ) {
         aiFace& f = *fac++;
         f.mNumIndices = pcount;
         f.mIndices = new unsigned int[ pcount ];
@@ -1287,7 +1286,7 @@ unsigned int Converter::ConvertMeshSingleMaterial( const MeshGeometry& mesh, con
         }
 
         aiVector3D* out_uv = out_mesh->mTextureCoords[ i ] = new aiVector3D[ vertices.size() ];
-        BOOST_FOREACH( const aiVector2D& v, uvs ) {
+        for( const aiVector2D& v : uvs ) {
             *out_uv++ = aiVector3D( v.x, v.y, 0.0f );
         }
 
@@ -1329,7 +1328,7 @@ std::vector<unsigned int> Converter::ConvertMeshMultiMaterial( const MeshGeometr
     std::set<MatIndexArray::value_type> had;
     std::vector<unsigned int> indices;
 
-    BOOST_FOREACH( MatIndexArray::value_type index, mindices ) {
+    for( MatIndexArray::value_type index : mindices ) {
         if ( had.find( index ) == had.end() ) {
 
             indices.push_back( ConvertMeshMultiMaterial( mesh, model, index, node_global_transform ) );
@@ -1537,7 +1536,7 @@ void Converter::ConvertWeights( aiMesh* out, const Model& model, const MeshGeome
 
     try {
 
-        BOOST_FOREACH( const Cluster* cluster, sk.Clusters() ) {
+        for( const Cluster* cluster : sk.Clusters() ) {
             ai_assert( cluster );
 
             const WeightIndexArray& indices = cluster->GetIndices();
@@ -1558,7 +1557,7 @@ void Converter::ConvertWeights( aiMesh* out, const Model& model, const MeshGeome
 
             // now check if *any* of these weights is contained in the output mesh,
             // taking notes so we don't need to do it twice.
-            BOOST_FOREACH( WeightIndexArray::value_type index, indices ) {
+            for( WeightIndexArray::value_type index : indices ) {
 
                 unsigned int count = 0;
                 const unsigned int* const out_idx = geo.ToOutputVertexIndex( index, count );
@@ -1839,7 +1838,7 @@ void Converter::TrySetTextureProperties( aiMaterial* out_mat, const TextureMap& 
                 uvIndex = -1;
                 if ( !mesh )
                 {
-                    BOOST_FOREACH( const MeshMap::value_type& v, meshes_converted ) {
+                    for( const MeshMap::value_type& v : meshes_converted ) {
                         const MeshGeometry* const mesh = dynamic_cast<const MeshGeometry*> ( v.first );
                         if ( !mesh ) {
                             continue;
@@ -1957,7 +1956,7 @@ void Converter::TrySetTextureProperties( aiMaterial* out_mat, const LayeredTextu
             uvIndex = -1;
             if ( !mesh )
             {
-                BOOST_FOREACH( const MeshMap::value_type& v, meshes_converted ) {
+                for( const MeshMap::value_type& v : meshes_converted ) {
                     const MeshGeometry* const mesh = dynamic_cast<const MeshGeometry*> ( v.first );
                     if ( !mesh ) {
                         continue;
@@ -2190,7 +2189,7 @@ void Converter::ConvertAnimations()
     anim_fps = FrameRateToDouble( fps, custom );
 
     const std::vector<const AnimationStack*>& animations = doc.AnimationStacks();
-    BOOST_FOREACH( const AnimationStack* stack, animations ) {
+    for( const AnimationStack* stack : animations ) {
         ConvertAnimationStack( *stack );
     }
 }
@@ -2205,21 +2204,21 @@ void Converter::RenameNode( const std::string& fixed_name, const std::string& ne
 
     const aiString fn( fixed_name );
 
-    BOOST_FOREACH( aiCamera* cam, cameras ) {
+    for( aiCamera* cam : cameras ) {
         if ( cam->mName == fn ) {
             cam->mName.Set( new_name );
             break;
         }
     }
 
-    BOOST_FOREACH( aiLight* light, lights ) {
+    for( aiLight* light : lights ) {
         if ( light->mName == fn ) {
             light->mName.Set( new_name );
             break;
         }
     }
 
-    BOOST_FOREACH( aiAnimation* anim, animations ) {
+    for( aiAnimation* anim : animations ) {
         for ( unsigned int i = 0; i < anim->mNumChannels; ++i ) {
             aiNodeAnim* const na = anim->mChannels[ i ];
             if ( na->mNodeName == fn ) {
@@ -2299,11 +2298,11 @@ void Converter::ConvertAnimationStack( const AnimationStack& st )
         "Lcl Translation"
     };
 
-    BOOST_FOREACH( const AnimationLayer* layer, layers ) {
+    for( const AnimationLayer* layer : layers ) {
         ai_assert( layer );
 
         const AnimationCurveNodeList& nodes = layer->Nodes( prop_whitelist, 3 );
-        BOOST_FOREACH( const AnimationCurveNode* node, nodes ) {
+        for( const AnimationCurveNode* node : nodes ) {
             ai_assert( node );
 
             const Model* const model = dynamic_cast<const Model*>( node->Target() );
@@ -2331,7 +2330,7 @@ void Converter::ConvertAnimationStack( const AnimationStack& st )
     double stop_timeF = CONVERT_FBX_TIME( stop_time );
 
     try {
-        BOOST_FOREACH( const NodeMap::value_type& kv, node_map ) {
+        for( const NodeMap::value_type& kv : node_map ) {
             GenerateNodeAnimations( node_anims,
                 kv.first,
                 kv.second,
@@ -2389,7 +2388,7 @@ void Converter::ConvertAnimationStack( const AnimationStack& st )
 static void validateAnimCurveNodes( const std::vector<const AnimationCurveNode*>& curves,
     bool strictMode ) {
     const Object* target( NULL );
-    BOOST_FOREACH( const AnimationCurveNode* node, curves ) {
+    for( const AnimationCurveNode* node : curves ) {
         if ( !target ) {
             target = node->Target();
         }
@@ -2419,7 +2418,7 @@ void Converter::GenerateNodeAnimations( std::vector<aiNodeAnim*>& node_anims,
     validateAnimCurveNodes( curves, doc.Settings().strictMode );
 #endif
     const AnimationCurveNode* curve_node = NULL;
-    BOOST_FOREACH( const AnimationCurveNode* node, curves ) {
+    for( const AnimationCurveNode* node : curves ) {
         ai_assert( node );
 
         if ( node->TargetProperty().empty() ) {
@@ -2927,11 +2926,11 @@ Converter::KeyFrameListList Converter::GetKeyframeList( const std::vector<const 
     int64_t adj_start = start - 10000;
     int64_t adj_stop = stop + 10000;
 
-    BOOST_FOREACH( const AnimationCurveNode* node, nodes ) {
+    for( const AnimationCurveNode* node : nodes ) {
         ai_assert( node );
 
         const AnimationCurveMap& curves = node->Curves();
-        BOOST_FOREACH( const AnimationCurveMap::value_type& kv, curves ) {
+        for( const AnimationCurveMap::value_type& kv : curves ) {
 
             unsigned int mapto;
             if ( kv.first == "d|X" ) {
@@ -2984,7 +2983,7 @@ KeyTimeList Converter::GetKeyTimeList( const KeyFrameListList& inputs )
     KeyTimeList keys;
 
     size_t estimate = 0;
-    BOOST_FOREACH( const KeyFrameList& kfl, inputs ) {
+    for( const KeyFrameList& kfl : inputs ) {
         estimate = std::max( estimate, kfl.get<0>()->size() );
     }
 
@@ -3037,7 +3036,7 @@ void Converter::InterpolateKeys( aiVectorKey* valOut, const KeyTimeList& keys, c
 
     next_pos.resize( inputs.size(), 0 );
 
-    BOOST_FOREACH( KeyTimeList::value_type time, keys ) {
+    for( KeyTimeList::value_type time : keys ) {
         float result[ 3 ] = { def_value.x, def_value.y, def_value.z };
 
         for ( size_t i = 0; i < count; ++i ) {

--- a/code/FBXDeformer.cpp
+++ b/code/FBXDeformer.cpp
@@ -50,7 +50,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "FBXImportSettings.h"
 #include "FBXDocumentUtil.h"
 #include "FBXProperties.h"
-#include <boost/foreach.hpp>
 
 namespace Assimp {
 namespace FBX {
@@ -107,7 +106,7 @@ Cluster::Cluster(uint64_t id, const Element& element, const Document& doc, const
 
     // read assigned node
     const std::vector<const Connection*>& conns = doc.GetConnectionsByDestinationSequenced(ID(),"Model");
-    BOOST_FOREACH(const Connection* con, conns) {
+    for(const Connection* con : conns) {
         const Model* const mod = ProcessSimpleConnection<Model>(*con, false, "Model -> Cluster", element);
         if(mod) {
             node = mod;
@@ -143,7 +142,7 @@ Skin::Skin(uint64_t id, const Element& element, const Document& doc, const std::
     const std::vector<const Connection*>& conns = doc.GetConnectionsByDestinationSequenced(ID(),"Deformer");
 
     clusters.reserve(conns.size());
-    BOOST_FOREACH(const Connection* con, conns) {
+    for(const Connection* con : conns) {
 
         const Cluster* const cluster = ProcessSimpleConnection<Cluster>(*con, false, "Cluster -> Skin", element);
         if(cluster) {

--- a/code/FBXDocument.cpp
+++ b/code/FBXDocument.cpp
@@ -53,7 +53,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "FBXDocumentUtil.h"
 #include "FBXProperties.h"
 
-#include <boost/make_shared.hpp>
+#include <memory>
 #include <functional>
 
 
@@ -248,7 +248,7 @@ Object::~Object()
 
 
 // ------------------------------------------------------------------------------------------------
-FileGlobalSettings::FileGlobalSettings(const Document& doc, boost::shared_ptr<const PropertyTable> props)
+FileGlobalSettings::FileGlobalSettings(const Document& doc, std::shared_ptr<const PropertyTable> props)
 : props(props)
 , doc(doc)
 {
@@ -358,11 +358,11 @@ void Document::ReadGlobalSettings()
     if(!ehead || !ehead->Compound()) {
         DOMWarning("no GlobalSettings dictionary found");
 
-        globals.reset(new FileGlobalSettings(*this, boost::make_shared<const PropertyTable>()));
+        globals.reset(new FileGlobalSettings(*this, std::make_shared<const PropertyTable>()));
         return;
     }
 
-    boost::shared_ptr<const PropertyTable> props = GetPropertyTable(*this, "", *ehead, *ehead->Compound(), true);
+    std::shared_ptr<const PropertyTable> props = GetPropertyTable(*this, "", *ehead, *ehead->Compound(), true);
 
     if(!props) {
         DOMError("GlobalSettings dictionary contains no property table");
@@ -469,8 +469,8 @@ void Document::ReadPropertyTemplates()
 
             const Element* Properties70 = (*sc)["Properties70"];
             if(Properties70) {
-                boost::shared_ptr<const PropertyTable> props = boost::make_shared<const PropertyTable>(
-                    *Properties70,boost::shared_ptr<const PropertyTable>(static_cast<const PropertyTable*>(NULL))
+                std::shared_ptr<const PropertyTable> props = std::make_shared<const PropertyTable>(
+                    *Properties70,std::shared_ptr<const PropertyTable>(static_cast<const PropertyTable*>(NULL))
                 );
 
                 templates[oname+"."+pname] = props;

--- a/code/FBXDocument.cpp
+++ b/code/FBXDocument.cpp
@@ -53,7 +53,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "FBXDocumentUtil.h"
 #include "FBXProperties.h"
 
-#include <boost/foreach.hpp>
 #include <boost/make_shared.hpp>
 #include <functional>
 
@@ -146,7 +145,7 @@ const Object* LazyObject::Get(bool dieOnError)
 
         // For debugging
         //dumpObjectClassInfo( objtype, classtag );
-        
+
         if (!strncmp(obtype,"Geometry",length)) {
             if (!strcmp(classtag.c_str(),"Mesh")) {
                 object.reset(new MeshGeometry(id,element,name,doc));
@@ -290,11 +289,11 @@ Document::Document(const Parser& parser, const ImportSettings& settings)
 // ------------------------------------------------------------------------------------------------
 Document::~Document()
 {
-    BOOST_FOREACH(ObjectMap::value_type& v, objects) {
+    for(ObjectMap::value_type& v : objects) {
         delete v.second;
     }
 
-    BOOST_FOREACH(ConnectionMap::value_type& v, src_connections) {
+    for(ConnectionMap::value_type& v : src_connections) {
         delete v.second;
     }
     // |dest_connections| contain the same Connection objects as the |src_connections|
@@ -388,7 +387,7 @@ void Document::ReadObjects()
     objects[0] = new LazyObject(0L, *eobjects, *this);
 
     const Scope& sobjects = *eobjects->Compound();
-    BOOST_FOREACH(const ElementMap::value_type& el, sobjects.Elements()) {
+    for(const ElementMap::value_type& el : sobjects.Elements()) {
 
         // extract ID
         const TokenList& tok = el.second->Tokens();
@@ -538,7 +537,7 @@ const std::vector<const AnimationStack*>& Document::AnimationStacks() const
     }
 
     animationStacksResolved.reserve(animationStacks.size());
-    BOOST_FOREACH(uint64_t id, animationStacks) {
+    for(uint64_t id : animationStacks) {
         LazyObject* const lazy = GetObject(id);
         const AnimationStack* stack;
         if(!lazy || !(stack = lazy->Get<AnimationStack>())) {

--- a/code/FBXDocument.h
+++ b/code/FBXDocument.h
@@ -118,7 +118,7 @@ public:
 private:
     const Document& doc;
     const Element& element;
-    boost::scoped_ptr<const Object> object;
+    std::unique_ptr<const Object> object;
 
     const uint64_t id;
 
@@ -174,7 +174,7 @@ public:
     }
 
 private:
-    boost::shared_ptr<const PropertyTable> props;
+    std::shared_ptr<const PropertyTable> props;
 };
 
 
@@ -484,7 +484,7 @@ private:
 
     std::string shading;
     std::string culling;
-    boost::shared_ptr<const PropertyTable> props;
+    std::shared_ptr<const PropertyTable> props;
 };
 
 /** DOM class for generic FBX textures */
@@ -541,7 +541,7 @@ private:
     std::string relativeFileName;
     std::string fileName;
     std::string alphaSource;
-    boost::shared_ptr<const PropertyTable> props;
+    std::shared_ptr<const PropertyTable> props;
 
     unsigned int crop[4];
 
@@ -663,7 +663,7 @@ private:
     std::string type;
     std::string relativeFileName;
     std::string fileName;
-    boost::shared_ptr<const PropertyTable> props;
+    std::shared_ptr<const PropertyTable> props;
 
     uint32_t contentLength;
     uint8_t* content;
@@ -700,7 +700,7 @@ public:
 private:
     std::string shading;
     bool multilayer;
-    boost::shared_ptr<const PropertyTable> props;
+    std::shared_ptr<const PropertyTable> props;
 
     TextureMap textures;
     LayeredTextureMap layeredTextures;
@@ -791,7 +791,7 @@ public:
 
 private:
     const Object* target;
-    boost::shared_ptr<const PropertyTable> props;
+    std::shared_ptr<const PropertyTable> props;
     mutable AnimationCurveMap curves;
 
     std::string prop;
@@ -819,7 +819,7 @@ public:
     AnimationCurveNodeList Nodes(const char* const * target_prop_whitelist = NULL, size_t whitelist_size = 0) const;
 
 private:
-    boost::shared_ptr<const PropertyTable> props;
+    std::shared_ptr<const PropertyTable> props;
     const Document& doc;
 };
 
@@ -850,7 +850,7 @@ public:
     }
 
 private:
-    boost::shared_ptr<const PropertyTable> props;
+    std::shared_ptr<const PropertyTable> props;
     AnimationLayerList layers;
 };
 
@@ -868,7 +868,7 @@ public:
     }
 
 private:
-    boost::shared_ptr<const PropertyTable> props;
+    std::shared_ptr<const PropertyTable> props;
 };
 
 typedef std::vector<float> WeightArray;
@@ -1002,7 +1002,7 @@ public:
 // up to many thousands of objects (most of which we never use),
 // so the memory overhead for them should be kept at a minimum.
 typedef std::map<uint64_t, LazyObject*> ObjectMap;
-typedef std::fbx_unordered_map<std::string, boost::shared_ptr<const PropertyTable> > PropertyTemplateMap;
+typedef std::fbx_unordered_map<std::string, std::shared_ptr<const PropertyTable> > PropertyTemplateMap;
 
 
 typedef std::multimap<uint64_t, const Connection*> ConnectionMap;
@@ -1013,7 +1013,7 @@ typedef std::multimap<uint64_t, const Connection*> ConnectionMap;
 class FileGlobalSettings
 {
 public:
-    FileGlobalSettings(const Document& doc, boost::shared_ptr<const PropertyTable> props);
+    FileGlobalSettings(const Document& doc, std::shared_ptr<const PropertyTable> props);
     ~FileGlobalSettings();
 
     const PropertyTable& Props() const {
@@ -1065,7 +1065,7 @@ public:
     fbx_simple_property(CustomFrameRate, float, -1.0f)
 
 private:
-    boost::shared_ptr<const PropertyTable> props;
+    std::shared_ptr<const PropertyTable> props;
     const Document& doc;
 };
 
@@ -1174,7 +1174,7 @@ private:
     std::vector<uint64_t> animationStacks;
     mutable std::vector<const AnimationStack*> animationStacksResolved;
 
-    boost::scoped_ptr<FileGlobalSettings> globals;
+    std::unique_ptr<FileGlobalSettings> globals;
 };
 
 } // Namespace FBX

--- a/code/FBXDocumentUtil.cpp
+++ b/code/FBXDocumentUtil.cpp
@@ -49,7 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "FBXUtil.h"
 #include "FBXDocumentUtil.h"
 #include "FBXProperties.h"
-#include <boost/make_shared.hpp>
+
 
 namespace Assimp {
 namespace FBX {
@@ -96,14 +96,14 @@ void DOMWarning(const std::string& message, const Element* element /*= NULL*/)
 
 // ------------------------------------------------------------------------------------------------
 // fetch a property table and the corresponding property template
-boost::shared_ptr<const PropertyTable> GetPropertyTable(const Document& doc,
+std::shared_ptr<const PropertyTable> GetPropertyTable(const Document& doc,
     const std::string& templateName,
     const Element &element,
     const Scope& sc,
     bool no_warn /*= false*/)
 {
     const Element* const Properties70 = sc["Properties70"];
-    boost::shared_ptr<const PropertyTable> templateProps = boost::shared_ptr<const PropertyTable>(
+    std::shared_ptr<const PropertyTable> templateProps = std::shared_ptr<const PropertyTable>(
         static_cast<const PropertyTable*>(NULL));
 
     if(templateName.length()) {
@@ -121,10 +121,10 @@ boost::shared_ptr<const PropertyTable> GetPropertyTable(const Document& doc,
             return templateProps;
         }
         else {
-            return boost::make_shared<const PropertyTable>();
+            return std::make_shared<const PropertyTable>();
         }
     }
-    return boost::make_shared<const PropertyTable>(*Properties70,templateProps);
+    return std::make_shared<const PropertyTable>(*Properties70,templateProps);
 }
 } // !Util
 } // !FBX

--- a/code/FBXDocumentUtil.h
+++ b/code/FBXDocumentUtil.h
@@ -46,7 +46,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "../include/assimp/defs.h"
 #include <string>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include "FBXDocument.h"
 
 struct Token;
@@ -67,7 +67,7 @@ void DOMWarning(const std::string& message, const Element* element = NULL);
 
 
 // fetch a property table and the corresponding property template
-boost::shared_ptr<const PropertyTable> GetPropertyTable(const Document& doc,
+std::shared_ptr<const PropertyTable> GetPropertyTable(const Document& doc,
     const std::string& templateName,
     const Element &element,
     const Scope& sc,

--- a/code/FBXImporter.cpp
+++ b/code/FBXImporter.cpp
@@ -46,7 +46,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <exception>
 #include <iterator>
-#include <boost/tuple/tuple.hpp>
 
 #include "FBXImporter.h"
 

--- a/code/FBXImporter.cpp
+++ b/code/FBXImporter.cpp
@@ -142,7 +142,7 @@ void FBXImporter::SetupProperties(const Importer* pImp)
 void FBXImporter::InternReadFile( const std::string& pFile,
     aiScene* pScene, IOSystem* pIOHandler)
 {
-    boost::scoped_ptr<IOStream> stream(pIOHandler->Open(pFile,"rb"));
+    std::unique_ptr<IOStream> stream(pIOHandler->Open(pFile,"rb"));
     if (!stream) {
         ThrowException("Could not open file for reading");
     }

--- a/code/FBXMaterial.cpp
+++ b/code/FBXMaterial.cpp
@@ -51,7 +51,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "FBXDocumentUtil.h"
 #include "FBXProperties.h"
 #include "ByteSwapper.h"
-#include <boost/foreach.hpp>
 
 namespace Assimp {
 namespace FBX {
@@ -96,7 +95,7 @@ Material::Material(uint64_t id, const Element& element, const Document& doc, con
 
     // resolve texture links
     const std::vector<const Connection*>& conns = doc.GetConnectionsByDestinationSequenced(ID());
-    BOOST_FOREACH(const Connection* con, conns) {
+    for(const Connection* con : conns) {
 
         // texture link to properties, not objects
         if (!con->PropertyName().length()) {
@@ -205,7 +204,7 @@ Texture::Texture(uint64_t id, const Element& element, const Document& doc, const
     // resolve video links
     if(doc.Settings().readTextures) {
         const std::vector<const Connection*>& conns = doc.GetConnectionsByDestinationSequenced(ID());
-        BOOST_FOREACH(const Connection* con, conns) {
+        for(const Connection* con : conns) {
             const Object* const ob = con->SourceObject();
             if(!ob) {
                 DOMWarning("failed to read source object for texture link, ignoring",&element);

--- a/code/FBXMeshGeometry.cpp
+++ b/code/FBXMeshGeometry.cpp
@@ -51,7 +51,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "FBXImporter.h"
 #include "FBXImportSettings.h"
 #include "FBXDocumentUtil.h"
-#include <boost/foreach.hpp>
 
 
 namespace Assimp {
@@ -65,7 +64,7 @@ Geometry::Geometry(uint64_t id, const Element& element, const std::string& name,
     , skin()
 {
     const std::vector<const Connection*>& conns = doc.GetConnectionsByDestinationSequenced(ID(),"Deformer");
-    BOOST_FOREACH(const Connection* con, conns) {
+    for(const Connection* con : conns) {
         const Skin* const sk = ProcessSimpleConnection<Skin>(*con, false, "Skin -> Geometry", element);
         if(sk) {
             skin = sk;
@@ -130,7 +129,7 @@ MeshGeometry::MeshGeometry(uint64_t id, const Element& element, const std::strin
     // generate output vertices, computing an adjacency table to
     // preserve the mapping from fbx indices to *this* indexing.
     unsigned int count = 0;
-    BOOST_FOREACH(int index, tempFaces) {
+    for(int index : tempFaces) {
         const int absi = index < 0 ? (-index - 1) : index;
         if(static_cast<size_t>(absi) >= vertex_count) {
             DOMError("polygon vertex index out of range",&PolygonVertexIndex);
@@ -156,7 +155,7 @@ MeshGeometry::MeshGeometry(uint64_t id, const Element& element, const std::strin
     }
 
     cursor = 0;
-    BOOST_FOREACH(int index, tempFaces) {
+    for(int index : tempFaces) {
         const int absi = index < 0 ? (-index - 1) : index;
         mappings[mapping_offsets[absi] + mapping_counts[absi]++] = cursor++;
     }
@@ -494,7 +493,7 @@ void ResolveVertexDataArray(std::vector<T>& data_out, const Scope& source,
         }
 
         unsigned int next = 0;
-        BOOST_FOREACH(int i, uvIndices) {
+        for(int i : uvIndices) {
 			if (static_cast<size_t>(i) >= tempData.size()) {
                 DOMError("index out of range",&GetRequiredElement(source,indexDataElementName));
             }

--- a/code/FBXModel.cpp
+++ b/code/FBXModel.cpp
@@ -51,7 +51,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "FBXImportSettings.h"
 #include "FBXDocumentUtil.h"
 #include "FBXProperties.h"
-#include <boost/foreach.hpp>
 
 namespace Assimp {
 namespace FBX {
@@ -98,7 +97,7 @@ void Model::ResolveLinks(const Element& element, const Document& doc)
     materials.reserve(conns.size());
     geometry.reserve(conns.size());
     attributes.reserve(conns.size());
-    BOOST_FOREACH(const Connection* con, conns) {
+    for(const Connection* con : conns) {
 
         // material and geometry links should be Object-Object connections
         if (con->PropertyName().length()) {
@@ -139,7 +138,7 @@ void Model::ResolveLinks(const Element& element, const Document& doc)
 bool Model::IsNull() const
 {
     const std::vector<const NodeAttribute*>& attrs = GetAttributes();
-    BOOST_FOREACH(const NodeAttribute* att, attrs) {
+    for(const NodeAttribute* att : attrs) {
 
         const Null* null_tag = dynamic_cast<const Null*>(att);
         if(null_tag) {

--- a/code/FBXParser.cpp
+++ b/code/FBXParser.cpp
@@ -58,7 +58,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "ParsingUtils.h"
 #include "fast_atof.h"
-#include <boost/foreach.hpp>
 #include "ByteSwapper.h"
 
 #include <iostream>
@@ -208,7 +207,7 @@ Scope::Scope(Parser& parser,bool topLevel)
 // ------------------------------------------------------------------------------------------------
 Scope::~Scope()
 {
-    BOOST_FOREACH(ElementMap::value_type& v, elements) {
+    for(ElementMap::value_type& v : elements) {
         delete v.second;
     }
 }

--- a/code/FBXParser.h
+++ b/code/FBXParser.h
@@ -46,7 +46,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <stdint.h>
 #include <map>
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include "LogAux.h"
 
 #include "FBXCompileConfig.h"
@@ -105,7 +105,7 @@ private:
 
     const Token& key_token;
     TokenList tokens;
-    boost::scoped_ptr<Scope> compound;
+    std::unique_ptr<Scope> compound;
 };
 
 
@@ -186,7 +186,7 @@ private:
 
     TokenPtr last, current;
     TokenList::const_iterator cursor;
-    boost::scoped_ptr<Scope> root;
+    std::unique_ptr<Scope> root;
 
     const bool is_binary;
 };

--- a/code/FBXProperties.cpp
+++ b/code/FBXProperties.cpp
@@ -139,7 +139,7 @@ PropertyTable::PropertyTable()
 
 
 // ------------------------------------------------------------------------------------------------
-PropertyTable::PropertyTable(const Element& element, boost::shared_ptr<const PropertyTable> templateProps)
+PropertyTable::PropertyTable(const Element& element, std::shared_ptr<const PropertyTable> templateProps)
 : templateProps(templateProps)
 , element(&element)
 {
@@ -216,7 +216,7 @@ DirectPropertyMap PropertyTable::GetUnparsedProperties() const
         // Read the element's value.
         // Wrap the naked pointer (since the call site is required to acquire ownership)
         // std::unique_ptr from C++11 would be preferred both as a wrapper and a return value.
-        boost::shared_ptr<Property> prop = boost::shared_ptr<Property>(ReadTypedProperty(*element.second));
+        std::shared_ptr<Property> prop = std::shared_ptr<Property>(ReadTypedProperty(*element.second));
 
         // Element could not be read. Skip it.
         if (!prop) continue;

--- a/code/FBXProperties.cpp
+++ b/code/FBXProperties.cpp
@@ -49,7 +49,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "FBXDocument.h"
 #include "FBXDocumentUtil.h"
 #include "FBXProperties.h"
-#include <boost/foreach.hpp>
 
 namespace Assimp {
 namespace FBX {
@@ -145,7 +144,7 @@ PropertyTable::PropertyTable(const Element& element, boost::shared_ptr<const Pro
 , element(&element)
 {
     const Scope& scope = GetRequiredScope(element);
-    BOOST_FOREACH(const ElementMap::value_type& v, scope.Elements()) {
+    for(const ElementMap::value_type& v : scope.Elements()) {
         if(v.first != "P") {
             DOMWarning("expected only P elements in property table",v.second);
             continue;
@@ -171,7 +170,7 @@ PropertyTable::PropertyTable(const Element& element, boost::shared_ptr<const Pro
 // ------------------------------------------------------------------------------------------------
 PropertyTable::~PropertyTable()
 {
-    BOOST_FOREACH(PropertyMap::value_type& v, props) {
+    for(PropertyMap::value_type& v : props) {
         delete v.second;
     }
 }
@@ -209,7 +208,7 @@ DirectPropertyMap PropertyTable::GetUnparsedProperties() const
     DirectPropertyMap result;
 
     // Loop through all the lazy properties (which is all the properties)
-    BOOST_FOREACH(const LazyPropertyMap::value_type& element, lazyProps) {
+    for(const LazyPropertyMap::value_type& element : lazyProps) {
 
         // Skip parsed properties
         if (props.end() != props.find(element.first)) continue;

--- a/code/FBXProperties.h
+++ b/code/FBXProperties.h
@@ -46,7 +46,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <map>
 #include "FBXCompileConfig.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace Assimp {
 namespace FBX {
@@ -97,7 +97,7 @@ private:
 };
 
 
-typedef std::fbx_unordered_map<std::string,boost::shared_ptr<Property> > DirectPropertyMap;
+typedef std::fbx_unordered_map<std::string,std::shared_ptr<Property> > DirectPropertyMap;
 typedef std::fbx_unordered_map<std::string,const Property*> PropertyMap;
 typedef std::fbx_unordered_map<std::string,const Element*> LazyPropertyMap;
 
@@ -109,7 +109,7 @@ class PropertyTable
 public:
     // in-memory property table with no source element
     PropertyTable();
-    PropertyTable(const Element& element, boost::shared_ptr<const PropertyTable> templateProps);
+    PropertyTable(const Element& element, std::shared_ptr<const PropertyTable> templateProps);
     ~PropertyTable();
 
 public:
@@ -129,7 +129,7 @@ public:
 private:
     LazyPropertyMap lazyProps;
     mutable PropertyMap props;
-    const boost::shared_ptr<const PropertyTable> templateProps;
+    const std::shared_ptr<const PropertyTable> templateProps;
     const Element* const element;
 };
 

--- a/code/FBXTokenizer.h
+++ b/code/FBXTokenizer.h
@@ -44,7 +44,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef INCLUDED_AI_FBX_TOKENIZER_H
 #define INCLUDED_AI_FBX_TOKENIZER_H
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include "FBXCompileConfig.h"
 #include "../include/assimp/ai_assert.h"
 #include <vector>

--- a/code/FindInstancesProcess.cpp
+++ b/code/FindInstancesProcess.cpp
@@ -45,7 +45,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include "FindInstancesProcess.h"
-#include <boost/scoped_array.hpp>
+#include <memory>
 #include <stdio.h>
 
 using namespace Assimp;
@@ -126,8 +126,8 @@ void FindInstancesProcess::Execute( aiScene* pScene)
         // have several thousand small meshes. That's too much for a brute
         // everyone-against-everyone check involving up to 10 comparisons
         // each.
-        boost::scoped_array<uint64_t> hashes (new uint64_t[pScene->mNumMeshes]);
-        boost::scoped_array<unsigned int> remapping (new unsigned int[pScene->mNumMeshes]);
+        std::unique_ptr<uint64_t[]> hashes (new uint64_t[pScene->mNumMeshes]);
+        std::unique_ptr<unsigned int[]> remapping (new unsigned int[pScene->mNumMeshes]);
 
         unsigned int numMeshesOut = 0;
         for (unsigned int i = 0; i < pScene->mNumMeshes; ++i) {
@@ -219,8 +219,8 @@ void FindInstancesProcess::Execute( aiScene* pScene)
 
                         // For completeness ... compare even the index buffers for equality
                         // face order & winding order doesn't care. Input data is in verbose format.
-                        boost::scoped_array<unsigned int> ftbl_orig(new unsigned int[orig->mNumVertices]);
-                        boost::scoped_array<unsigned int> ftbl_inst(new unsigned int[orig->mNumVertices]);
+                        std::unique_ptr<unsigned int[]> ftbl_orig(new unsigned int[orig->mNumVertices]);
+                        std::unique_ptr<unsigned int[]> ftbl_inst(new unsigned int[orig->mNumVertices]);
 
                         for (unsigned int tt = 0; tt < orig->mNumFaces;++tt) {
                             aiFace& f = orig->mFaces[tt];

--- a/code/HMPLoader.cpp
+++ b/code/HMPLoader.cpp
@@ -47,7 +47,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // internal headers
 #include "HMPLoader.h"
 #include "MD2FileData.h"
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include "../include/assimp/IOSystem.hpp"
 #include "../include/assimp/DefaultLogger.hpp"
 #include "../include/assimp/scene.h"
@@ -114,7 +114,7 @@ void HMPImporter::InternReadFile( const std::string& pFile,
 {
     pScene     = _pScene;
     pIOHandler = _pIOHandler;
-    boost::scoped_ptr<IOStream> file( pIOHandler->Open( pFile));
+    std::unique_ptr<IOStream> file( pIOHandler->Open( pFile));
 
     // Check whether we can read from the file
     if( file.get() == NULL)

--- a/code/IFCBoolean.cpp
+++ b/code/IFCBoolean.cpp
@@ -740,7 +740,7 @@ void ProcessBooleanExtrudedAreaSolidDifference(const IfcExtrudedAreaSolid* as, T
     TempMesh temp;
 
     std::vector<IfcVector3>::const_iterator vit = first_operand.verts.begin();
-    BOOST_FOREACH(unsigned int pcount, first_operand.vertcnt) {
+    for(unsigned int pcount : first_operand.vertcnt) {
         temp.Clear();
 
         temp.verts.insert(temp.verts.end(), vit, vit + pcount);

--- a/code/IFCBoolean.cpp
+++ b/code/IFCBoolean.cpp
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "Defines.h"
 
 #include <iterator>
-#include <boost/tuple/tuple.hpp>
+#include <tuple>
 
 
 namespace Assimp {
@@ -510,7 +510,7 @@ void ProcessPolygonalBoundedBooleanHalfSpaceDifference(const IfcPolygonalBounded
         if( !blackside.empty() )
         {
             // poly edge index, intersection point, edge index in boundary poly
-            std::vector<boost::tuple<size_t, IfcVector3, size_t> > intersections;
+            std::vector<std::tuple<size_t, IfcVector3, size_t> > intersections;
             bool startedInside = PointInPoly(proj * blackside.front(), profile->verts);
             bool isCurrentlyInside = startedInside;
 
@@ -542,7 +542,7 @@ void ProcessPolygonalBoundedBooleanHalfSpaceDifference(const IfcPolygonalBounded
                 }
                 // now add them to the list of intersections
                 for( size_t b = 0; b < intersected_boundary.size(); ++b )
-                    intersections.push_back(boost::make_tuple(a, proj_inv * intersected_boundary[b].second, intersected_boundary[b].first));
+                    intersections.push_back(std::make_tuple(a, proj_inv * intersected_boundary[b].second, intersected_boundary[b].first));
 
                 // and calculate our new inside/outside state
                 if( intersected_boundary.size() & 1 )
@@ -568,12 +568,12 @@ void ProcessPolygonalBoundedBooleanHalfSpaceDifference(const IfcPolygonalBounded
                 // Filter pairs of out->in->out that lie too close to each other.
                 for( size_t a = 0; intersections.size() > 0 && a < intersections.size() - 1; /**/ )
                 {
-                    if( (intersections[a].get<1>() - intersections[(a + 1) % intersections.size()].get<1>()).SquareLength() < 1e-10 )
+                    if( (std::get<1>(intersections[a]) - std::get<1>(intersections[(a + 1) % intersections.size()])).SquareLength() < 1e-10 )
                         intersections.erase(intersections.begin() + a, intersections.begin() + a + 2);
                     else
                         a++;
                 }
-                if( intersections.size() > 1 && (intersections.back().get<1>() - intersections.front().get<1>()).SquareLength() < 1e-10 )
+                if( intersections.size() > 1 && (std::get<1>(intersections.back()) - std::get<1>(intersections.front())).SquareLength() < 1e-10 )
                 {
                     intersections.pop_back(); intersections.erase(intersections.begin());
                 }
@@ -619,23 +619,23 @@ void ProcessPolygonalBoundedBooleanHalfSpaceDifference(const IfcPolygonalBounded
                 while( true )
                 {
                     ai_assert(intersections.size() > currentIntersecIdx + 1);
-                    boost::tuple<size_t, IfcVector3, size_t> currintsec = intersections[currentIntersecIdx + 0];
-                    boost::tuple<size_t, IfcVector3, size_t> nextintsec = intersections[currentIntersecIdx + 1];
+                    std::tuple<size_t, IfcVector3, size_t> currintsec = intersections[currentIntersecIdx + 0];
+                    std::tuple<size_t, IfcVector3, size_t> nextintsec = intersections[currentIntersecIdx + 1];
                     intersections.erase(intersections.begin() + currentIntersecIdx, intersections.begin() + currentIntersecIdx + 2);
 
                     // we start with an in->out intersection
-                    resultpoly.push_back(currintsec.get<1>());
+                    resultpoly.push_back(std::get<1>(currintsec));
                     // climb along the polygon to the next intersection, which should be an out->in
-                    size_t numPolyPoints = (currintsec.get<0>() > nextintsec.get<0>() ? blackside.size() : 0)
-                        + nextintsec.get<0>() - currintsec.get<0>();
+                    size_t numPolyPoints = (std::get<0>(currintsec) > std::get<0>(nextintsec) ? blackside.size() : 0)
+                        + std::get<0>(nextintsec) - std::get<0>(currintsec);
                     for( size_t a = 1; a <= numPolyPoints; ++a )
-                        resultpoly.push_back(blackside[(currintsec.get<0>() + a) % blackside.size()]);
+                        resultpoly.push_back(blackside[(std::get<0>(currintsec) + a) % blackside.size()]);
                     // put the out->in intersection
-                    resultpoly.push_back(nextintsec.get<1>());
+                    resultpoly.push_back(std::get<1>(nextintsec));
 
                     // generate segments along the boundary polygon that lie in the poly's plane until we hit another intersection
-                    IfcVector3 startingPoint = proj * nextintsec.get<1>();
-                    size_t currentBoundaryEdgeIdx = (nextintsec.get<2>() + (marchBackwardsOnBoundary ? 1 : 0)) % profile->verts.size();
+                    IfcVector3 startingPoint = proj * std::get<1>(nextintsec);
+                    size_t currentBoundaryEdgeIdx = (std::get<2>(nextintsec) + (marchBackwardsOnBoundary ? 1 : 0)) % profile->verts.size();
                     size_t nextIntsecIdx = SIZE_MAX;
                     while( nextIntsecIdx == SIZE_MAX )
                     {
@@ -676,7 +676,7 @@ void ProcessPolygonalBoundedBooleanHalfSpaceDifference(const IfcPolygonalBounded
                         // to marching along the poly border from that intersection point
                         for( size_t a = 0; a < intersections.size(); a += 2 )
                         {
-                            dirToThatPoint = proj * intersections[a].get<1>() - startingPoint;
+                            dirToThatPoint = proj * std::get<1>(intersections[a]) - startingPoint;
                             tpt = dirToThatPoint * dirAtPolyPlane;
                             if( tpt > -1e-6 && tpt <= t && (dirToThatPoint - tpt * dirAtPolyPlane).SquareLength() < 1e-10 )
                             {

--- a/code/IFCBoolean.cpp
+++ b/code/IFCBoolean.cpp
@@ -413,7 +413,7 @@ void ProcessPolygonalBoundedBooleanHalfSpaceDifference(const IfcPolygonalBounded
     n.Normalize();
 
     // obtain the polygonal bounding volume
-    boost::shared_ptr<TempMesh> profile = boost::shared_ptr<TempMesh>(new TempMesh());
+    std::shared_ptr<TempMesh> profile = std::shared_ptr<TempMesh>(new TempMesh());
     if(!ProcessCurve(hs->PolygonalBoundary, *profile.get(), conv)) {
         IFCImporter::LogError("expected valid polyline for boundary of boolean halfspace");
         return;
@@ -730,10 +730,10 @@ void ProcessBooleanExtrudedAreaSolidDifference(const IfcExtrudedAreaSolid* as, T
     // operand should be near-planar. Luckily, this is usually the case in Ifc
     // buildings.
 
-    boost::shared_ptr<TempMesh> meshtmp = boost::shared_ptr<TempMesh>(new TempMesh());
+    std::shared_ptr<TempMesh> meshtmp = std::shared_ptr<TempMesh>(new TempMesh());
     ProcessExtrudedAreaSolid(*as,*meshtmp,conv,false);
 
-    std::vector<TempOpening> openings(1, TempOpening(as,IfcVector3(0,0,0),meshtmp,boost::shared_ptr<TempMesh>()));
+    std::vector<TempOpening> openings(1, TempOpening(as,IfcVector3(0,0,0),meshtmp,std::shared_ptr<TempMesh>()));
 
     result = first_operand;
 

--- a/code/IFCCurve.cpp
+++ b/code/IFCCurve.cpp
@@ -229,7 +229,7 @@ private:
 class CompositeCurve : public BoundedCurve
 {
 
-    typedef std::pair< boost::shared_ptr< BoundedCurve >, bool > CurveEntry;
+    typedef std::pair< std::shared_ptr< BoundedCurve >, bool > CurveEntry;
 
 public:
 
@@ -241,8 +241,8 @@ public:
         curves.reserve(entity.Segments.size());
         for(const IfcCompositeCurveSegment& curveSegment :entity.Segments) {
             // according to the specification, this must be a bounded curve
-            boost::shared_ptr< Curve > cv(Curve::Convert(curveSegment.ParentCurve,conv));
-            boost::shared_ptr< BoundedCurve > bc = boost::dynamic_pointer_cast<BoundedCurve>(cv);
+            std::shared_ptr< Curve > cv(Curve::Convert(curveSegment.ParentCurve,conv));
+            std::shared_ptr< BoundedCurve > bc = std::dynamic_pointer_cast<BoundedCurve>(cv);
 
             if (!bc) {
                 IFCImporter::LogError("expected segment of composite curve to be a bounded curve");
@@ -346,9 +346,9 @@ public:
     TrimmedCurve(const IfcTrimmedCurve& entity, ConversionData& conv)
         : BoundedCurve(entity,conv)
     {
-        base = boost::shared_ptr<const Curve>(Curve::Convert(entity.BasisCurve,conv));
+        base = std::shared_ptr<const Curve>(Curve::Convert(entity.BasisCurve,conv));
 
-        typedef boost::shared_ptr<const STEP::EXPRESS::DataType> Entry;
+        typedef std::shared_ptr<const STEP::EXPRESS::DataType> Entry;
 
         // for some reason, trimmed curves can either specify a parametric value
         // or a point on the curve, or both. And they can even specify which of the
@@ -446,7 +446,7 @@ private:
     IfcFloat maxval;
     bool agree_sense;
 
-    boost::shared_ptr<const Curve> base;
+    std::shared_ptr<const Curve> base;
 };
 
 

--- a/code/IFCCurve.cpp
+++ b/code/IFCCurve.cpp
@@ -239,7 +239,7 @@ public:
         , total()
     {
         curves.reserve(entity.Segments.size());
-        BOOST_FOREACH(const IfcCompositeCurveSegment& curveSegment,entity.Segments) {
+        for(const IfcCompositeCurveSegment& curveSegment :entity.Segments) {
             // according to the specification, this must be a bounded curve
             boost::shared_ptr< Curve > cv(Curve::Convert(curveSegment.ParentCurve,conv));
             boost::shared_ptr< BoundedCurve > bc = boost::dynamic_pointer_cast<BoundedCurve>(cv);
@@ -271,7 +271,7 @@ public:
         }
 
         IfcFloat acc = 0;
-        BOOST_FOREACH(const CurveEntry& entry, curves) {
+        for(const CurveEntry& entry : curves) {
             const ParamRange& range = entry.first->GetParametricRange();
             const IfcFloat delta = std::abs(range.second-range.first);
             if (u < acc+delta) {
@@ -290,7 +290,7 @@ public:
         size_t cnt = 0;
 
         IfcFloat acc = 0;
-        BOOST_FOREACH(const CurveEntry& entry, curves) {
+        for(const CurveEntry& entry : curves) {
             const ParamRange& range = entry.first->GetParametricRange();
             const IfcFloat delta = std::abs(range.second-range.first);
             if (a <= acc+delta && b >= acc) {
@@ -312,7 +312,7 @@ public:
         const size_t cnt = EstimateSampleCount(a,b);
         out.verts.reserve(out.verts.size() + cnt);
 
-        BOOST_FOREACH(const CurveEntry& entry, curves) {
+        for(const CurveEntry& entry : curves) {
             const size_t cnt = out.verts.size();
             entry.first->SampleDiscrete(out);
 
@@ -357,7 +357,7 @@ public:
         // oh well.
         bool have_param = false, have_point = false;
         IfcVector3 point;
-        BOOST_FOREACH(const Entry sel,entity.Trim1) {
+        for(const Entry sel :entity.Trim1) {
             if (const EXPRESS::REAL* const r = sel->ToPtr<EXPRESS::REAL>()) {
                 range.first = *r;
                 have_param = true;
@@ -374,7 +374,7 @@ public:
             }
         }
         have_param = false, have_point = false;
-        BOOST_FOREACH(const Entry sel,entity.Trim2) {
+        for(const Entry sel :entity.Trim2) {
             if (const EXPRESS::REAL* const r = sel->ToPtr<EXPRESS::REAL>()) {
                 range.second = *r;
                 have_param = true;
@@ -465,7 +465,7 @@ public:
         points.reserve(entity.Points.size());
 
         IfcVector3 t;
-        BOOST_FOREACH(const IfcCartesianPoint& cp, entity.Points) {
+        for(const IfcCartesianPoint& cp : entity.Points) {
             ConvertCartesianPoint(t,cp);
             points.push_back(t);
         }

--- a/code/IFCGeometry.cpp
+++ b/code/IFCGeometry.cpp
@@ -62,7 +62,7 @@ namespace Assimp {
 bool ProcessPolyloop(const IfcPolyLoop& loop, TempMesh& meshout, ConversionData& /*conv*/)
 {
     size_t cnt = 0;
-    BOOST_FOREACH(const IfcCartesianPoint& c, loop.Polygon) {
+    for(const IfcCartesianPoint& c : loop.Polygon) {
         IfcVector3 tmp;
         ConvertCartesianPoint(tmp,c);
 
@@ -191,10 +191,10 @@ void ProcessPolygonBoundaries(TempMesh& result, const TempMesh& inmesh, size_t m
 // ------------------------------------------------------------------------------------------------
 void ProcessConnectedFaceSet(const IfcConnectedFaceSet& fset, TempMesh& result, ConversionData& conv)
 {
-    BOOST_FOREACH(const IfcFace& face, fset.CfsFaces) {
+    for(const IfcFace& face : fset.CfsFaces) {
         // size_t ob = -1, cnt = 0;
         TempMesh meshout;
-        BOOST_FOREACH(const IfcFaceBound& bound, face.Bounds) {
+        for(const IfcFaceBound& bound : face.Bounds) {
 
             if(const IfcPolyLoop* const polyloop = bound.Bound->ToPtr<IfcPolyLoop>()) {
                 if(ProcessPolyloop(*polyloop, meshout,conv)) {
@@ -219,7 +219,7 @@ void ProcessConnectedFaceSet(const IfcConnectedFaceSet& fset, TempMesh& result, 
 
             /*if(!IsTrue(bound.Orientation)) {
                 size_t c = 0;
-                BOOST_FOREACH(unsigned int& c, meshout.vertcnt) {
+                for(unsigned int& c : meshout.vertcnt) {
                     std::reverse(result.verts.begin() + cnt,result.verts.begin() + cnt + c);
                     cnt += c;
                 }
@@ -547,7 +547,7 @@ void ProcessExtrudedArea(const IfcExtrudedAreaSolid& solid, const TempMesh& curv
 
     IfcVector3 vmin, vmax;
     MinMaxChooser<IfcVector3>()(vmin, vmax);
-    BOOST_FOREACH(IfcVector3& v, in) {
+    for(IfcVector3& v : in) {
         v *= trafo;
 
         vmin = std::min(vmin, v);
@@ -579,7 +579,7 @@ void ProcessExtrudedArea(const IfcExtrudedAreaSolid& solid, const TempMesh& curv
         }
 
         nors.reserve(conv.apply_openings->size());
-        BOOST_FOREACH(TempOpening& t, *conv.apply_openings) {
+        for(TempOpening& t : *conv.apply_openings) {
             TempMesh& bounds = *t.profileMesh.get();
 
             if( bounds.verts.size() <= 2 ) {
@@ -617,7 +617,7 @@ void ProcessExtrudedArea(const IfcExtrudedAreaSolid& solid, const TempMesh& curv
     }
 
     if( openings ) {
-        BOOST_FOREACH(TempOpening& opening, *conv.apply_openings) {
+        for(TempOpening& opening : *conv.apply_openings) {
             if( !opening.wallPoints.empty() ) {
                 IFCImporter::LogError("failed to generate all window caps");
             }
@@ -697,7 +697,7 @@ void ProcessExtrudedAreaSolid(const IfcExtrudedAreaSolid& solid, TempMesh& resul
             std::vector<TempOpening>* oldCollectOpenings = conv.collect_openings;
             conv.collect_openings = &fisherPriceMyFirstOpenings;
 
-            BOOST_FOREACH(const IfcCurve* curve, cprofile->InnerCurves) {
+            for(const IfcCurve* curve : cprofile->InnerCurves) {
                 TempMesh curveMesh, tempMesh;
                 ProcessCurve(*curve, curveMesh, conv);
                 ProcessExtrudedArea(solid, curveMesh, dir, tempMesh, conv, true);
@@ -734,7 +734,7 @@ bool ProcessGeometricItem(const IfcRepresentationItem& geo, unsigned int matid, 
     bool fix_orientation = false;
     boost::shared_ptr< TempMesh > meshtmp = boost::make_shared<TempMesh>();
     if(const IfcShellBasedSurfaceModel* shellmod = geo.ToPtr<IfcShellBasedSurfaceModel>()) {
-        BOOST_FOREACH(boost::shared_ptr<const IfcShell> shell,shellmod->SbsmBoundary) {
+        for(boost::shared_ptr<const IfcShell> shell :shellmod->SbsmBoundary) {
             try {
                 const EXPRESS::ENTITY& e = shell->To<ENTITY>();
                 const IfcConnectedFaceSet& fs = conv.db.MustGetObject(e).To<IfcConnectedFaceSet>();
@@ -762,7 +762,7 @@ bool ProcessGeometricItem(const IfcRepresentationItem& geo, unsigned int matid, 
         fix_orientation = true;
     }
     else if(const IfcFaceBasedSurfaceModel* surf = geo.ToPtr<IfcFaceBasedSurfaceModel>()) {
-        BOOST_FOREACH(const IfcConnectedFaceSet& fc, surf->FbsmFaces) {
+        for(const IfcConnectedFaceSet& fc : surf->FbsmFaces) {
             ProcessConnectedFaceSet(fc,*meshtmp.get(),conv);
         }
         fix_orientation = true;

--- a/code/IFCGeometry.cpp
+++ b/code/IFCGeometry.cpp
@@ -51,7 +51,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "../contrib/poly2tri/poly2tri/poly2tri.h"
 #include "../contrib/clipper/clipper.hpp"
-#include <boost/make_shared.hpp>
+#include <memory>
 
 #include <iterator>
 
@@ -170,7 +170,7 @@ void ProcessPolygonBoundaries(TempMesh& result, const TempMesh& inmesh, size_t m
         opening.extrusionDir = master_normal;
         opening.solid = NULL;
 
-        opening.profileMesh = boost::make_shared<TempMesh>();
+        opening.profileMesh = std::make_shared<TempMesh>();
         opening.profileMesh->verts.reserve(*iit);
         opening.profileMesh->vertcnt.push_back(*iit);
 
@@ -660,10 +660,10 @@ void ProcessExtrudedArea(const IfcExtrudedAreaSolid& solid, const TempMesh& curv
     // it was created from. Return an empty mesh to the caller.
     if( collect_openings && !result.IsEmpty() ) {
         ai_assert(conv.collect_openings);
-        boost::shared_ptr<TempMesh> profile = boost::shared_ptr<TempMesh>(new TempMesh());
+        std::shared_ptr<TempMesh> profile = std::shared_ptr<TempMesh>(new TempMesh());
         profile->Swap(result);
 
-        boost::shared_ptr<TempMesh> profile2D = boost::shared_ptr<TempMesh>(new TempMesh());
+        std::shared_ptr<TempMesh> profile2D = std::shared_ptr<TempMesh>(new TempMesh());
         profile2D->verts.insert(profile2D->verts.end(), in.begin(), in.end());
         profile2D->vertcnt.push_back(in.size());
         conv.collect_openings->push_back(TempOpening(&solid, dir, profile, profile2D));
@@ -732,9 +732,9 @@ bool ProcessGeometricItem(const IfcRepresentationItem& geo, unsigned int matid, 
     ConversionData& conv)
 {
     bool fix_orientation = false;
-    boost::shared_ptr< TempMesh > meshtmp = boost::make_shared<TempMesh>();
+    std::shared_ptr< TempMesh > meshtmp = std::make_shared<TempMesh>();
     if(const IfcShellBasedSurfaceModel* shellmod = geo.ToPtr<IfcShellBasedSurfaceModel>()) {
-        for(boost::shared_ptr<const IfcShell> shell :shellmod->SbsmBoundary) {
+        for(std::shared_ptr<const IfcShell> shell :shellmod->SbsmBoundary) {
             try {
                 const EXPRESS::ENTITY& e = shell->To<ENTITY>();
                 const IfcConnectedFaceSet& fs = conv.db.MustGetObject(e).To<IfcConnectedFaceSet>();
@@ -791,7 +791,7 @@ bool ProcessGeometricItem(const IfcRepresentationItem& geo, unsigned int matid, 
             conv.collect_openings->push_back(TempOpening(geo.ToPtr<IfcSolidModel>(),
                 IfcVector3(0,0,0),
                 meshtmp,
-                boost::shared_ptr<TempMesh>()));
+                std::shared_ptr<TempMesh>()));
         }
         return true;
     }

--- a/code/IFCLoader.cpp
+++ b/code/IFCLoader.cpp
@@ -383,7 +383,7 @@ void SetUnits(ConversionData& conv)
 void SetCoordinateSpace(ConversionData& conv)
 {
     const IfcRepresentationContext* fav = NULL;
-    BOOST_FOREACH(const IfcRepresentationContext& v, conv.proj.RepresentationContexts) {
+    for(const IfcRepresentationContext& v : conv.proj.RepresentationContexts) {
         fav = &v;
         // Model should be the most suitable type of context, hence ignore the others
         if (v.ContextType && v.ContextType.Get() == "Model") {
@@ -440,7 +440,7 @@ bool ProcessMappedItem(const IfcMappedItem& mapped, aiNode* nd_src, std::vector<
     if (conv.apply_openings) {
         IfcMatrix4 minv = msrc;
         minv.Inverse();
-        BOOST_FOREACH(TempOpening& open,*conv.apply_openings){
+        for(TempOpening& open :*conv.apply_openings){
             open.Transform(minv);
         }
     }
@@ -449,7 +449,7 @@ bool ProcessMappedItem(const IfcMappedItem& mapped, aiNode* nd_src, std::vector<
     const IfcRepresentation& repr = mapped.MappingSource->MappedRepresentation;
 
     bool got = false;
-    BOOST_FOREACH(const IfcRepresentationItem& item, repr.Items) {
+    for(const IfcRepresentationItem& item : repr.Items) {
         if(!ProcessRepresentationItem(item,localmatid,meshes,conv)) {
             IFCImporter::LogWarn("skipping mapped entity of type " + item.GetClassName() + ", no representations could be generated");
         }
@@ -564,9 +564,9 @@ void ProcessProductRepresentation(const IfcProduct& el, aiNode* nd, std::vector<
     std::vector<const IfcRepresentation*> repr_ordered(src.size());
     std::copy(src.begin(),src.end(),repr_ordered.begin());
     std::sort(repr_ordered.begin(),repr_ordered.end(),RateRepresentationPredicate());
-    BOOST_FOREACH(const IfcRepresentation* repr, repr_ordered) {
+    for(const IfcRepresentation* repr : repr_ordered) {
         bool res = false;
-        BOOST_FOREACH(const IfcRepresentationItem& item, repr->Items) {
+        for(const IfcRepresentationItem& item : repr->Items) {
             if(const IfcMappedItem* const geo = item.ToPtr<IfcMappedItem>()) {
                 res = ProcessMappedItem(*geo,nd,subnodes,matid,conv) || res;
             }
@@ -589,7 +589,7 @@ void ProcessMetadata(const ListOf< Lazy< IfcProperty >, 1, 0 >& set, ConversionD
     const std::string& prefix = "",
     unsigned int nest = 0)
 {
-    BOOST_FOREACH(const IfcProperty& property, set) {
+    for(const IfcProperty& property : set) {
         const std::string& key = prefix.length() > 0 ? (prefix + "." + property.Name) : property.Name;
         if (const IfcPropertySingleValue* const singleValue = property.ToPtr<IfcPropertySingleValue>()) {
             if (singleValue->NominalValue) {
@@ -615,7 +615,7 @@ void ProcessMetadata(const ListOf< Lazy< IfcProperty >, 1, 0 >& set, ConversionD
             std::stringstream ss;
             ss << "[";
             unsigned index=0;
-            BOOST_FOREACH(const IfcValue::Out& v, listValue->ListValues) {
+            for(const IfcValue::Out& v : listValue->ListValues) {
                 if (!v) continue;
                 if (const EXPRESS::STRING* str = v->ToPtr<EXPRESS::STRING>()) {
                     std::string value = static_cast<std::string>(*str);
@@ -713,7 +713,7 @@ aiNode* ProcessSpatialStructure(aiNode* parent, const IfcProduct& el, Conversion
             data->mValues = new aiMetadataEntry[data->mNumProperties]();
 
             unsigned int index = 0;
-            BOOST_FOREACH(const Metadata::value_type& kv, properties)
+            for(const Metadata::value_type& kv : properties)
                 data->Set(index++, kv.first, aiString(kv.second));
 
             nd->mMetaData = data;
@@ -751,7 +751,7 @@ aiNode* ProcessSpatialStructure(aiNode* parent, const IfcProduct& el, Conversion
                 if(cont->RelatingStructure->GetID() != el.GetID()) {
                     continue;
                 }
-                BOOST_FOREACH(const IfcProduct& pro, cont->RelatedElements) {
+                for(const IfcProduct& pro : cont->RelatedElements) {
                     if(pro.ToPtr<IfcOpeningElement>()) {
                         // IfcOpeningElement is handled below. Sadly we can't use it here as is:
                         // The docs say that opening elements are USUALLY attached to building storey,
@@ -794,7 +794,7 @@ aiNode* ProcessSpatialStructure(aiNode* parent, const IfcProduct& el, Conversion
                             }
 
                             // we need all openings to be in the local space of *this* node, so transform them
-                            BOOST_FOREACH(TempOpening& op,openings_local) {
+                            for(TempOpening& op :openings_local) {
                                 op.Transform( myInv*nd_aggr->mChildren[0]->mTransformation);
                                 openings.push_back(op);
                             }
@@ -823,7 +823,7 @@ aiNode* ProcessSpatialStructure(aiNode* parent, const IfcProduct& el, Conversion
                 nd_aggr->mTransformation = nd->mTransformation;
 
                 nd_aggr->mChildren = new aiNode*[aggr->RelatedObjects.size()]();
-                BOOST_FOREACH(const IfcObjectDefinition& def, aggr->RelatedObjects) {
+                for(const IfcObjectDefinition& def : aggr->RelatedObjects) {
                     if(const IfcProduct* const prod = def.ToPtr<IfcProduct>()) {
 
                         aiNode* const ndnew = ProcessSpatialStructure(nd_aggr.get(),*prod,conv,NULL);
@@ -849,7 +849,7 @@ aiNode* ProcessSpatialStructure(aiNode* parent, const IfcProduct& el, Conversion
 
         if (subnodes.size()) {
             nd->mChildren = new aiNode*[subnodes.size()]();
-            BOOST_FOREACH(aiNode* nd2, subnodes) {
+            for(aiNode* nd2 : subnodes) {
                 nd->mChildren[nd->mNumChildren++] = nd2;
                 nd2->mParent = nd.get();
             }
@@ -889,7 +889,7 @@ void ProcessSpatialStructures(ConversionData& conv)
     }
 
 
-    BOOST_FOREACH(const STEP::LazyObject* lz, *range) {
+    for(const STEP::LazyObject* lz : *range) {
         const IfcSpatialStructureElement* const prod = lz->ToPtr<IfcSpatialStructureElement>();
         if(!prod) {
             continue;
@@ -902,7 +902,7 @@ void ProcessSpatialStructures(ConversionData& conv)
         for(;range.first != range.second; ++range.first) {
             if(const IfcRelAggregates* const aggr = conv.db.GetObject((*range.first).second)->ToPtr<IfcRelAggregates>()) {
 
-                BOOST_FOREACH(const IfcObjectDefinition& def, aggr->RelatedObjects) {
+                for(const IfcObjectDefinition& def : aggr->RelatedObjects) {
                     // comparing pointer values is not sufficient, we would need to cast them to the same type first
                     // as there is multiple inheritance in the game.
                     if (def.GetID() == prod->GetID()) {
@@ -919,7 +919,7 @@ void ProcessSpatialStructures(ConversionData& conv)
 
 
     IFCImporter::LogWarn("failed to determine primary site element, taking the first IfcSite");
-    BOOST_FOREACH(const STEP::LazyObject* lz, *range) {
+    for(const STEP::LazyObject* lz : *range) {
         const IfcSpatialStructureElement* const prod = lz->ToPtr<IfcSpatialStructureElement>();
         if(!prod) {
             continue;

--- a/code/IFCLoader.cpp
+++ b/code/IFCLoader.cpp
@@ -47,7 +47,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <iterator>
 #include <limits>
-#include <boost/tuple/tuple.hpp>
+#include <tuple>
 
 #ifndef ASSIMP_BUILD_NO_COMPRESSED_IFC
 #   include "../contrib/unzip/unzip.h"

--- a/code/IFCLoader.cpp
+++ b/code/IFCLoader.cpp
@@ -168,7 +168,7 @@ void IFCImporter::SetupProperties(const Importer* pImp)
 void IFCImporter::InternReadFile( const std::string& pFile,
     aiScene* pScene, IOSystem* pIOHandler)
 {
-    boost::shared_ptr<IOStream> stream(pIOHandler->Open(pFile));
+    std::shared_ptr<IOStream> stream(pIOHandler->Open(pFile));
     if (!stream) {
         ThrowException("Could not open file for reading");
     }
@@ -233,7 +233,7 @@ void IFCImporter::InternReadFile( const std::string& pFile,
 #endif
     }
 
-    boost::scoped_ptr<STEP::DB> db(STEP::ReadFileHeader(stream));
+    std::unique_ptr<STEP::DB> db(STEP::ReadFileHeader(stream));
     const STEP::HeaderInfo& head = static_cast<const STEP::DB&>(*db).GetHeader();
 
     if(!head.fileSchema.size() || head.fileSchema.substr(0,3) != "IFC") {

--- a/code/IFCLoader.cpp
+++ b/code/IFCLoader.cpp
@@ -423,7 +423,7 @@ void ResolveObjectPlacement(aiMatrix4x4& m, const IfcObjectPlacement& place, Con
 bool ProcessMappedItem(const IfcMappedItem& mapped, aiNode* nd_src, std::vector< aiNode* >& subnodes_src, unsigned int matid, ConversionData& conv)
 {
     // insert a custom node here, the cartesian transform operator is simply a conventional transformation matrix
-    std::auto_ptr<aiNode> nd(new aiNode());
+    std::unique_ptr<aiNode> nd(new aiNode());
     nd->mName.Set("IfcMappedItem");
 
     // handle the Cartesian operator
@@ -684,7 +684,7 @@ aiNode* ProcessSpatialStructure(aiNode* parent, const IfcProduct& el, Conversion
     }
 
     // add an output node for this spatial structure
-    std::auto_ptr<aiNode> nd(new aiNode());
+    std::unique_ptr<aiNode> nd(new aiNode());
     nd->mName.Set(el.GetClassName()+"_"+(el.Name?el.Name.Get():"Unnamed")+"_"+el.GlobalId);
     nd->mParent = parent;
 
@@ -771,7 +771,7 @@ aiNode* ProcessSpatialStructure(aiNode* parent, const IfcProduct& el, Conversion
                     const IfcFeatureElementSubtraction& open = fills->RelatedOpeningElement;
 
                     // move opening elements to a separate node since they are semantically different than elements that are just 'contained'
-                    std::auto_ptr<aiNode> nd_aggr(new aiNode());
+                    std::unique_ptr<aiNode> nd_aggr(new aiNode());
                     nd_aggr->mName.Set("$RelVoidsElement");
                     nd_aggr->mParent = nd.get();
 
@@ -816,7 +816,7 @@ aiNode* ProcessSpatialStructure(aiNode* parent, const IfcProduct& el, Conversion
                 }
 
                 // move aggregate elements to a separate node since they are semantically different than elements that are just 'contained'
-                std::auto_ptr<aiNode> nd_aggr(new aiNode());
+                std::unique_ptr<aiNode> nd_aggr(new aiNode());
                 nd_aggr->mName.Set("$RelAggregates");
                 nd_aggr->mParent = nd.get();
 

--- a/code/IFCMaterial.cpp
+++ b/code/IFCMaterial.cpp
@@ -154,7 +154,7 @@ unsigned int ProcessMaterials(uint64_t id, unsigned int prevMatId, ConversionDat
                             IFCImporter::LogWarn("ignoring surface side marker on IFC::IfcSurfaceStyle: " + side);
                         }
 
-                        std::auto_ptr<aiMaterial> mat(new aiMaterial());
+                        std::unique_ptr<aiMaterial> mat(new aiMaterial());
 
                         FillMaterial(mat.get(), surf, conv);
 
@@ -190,7 +190,7 @@ unsigned int ProcessMaterials(uint64_t id, unsigned int prevMatId, ConversionDat
     }
 
     // we're here, yet - no default material with suitable color available. Generate one
-    std::auto_ptr<aiMaterial> mat(new aiMaterial());
+    std::unique_ptr<aiMaterial> mat(new aiMaterial());
     mat->AddProperty(&name,AI_MATKEY_NAME);
 
     const aiColor4D col = aiColor4D( 0.6f, 0.6f, 0.6f, 1.0f); // aiColor4D( color.r, color.g, color.b, 1.0f);

--- a/code/IFCMaterial.cpp
+++ b/code/IFCMaterial.cpp
@@ -76,7 +76,7 @@ void FillMaterial(aiMaterial* mat,const IFC::IfcSurfaceStyle* surf,ConversionDat
     mat->AddProperty(&name,AI_MATKEY_NAME);
 
     // now see which kinds of surface information are present
-    for(boost::shared_ptr< const IFC::IfcSurfaceStyleElementSelect > sel2 : surf->Styles) {
+    for(std::shared_ptr< const IFC::IfcSurfaceStyleElementSelect > sel2 : surf->Styles) {
         if (const IFC::IfcSurfaceStyleShading* shade = sel2->ResolveSelectPtr<IFC::IfcSurfaceStyleShading>(conv.db)) {
             aiColor4D col_base,col;
 
@@ -140,7 +140,7 @@ unsigned int ProcessMaterials(uint64_t id, unsigned int prevMatId, ConversionDat
     for(;range.first != range.second; ++range.first) {
         if(const IFC::IfcStyledItem* const styled = conv.db.GetObject((*range.first).second)->ToPtr<IFC::IfcStyledItem>()) {
             for(const IFC::IfcPresentationStyleAssignment& as : styled->Styles) {
-                for(boost::shared_ptr<const IFC::IfcPresentationStyleSelect> sel : as.Styles) {
+                for(std::shared_ptr<const IFC::IfcPresentationStyleSelect> sel : as.Styles) {
 
                     if( const IFC::IfcSurfaceStyle* const surf = sel->ResolveSelectPtr<IFC::IfcSurfaceStyle>(conv.db) ) {
                         // try to satisfy from cache

--- a/code/IFCMaterial.cpp
+++ b/code/IFCMaterial.cpp
@@ -76,7 +76,7 @@ void FillMaterial(aiMaterial* mat,const IFC::IfcSurfaceStyle* surf,ConversionDat
     mat->AddProperty(&name,AI_MATKEY_NAME);
 
     // now see which kinds of surface information are present
-    BOOST_FOREACH(boost::shared_ptr< const IFC::IfcSurfaceStyleElementSelect > sel2, surf->Styles) {
+    for(boost::shared_ptr< const IFC::IfcSurfaceStyleElementSelect > sel2 : surf->Styles) {
         if (const IFC::IfcSurfaceStyleShading* shade = sel2->ResolveSelectPtr<IFC::IfcSurfaceStyleShading>(conv.db)) {
             aiColor4D col_base,col;
 
@@ -139,8 +139,8 @@ unsigned int ProcessMaterials(uint64_t id, unsigned int prevMatId, ConversionDat
     STEP::DB::RefMapRange range = conv.db.GetRefs().equal_range(id);
     for(;range.first != range.second; ++range.first) {
         if(const IFC::IfcStyledItem* const styled = conv.db.GetObject((*range.first).second)->ToPtr<IFC::IfcStyledItem>()) {
-            BOOST_FOREACH(const IFC::IfcPresentationStyleAssignment& as, styled->Styles) {
-                BOOST_FOREACH(boost::shared_ptr<const IFC::IfcPresentationStyleSelect> sel, as.Styles) {
+            for(const IFC::IfcPresentationStyleAssignment& as : styled->Styles) {
+                for(boost::shared_ptr<const IFC::IfcPresentationStyleSelect> sel : as.Styles) {
 
                     if( const IFC::IfcSurfaceStyle* const surf = sel->ResolveSelectPtr<IFC::IfcSurfaceStyle>(conv.db) ) {
                         // try to satisfy from cache

--- a/code/IFCOpenings.cpp
+++ b/code/IFCOpenings.cpp
@@ -213,7 +213,7 @@ bool BoundingBoxesOverlapping( const BoundingBox &ibb, const BoundingBox &bb )
 bool IsDuplicateVertex(const IfcVector2& vv, const std::vector<IfcVector2>& temp_contour)
 {
     // sanity check for duplicate vertices
-    BOOST_FOREACH(const IfcVector2& cp, temp_contour) {
+    for(const IfcVector2& cp : temp_contour) {
         if ((cp-vv).SquareLength() < 1e-5f) {
             return true;
         }
@@ -226,7 +226,7 @@ void ExtractVerticesFromClipper(const ClipperLib::Polygon& poly, std::vector<Ifc
     bool filter_duplicates = false)
 {
     temp_contour.clear();
-    BOOST_FOREACH(const ClipperLib::IntPoint& point, poly) {
+    for(const ClipperLib::IntPoint& point : poly) {
         IfcVector2 vv = IfcVector2( from_int64(point.X), from_int64(point.Y));
         vv = std::max(vv,IfcVector2());
         vv = std::min(vv,one_vec);
@@ -243,7 +243,7 @@ BoundingBox GetBoundingBox(const ClipperLib::Polygon& poly)
     IfcVector2 newbb_min, newbb_max;
     MinMaxChooser<IfcVector2>()(newbb_min, newbb_max);
 
-    BOOST_FOREACH(const ClipperLib::IntPoint& point, poly) {
+    for(const ClipperLib::IntPoint& point : poly) {
         IfcVector2 vv = IfcVector2( from_int64(point.X), from_int64(point.Y));
 
         // sanity rounding
@@ -391,7 +391,7 @@ void MergeWindowContours (const std::vector<IfcVector2>& a,
     ClipperLib::Clipper clipper;
     ClipperLib::Polygon clip;
 
-    BOOST_FOREACH(const IfcVector2& pip, a) {
+    for(const IfcVector2& pip : a) {
         clip.push_back(ClipperLib::IntPoint(  to_int64(pip.x), to_int64(pip.y) ));
     }
 
@@ -402,7 +402,7 @@ void MergeWindowContours (const std::vector<IfcVector2>& a,
     clipper.AddPolygon(clip, ClipperLib::ptSubject);
     clip.clear();
 
-    BOOST_FOREACH(const IfcVector2& pip, b) {
+    for(const IfcVector2& pip : b) {
         clip.push_back(ClipperLib::IntPoint(  to_int64(pip.x), to_int64(pip.y) ));
     }
 
@@ -425,7 +425,7 @@ void MakeDisjunctWindowContours (const std::vector<IfcVector2>& a,
     ClipperLib::Clipper clipper;
     ClipperLib::Polygon clip;
 
-    BOOST_FOREACH(const IfcVector2& pip, a) {
+    for(const IfcVector2& pip : a) {
         clip.push_back(ClipperLib::IntPoint(  to_int64(pip.x), to_int64(pip.y) ));
     }
 
@@ -436,7 +436,7 @@ void MakeDisjunctWindowContours (const std::vector<IfcVector2>& a,
     clipper.AddPolygon(clip, ClipperLib::ptClip);
     clip.clear();
 
-    BOOST_FOREACH(const IfcVector2& pip, b) {
+    for(const IfcVector2& pip : b) {
         clip.push_back(ClipperLib::IntPoint(  to_int64(pip.x), to_int64(pip.y) ));
     }
 
@@ -458,7 +458,7 @@ void CleanupWindowContour(ProjectedWindowContour& window)
     ClipperLib::Clipper clipper;
     ClipperLib::ExPolygons clipped;
 
-    BOOST_FOREACH(const IfcVector2& pip, contour) {
+    for(const IfcVector2& pip : contour) {
         subject.push_back(ClipperLib::IntPoint(  to_int64(pip.x), to_int64(pip.y) ));
     }
 
@@ -488,7 +488,7 @@ void CleanupWindowContours(ContourVector& contours)
 {
     // Use PolyClipper to clean up window contours
     try {
-        BOOST_FOREACH(ProjectedWindowContour& window, contours) {
+        for(ProjectedWindowContour& window : contours) {
             CleanupWindowContour(window);
         }
     }
@@ -516,7 +516,7 @@ void CleanupOuterContour(const std::vector<IfcVector2>& contour_flat, TempMesh& 
 
         ClipperLib::Polygon clip;
         clip.reserve(contour_flat.size());
-        BOOST_FOREACH(const IfcVector2& pip, contour_flat) {
+        for(const IfcVector2& pip : contour_flat) {
             clip.push_back(ClipperLib::IntPoint(  to_int64(pip.x), to_int64(pip.y) ));
         }
 
@@ -530,7 +530,7 @@ void CleanupOuterContour(const std::vector<IfcVector2>& contour_flat, TempMesh& 
         subject.reserve(4);
         size_t index = 0;
         size_t countdown = 0;
-        BOOST_FOREACH(const IfcVector3& pip, curmesh.verts) {
+        for(const IfcVector3& pip : curmesh.verts) {
             if (!countdown) {
                 countdown = curmesh.vertcnt[index++];
                 if (!countdown) {
@@ -548,9 +548,9 @@ void CleanupOuterContour(const std::vector<IfcVector2>& contour_flat, TempMesh& 
 
                 clipper.Execute(ClipperLib::ctIntersection,clipped,ClipperLib::pftNonZero,ClipperLib::pftNonZero);
 
-                BOOST_FOREACH(const ClipperLib::ExPolygon& ex, clipped) {
+                for(const ClipperLib::ExPolygon& ex : clipped) {
                     iold.push_back(ex.outer.size());
-                    BOOST_FOREACH(const ClipperLib::IntPoint& point, ex.outer) {
+                    for(const ClipperLib::IntPoint& point : ex.outer) {
                         vold.push_back(IfcVector3(
                             from_int64(point.X),
                             from_int64(point.Y),
@@ -866,7 +866,7 @@ size_t CloseWindows(ContourVector& contours,
         OpeningRefs& refs = contours_to_openings[std::distance(contours.begin(), it)];
 
         bool has_other_side = false;
-        BOOST_FOREACH(const TempOpening* opening, refs) {
+        for(const TempOpening* opening : refs) {
             if(!opening->wallPoints.empty()) {
                 has_other_side = true;
                 break;
@@ -929,8 +929,8 @@ size_t CloseWindows(ContourVector& contours,
 
                 const IfcVector3 world_point = minv * IfcVector3(proj_point.x,proj_point.y,0.0f);
 
-                BOOST_FOREACH(const TempOpening* opening, refs) {
-                    BOOST_FOREACH(const IfcVector3& other, opening->wallPoints) {
+                for(const TempOpening* opening : refs) {
+                    for(const IfcVector3& other : opening->wallPoints) {
                         const IfcFloat sqdist = (world_point - other).SquareLength();
 
                         if (sqdist < best) {
@@ -987,7 +987,7 @@ size_t CloseWindows(ContourVector& contours,
         else {
 
             const Contour::const_iterator cbegin = (*it).contour.begin(), cend = (*it).contour.end();
-            BOOST_FOREACH(TempOpening* opening, refs) {
+            for(TempOpening* opening : refs) {
                 ai_assert(opening->wallPoints.empty());
                 opening->wallPoints.reserve(opening->wallPoints.capacity() + (*it).contour.size());
                 for (Contour::const_iterator cit = cbegin; cit != cend; ++cit) {
@@ -1023,7 +1023,7 @@ void Quadrify(const std::vector< BoundingBox >& bbs, TempMesh& curmesh)
 
     curmesh.vertcnt.resize(quads.size()/4,4);
     curmesh.verts.reserve(quads.size());
-    BOOST_FOREACH(const IfcVector2& v2, quads) {
+    for(const IfcVector2& v2 : quads) {
         curmesh.verts.push_back(IfcVector3(v2.x, v2.y, static_cast<IfcFloat>(0.0)));
     }
 }
@@ -1034,7 +1034,7 @@ void Quadrify(const ContourVector& contours, TempMesh& curmesh)
     std::vector<BoundingBox> bbs;
     bbs.reserve(contours.size());
 
-    BOOST_FOREACH(const ContourVector::value_type& val, contours) {
+    for(const ContourVector::value_type& val : contours) {
         bbs.push_back(val.bb);
     }
 
@@ -1065,7 +1065,7 @@ IfcMatrix4 ProjectOntoPlane(std::vector<IfcVector2>& out_contour, const TempMesh
     MinMaxChooser<IfcVector3>()(vmin, vmax);
 
     // Project all points into the new coordinate system, collect min/max verts on the way
-    BOOST_FOREACH(const IfcVector3& x, in_verts) {
+    for(const IfcVector3& x : in_verts) {
         const IfcVector3 vv = m * x;
         // keep Z offset in the plane coordinate system. Ignoring precision issues
         // (which  are present, of course), this should be the same value for
@@ -1089,7 +1089,7 @@ IfcMatrix4 ProjectOntoPlane(std::vector<IfcVector2>& out_contour, const TempMesh
     // [0,1] range. This gives us a consistent data range so all epsilons
     // used below can be constants.
     vmax -= vmin;
-    BOOST_FOREACH(IfcVector2& vv, out_contour) {
+    for(IfcVector2& vv : out_contour) {
         vv.x  = (vv.x - vmin.x) / vmax.x;
         vv.y  = (vv.y - vmin.y) / vmax.y;
 
@@ -1110,7 +1110,7 @@ IfcMatrix4 ProjectOntoPlane(std::vector<IfcVector2>& out_contour, const TempMesh
     // debug code to verify correctness
 #ifdef ASSIMP_BUILD_DEBUG
     std::vector<IfcVector2> out_contour2;
-    BOOST_FOREACH(const IfcVector3& x, in_verts) {
+    for(const IfcVector3& x : in_verts) {
         const IfcVector3& vv = m * x;
 
         out_contour2.push_back(IfcVector2(vv.x,vv.y));
@@ -1161,7 +1161,7 @@ bool GenerateOpenings(std::vector<TempOpening>& openings,
     IfcVector3 wall_extrusion_axis_norm = wall_extrusion_axis;
     wall_extrusion_axis_norm.Normalize();
 
-    BOOST_FOREACH(TempOpening& opening,openings) {
+    for(TempOpening& opening :openings) {
 
         // extrusionDir may be 0,0,0 on case where the opening mesh is not an
         // IfcExtrudedAreaSolid but something else (i.e. a brep)
@@ -1413,7 +1413,7 @@ bool GenerateOpenings(std::vector<TempOpening>& openings,
     CleanupOuterContour(contour_flat, curmesh);
 
     // Undo the projection and get back to world (or local object) space
-    BOOST_FOREACH(IfcVector3& v3, curmesh.verts) {
+    for(IfcVector3& v3 : curmesh.verts) {
         v3 = minv * v3;
     }
 
@@ -1455,7 +1455,7 @@ bool TryAddOpenings_Poly2Tri(const std::vector<TempOpening>& openings,const std:
     MinMaxChooser<IfcVector2>()(vmin, vmax);
 
     // Move all points into the new coordinate system, collecting min/max verts on the way
-    BOOST_FOREACH(IfcVector3& x, out) {
+    for(IfcVector3& x : out) {
         const IfcVector3 vv = m * x;
 
         // keep Z offset in the plane coordinate system. Ignoring precision issues
@@ -1498,7 +1498,7 @@ bool TryAddOpenings_Poly2Tri(const std::vector<TempOpening>& openings,const std:
         ClipperLib::Clipper clipper_holes;
         size_t c = 0;
 
-        BOOST_FOREACH(const TempOpening& t,openings) {
+        for(const TempOpening& t :openings) {
             const IfcVector3& outernor = nors[c++];
             const IfcFloat dot = nor * outernor;
             if (std::fabs(dot)<1.f-1e-6f) {
@@ -1512,7 +1512,7 @@ bool TryAddOpenings_Poly2Tri(const std::vector<TempOpening>& openings,const std:
 
             std::vector<IfcVector2> contour;
 
-            BOOST_FOREACH(const IfcVector3& xx, t.profileMesh->verts) {
+            for(const IfcVector3& xx : t.profileMesh->verts) {
                 IfcVector3 vv = m *  xx, vv_extr = m * (xx + t.extrusionDir);
 
                 const bool is_extruded_side = std::fabs(vv.z - coord) > std::fabs(vv_extr.z - coord);
@@ -1533,7 +1533,7 @@ bool TryAddOpenings_Poly2Tri(const std::vector<TempOpening>& openings,const std:
             }
 
             ClipperLib::Polygon hole;
-            BOOST_FOREACH(IfcVector2& pip, contour) {
+            for(IfcVector2& pip : contour) {
                 pip.x  = (pip.x - vmin.x) / vmax.x;
                 pip.y  = (pip.y - vmin.y) / vmax.y;
 
@@ -1566,7 +1566,7 @@ bool TryAddOpenings_Poly2Tri(const std::vector<TempOpening>& openings,const std:
         // to obtain the final polygon to feed into the triangulator.
         {
             ClipperLib::Polygon poly;
-            BOOST_FOREACH(IfcVector2& pip, contour_flat) {
+            for(IfcVector2& pip : contour_flat) {
                 pip.x  = (pip.x - vmin.x) / vmax.x;
                 pip.y  = (pip.y - vmin.y) / vmax.y;
 
@@ -1606,13 +1606,13 @@ bool TryAddOpenings_Poly2Tri(const std::vector<TempOpening>& openings,const std:
     if (false && do_connections) {
 
         std::vector<IfcVector3> tmpvec;
-        BOOST_FOREACH(ClipperLib::Polygon& opening, holes_union) {
+        for(ClipperLib::Polygon& opening : holes_union) {
 
             assert(ClipperLib::Orientation(opening));
 
             tmpvec.clear();
 
-            BOOST_FOREACH(ClipperLib::IntPoint& point, opening) {
+            for(ClipperLib::IntPoint& point : opening) {
 
                 tmpvec.push_back( minv * IfcVector3(
                     vmin.x + from_int64(point.X) * vmax.x,
@@ -1638,13 +1638,13 @@ bool TryAddOpenings_Poly2Tri(const std::vector<TempOpening>& openings,const std:
     }
 
     std::vector< std::vector<p2t::Point*> > contours;
-    BOOST_FOREACH(ClipperLib::ExPolygon& clip, clipped) {
+    for(ClipperLib::ExPolygon& clip : clipped) {
 
         contours.clear();
 
         // Build the outer polygon contour line for feeding into poly2tri
         std::vector<p2t::Point*> contour_points;
-        BOOST_FOREACH(ClipperLib::IntPoint& point, clip.outer) {
+        for(ClipperLib::IntPoint& point : clip.outer) {
             contour_points.push_back( new p2t::Point(from_int64(point.X), from_int64(point.Y)) );
         }
 
@@ -1664,12 +1664,12 @@ bool TryAddOpenings_Poly2Tri(const std::vector<TempOpening>& openings,const std:
 
 
         // Build the poly2tri inner contours for all holes we got from ClipperLib
-        BOOST_FOREACH(ClipperLib::Polygon& opening, clip.holes) {
+        for(ClipperLib::Polygon& opening : clip.holes) {
 
             contours.push_back(std::vector<p2t::Point*>());
             std::vector<p2t::Point*>& contour = contours.back();
 
-            BOOST_FOREACH(ClipperLib::IntPoint& point, opening) {
+            for(ClipperLib::IntPoint& point : opening) {
                 contour.push_back( new p2t::Point(from_int64(point.X), from_int64(point.Y)) );
             }
 
@@ -1689,7 +1689,7 @@ bool TryAddOpenings_Poly2Tri(const std::vector<TempOpening>& openings,const std:
         const std::vector<p2t::Triangle*> tris = cdt->GetTriangles();
 
         // Collect the triangles we just produced
-        BOOST_FOREACH(p2t::Triangle* tri, tris) {
+        for(p2t::Triangle* tri : tris) {
             for(int i = 0; i < 3; ++i) {
 
                 const IfcVector2 v = IfcVector2(

--- a/code/IFCProfile.cpp
+++ b/code/IFCProfile.cpp
@@ -65,7 +65,7 @@ void ProcessPolyLine(const IfcPolyline& def, TempMesh& meshout, ConversionData& 
 // ------------------------------------------------------------------------------------------------
 bool ProcessCurve(const IfcCurve& curve,  TempMesh& meshout, ConversionData& conv)
 {
-    boost::scoped_ptr<const Curve> cv(Curve::Convert(curve,conv));
+    std::unique_ptr<const Curve> cv(Curve::Convert(curve,conv));
     if (!cv) {
         IFCImporter::LogWarn("skipping unknown IfcCurve entity, type is " + curve.GetClassName());
         return false;

--- a/code/IFCProfile.cpp
+++ b/code/IFCProfile.cpp
@@ -55,7 +55,7 @@ void ProcessPolyLine(const IfcPolyline& def, TempMesh& meshout, ConversionData& 
 {
     // this won't produce a valid mesh, it just spits out a list of vertices
     IfcVector3 t;
-    BOOST_FOREACH(const IfcCartesianPoint& cp, def.Points) {
+    for(const IfcCartesianPoint& cp : def.Points) {
         ConvertCartesianPoint(t,cp);
         meshout.verts.push_back(t);
     }

--- a/code/IFCReaderGen.cpp
+++ b/code/IFCReaderGen.cpp
@@ -1081,13 +1081,13 @@ template <> size_t GenericFill<IfcCompositeCurve>(const DB& db, const LIST& para
 {
     size_t base = GenericFill(db,params,static_cast<IfcBoundedCurve*>(in));
     if (params.GetSize() < 2) { throw STEP::TypeError("expected 2 arguments to IfcCompositeCurve"); }    do { // convert the 'Segments' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcCompositeCurve,2>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->Segments, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcCompositeCurve to be a `LIST [1:?] OF IfcCompositeCurveSegment`")); }
     } while(0);
     do { // convert the 'SelfIntersect' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcCompositeCurve,2>::aux_is_derived[1]=true; break; }
         try { GenericConvert( in->SelfIntersect, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcCompositeCurve to be a `LOGICAL`")); }
@@ -1106,26 +1106,26 @@ template <> size_t GenericFill<IfcRoot>(const DB& db, const LIST& params, IfcRoo
 {
     size_t base = 0;
     if (params.GetSize() < 4) { throw STEP::TypeError("expected 4 arguments to IfcRoot"); }    do { // convert the 'GlobalId' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcRoot,4>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->GlobalId, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcRoot to be a `IfcGloballyUniqueId`")); }
     } while(0);
     do { // convert the 'OwnerHistory' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcRoot,4>::aux_is_derived[1]=true; break; }
         try { GenericConvert( in->OwnerHistory, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcRoot to be a `IfcOwnerHistory`")); }
     } while(0);
     do { // convert the 'Name' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcRoot,4>::aux_is_derived[2]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Name, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcRoot to be a `IfcLabel`")); }
     } while(0);
     do { // convert the 'Description' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcRoot,4>::aux_is_derived[3]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Description, arg, db ); break; }
@@ -1144,7 +1144,7 @@ template <> size_t GenericFill<IfcObject>(const DB& db, const LIST& params, IfcO
 {
     size_t base = GenericFill(db,params,static_cast<IfcObjectDefinition*>(in));
     if (params.GetSize() < 5) { throw STEP::TypeError("expected 5 arguments to IfcObject"); }    do { // convert the 'ObjectType' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcObject,1>::aux_is_derived[0]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->ObjectType, arg, db ); break; }
@@ -1297,14 +1297,14 @@ template <> size_t GenericFill<IfcProduct>(const DB& db, const LIST& params, Ifc
 {
     size_t base = GenericFill(db,params,static_cast<IfcObject*>(in));
     if (params.GetSize() < 7) { throw STEP::TypeError("expected 7 arguments to IfcProduct"); }    do { // convert the 'ObjectPlacement' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcProduct,2>::aux_is_derived[0]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->ObjectPlacement, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 5 to IfcProduct to be a `IfcObjectPlacement`")); }
     } while(0);
     do { // convert the 'Representation' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcProduct,2>::aux_is_derived[1]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Representation, arg, db ); break; }
@@ -1323,20 +1323,20 @@ template <> size_t GenericFill<IfcStyledItem>(const DB& db, const LIST& params, 
 {
     size_t base = GenericFill(db,params,static_cast<IfcRepresentationItem*>(in));
     if (params.GetSize() < 3) { throw STEP::TypeError("expected 3 arguments to IfcStyledItem"); }    do { // convert the 'Item' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcStyledItem,3>::aux_is_derived[0]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Item, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcStyledItem to be a `IfcRepresentationItem`")); }
     } while(0);
     do { // convert the 'Styles' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcStyledItem,3>::aux_is_derived[1]=true; break; }
         try { GenericConvert( in->Styles, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcStyledItem to be a `SET [1:?] OF IfcPresentationStyleAssignment`")); }
     } while(0);
     do { // convert the 'Name' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcStyledItem,3>::aux_is_derived[2]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Name, arg, db ); break; }
@@ -1405,13 +1405,13 @@ template <> size_t GenericFill<IfcProfileDef>(const DB& db, const LIST& params, 
 {
     size_t base = 0;
     if (params.GetSize() < 2) { throw STEP::TypeError("expected 2 arguments to IfcProfileDef"); }    do { // convert the 'ProfileType' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcProfileDef,2>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->ProfileType, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcProfileDef to be a `IfcProfileTypeEnum`")); }
     } while(0);
     do { // convert the 'ProfileName' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcProfileDef,2>::aux_is_derived[1]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->ProfileName, arg, db ); break; }
@@ -1424,7 +1424,7 @@ template <> size_t GenericFill<IfcArbitraryClosedProfileDef>(const DB& db, const
 {
     size_t base = GenericFill(db,params,static_cast<IfcProfileDef*>(in));
     if (params.GetSize() < 3) { throw STEP::TypeError("expected 3 arguments to IfcArbitraryClosedProfileDef"); }    do { // convert the 'OuterCurve' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcArbitraryClosedProfileDef,1>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->OuterCurve, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcArbitraryClosedProfileDef to be a `IfcCurve`")); }
@@ -1436,7 +1436,7 @@ template <> size_t GenericFill<IfcArbitraryOpenProfileDef>(const DB& db, const L
 {
     size_t base = GenericFill(db,params,static_cast<IfcProfileDef*>(in));
     if (params.GetSize() < 3) { throw STEP::TypeError("expected 3 arguments to IfcArbitraryOpenProfileDef"); }    do { // convert the 'Curve' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcArbitraryOpenProfileDef,1>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->Curve, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcArbitraryOpenProfileDef to be a `IfcBoundedCurve`")); }
@@ -1448,7 +1448,7 @@ template <> size_t GenericFill<IfcArbitraryProfileDefWithVoids>(const DB& db, co
 {
     size_t base = GenericFill(db,params,static_cast<IfcArbitraryClosedProfileDef*>(in));
     if (params.GetSize() < 4) { throw STEP::TypeError("expected 4 arguments to IfcArbitraryProfileDefWithVoids"); }    do { // convert the 'InnerCurves' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->InnerCurves, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcArbitraryProfileDefWithVoids to be a `SET [1:?] OF IfcCurve`")); }
     } while(0);
@@ -1473,7 +1473,7 @@ template <> size_t GenericFill<IfcParameterizedProfileDef>(const DB& db, const L
 {
     size_t base = GenericFill(db,params,static_cast<IfcProfileDef*>(in));
     if (params.GetSize() < 3) { throw STEP::TypeError("expected 3 arguments to IfcParameterizedProfileDef"); }    do { // convert the 'Position' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcParameterizedProfileDef,1>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->Position, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcParameterizedProfileDef to be a `IfcAxis2Placement2D`")); }
@@ -1485,31 +1485,31 @@ template <> size_t GenericFill<IfcIShapeProfileDef>(const DB& db, const LIST& pa
 {
     size_t base = GenericFill(db,params,static_cast<IfcParameterizedProfileDef*>(in));
     if (params.GetSize() < 8) { throw STEP::TypeError("expected 8 arguments to IfcIShapeProfileDef"); }    do { // convert the 'OverallWidth' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcIShapeProfileDef,5>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->OverallWidth, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcIShapeProfileDef to be a `IfcPositiveLengthMeasure`")); }
     } while(0);
     do { // convert the 'OverallDepth' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcIShapeProfileDef,5>::aux_is_derived[1]=true; break; }
         try { GenericConvert( in->OverallDepth, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 4 to IfcIShapeProfileDef to be a `IfcPositiveLengthMeasure`")); }
     } while(0);
     do { // convert the 'WebThickness' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcIShapeProfileDef,5>::aux_is_derived[2]=true; break; }
         try { GenericConvert( in->WebThickness, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 5 to IfcIShapeProfileDef to be a `IfcPositiveLengthMeasure`")); }
     } while(0);
     do { // convert the 'FlangeThickness' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcIShapeProfileDef,5>::aux_is_derived[3]=true; break; }
         try { GenericConvert( in->FlangeThickness, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 6 to IfcIShapeProfileDef to be a `IfcPositiveLengthMeasure`")); }
     } while(0);
     do { // convert the 'FilletRadius' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcIShapeProfileDef,5>::aux_is_derived[4]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->FilletRadius, arg, db ); break; }
@@ -1529,7 +1529,7 @@ template <> size_t GenericFill<IfcPlacement>(const DB& db, const LIST& params, I
 {
     size_t base = GenericFill(db,params,static_cast<IfcGeometricRepresentationItem*>(in));
     if (params.GetSize() < 1) { throw STEP::TypeError("expected 1 arguments to IfcPlacement"); }    do { // convert the 'Location' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcPlacement,1>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->Location, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcPlacement to be a `IfcCartesianPoint`")); }
@@ -1541,7 +1541,7 @@ template <> size_t GenericFill<IfcAxis1Placement>(const DB& db, const LIST& para
 {
     size_t base = GenericFill(db,params,static_cast<IfcPlacement*>(in));
     if (params.GetSize() < 2) { throw STEP::TypeError("expected 2 arguments to IfcAxis1Placement"); }    do { // convert the 'Axis' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Axis, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcAxis1Placement to be a `IfcDirection`")); }
@@ -1553,7 +1553,7 @@ template <> size_t GenericFill<IfcAxis2Placement2D>(const DB& db, const LIST& pa
 {
     size_t base = GenericFill(db,params,static_cast<IfcPlacement*>(in));
     if (params.GetSize() < 2) { throw STEP::TypeError("expected 2 arguments to IfcAxis2Placement2D"); }    do { // convert the 'RefDirection' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->RefDirection, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcAxis2Placement2D to be a `IfcDirection`")); }
@@ -1565,13 +1565,13 @@ template <> size_t GenericFill<IfcAxis2Placement3D>(const DB& db, const LIST& pa
 {
     size_t base = GenericFill(db,params,static_cast<IfcPlacement*>(in));
     if (params.GetSize() < 3) { throw STEP::TypeError("expected 3 arguments to IfcAxis2Placement3D"); }    do { // convert the 'Axis' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Axis, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcAxis2Placement3D to be a `IfcDirection`")); }
     } while(0);
     do { // convert the 'RefDirection' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->RefDirection, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcAxis2Placement3D to be a `IfcDirection`")); }
@@ -1583,31 +1583,31 @@ template <> size_t GenericFill<IfcBSplineCurve>(const DB& db, const LIST& params
 {
     size_t base = GenericFill(db,params,static_cast<IfcBoundedCurve*>(in));
     if (params.GetSize() < 5) { throw STEP::TypeError("expected 5 arguments to IfcBSplineCurve"); }    do { // convert the 'Degree' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcBSplineCurve,5>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->Degree, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcBSplineCurve to be a `INTEGER`")); }
     } while(0);
     do { // convert the 'ControlPointsList' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcBSplineCurve,5>::aux_is_derived[1]=true; break; }
         try { GenericConvert( in->ControlPointsList, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcBSplineCurve to be a `LIST [2:?] OF IfcCartesianPoint`")); }
     } while(0);
     do { // convert the 'CurveForm' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcBSplineCurve,5>::aux_is_derived[2]=true; break; }
         try { GenericConvert( in->CurveForm, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcBSplineCurve to be a `IfcBSplineCurveForm`")); }
     } while(0);
     do { // convert the 'ClosedCurve' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcBSplineCurve,5>::aux_is_derived[3]=true; break; }
         try { GenericConvert( in->ClosedCurve, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcBSplineCurve to be a `LOGICAL`")); }
     } while(0);
     do { // convert the 'SelfIntersect' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcBSplineCurve,5>::aux_is_derived[4]=true; break; }
         try { GenericConvert( in->SelfIntersect, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 4 to IfcBSplineCurve to be a `LOGICAL`")); }
@@ -1619,7 +1619,7 @@ template <> size_t GenericFill<IfcElement>(const DB& db, const LIST& params, Ifc
 {
     size_t base = GenericFill(db,params,static_cast<IfcProduct*>(in));
     if (params.GetSize() < 8) { throw STEP::TypeError("expected 8 arguments to IfcElement"); }    do { // convert the 'Tag' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcElement,1>::aux_is_derived[0]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Tag, arg, db ); break; }
@@ -1687,19 +1687,19 @@ template <> size_t GenericFill<IfcBooleanResult>(const DB& db, const LIST& param
 {
     size_t base = GenericFill(db,params,static_cast<IfcGeometricRepresentationItem*>(in));
     if (params.GetSize() < 3) { throw STEP::TypeError("expected 3 arguments to IfcBooleanResult"); }    do { // convert the 'Operator' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcBooleanResult,3>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->Operator, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcBooleanResult to be a `IfcBooleanOperator`")); }
     } while(0);
     do { // convert the 'FirstOperand' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcBooleanResult,3>::aux_is_derived[1]=true; break; }
         try { GenericConvert( in->FirstOperand, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcBooleanResult to be a `IfcBooleanOperand`")); }
     } while(0);
     do { // convert the 'SecondOperand' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcBooleanResult,3>::aux_is_derived[2]=true; break; }
         try { GenericConvert( in->SecondOperand, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcBooleanResult to be a `IfcBooleanOperand`")); }
@@ -1730,22 +1730,22 @@ template <> size_t GenericFill<IfcBoundingBox>(const DB& db, const LIST& params,
 {
     size_t base = GenericFill(db,params,static_cast<IfcGeometricRepresentationItem*>(in));
     if (params.GetSize() < 4) { throw STEP::TypeError("expected 4 arguments to IfcBoundingBox"); }    do { // convert the 'Corner' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Corner, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcBoundingBox to be a `IfcCartesianPoint`")); }
     } while(0);
     do { // convert the 'XDim' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->XDim, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcBoundingBox to be a `IfcPositiveLengthMeasure`")); }
     } while(0);
     do { // convert the 'YDim' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->YDim, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcBoundingBox to be a `IfcPositiveLengthMeasure`")); }
     } while(0);
     do { // convert the 'ZDim' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->ZDim, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcBoundingBox to be a `IfcPositiveLengthMeasure`")); }
     } while(0);
@@ -1756,13 +1756,13 @@ template <> size_t GenericFill<IfcHalfSpaceSolid>(const DB& db, const LIST& para
 {
     size_t base = GenericFill(db,params,static_cast<IfcGeometricRepresentationItem*>(in));
     if (params.GetSize() < 2) { throw STEP::TypeError("expected 2 arguments to IfcHalfSpaceSolid"); }    do { // convert the 'BaseSurface' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcHalfSpaceSolid,2>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->BaseSurface, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcHalfSpaceSolid to be a `IfcSurface`")); }
     } while(0);
     do { // convert the 'AgreementFlag' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcHalfSpaceSolid,2>::aux_is_derived[1]=true; break; }
         try { GenericConvert( in->AgreementFlag, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcHalfSpaceSolid to be a `BOOLEAN`")); }
@@ -1781,14 +1781,14 @@ template <> size_t GenericFill<IfcSpatialStructureElement>(const DB& db, const L
 {
     size_t base = GenericFill(db,params,static_cast<IfcProduct*>(in));
     if (params.GetSize() < 9) { throw STEP::TypeError("expected 9 arguments to IfcSpatialStructureElement"); }    do { // convert the 'LongName' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcSpatialStructureElement,2>::aux_is_derived[0]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->LongName, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 7 to IfcSpatialStructureElement to be a `IfcLabel`")); }
     } while(0);
     do { // convert the 'CompositionType' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcSpatialStructureElement,2>::aux_is_derived[1]=true; break; }
         try { GenericConvert( in->CompositionType, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 8 to IfcSpatialStructureElement to be a `IfcElementCompositionEnum`")); }
@@ -1800,19 +1800,19 @@ template <> size_t GenericFill<IfcBuilding>(const DB& db, const LIST& params, If
 {
     size_t base = GenericFill(db,params,static_cast<IfcSpatialStructureElement*>(in));
     if (params.GetSize() < 12) { throw STEP::TypeError("expected 12 arguments to IfcBuilding"); }    do { // convert the 'ElevationOfRefHeight' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->ElevationOfRefHeight, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 9 to IfcBuilding to be a `IfcLengthMeasure`")); }
     } while(0);
     do { // convert the 'ElevationOfTerrain' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->ElevationOfTerrain, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 10 to IfcBuilding to be a `IfcLengthMeasure`")); }
     } while(0);
     do { // convert the 'BuildingAddress' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->BuildingAddress, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 11 to IfcBuilding to be a `IfcPostalAddress`")); }
@@ -1907,7 +1907,7 @@ template <> size_t GenericFill<IfcCartesianPoint>(const DB& db, const LIST& para
 {
     size_t base = GenericFill(db,params,static_cast<IfcPoint*>(in));
     if (params.GetSize() < 1) { throw STEP::TypeError("expected 1 arguments to IfcCartesianPoint"); }    do { // convert the 'Coordinates' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Coordinates, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcCartesianPoint to be a `LIST [1:3] OF IfcLengthMeasure`")); }
     } while(0);
@@ -1918,27 +1918,27 @@ template <> size_t GenericFill<IfcCartesianTransformationOperator>(const DB& db,
 {
     size_t base = GenericFill(db,params,static_cast<IfcGeometricRepresentationItem*>(in));
     if (params.GetSize() < 4) { throw STEP::TypeError("expected 4 arguments to IfcCartesianTransformationOperator"); }    do { // convert the 'Axis1' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcCartesianTransformationOperator,4>::aux_is_derived[0]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Axis1, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcCartesianTransformationOperator to be a `IfcDirection`")); }
     } while(0);
     do { // convert the 'Axis2' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcCartesianTransformationOperator,4>::aux_is_derived[1]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Axis2, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcCartesianTransformationOperator to be a `IfcDirection`")); }
     } while(0);
     do { // convert the 'LocalOrigin' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcCartesianTransformationOperator,4>::aux_is_derived[2]=true; break; }
         try { GenericConvert( in->LocalOrigin, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcCartesianTransformationOperator to be a `IfcCartesianPoint`")); }
     } while(0);
     do { // convert the 'Scale' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcCartesianTransformationOperator,4>::aux_is_derived[3]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Scale, arg, db ); break; }
@@ -1965,7 +1965,7 @@ template <> size_t GenericFill<IfcCartesianTransformationOperator3D>(const DB& d
 {
     size_t base = GenericFill(db,params,static_cast<IfcCartesianTransformationOperator*>(in));
     if (params.GetSize() < 5) { throw STEP::TypeError("expected 5 arguments to IfcCartesianTransformationOperator3D"); }    do { // convert the 'Axis3' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcCartesianTransformationOperator3D,1>::aux_is_derived[0]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Axis3, arg, db ); break; }
@@ -1978,13 +1978,13 @@ template <> size_t GenericFill<IfcCartesianTransformationOperator3DnonUniform>(c
 {
     size_t base = GenericFill(db,params,static_cast<IfcCartesianTransformationOperator3D*>(in));
     if (params.GetSize() < 7) { throw STEP::TypeError("expected 7 arguments to IfcCartesianTransformationOperator3DnonUniform"); }    do { // convert the 'Scale2' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Scale2, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 5 to IfcCartesianTransformationOperator3DnonUniform to be a `REAL`")); }
     } while(0);
     do { // convert the 'Scale3' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Scale3, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 6 to IfcCartesianTransformationOperator3DnonUniform to be a `REAL`")); }
@@ -2036,7 +2036,7 @@ template <> size_t GenericFill<IfcConic>(const DB& db, const LIST& params, IfcCo
 {
     size_t base = GenericFill(db,params,static_cast<IfcCurve*>(in));
     if (params.GetSize() < 1) { throw STEP::TypeError("expected 1 arguments to IfcConic"); }    do { // convert the 'Position' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcConic,1>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->Position, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcConic to be a `IfcAxis2Placement`")); }
@@ -2048,7 +2048,7 @@ template <> size_t GenericFill<IfcCircle>(const DB& db, const LIST& params, IfcC
 {
     size_t base = GenericFill(db,params,static_cast<IfcConic*>(in));
     if (params.GetSize() < 2) { throw STEP::TypeError("expected 2 arguments to IfcCircle"); }    do { // convert the 'Radius' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Radius, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcCircle to be a `IfcPositiveLengthMeasure`")); }
     } while(0);
@@ -2059,7 +2059,7 @@ template <> size_t GenericFill<IfcCircleProfileDef>(const DB& db, const LIST& pa
 {
     size_t base = GenericFill(db,params,static_cast<IfcParameterizedProfileDef*>(in));
     if (params.GetSize() < 4) { throw STEP::TypeError("expected 4 arguments to IfcCircleProfileDef"); }    do { // convert the 'Radius' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcCircleProfileDef,1>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->Radius, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcCircleProfileDef to be a `IfcPositiveLengthMeasure`")); }
@@ -2071,7 +2071,7 @@ template <> size_t GenericFill<IfcCircleHollowProfileDef>(const DB& db, const LI
 {
     size_t base = GenericFill(db,params,static_cast<IfcCircleProfileDef*>(in));
     if (params.GetSize() < 5) { throw STEP::TypeError("expected 5 arguments to IfcCircleHollowProfileDef"); }    do { // convert the 'WallThickness' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->WallThickness, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 4 to IfcCircleHollowProfileDef to be a `IfcPositiveLengthMeasure`")); }
     } while(0);
@@ -2088,7 +2088,7 @@ template <> size_t GenericFill<IfcConnectedFaceSet>(const DB& db, const LIST& pa
 {
     size_t base = GenericFill(db,params,static_cast<IfcTopologicalRepresentationItem*>(in));
     if (params.GetSize() < 1) { throw STEP::TypeError("expected 1 arguments to IfcConnectedFaceSet"); }    do { // convert the 'CfsFaces' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcConnectedFaceSet,1>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->CfsFaces, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcConnectedFaceSet to be a `SET [1:?] OF IfcFace`")); }
@@ -2113,7 +2113,7 @@ template <> size_t GenericFill<IfcColourSpecification>(const DB& db, const LIST&
 {
     size_t base = 0;
     if (params.GetSize() < 1) { throw STEP::TypeError("expected 1 arguments to IfcColourSpecification"); }    do { // convert the 'Name' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcColourSpecification,1>::aux_is_derived[0]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Name, arg, db ); break; }
@@ -2126,17 +2126,17 @@ template <> size_t GenericFill<IfcColourRgb>(const DB& db, const LIST& params, I
 {
     size_t base = GenericFill(db,params,static_cast<IfcColourSpecification*>(in));
     if (params.GetSize() < 4) { throw STEP::TypeError("expected 4 arguments to IfcColourRgb"); }    do { // convert the 'Red' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Red, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcColourRgb to be a `IfcNormalisedRatioMeasure`")); }
     } while(0);
     do { // convert the 'Green' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Green, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcColourRgb to be a `IfcNormalisedRatioMeasure`")); }
     } while(0);
     do { // convert the 'Blue' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Blue, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcColourRgb to be a `IfcNormalisedRatioMeasure`")); }
     } while(0);
@@ -2161,13 +2161,13 @@ template <> size_t GenericFill<IfcProperty>(const DB& db, const LIST& params, If
 {
     size_t base = 0;
     if (params.GetSize() < 2) { throw STEP::TypeError("expected 2 arguments to IfcProperty"); }    do { // convert the 'Name' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcProperty,2>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->Name, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcProperty to be a `IfcIdentifier`")); }
     } while(0);
     do { // convert the 'Description' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcProperty,2>::aux_is_derived[1]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Description, arg, db ); break; }
@@ -2180,12 +2180,12 @@ template <> size_t GenericFill<IfcComplexProperty>(const DB& db, const LIST& par
 {
     size_t base = GenericFill(db,params,static_cast<IfcProperty*>(in));
     if (params.GetSize() < 4) { throw STEP::TypeError("expected 4 arguments to IfcComplexProperty"); }    do { // convert the 'UsageName' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->UsageName, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcComplexProperty to be a `IfcIdentifier`")); }
     } while(0);
     do { // convert the 'HasProperties' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->HasProperties, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcComplexProperty to be a `SET [1:?] OF IfcProperty`")); }
     } while(0);
@@ -2196,17 +2196,17 @@ template <> size_t GenericFill<IfcCompositeCurveSegment>(const DB& db, const LIS
 {
     size_t base = GenericFill(db,params,static_cast<IfcGeometricRepresentationItem*>(in));
     if (params.GetSize() < 3) { throw STEP::TypeError("expected 3 arguments to IfcCompositeCurveSegment"); }    do { // convert the 'Transition' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Transition, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcCompositeCurveSegment to be a `IfcTransitionCode`")); }
     } while(0);
     do { // convert the 'SameSense' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->SameSense, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcCompositeCurveSegment to be a `BOOLEAN`")); }
     } while(0);
     do { // convert the 'ParentCurve' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->ParentCurve, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcCompositeCurveSegment to be a `IfcCurve`")); }
     } while(0);
@@ -2294,13 +2294,13 @@ template <> size_t GenericFill<IfcNamedUnit>(const DB& db, const LIST& params, I
 {
     size_t base = 0;
     if (params.GetSize() < 2) { throw STEP::TypeError("expected 2 arguments to IfcNamedUnit"); }    do { // convert the 'Dimensions' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcNamedUnit,2>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->Dimensions, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcNamedUnit to be a `IfcDimensionalExponents`")); }
     } while(0);
     do { // convert the 'UnitType' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcNamedUnit,2>::aux_is_derived[1]=true; break; }
         try { GenericConvert( in->UnitType, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcNamedUnit to be a `IfcUnitEnum`")); }
@@ -2326,12 +2326,12 @@ template <> size_t GenericFill<IfcConversionBasedUnit>(const DB& db, const LIST&
 {
     size_t base = GenericFill(db,params,static_cast<IfcNamedUnit*>(in));
     if (params.GetSize() < 4) { throw STEP::TypeError("expected 4 arguments to IfcConversionBasedUnit"); }    do { // convert the 'Name' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Name, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcConversionBasedUnit to be a `IfcLabel`")); }
     } while(0);
     do { // convert the 'ConversionFactor' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->ConversionFactor, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcConversionBasedUnit to be a `IfcMeasureWithUnit`")); }
     } while(0);
@@ -2439,7 +2439,7 @@ template <> size_t GenericFill<IfcPresentationStyle>(const DB& db, const LIST& p
 {
     size_t base = 0;
     if (params.GetSize() < 1) { throw STEP::TypeError("expected 1 arguments to IfcPresentationStyle"); }    do { // convert the 'Name' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcPresentationStyle,1>::aux_is_derived[0]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Name, arg, db ); break; }
@@ -2501,7 +2501,7 @@ template <> size_t GenericFill<IfcDirection>(const DB& db, const LIST& params, I
 {
     size_t base = GenericFill(db,params,static_cast<IfcGeometricRepresentationItem*>(in));
     if (params.GetSize() < 1) { throw STEP::TypeError("expected 1 arguments to IfcDirection"); }    do { // convert the 'DirectionRatios' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->DirectionRatios, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcDirection to be a `LIST [2:3] OF REAL`")); }
     } while(0);
@@ -2589,13 +2589,13 @@ template <> size_t GenericFill<IfcDoor>(const DB& db, const LIST& params, IfcDoo
 {
     size_t base = GenericFill(db,params,static_cast<IfcBuildingElement*>(in));
     if (params.GetSize() < 10) { throw STEP::TypeError("expected 10 arguments to IfcDoor"); }    do { // convert the 'OverallHeight' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->OverallHeight, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 8 to IfcDoor to be a `IfcPositiveLengthMeasure`")); }
     } while(0);
     do { // convert the 'OverallWidth' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->OverallWidth, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 9 to IfcDoor to be a `IfcPositiveLengthMeasure`")); }
@@ -2772,13 +2772,13 @@ template <> size_t GenericFill<IfcElementQuantity>(const DB& db, const LIST& par
 {
     size_t base = GenericFill(db,params,static_cast<IfcPropertySetDefinition*>(in));
     if (params.GetSize() < 6) { throw STEP::TypeError("expected 6 arguments to IfcElementQuantity"); }    do { // convert the 'MethodOfMeasurement' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->MethodOfMeasurement, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 4 to IfcElementQuantity to be a `IfcLabel`")); }
     } while(0);
     do { // convert the 'Quantities' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Quantities, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 5 to IfcElementQuantity to be a `SET [1:?] OF IfcPhysicalQuantity`")); }
     } while(0);
@@ -2789,7 +2789,7 @@ template <> size_t GenericFill<IfcElementarySurface>(const DB& db, const LIST& p
 {
     size_t base = GenericFill(db,params,static_cast<IfcSurface*>(in));
     if (params.GetSize() < 1) { throw STEP::TypeError("expected 1 arguments to IfcElementarySurface"); }    do { // convert the 'Position' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcElementarySurface,1>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->Position, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcElementarySurface to be a `IfcAxis2Placement3D`")); }
@@ -2801,12 +2801,12 @@ template <> size_t GenericFill<IfcEllipse>(const DB& db, const LIST& params, Ifc
 {
     size_t base = GenericFill(db,params,static_cast<IfcConic*>(in));
     if (params.GetSize() < 3) { throw STEP::TypeError("expected 3 arguments to IfcEllipse"); }    do { // convert the 'SemiAxis1' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->SemiAxis1, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcEllipse to be a `IfcPositiveLengthMeasure`")); }
     } while(0);
     do { // convert the 'SemiAxis2' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->SemiAxis2, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcEllipse to be a `IfcPositiveLengthMeasure`")); }
     } while(0);
@@ -2859,13 +2859,13 @@ template <> size_t GenericFill<IfcSweptAreaSolid>(const DB& db, const LIST& para
 {
     size_t base = GenericFill(db,params,static_cast<IfcSolidModel*>(in));
     if (params.GetSize() < 2) { throw STEP::TypeError("expected 2 arguments to IfcSweptAreaSolid"); }    do { // convert the 'SweptArea' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcSweptAreaSolid,2>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->SweptArea, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcSweptAreaSolid to be a `IfcProfileDef`")); }
     } while(0);
     do { // convert the 'Position' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcSweptAreaSolid,2>::aux_is_derived[1]=true; break; }
         try { GenericConvert( in->Position, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcSweptAreaSolid to be a `IfcAxis2Placement3D`")); }
@@ -2877,12 +2877,12 @@ template <> size_t GenericFill<IfcExtrudedAreaSolid>(const DB& db, const LIST& p
 {
     size_t base = GenericFill(db,params,static_cast<IfcSweptAreaSolid*>(in));
     if (params.GetSize() < 4) { throw STEP::TypeError("expected 4 arguments to IfcExtrudedAreaSolid"); }    do { // convert the 'ExtrudedDirection' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->ExtrudedDirection, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcExtrudedAreaSolid to be a `IfcDirection`")); }
     } while(0);
     do { // convert the 'Depth' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Depth, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcExtrudedAreaSolid to be a `IfcPositiveLengthMeasure`")); }
     } while(0);
@@ -2893,7 +2893,7 @@ template <> size_t GenericFill<IfcFace>(const DB& db, const LIST& params, IfcFac
 {
     size_t base = GenericFill(db,params,static_cast<IfcTopologicalRepresentationItem*>(in));
     if (params.GetSize() < 1) { throw STEP::TypeError("expected 1 arguments to IfcFace"); }    do { // convert the 'Bounds' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcFace,1>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->Bounds, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcFace to be a `SET [1:?] OF IfcFaceBound`")); }
@@ -2905,7 +2905,7 @@ template <> size_t GenericFill<IfcFaceBasedSurfaceModel>(const DB& db, const LIS
 {
     size_t base = GenericFill(db,params,static_cast<IfcGeometricRepresentationItem*>(in));
     if (params.GetSize() < 1) { throw STEP::TypeError("expected 1 arguments to IfcFaceBasedSurfaceModel"); }    do { // convert the 'FbsmFaces' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->FbsmFaces, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcFaceBasedSurfaceModel to be a `SET [1:?] OF IfcConnectedFaceSet`")); }
     } while(0);
@@ -2916,13 +2916,13 @@ template <> size_t GenericFill<IfcFaceBound>(const DB& db, const LIST& params, I
 {
     size_t base = GenericFill(db,params,static_cast<IfcTopologicalRepresentationItem*>(in));
     if (params.GetSize() < 2) { throw STEP::TypeError("expected 2 arguments to IfcFaceBound"); }    do { // convert the 'Bound' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcFaceBound,2>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->Bound, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcFaceBound to be a `IfcLoop`")); }
     } while(0);
     do { // convert the 'Orientation' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcFaceBound,2>::aux_is_derived[1]=true; break; }
         try { GenericConvert( in->Orientation, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcFaceBound to be a `BOOLEAN`")); }
@@ -2947,7 +2947,7 @@ template <> size_t GenericFill<IfcManifoldSolidBrep>(const DB& db, const LIST& p
 {
     size_t base = GenericFill(db,params,static_cast<IfcSolidModel*>(in));
     if (params.GetSize() < 1) { throw STEP::TypeError("expected 1 arguments to IfcManifoldSolidBrep"); }    do { // convert the 'Outer' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcManifoldSolidBrep,1>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->Outer, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcManifoldSolidBrep to be a `IfcClosedShell`")); }
@@ -3148,14 +3148,14 @@ template <> size_t GenericFill<IfcRepresentationContext>(const DB& db, const LIS
 {
     size_t base = 0;
     if (params.GetSize() < 2) { throw STEP::TypeError("expected 2 arguments to IfcRepresentationContext"); }    do { // convert the 'ContextIdentifier' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcRepresentationContext,2>::aux_is_derived[0]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->ContextIdentifier, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcRepresentationContext to be a `IfcLabel`")); }
     } while(0);
     do { // convert the 'ContextType' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcRepresentationContext,2>::aux_is_derived[1]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->ContextType, arg, db ); break; }
@@ -3168,26 +3168,26 @@ template <> size_t GenericFill<IfcGeometricRepresentationContext>(const DB& db, 
 {
     size_t base = GenericFill(db,params,static_cast<IfcRepresentationContext*>(in));
     if (params.GetSize() < 6) { throw STEP::TypeError("expected 6 arguments to IfcGeometricRepresentationContext"); }    do { // convert the 'CoordinateSpaceDimension' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcGeometricRepresentationContext,4>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->CoordinateSpaceDimension, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcGeometricRepresentationContext to be a `IfcDimensionCount`")); }
     } while(0);
     do { // convert the 'Precision' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcGeometricRepresentationContext,4>::aux_is_derived[1]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Precision, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcGeometricRepresentationContext to be a `REAL`")); }
     } while(0);
     do { // convert the 'WorldCoordinateSystem' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcGeometricRepresentationContext,4>::aux_is_derived[2]=true; break; }
         try { GenericConvert( in->WorldCoordinateSystem, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 4 to IfcGeometricRepresentationContext to be a `IfcAxis2Placement`")); }
     } while(0);
     do { // convert the 'TrueNorth' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcGeometricRepresentationContext,4>::aux_is_derived[3]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->TrueNorth, arg, db ); break; }
@@ -3325,12 +3325,12 @@ template <> size_t GenericFill<IfcLine>(const DB& db, const LIST& params, IfcLin
 {
     size_t base = GenericFill(db,params,static_cast<IfcCurve*>(in));
     if (params.GetSize() < 2) { throw STEP::TypeError("expected 2 arguments to IfcLine"); }    do { // convert the 'Pnt' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Pnt, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcLine to be a `IfcCartesianPoint`")); }
     } while(0);
     do { // convert the 'Dir' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Dir, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcLine to be a `IfcVector`")); }
     } while(0);
@@ -3348,13 +3348,13 @@ template <> size_t GenericFill<IfcLocalPlacement>(const DB& db, const LIST& para
 {
     size_t base = GenericFill(db,params,static_cast<IfcObjectPlacement*>(in));
     if (params.GetSize() < 2) { throw STEP::TypeError("expected 2 arguments to IfcLocalPlacement"); }    do { // convert the 'PlacementRelTo' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->PlacementRelTo, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcLocalPlacement to be a `IfcObjectPlacement`")); }
     } while(0);
     do { // convert the 'RelativePlacement' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->RelativePlacement, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcLocalPlacement to be a `IfcAxis2Placement`")); }
     } while(0);
@@ -3365,12 +3365,12 @@ template <> size_t GenericFill<IfcMappedItem>(const DB& db, const LIST& params, 
 {
     size_t base = GenericFill(db,params,static_cast<IfcRepresentationItem*>(in));
     if (params.GetSize() < 2) { throw STEP::TypeError("expected 2 arguments to IfcMappedItem"); }    do { // convert the 'MappingSource' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->MappingSource, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcMappedItem to be a `IfcRepresentationMap`")); }
     } while(0);
     do { // convert the 'MappingTarget' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->MappingTarget, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcMappedItem to be a `IfcCartesianTransformationOperator`")); }
     } while(0);
@@ -3381,21 +3381,21 @@ template <> size_t GenericFill<IfcProductRepresentation>(const DB& db, const LIS
 {
     size_t base = 0;
     if (params.GetSize() < 3) { throw STEP::TypeError("expected 3 arguments to IfcProductRepresentation"); }    do { // convert the 'Name' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcProductRepresentation,3>::aux_is_derived[0]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Name, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcProductRepresentation to be a `IfcLabel`")); }
     } while(0);
     do { // convert the 'Description' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcProductRepresentation,3>::aux_is_derived[1]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Description, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcProductRepresentation to be a `IfcText`")); }
     } while(0);
     do { // convert the 'Representations' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcProductRepresentation,3>::aux_is_derived[2]=true; break; }
         try { GenericConvert( in->Representations, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcProductRepresentation to be a `LIST [1:?] OF IfcRepresentation`")); }
@@ -3414,12 +3414,12 @@ template <> size_t GenericFill<IfcMeasureWithUnit>(const DB& db, const LIST& par
 {
     size_t base = 0;
     if (params.GetSize() < 2) { throw STEP::TypeError("expected 2 arguments to IfcMeasureWithUnit"); }    do { // convert the 'ValueComponent' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->ValueComponent, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcMeasureWithUnit to be a `IfcValue`")); }
     } while(0);
     do { // convert the 'UnitComponent' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->UnitComponent, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcMeasureWithUnit to be a `IfcUnit`")); }
     } while(0);
@@ -3638,7 +3638,7 @@ template <> size_t GenericFill<IfcPolyLoop>(const DB& db, const LIST& params, If
 {
     size_t base = GenericFill(db,params,static_cast<IfcLoop*>(in));
     if (params.GetSize() < 1) { throw STEP::TypeError("expected 1 arguments to IfcPolyLoop"); }    do { // convert the 'Polygon' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Polygon, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcPolyLoop to be a `LIST [3:?] OF IfcCartesianPoint`")); }
     } while(0);
@@ -3649,12 +3649,12 @@ template <> size_t GenericFill<IfcPolygonalBoundedHalfSpace>(const DB& db, const
 {
     size_t base = GenericFill(db,params,static_cast<IfcHalfSpaceSolid*>(in));
     if (params.GetSize() < 4) { throw STEP::TypeError("expected 4 arguments to IfcPolygonalBoundedHalfSpace"); }    do { // convert the 'Position' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Position, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcPolygonalBoundedHalfSpace to be a `IfcAxis2Placement3D`")); }
     } while(0);
     do { // convert the 'PolygonalBoundary' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->PolygonalBoundary, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcPolygonalBoundedHalfSpace to be a `IfcBoundedCurve`")); }
     } while(0);
@@ -3665,7 +3665,7 @@ template <> size_t GenericFill<IfcPolyline>(const DB& db, const LIST& params, If
 {
     size_t base = GenericFill(db,params,static_cast<IfcBoundedCurve*>(in));
     if (params.GetSize() < 1) { throw STEP::TypeError("expected 1 arguments to IfcPolyline"); }    do { // convert the 'Points' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Points, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcPolyline to be a `LIST [2:?] OF IfcCartesianPoint`")); }
     } while(0);
@@ -3676,7 +3676,7 @@ template <> size_t GenericFill<IfcPresentationStyleAssignment>(const DB& db, con
 {
     size_t base = 0;
     if (params.GetSize() < 1) { throw STEP::TypeError("expected 1 arguments to IfcPresentationStyleAssignment"); }    do { // convert the 'Styles' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Styles, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcPresentationStyleAssignment to be a `SET [1:?] OF IfcPresentationStyleSelect`")); }
     } while(0);
@@ -3701,24 +3701,24 @@ template <> size_t GenericFill<IfcProject>(const DB& db, const LIST& params, Ifc
 {
     size_t base = GenericFill(db,params,static_cast<IfcObject*>(in));
     if (params.GetSize() < 9) { throw STEP::TypeError("expected 9 arguments to IfcProject"); }    do { // convert the 'LongName' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->LongName, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 5 to IfcProject to be a `IfcLabel`")); }
     } while(0);
     do { // convert the 'Phase' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Phase, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 6 to IfcProject to be a `IfcLabel`")); }
     } while(0);
     do { // convert the 'RepresentationContexts' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->RepresentationContexts, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 7 to IfcProject to be a `SET [1:?] OF IfcRepresentationContext`")); }
     } while(0);
     do { // convert the 'UnitsInContext' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->UnitsInContext, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 8 to IfcProject to be a `IfcUnitAssignment`")); }
     } while(0);
@@ -3777,12 +3777,12 @@ template <> size_t GenericFill<IfcPropertyListValue>(const DB& db, const LIST& p
 {
     size_t base = GenericFill(db,params,static_cast<IfcSimpleProperty*>(in));
     if (params.GetSize() < 4) { throw STEP::TypeError("expected 4 arguments to IfcPropertyListValue"); }    do { // convert the 'ListValues' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->ListValues, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcPropertyListValue to be a `LIST [1:?] OF IfcValue`")); }
     } while(0);
     do { // convert the 'Unit' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Unit, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcPropertyListValue to be a `IfcUnit`")); }
@@ -3801,7 +3801,7 @@ template <> size_t GenericFill<IfcPropertySet>(const DB& db, const LIST& params,
 {
     size_t base = GenericFill(db,params,static_cast<IfcPropertySetDefinition*>(in));
     if (params.GetSize() < 5) { throw STEP::TypeError("expected 5 arguments to IfcPropertySet"); }    do { // convert the 'HasProperties' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->HasProperties, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 4 to IfcPropertySet to be a `SET [1:?] OF IfcProperty`")); }
     } while(0);
@@ -3812,13 +3812,13 @@ template <> size_t GenericFill<IfcPropertySingleValue>(const DB& db, const LIST&
 {
     size_t base = GenericFill(db,params,static_cast<IfcSimpleProperty*>(in));
     if (params.GetSize() < 4) { throw STEP::TypeError("expected 4 arguments to IfcPropertySingleValue"); }    do { // convert the 'NominalValue' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->NominalValue, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcPropertySingleValue to be a `IfcValue`")); }
     } while(0);
     do { // convert the 'Unit' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Unit, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcPropertySingleValue to be a `IfcUnit`")); }
@@ -3907,13 +3907,13 @@ template <> size_t GenericFill<IfcRectangleProfileDef>(const DB& db, const LIST&
 {
     size_t base = GenericFill(db,params,static_cast<IfcParameterizedProfileDef*>(in));
     if (params.GetSize() < 5) { throw STEP::TypeError("expected 5 arguments to IfcRectangleProfileDef"); }    do { // convert the 'XDim' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcRectangleProfileDef,2>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->XDim, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcRectangleProfileDef to be a `IfcPositiveLengthMeasure`")); }
     } while(0);
     do { // convert the 'YDim' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcRectangleProfileDef,2>::aux_is_derived[1]=true; break; }
         try { GenericConvert( in->YDim, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 4 to IfcRectangleProfileDef to be a `IfcPositiveLengthMeasure`")); }
@@ -3973,13 +3973,13 @@ template <> size_t GenericFill<IfcRelDecomposes>(const DB& db, const LIST& param
 {
     size_t base = GenericFill(db,params,static_cast<IfcRelationship*>(in));
     if (params.GetSize() < 6) { throw STEP::TypeError("expected 6 arguments to IfcRelDecomposes"); }    do { // convert the 'RelatingObject' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcRelDecomposes,2>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->RelatingObject, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 4 to IfcRelDecomposes to be a `IfcObjectDefinition`")); }
     } while(0);
     do { // convert the 'RelatedObjects' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcRelDecomposes,2>::aux_is_derived[1]=true; break; }
         try { GenericConvert( in->RelatedObjects, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 5 to IfcRelDecomposes to be a `SET [1:?] OF IfcObjectDefinition`")); }
@@ -4003,12 +4003,12 @@ template <> size_t GenericFill<IfcRelContainedInSpatialStructure>(const DB& db, 
 {
     size_t base = GenericFill(db,params,static_cast<IfcRelConnects*>(in));
     if (params.GetSize() < 6) { throw STEP::TypeError("expected 6 arguments to IfcRelContainedInSpatialStructure"); }    do { // convert the 'RelatedElements' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->RelatedElements, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 4 to IfcRelContainedInSpatialStructure to be a `SET [1:?] OF IfcProduct`")); }
     } while(0);
     do { // convert the 'RelatingStructure' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->RelatingStructure, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 5 to IfcRelContainedInSpatialStructure to be a `IfcSpatialStructureElement`")); }
     } while(0);
@@ -4019,7 +4019,7 @@ template <> size_t GenericFill<IfcRelDefines>(const DB& db, const LIST& params, 
 {
     size_t base = GenericFill(db,params,static_cast<IfcRelationship*>(in));
     if (params.GetSize() < 5) { throw STEP::TypeError("expected 5 arguments to IfcRelDefines"); }    do { // convert the 'RelatedObjects' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcRelDefines,1>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->RelatedObjects, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 4 to IfcRelDefines to be a `SET [1:?] OF IfcObject`")); }
@@ -4031,7 +4031,7 @@ template <> size_t GenericFill<IfcRelDefinesByProperties>(const DB& db, const LI
 {
     size_t base = GenericFill(db,params,static_cast<IfcRelDefines*>(in));
     if (params.GetSize() < 6) { throw STEP::TypeError("expected 6 arguments to IfcRelDefinesByProperties"); }    do { // convert the 'RelatingPropertyDefinition' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcRelDefinesByProperties,1>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->RelatingPropertyDefinition, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 5 to IfcRelDefinesByProperties to be a `IfcPropertySetDefinition`")); }
@@ -4043,12 +4043,12 @@ template <> size_t GenericFill<IfcRelFillsElement>(const DB& db, const LIST& par
 {
     size_t base = GenericFill(db,params,static_cast<IfcRelConnects*>(in));
     if (params.GetSize() < 6) { throw STEP::TypeError("expected 6 arguments to IfcRelFillsElement"); }    do { // convert the 'RelatingOpeningElement' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->RelatingOpeningElement, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 4 to IfcRelFillsElement to be a `IfcOpeningElement`")); }
     } while(0);
     do { // convert the 'RelatedBuildingElement' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->RelatedBuildingElement, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 5 to IfcRelFillsElement to be a `IfcElement`")); }
     } while(0);
@@ -4066,12 +4066,12 @@ template <> size_t GenericFill<IfcRelVoidsElement>(const DB& db, const LIST& par
 {
     size_t base = GenericFill(db,params,static_cast<IfcRelConnects*>(in));
     if (params.GetSize() < 6) { throw STEP::TypeError("expected 6 arguments to IfcRelVoidsElement"); }    do { // convert the 'RelatingBuildingElement' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->RelatingBuildingElement, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 4 to IfcRelVoidsElement to be a `IfcElement`")); }
     } while(0);
     do { // convert the 'RelatedOpeningElement' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->RelatedOpeningElement, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 5 to IfcRelVoidsElement to be a `IfcFeatureElementSubtraction`")); }
     } while(0);
@@ -4082,27 +4082,27 @@ template <> size_t GenericFill<IfcRepresentation>(const DB& db, const LIST& para
 {
     size_t base = 0;
     if (params.GetSize() < 4) { throw STEP::TypeError("expected 4 arguments to IfcRepresentation"); }    do { // convert the 'ContextOfItems' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcRepresentation,4>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->ContextOfItems, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcRepresentation to be a `IfcRepresentationContext`")); }
     } while(0);
     do { // convert the 'RepresentationIdentifier' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcRepresentation,4>::aux_is_derived[1]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->RepresentationIdentifier, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcRepresentation to be a `IfcLabel`")); }
     } while(0);
     do { // convert the 'RepresentationType' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcRepresentation,4>::aux_is_derived[2]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->RepresentationType, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcRepresentation to be a `IfcLabel`")); }
     } while(0);
     do { // convert the 'Items' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcRepresentation,4>::aux_is_derived[3]=true; break; }
         try { GenericConvert( in->Items, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcRepresentation to be a `SET [1:?] OF IfcRepresentationItem`")); }
@@ -4114,12 +4114,12 @@ template <> size_t GenericFill<IfcRepresentationMap>(const DB& db, const LIST& p
 {
     size_t base = 0;
     if (params.GetSize() < 2) { throw STEP::TypeError("expected 2 arguments to IfcRepresentationMap"); }    do { // convert the 'MappingOrigin' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->MappingOrigin, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcRepresentationMap to be a `IfcAxis2Placement`")); }
     } while(0);
     do { // convert the 'MappedRepresentation' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->MappedRepresentation, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcRepresentationMap to be a `IfcRepresentation`")); }
     } while(0);
@@ -4130,12 +4130,12 @@ template <> size_t GenericFill<IfcRevolvedAreaSolid>(const DB& db, const LIST& p
 {
     size_t base = GenericFill(db,params,static_cast<IfcSweptAreaSolid*>(in));
     if (params.GetSize() < 4) { throw STEP::TypeError("expected 4 arguments to IfcRevolvedAreaSolid"); }    do { // convert the 'Axis' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Axis, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcRevolvedAreaSolid to be a `IfcAxis1Placement`")); }
     } while(0);
     do { // convert the 'Angle' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Angle, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcRevolvedAreaSolid to be a `IfcPlaneAngleMeasure`")); }
     } while(0);
@@ -4181,13 +4181,13 @@ template <> size_t GenericFill<IfcSIUnit>(const DB& db, const LIST& params, IfcS
 {
     size_t base = GenericFill(db,params,static_cast<IfcNamedUnit*>(in));
     if (params.GetSize() < 4) { throw STEP::TypeError("expected 4 arguments to IfcSIUnit"); }    do { // convert the 'Prefix' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Prefix, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcSIUnit to be a `IfcSIPrefix`")); }
     } while(0);
     do { // convert the 'Name' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Name, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcSIUnit to be a `IfcSIUnitName`")); }
     } while(0);
@@ -4247,7 +4247,7 @@ template <> size_t GenericFill<IfcShellBasedSurfaceModel>(const DB& db, const LI
 {
     size_t base = GenericFill(db,params,static_cast<IfcGeometricRepresentationItem*>(in));
     if (params.GetSize() < 1) { throw STEP::TypeError("expected 1 arguments to IfcShellBasedSurfaceModel"); }    do { // convert the 'SbsmBoundary' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->SbsmBoundary, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcShellBasedSurfaceModel to be a `SET [1:?] OF IfcShell`")); }
     } while(0);
@@ -4258,31 +4258,31 @@ template <> size_t GenericFill<IfcSite>(const DB& db, const LIST& params, IfcSit
 {
     size_t base = GenericFill(db,params,static_cast<IfcSpatialStructureElement*>(in));
     if (params.GetSize() < 14) { throw STEP::TypeError("expected 14 arguments to IfcSite"); }    do { // convert the 'RefLatitude' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->RefLatitude, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 9 to IfcSite to be a `IfcCompoundPlaneAngleMeasure`")); }
     } while(0);
     do { // convert the 'RefLongitude' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->RefLongitude, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 10 to IfcSite to be a `IfcCompoundPlaneAngleMeasure`")); }
     } while(0);
     do { // convert the 'RefElevation' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->RefElevation, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 11 to IfcSite to be a `IfcLengthMeasure`")); }
     } while(0);
     do { // convert the 'LandTitleNumber' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->LandTitleNumber, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 12 to IfcSite to be a `IfcLabel`")); }
     } while(0);
     do { // convert the 'SiteAddress' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->SiteAddress, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 13 to IfcSite to be a `IfcPostalAddress`")); }
@@ -4308,12 +4308,12 @@ template <> size_t GenericFill<IfcSpace>(const DB& db, const LIST& params, IfcSp
 {
     size_t base = GenericFill(db,params,static_cast<IfcSpatialStructureElement*>(in));
     if (params.GetSize() < 11) { throw STEP::TypeError("expected 11 arguments to IfcSpace"); }    do { // convert the 'InteriorOrExteriorSpace' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->InteriorOrExteriorSpace, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 9 to IfcSpace to be a `IfcInternalOrExternalEnum`")); }
     } while(0);
     do { // convert the 'ElevationWithFlooring' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->ElevationWithFlooring, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 10 to IfcSpace to be a `IfcLengthMeasure`")); }
@@ -4605,12 +4605,12 @@ template <> size_t GenericFill<IfcSurfaceStyle>(const DB& db, const LIST& params
 {
     size_t base = GenericFill(db,params,static_cast<IfcPresentationStyle*>(in));
     if (params.GetSize() < 3) { throw STEP::TypeError("expected 3 arguments to IfcSurfaceStyle"); }    do { // convert the 'Side' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Side, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcSurfaceStyle to be a `IfcSurfaceSide`")); }
     } while(0);
     do { // convert the 'Styles' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Styles, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcSurfaceStyle to be a `SET [1:5] OF IfcSurfaceStyleElementSelect`")); }
     } while(0);
@@ -4621,7 +4621,7 @@ template <> size_t GenericFill<IfcSurfaceStyleShading>(const DB& db, const LIST&
 {
     size_t base = 0;
     if (params.GetSize() < 1) { throw STEP::TypeError("expected 1 arguments to IfcSurfaceStyleShading"); }    do { // convert the 'SurfaceColour' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::IfcSurfaceStyleShading,1>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->SurfaceColour, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcSurfaceStyleShading to be a `IfcColourRgb`")); }
@@ -4633,49 +4633,49 @@ template <> size_t GenericFill<IfcSurfaceStyleRendering>(const DB& db, const LIS
 {
     size_t base = GenericFill(db,params,static_cast<IfcSurfaceStyleShading*>(in));
     if (params.GetSize() < 9) { throw STEP::TypeError("expected 9 arguments to IfcSurfaceStyleRendering"); }    do { // convert the 'Transparency' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Transparency, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcSurfaceStyleRendering to be a `IfcNormalisedRatioMeasure`")); }
     } while(0);
     do { // convert the 'DiffuseColour' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->DiffuseColour, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcSurfaceStyleRendering to be a `IfcColourOrFactor`")); }
     } while(0);
     do { // convert the 'TransmissionColour' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->TransmissionColour, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcSurfaceStyleRendering to be a `IfcColourOrFactor`")); }
     } while(0);
     do { // convert the 'DiffuseTransmissionColour' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->DiffuseTransmissionColour, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 4 to IfcSurfaceStyleRendering to be a `IfcColourOrFactor`")); }
     } while(0);
     do { // convert the 'ReflectionColour' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->ReflectionColour, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 5 to IfcSurfaceStyleRendering to be a `IfcColourOrFactor`")); }
     } while(0);
     do { // convert the 'SpecularColour' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->SpecularColour, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 6 to IfcSurfaceStyleRendering to be a `IfcColourOrFactor`")); }
     } while(0);
     do { // convert the 'SpecularHighlight' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->SpecularHighlight, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 7 to IfcSurfaceStyleRendering to be a `IfcSpecularHighlightSelect`")); }
     } while(0);
     do { // convert the 'ReflectanceMethod' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->ReflectanceMethod, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 8 to IfcSurfaceStyleRendering to be a `IfcReflectanceMethodEnum`")); }
     } while(0);
@@ -4686,7 +4686,7 @@ template <> size_t GenericFill<IfcSurfaceStyleWithTextures>(const DB& db, const 
 {
     size_t base = 0;
     if (params.GetSize() < 1) { throw STEP::TypeError("expected 1 arguments to IfcSurfaceStyleWithTextures"); }    do { // convert the 'Textures' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Textures, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcSurfaceStyleWithTextures to be a `LIST [1:?] OF IfcSurfaceTexture`")); }
     } while(0);
@@ -4697,28 +4697,28 @@ template <> size_t GenericFill<IfcSweptDiskSolid>(const DB& db, const LIST& para
 {
     size_t base = GenericFill(db,params,static_cast<IfcSolidModel*>(in));
     if (params.GetSize() < 5) { throw STEP::TypeError("expected 5 arguments to IfcSweptDiskSolid"); }    do { // convert the 'Directrix' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Directrix, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcSweptDiskSolid to be a `IfcCurve`")); }
     } while(0);
     do { // convert the 'Radius' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Radius, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcSweptDiskSolid to be a `IfcPositiveLengthMeasure`")); }
     } while(0);
     do { // convert the 'InnerRadius' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->InnerRadius, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcSweptDiskSolid to be a `IfcPositiveLengthMeasure`")); }
     } while(0);
     do { // convert the 'StartParam' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->StartParam, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcSweptDiskSolid to be a `IfcParameterValue`")); }
     } while(0);
     do { // convert the 'EndParam' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->EndParam, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 4 to IfcSweptDiskSolid to be a `IfcParameterValue`")); }
     } while(0);
@@ -4827,27 +4827,27 @@ template <> size_t GenericFill<IfcTrimmedCurve>(const DB& db, const LIST& params
 {
     size_t base = GenericFill(db,params,static_cast<IfcBoundedCurve*>(in));
     if (params.GetSize() < 5) { throw STEP::TypeError("expected 5 arguments to IfcTrimmedCurve"); }    do { // convert the 'BasisCurve' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->BasisCurve, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcTrimmedCurve to be a `IfcCurve`")); }
     } while(0);
     do { // convert the 'Trim1' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Trim1, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcTrimmedCurve to be a `SET [1:2] OF IfcTrimmingSelect`")); }
     } while(0);
     do { // convert the 'Trim2' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Trim2, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcTrimmedCurve to be a `SET [1:2] OF IfcTrimmingSelect`")); }
     } while(0);
     do { // convert the 'SenseAgreement' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->SenseAgreement, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcTrimmedCurve to be a `BOOLEAN`")); }
     } while(0);
     do { // convert the 'MasterRepresentation' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->MasterRepresentation, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 4 to IfcTrimmedCurve to be a `IfcTrimmingPreference`")); }
     } while(0);
@@ -4879,7 +4879,7 @@ template <> size_t GenericFill<IfcUnitAssignment>(const DB& db, const LIST& para
 {
     size_t base = 0;
     if (params.GetSize() < 1) { throw STEP::TypeError("expected 1 arguments to IfcUnitAssignment"); }    do { // convert the 'Units' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Units, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcUnitAssignment to be a `SET [1:?] OF IfcUnit`")); }
     } while(0);
@@ -4904,12 +4904,12 @@ template <> size_t GenericFill<IfcVector>(const DB& db, const LIST& params, IfcV
 {
     size_t base = GenericFill(db,params,static_cast<IfcGeometricRepresentationItem*>(in));
     if (params.GetSize() < 2) { throw STEP::TypeError("expected 2 arguments to IfcVector"); }    do { // convert the 'Orientation' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Orientation, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcVector to be a `IfcDirection`")); }
     } while(0);
     do { // convert the 'Magnitude' argument
-        boost::shared_ptr<const DataType> arg = params[base++];
+        std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Magnitude, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcVector to be a `IfcLengthMeasure`")); }
     } while(0);

--- a/code/IFCUtil.cpp
+++ b/code/IFCUtil.cpp
@@ -75,7 +75,7 @@ aiMesh* TempMesh::ToMesh()
         return NULL;
     }
 
-    std::auto_ptr<aiMesh> mesh(new aiMesh());
+    std::unique_ptr<aiMesh> mesh(new aiMesh());
 
     // copy vertices
     mesh->mNumVertices = static_cast<unsigned int>(verts.size());

--- a/code/IFCUtil.cpp
+++ b/code/IFCUtil.cpp
@@ -115,7 +115,7 @@ void TempMesh::Clear()
 // ------------------------------------------------------------------------------------------------
 void TempMesh::Transform(const IfcMatrix4& mat)
 {
-    BOOST_FOREACH(IfcVector3& v, verts) {
+    for(IfcVector3& v : verts) {
         v *= mat;
     }
 }
@@ -222,7 +222,7 @@ void TempMesh::ComputePolygonNormals(std::vector<IfcVector3>& normals,
     }
 
     if(normalize) {
-        BOOST_FOREACH(IfcVector3& n, normals) {
+        for(IfcVector3& n : normals) {
             n.Normalize();
         }
     }
@@ -383,7 +383,7 @@ void TempMesh::RemoveAdjacentDuplicates()
 
     bool drop = false;
     std::vector<IfcVector3>::iterator base = verts.begin();
-    BOOST_FOREACH(unsigned int& cnt, vertcnt) {
+    for(unsigned int& cnt : vertcnt) {
         if (cnt < 2){
             base += cnt;
             continue;

--- a/code/IFCUtil.h
+++ b/code/IFCUtil.h
@@ -120,8 +120,8 @@ struct TempOpening
     const IFC::IfcSolidModel* solid;
     IfcVector3 extrusionDir;
 
-    boost::shared_ptr<TempMesh> profileMesh;
-    boost::shared_ptr<TempMesh> profileMesh2D;
+    std::shared_ptr<TempMesh> profileMesh;
+    std::shared_ptr<TempMesh> profileMesh2D;
 
     // list of points generated for this opening. This is used to
     // create connections between two opposing holes created
@@ -140,8 +140,8 @@ struct TempOpening
 
     // ------------------------------------------------------------------------------
     TempOpening(const IFC::IfcSolidModel* solid,IfcVector3 extrusionDir,
-        boost::shared_ptr<TempMesh> profileMesh,
-        boost::shared_ptr<TempMesh> profileMesh2D)
+        std::shared_ptr<TempMesh> profileMesh,
+        std::shared_ptr<TempMesh> profileMesh2D)
         : solid(solid)
         , extrusionDir(extrusionDir)
         , profileMesh(profileMesh)

--- a/code/IRRLoader.cpp
+++ b/code/IRRLoader.cpp
@@ -56,8 +56,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "StandardShapes.h"
 #include "Importer.h"
 
-// We need boost::common_factor to compute the lcm/gcd of a number
-#include <boost/math/common_factor_rt.hpp>
+// We need Math.h to compute the lcm/gcd of a number
+#include "Math.h"
 #include <memory>
 #include "../include/assimp/DefaultLogger.hpp"
 #include "../include/assimp/mesh.h"
@@ -402,13 +402,13 @@ void IRRImporter::ComputeAnimations(Node* root, aiNode* real, std::vector<aiNode
                 int lcm = 360;
 
                 if (angles[0])
-                    lcm  = boost::math::lcm(lcm,angles[0]);
+                    lcm  = Math::lcm(lcm,angles[0]);
 
                 if (angles[1])
-                    lcm  = boost::math::lcm(lcm,angles[1]);
+                    lcm  = Math::lcm(lcm,angles[1]);
 
                 if (angles[2])
-                    lcm  = boost::math::lcm(lcm,angles[2]);
+                    lcm  = Math::lcm(lcm,angles[2]);
 
                 if (360 == lcm)
                     break;

--- a/code/IRRLoader.cpp
+++ b/code/IRRLoader.cpp
@@ -56,8 +56,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "StandardShapes.h"
 #include "Importer.h"
 
-// We need Math.h to compute the lcm/gcd of a number
-#include "Math.h"
+// We need MathFunctions.h to compute the lcm/gcd of a number
+#include "MathFunctions.h"
 #include <memory>
 #include "../include/assimp/DefaultLogger.hpp"
 #include "../include/assimp/mesh.h"

--- a/code/IRRLoader.cpp
+++ b/code/IRRLoader.cpp
@@ -58,7 +58,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // We need boost::common_factor to compute the lcm/gcd of a number
 #include <boost/math/common_factor_rt.hpp>
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include "../include/assimp/DefaultLogger.hpp"
 #include "../include/assimp/mesh.h"
 #include "../include/assimp/material.h"
@@ -902,7 +902,7 @@ void IRRImporter::GenerateGraph(Node* root,aiNode* rootOut ,aiScene* scene,
 void IRRImporter::InternReadFile( const std::string& pFile,
     aiScene* pScene, IOSystem* pIOHandler)
 {
-    boost::scoped_ptr<IOStream> file( pIOHandler->Open( pFile));
+    std::unique_ptr<IOStream> file( pIOHandler->Open( pFile));
 
     // Check whether we can read from the file
     if( file.get() == NULL)

--- a/code/IRRMeshLoader.cpp
+++ b/code/IRRMeshLoader.cpp
@@ -48,7 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "IRRMeshLoader.h"
 #include "ParsingUtils.h"
 #include "fast_atof.h"
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include "../include/assimp/IOSystem.hpp"
 #include "../include/assimp/mesh.h"
 #include "../include/assimp/DefaultLogger.hpp"
@@ -121,7 +121,7 @@ const aiImporterDesc* IRRMeshImporter::GetInfo () const
 void IRRMeshImporter::InternReadFile( const std::string& pFile,
     aiScene* pScene, IOSystem* pIOHandler)
 {
-    boost::scoped_ptr<IOStream> file( pIOHandler->Open( pFile));
+    std::unique_ptr<IOStream> file( pIOHandler->Open( pFile));
 
     // Check whether we can read from the file
     if( file.get() == NULL)

--- a/code/Importer.cpp
+++ b/code/Importer.cpp
@@ -77,7 +77,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "Exceptional.h"
 #include "Profiler.h"
 #include <set>
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include <cctype>
 
 #ifndef ASSIMP_BUILD_NO_VALIDATEDS_PROCESS
@@ -612,7 +612,7 @@ const aiScene* Importer::ReadFile( const char* _pFile, unsigned int pFlags)
             return NULL;
         }
 
-        boost::scoped_ptr<Profiler> profiler(GetPropertyInteger(AI_CONFIG_GLOB_MEASURE_TIME,0)?new Profiler():NULL);
+        std::unique_ptr<Profiler> profiler(GetPropertyInteger(AI_CONFIG_GLOB_MEASURE_TIME,0)?new Profiler():NULL);
         if (profiler) {
             profiler->BeginRegion("total");
         }
@@ -785,7 +785,7 @@ const aiScene* Importer::ApplyPostProcessing(unsigned int pFlags)
     }
 #endif // ! DEBUG
 
-    boost::scoped_ptr<Profiler> profiler(GetPropertyInteger(AI_CONFIG_GLOB_MEASURE_TIME,0)?new Profiler():NULL);
+    std::unique_ptr<Profiler> profiler(GetPropertyInteger(AI_CONFIG_GLOB_MEASURE_TIME,0)?new Profiler():NULL);
     for( unsigned int a = 0; a < pimpl->mPostProcessingSteps.size(); a++)   {
 
         BaseProcess* process = pimpl->mPostProcessingSteps[a];
@@ -841,7 +841,7 @@ const aiScene* Importer::ApplyPostProcessing(unsigned int pFlags)
 // ------------------------------------------------------------------------------------------------
 const aiScene* Importer::ApplyCustomizedPostProcessing( BaseProcess *rootProcess, bool requestValidation ) {
     ASSIMP_BEGIN_EXCEPTION_REGION();
-    
+
     // Return immediately if no scene is active
     if ( NULL == pimpl->mScene ) {
         return NULL;
@@ -880,7 +880,7 @@ const aiScene* Importer::ApplyCustomizedPostProcessing( BaseProcess *rootProcess
     }
 #endif // ! DEBUG
 
-    boost::scoped_ptr<Profiler> profiler( GetPropertyInteger( AI_CONFIG_GLOB_MEASURE_TIME, 0 ) ? new Profiler() : NULL );
+    std::unique_ptr<Profiler> profiler( GetPropertyInteger( AI_CONFIG_GLOB_MEASURE_TIME, 0 ) ? new Profiler() : NULL );
 
     if ( profiler ) {
         profiler->BeginRegion( "postprocess" );
@@ -908,7 +908,7 @@ const aiScene* Importer::ApplyCustomizedPostProcessing( BaseProcess *rootProcess
     DefaultLogger::get()->info( "Leaving customized post processing pipeline" );
 
     ASSIMP_END_EXCEPTION_REGION( const aiScene* );
-    
+
     return pimpl->mScene;
 }
 

--- a/code/LWOLoader.cpp
+++ b/code/LWOLoader.cpp
@@ -53,7 +53,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "ByteSwapper.h"
 #include "ProcessHelper.h"
 #include "ConvertToLHProcess.h"
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include "../include/assimp/IOSystem.hpp"
 #include <sstream>
 #include <iomanip>
@@ -139,7 +139,7 @@ void LWOImporter::InternReadFile( const std::string& pFile,
     aiScene* pScene,
     IOSystem* pIOHandler)
 {
-    boost::scoped_ptr<IOStream> file( pIOHandler->Open( pFile, "rb"));
+    std::unique_ptr<IOStream> file( pIOHandler->Open( pFile, "rb"));
 
     // Check whether we can read from the file
     if( file.get() == NULL)

--- a/code/LWSLoader.cpp
+++ b/code/LWSLoader.cpp
@@ -58,7 +58,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "../include/assimp/DefaultLogger.hpp"
 #include "../include/assimp/scene.h"
 #include "../include/assimp/IOSystem.hpp"
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 
 
 using namespace Assimp;
@@ -511,7 +511,7 @@ void LWSImporter::InternReadFile( const std::string& pFile, aiScene* pScene,
     IOSystem* pIOHandler)
 {
     io = pIOHandler;
-    boost::scoped_ptr<IOStream> file( pIOHandler->Open( pFile, "rb"));
+    std::unique_ptr<IOStream> file( pIOHandler->Open( pFile, "rb"));
 
     // Check whether we can read from the file
     if( file.get() == NULL) {

--- a/code/MD2Loader.cpp
+++ b/code/MD2Loader.cpp
@@ -48,7 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "MD2NormalTable.h" // shouldn't be included by other units
 #include "../include/assimp/DefaultLogger.hpp"
 #include "../include/assimp/Importer.hpp"
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include "../include/assimp/IOSystem.hpp"
 #include "../include/assimp/scene.h"
 
@@ -217,7 +217,7 @@ void MD2Importer::ValidateHeader( )
 void MD2Importer::InternReadFile( const std::string& pFile,
     aiScene* pScene, IOSystem* pIOHandler)
 {
-    boost::scoped_ptr<IOStream> file( pIOHandler->Open( pFile));
+    std::unique_ptr<IOStream> file( pIOHandler->Open( pFile));
 
     // Check whether we can read from the file
     if( file.get() == NULL)

--- a/code/MD3Loader.cpp
+++ b/code/MD3Loader.cpp
@@ -58,7 +58,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "ParsingUtils.h"
 #include "Importer.h"
 #include "../include/assimp/DefaultLogger.hpp"
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include "../include/assimp/IOSystem.hpp"
 #include "../include/assimp/material.h"
 #include "../include/assimp/scene.h"
@@ -108,7 +108,7 @@ Q3Shader::BlendFunc StringToBlendFunc(const std::string& m)
 // Load a Quake 3 shader
 bool Q3Shader::LoadShader(ShaderData& fill, const std::string& pFile,IOSystem* io)
 {
-    boost::scoped_ptr<IOStream> file( io->Open( pFile, "rt"));
+    std::unique_ptr<IOStream> file( io->Open( pFile, "rt"));
     if (!file.get())
         return false; // if we can't access the file, don't worry and return
 
@@ -233,7 +233,7 @@ bool Q3Shader::LoadShader(ShaderData& fill, const std::string& pFile,IOSystem* i
 // Load a Quake 3 skin
 bool Q3Shader::LoadSkin(SkinData& fill, const std::string& pFile,IOSystem* io)
 {
-    boost::scoped_ptr<IOStream> file( io->Open( pFile, "rt"));
+    std::unique_ptr<IOStream> file( io->Open( pFile, "rt"));
     if (!file.get())
         return false; // if we can't access the file, don't worry and return
 
@@ -745,7 +745,7 @@ void MD3Importer::InternReadFile( const std::string& pFile,
             return;
     }
 
-    boost::scoped_ptr<IOStream> file( pIOHandler->Open( pFile));
+    std::unique_ptr<IOStream> file( pIOHandler->Open( pFile));
 
     // Check whether we can read from the file
     if( file.get() == NULL)

--- a/code/MD5Loader.cpp
+++ b/code/MD5Loader.cpp
@@ -54,7 +54,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "SkeletonMeshBuilder.h"
 #include "../include/assimp/Importer.hpp"
 #include "../include/assimp/scene.h"
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include "../include/assimp/IOSystem.hpp"
 #include "../include/assimp/DefaultLogger.hpp"
 
@@ -354,7 +354,7 @@ void MD5Importer::AttachChilds_Anim(int iParentID,aiNode* piParent, AnimBoneList
 void MD5Importer::LoadMD5MeshFile ()
 {
     std::string pFile = mFile + "md5mesh";
-    boost::scoped_ptr<IOStream> file( pIOHandler->Open( pFile, "rb"));
+    std::unique_ptr<IOStream> file( pIOHandler->Open( pFile, "rb"));
 
     // Check whether we can read from the file
     if( file.get() == NULL || !file->FileSize())    {
@@ -569,7 +569,7 @@ void MD5Importer::LoadMD5MeshFile ()
 void MD5Importer::LoadMD5AnimFile ()
 {
     std::string pFile = mFile + "md5anim";
-    boost::scoped_ptr<IOStream> file( pIOHandler->Open( pFile, "rb"));
+    std::unique_ptr<IOStream> file( pIOHandler->Open( pFile, "rb"));
 
     // Check whether we can read from the file
     if( !file.get() || !file->FileSize())   {
@@ -681,7 +681,7 @@ void MD5Importer::LoadMD5AnimFile ()
 void MD5Importer::LoadMD5CameraFile ()
 {
     std::string pFile = mFile + "md5camera";
-    boost::scoped_ptr<IOStream> file( pIOHandler->Open( pFile, "rb"));
+    std::unique_ptr<IOStream> file( pIOHandler->Open( pFile, "rb"));
 
     // Check whether we can read from the file
     if( !file.get() || !file->FileSize())   {

--- a/code/MDCLoader.cpp
+++ b/code/MDCLoader.cpp
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "MDCNormalTable.h" // shouldn't be included by other units
 #include "../include/assimp/DefaultLogger.hpp"
 #include "../include/assimp/Importer.hpp"
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include "../include/assimp/IOSystem.hpp"
 #include "../include/assimp/scene.h"
 
@@ -219,7 +219,7 @@ void MDCImporter::SetupProperties(const Importer* pImp)
 void MDCImporter::InternReadFile(
     const std::string& pFile, aiScene* pScene, IOSystem* pIOHandler)
 {
-    boost::scoped_ptr<IOStream> file( pIOHandler->Open( pFile));
+    std::unique_ptr<IOStream> file( pIOHandler->Open( pFile));
 
     // Check whether we can read from the file
     if( file.get() == NULL)

--- a/code/MDLLoader.cpp
+++ b/code/MDLLoader.cpp
@@ -53,7 +53,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "MD2FileData.h"
 #include "StringUtils.h"
 #include "../include/assimp/Importer.hpp"
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include "../include/assimp/IOSystem.hpp"
 #include "../include/assimp/scene.h"
 #include "../include/assimp/DefaultLogger.hpp"
@@ -156,7 +156,7 @@ void MDLImporter::InternReadFile( const std::string& pFile,
 {
     pScene     = _pScene;
     pIOHandler = _pIOHandler;
-    boost::scoped_ptr<IOStream> file( pIOHandler->Open( pFile));
+    std::unique_ptr<IOStream> file( pIOHandler->Open( pFile));
 
     // Check whether we can read from the file
     if( file.get() == NULL) {

--- a/code/Math.h
+++ b/code/Math.h
@@ -1,0 +1,77 @@
+/*
+---------------------------------------------------------------------------
+Open Asset Import Library (assimp)
+---------------------------------------------------------------------------
+
+Copyright (c) 2006-2016, assimp team
+
+All rights reserved.
+
+Redistribution and use of this software in source and binary forms,
+with or without modification, are permitted provided that the following
+conditions are met:
+
+* Redistributions of source code must retain the above
+  copyright notice, this list of conditions and the
+  following disclaimer.
+
+* Redistributions in binary form must reproduce the above
+  copyright notice, this list of conditions and the
+  following disclaimer in the documentation and/or other
+  materials provided with the distribution.
+
+* Neither the name of the assimp team, nor the names of its
+  contributors may be used to endorse or promote products
+  derived from this software without specific prior
+  written permission of the assimp team.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+---------------------------------------------------------------------------
+*/
+
+/** @file  Math.h
+ *  @brief Implementation of the math functions (gcd and lcm)
+ *
+ *  Copied from BoostWorkaround/math
+ */
+
+namespace Assimp {
+namespace Math {
+
+// TODO: use binary GCD for unsigned integers ....
+template < typename IntegerType >
+IntegerType  gcd( IntegerType a, IntegerType b )
+{
+	const IntegerType zero = (IntegerType)0;
+	while ( true )
+	{
+		if ( a == zero )
+			return b;
+		b %= a;
+
+		if ( b == zero )
+			return a;
+		a %= b;
+	}
+}
+
+template < typename IntegerType >
+IntegerType  lcm( IntegerType a, IntegerType b )
+{
+	const IntegerType t = gcd (a,b);
+	if (!t)return t;
+	return a / t * b;
+}
+
+}
+}

--- a/code/MathFunctions.h
+++ b/code/MathFunctions.h
@@ -39,7 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ---------------------------------------------------------------------------
 */
 
-/** @file  Math.h
+/** @file  MathFunctions.h
  *  @brief Implementation of the math functions (gcd and lcm)
  *
  *  Copied from BoostWorkaround/math

--- a/code/NDOLoader.cpp
+++ b/code/NDOLoader.cpp
@@ -50,10 +50,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "../include/assimp/IOSystem.hpp"
 #include "../include/assimp/scene.h"
 #include "StreamReader.h"
-#include <boost/foreach.hpp>
 
 using namespace Assimp;
-#define for_each BOOST_FOREACH
 
 static const aiImporterDesc desc = {
     "Nendo Mesh Importer",
@@ -241,7 +239,7 @@ void NDOImporter::InternReadFile( const std::string& pFile,
     std::vector<aiVector3D> vertices;
     std::vector<unsigned int> indices;
 
-    for_each(const Object& obj,objects) {
+    for(const Object& obj : objects) {
         aiNode* nd = *cc++ = new aiNode(obj.name);
         nd->mParent = root;
 
@@ -250,7 +248,7 @@ void NDOImporter::InternReadFile( const std::string& pFile,
         FaceTable face_table;
 
         unsigned int n = 0;
-        for_each(const Edge& edge, obj.edges) {
+        for(const Edge& edge : obj.edges) {
 
             face_table[edge.edge[2]] = n;
             face_table[edge.edge[3]] = n;
@@ -263,7 +261,7 @@ void NDOImporter::InternReadFile( const std::string& pFile,
 
         vertices.clear();
         vertices.reserve(4 * face_table.size()); // arbitrarily chosen
-        for_each(FaceTable::value_type& v, face_table) {
+        for(FaceTable::value_type& v : face_table) {
             indices.clear();
 
             aiFace& f = *faces++;

--- a/code/NFFLoader.cpp
+++ b/code/NFFLoader.cpp
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "StandardShapes.h"
 #include "fast_atof.h"
 #include "RemoveComments.h"
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include "../include/assimp/IOSystem.hpp"
 #include "../include/assimp/DefaultLogger.hpp"
 #include "../include/assimp/scene.h"
@@ -133,7 +133,7 @@ const aiImporterDesc* NFFImporter::GetInfo () const
 void NFFImporter::LoadNFF2MaterialTable(std::vector<ShadingInfo>& output,
     const std::string& path, IOSystem* pIOHandler)
 {
-    boost::scoped_ptr<IOStream> file( pIOHandler->Open( path, "rb"));
+    std::unique_ptr<IOStream> file( pIOHandler->Open( path, "rb"));
 
     // Check whether we can read from the file
     if( !file.get())    {
@@ -235,7 +235,7 @@ void NFFImporter::LoadNFF2MaterialTable(std::vector<ShadingInfo>& output,
 void NFFImporter::InternReadFile( const std::string& pFile,
     aiScene* pScene, IOSystem* pIOHandler)
 {
-    boost::scoped_ptr<IOStream> file( pIOHandler->Open( pFile, "rb"));
+    std::unique_ptr<IOStream> file( pIOHandler->Open( pFile, "rb"));
 
     // Check whether we can read from the file
     if( !file.get())

--- a/code/OFFLoader.cpp
+++ b/code/OFFLoader.cpp
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "OFFLoader.h"
 #include "ParsingUtils.h"
 #include "fast_atof.h"
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include "../include/assimp/IOSystem.hpp"
 #include "../include/assimp/scene.h"
 #include "../include/assimp/DefaultLogger.hpp"
@@ -109,7 +109,7 @@ const aiImporterDesc* OFFImporter::GetInfo () const
 void OFFImporter::InternReadFile( const std::string& pFile,
     aiScene* pScene, IOSystem* pIOHandler)
 {
-    boost::scoped_ptr<IOStream> file( pIOHandler->Open( pFile, "rb"));
+    std::unique_ptr<IOStream> file( pIOHandler->Open( pFile, "rb"));
 
     // Check whether we can read from the file
     if( file.get() == NULL) {

--- a/code/ObjExporter.cpp
+++ b/code/ObjExporter.cpp
@@ -51,7 +51,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/Exporter.hpp>
 #include <assimp/material.h>
 #include <assimp/scene.h>
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 
 
 using namespace Assimp;
@@ -66,14 +66,14 @@ void ExportSceneObj(const char* pFile,IOSystem* pIOSystem, const aiScene* pScene
 
     // we're still here - export successfully completed. Write both the main OBJ file and the material script
     {
-        boost::scoped_ptr<IOStream> outfile (pIOSystem->Open(pFile,"wt"));
+        std::unique_ptr<IOStream> outfile (pIOSystem->Open(pFile,"wt"));
         if(outfile == NULL) {
             throw DeadlyExportError("could not open output .obj file: " + std::string(pFile));
         }
         outfile->Write( exporter.mOutput.str().c_str(), static_cast<size_t>(exporter.mOutput.tellp()),1);
     }
     {
-        boost::scoped_ptr<IOStream> outfile (pIOSystem->Open(exporter.GetMaterialLibFileName(),"wt"));
+        std::unique_ptr<IOStream> outfile (pIOSystem->Open(exporter.GetMaterialLibFileName(),"wt"));
         if(outfile == NULL) {
             throw DeadlyExportError("could not open output .mtl file: " + std::string(exporter.GetMaterialLibFileName()));
         }

--- a/code/ObjExporter.cpp
+++ b/code/ObjExporter.cpp
@@ -51,7 +51,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/Exporter.hpp>
 #include <assimp/material.h>
 #include <assimp/scene.h>
-#include <boost/foreach.hpp>
 #include <boost/scoped_ptr.hpp>
 
 
@@ -217,7 +216,7 @@ void ObjExporter :: WriteGeometryFile()
     // write vertex positions
     vpMap.getVectors(vp);
     mOutput << "# " << vp.size() << " vertex positions" << endl;
-    BOOST_FOREACH(const aiVector3D& v, vp) {
+    for(const aiVector3D& v : vp) {
         mOutput << "v  " << v.x << " " << v.y << " " << v.z << endl;
     }
     mOutput << endl;
@@ -225,7 +224,7 @@ void ObjExporter :: WriteGeometryFile()
     // write uv coordinates
     vtMap.getVectors(vt);
     mOutput << "# " << vt.size() << " UV coordinates" << endl;
-    BOOST_FOREACH(const aiVector3D& v, vt) {
+    for(const aiVector3D& v : vt) {
         mOutput << "vt " << v.x << " " << v.y << " " << v.z << endl;
     }
     mOutput << endl;
@@ -233,22 +232,22 @@ void ObjExporter :: WriteGeometryFile()
     // write vertex normals
     vnMap.getVectors(vn);
     mOutput << "# " << vn.size() << " vertex normals" << endl;
-    BOOST_FOREACH(const aiVector3D& v, vn) {
+    for(const aiVector3D& v : vn) {
         mOutput << "vn " << v.x << " " << v.y << " " << v.z << endl;
     }
     mOutput << endl;
 
     // now write all mesh instances
-    BOOST_FOREACH(const MeshInstance& m, meshes) {
+    for(const MeshInstance& m : meshes) {
         mOutput << "# Mesh \'" << m.name << "\' with " << m.faces.size() << " faces" << endl;
         if (!m.name.empty()) {
             mOutput << "g " << m.name << endl;
         }
         mOutput << "usemtl " << m.matname << endl;
 
-        BOOST_FOREACH(const Face& f, m.faces) {
+        for(const Face& f : m.faces) {
             mOutput << f.kind << ' ';
-            BOOST_FOREACH(const FaceVertex& fv, f.indices) {
+            for(const FaceVertex& fv : f.indices) {
                 mOutput << ' ' << fv.vp;
 
                 if (f.kind != 'p') {

--- a/code/ObjFileImporter.cpp
+++ b/code/ObjFileImporter.cpp
@@ -46,7 +46,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "ObjFileImporter.h"
 #include "ObjFileParser.h"
 #include "ObjFileData.h"
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include <assimp/Importer.hpp>
 #include <assimp/scene.h>
 #include <assimp/ai_assert.h>
@@ -117,7 +117,7 @@ const aiImporterDesc* ObjFileImporter::GetInfo () const
 void ObjFileImporter::InternReadFile( const std::string &file, aiScene* pScene, IOSystem* pIOHandler) {
     // Read file into memory
     static const std::string mode = "rb";
-    boost::scoped_ptr<IOStream> fileStream( pIOHandler->Open( file, mode));
+    std::unique_ptr<IOStream> fileStream( pIOHandler->Open( file, mode));
     if( !fileStream.get() ) {
         throw DeadlyImportError( "Failed to open file " + file + "." );
     }

--- a/code/OgreBinarySerializer.h
+++ b/code/OgreBinarySerializer.h
@@ -52,7 +52,7 @@ namespace Ogre
 {
 
 typedef Assimp::StreamReaderLE MemoryStreamReader;
-typedef boost::shared_ptr<MemoryStreamReader> MemoryStreamReaderPtr;
+typedef std::shared_ptr<MemoryStreamReader> MemoryStreamReaderPtr;
 
 class OgreBinarySerializer
 {

--- a/code/OgreImporter.cpp
+++ b/code/OgreImporter.cpp
@@ -46,7 +46,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "OgreBinarySerializer.h"
 #include "OgreXmlSerializer.h"
 #include "../include/assimp/Importer.hpp"
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 
 static const aiImporterDesc desc = {
     "Ogre3D Mesh Importer",
@@ -110,7 +110,7 @@ void OgreImporter::InternReadFile(const std::string &pFile, aiScene *pScene, Ass
         MemoryStreamReader reader(f);
 
         // Import mesh
-        boost::scoped_ptr<Mesh> mesh(OgreBinarySerializer::ImportMesh(&reader));
+        std::unique_ptr<Mesh> mesh(OgreBinarySerializer::ImportMesh(&reader));
 
         // Import skeleton
         OgreBinarySerializer::ImportSkeleton(pIOHandler, mesh.get());
@@ -125,12 +125,12 @@ void OgreImporter::InternReadFile(const std::string &pFile, aiScene *pScene, Ass
     else
     {
         /// @note XmlReader does not take ownership of f, hence the scoped ptr.
-        boost::scoped_ptr<IOStream> scopedFile(f);
-        boost::scoped_ptr<CIrrXML_IOStreamReader> xmlStream(new CIrrXML_IOStreamReader(scopedFile.get()));
-        boost::scoped_ptr<XmlReader> reader(irr::io::createIrrXMLReader(xmlStream.get()));
+        std::unique_ptr<IOStream> scopedFile(f);
+        std::unique_ptr<CIrrXML_IOStreamReader> xmlStream(new CIrrXML_IOStreamReader(scopedFile.get()));
+        std::unique_ptr<XmlReader> reader(irr::io::createIrrXMLReader(xmlStream.get()));
 
         // Import mesh
-        boost::scoped_ptr<MeshXml> mesh(OgreXmlSerializer::ImportMesh(reader.get()));
+        std::unique_ptr<MeshXml> mesh(OgreXmlSerializer::ImportMesh(reader.get()));
 
         // Import skeleton
         OgreXmlSerializer::ImportSkeleton(pIOHandler, mesh.get());

--- a/code/OgreMaterial.cpp
+++ b/code/OgreMaterial.cpp
@@ -51,7 +51,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <vector>
 #include <sstream>
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 
 using namespace std;
 
@@ -181,7 +181,7 @@ aiMaterial* OgreImporter::ReadMaterial(const std::string &pFile, Assimp::IOSyste
             return 0;
         }
 
-        boost::scoped_ptr<IOStream> stream(materialFile);
+        std::unique_ptr<IOStream> stream(materialFile);
         if (stream->FileSize() == 0)
         {
             DefaultLogger::get()->warn(Formatter::format() << "Source file for material '" << materialName << "' is empty (size is 0 bytes)");

--- a/code/OgreStructs.h
+++ b/code/OgreStructs.h
@@ -44,7 +44,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef ASSIMP_BUILD_NO_OGRE_IMPORTER
 
 #include "MemoryIOWrapper.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include "../include/assimp/mesh.h"
 #include <map>
 #include <vector>
@@ -76,7 +76,7 @@ class Skeleton;
 
 // Typedefs
 typedef Assimp::MemoryIOStream MemoryStream;
-typedef boost::shared_ptr<MemoryStream> MemoryStreamPtr;
+typedef std::shared_ptr<MemoryStream> MemoryStreamPtr;
 typedef std::map<uint16_t, MemoryStreamPtr> VertexBufferBindings;
 
 // Ogre Vertex Element

--- a/code/OgreXmlSerializer.cpp
+++ b/code/OgreXmlSerializer.cpp
@@ -44,7 +44,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "TinyFormatter.h"
 #include "../include/assimp/DefaultLogger.hpp"
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 
 #ifndef ASSIMP_BUILD_NO_OGRE_IMPORTER
 
@@ -742,12 +742,12 @@ XmlReaderPtr OgreXmlSerializer::OpenReader(Assimp::IOSystem *pIOHandler, const s
         return XmlReaderPtr();
     }
 
-    boost::scoped_ptr<IOStream> file(pIOHandler->Open(filename));
+    std::unique_ptr<IOStream> file(pIOHandler->Open(filename));
     if (!file.get()) {
         throw DeadlyImportError("Failed to open skeleton file " + filename);
     }
 
-    boost::scoped_ptr<CIrrXML_IOStreamReader> stream(new CIrrXML_IOStreamReader(file.get()));
+    std::unique_ptr<CIrrXML_IOStreamReader> stream(new CIrrXML_IOStreamReader(file.get()));
     XmlReaderPtr reader = XmlReaderPtr(irr::io::createIrrXMLReader(stream.get()));
     if (!reader.get()) {
         throw DeadlyImportError("Failed to create XML reader for skeleton file " + filename);

--- a/code/OgreXmlSerializer.h
+++ b/code/OgreXmlSerializer.h
@@ -52,7 +52,7 @@ namespace Ogre
 {
 
 typedef irr::io::IrrXMLReader XmlReader;
-typedef boost::shared_ptr<XmlReader> XmlReaderPtr;
+typedef std::shared_ptr<XmlReader> XmlReaderPtr;
 
 class OgreXmlSerializer
 {

--- a/code/PlyExporter.cpp
+++ b/code/PlyExporter.cpp
@@ -43,7 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #if !defined(ASSIMP_BUILD_NO_EXPORT) && !defined(ASSIMP_BUILD_NO_PLY_EXPORTER)
 
 #include "PlyExporter.h"
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include <cmath>
 #include "Exceptional.h"
 #include "../include/assimp/scene.h"
@@ -64,7 +64,7 @@ void ExportScenePly(const char* pFile,IOSystem* pIOSystem, const aiScene* pScene
     PlyExporter exporter(pFile, pScene);
 
     // we're still here - export successfully completed. Write the file.
-    boost::scoped_ptr<IOStream> outfile (pIOSystem->Open(pFile,"wt"));
+    std::unique_ptr<IOStream> outfile (pIOSystem->Open(pFile,"wt"));
     if(outfile == NULL) {
         throw DeadlyExportError("could not open output .ply file: " + std::string(pFile));
     }
@@ -78,7 +78,7 @@ void ExportScenePlyBinary(const char* pFile, IOSystem* pIOSystem, const aiScene*
     PlyExporter exporter(pFile, pScene, true);
 
     // we're still here - export successfully completed. Write the file.
-    boost::scoped_ptr<IOStream> outfile(pIOSystem->Open(pFile, "wb"));
+    std::unique_ptr<IOStream> outfile(pIOSystem->Open(pFile, "wb"));
     if (outfile == NULL) {
         throw DeadlyExportError("could not open output .ply file: " + std::string(pFile));
     }

--- a/code/PlyLoader.cpp
+++ b/code/PlyLoader.cpp
@@ -48,7 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // internal headers
 #include "PlyLoader.h"
 #include "Macros.h"
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include "../include/assimp/IOSystem.hpp"
 #include "../include/assimp/scene.h"
 
@@ -147,7 +147,7 @@ static bool isBigEndian( const char* szMe ) {
 void PLYImporter::InternReadFile( const std::string& pFile,
     aiScene* pScene, IOSystem* pIOHandler)
 {
-    boost::scoped_ptr<IOStream> file( pIOHandler->Open( pFile));
+    std::unique_ptr<IOStream> file( pIOHandler->Open( pFile));
 
     // Check whether we can read from the file
     if( file.get() == NULL) {

--- a/code/Profiler.h
+++ b/code/Profiler.h
@@ -83,7 +83,7 @@ public:
             return;
         }
 
-        std::chrono::duration<double> elapsedSeconds = std::chrono::system_clock::now() - regions[region];
+        auto elapsedSeconds = std::chrono::system_clock::now() - regions[region];
         DefaultLogger::get()->debug((format("END   `"),region,"`, dt= ", elapsedSeconds.count()," s"));
     }
 

--- a/code/Profiler.h
+++ b/code/Profiler.h
@@ -44,7 +44,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef INCLUDED_PROFILER_H
 #define INCLUDED_PROFILER_H
 
-#include "boost/timer.hpp"
+#include <chrono>
 #include "../include/assimp/DefaultLogger.hpp"
 #include "TinyFormatter.h"
 
@@ -71,7 +71,7 @@ public:
 
     /** Start a named timer */
     void BeginRegion(const std::string& region) {
-        regions[region] = boost::timer();
+        regions[region] = std::chrono::system_clock::now();
         DefaultLogger::get()->debug((format("START `"),region,"`"));
     }
 
@@ -83,12 +83,13 @@ public:
             return;
         }
 
-        DefaultLogger::get()->debug((format("END   `"),region,"`, dt= ",(*it).second.elapsed()," s"));
+        std::chrono::duration<double> elapsedSeconds = std::chrono::system_clock::now() - regions[region];
+        DefaultLogger::get()->debug((format("END   `"),region,"`, dt= ", elapsedSeconds.count()," s"));
     }
 
 private:
 
-    typedef std::map<std::string,boost::timer> RegionMap;
+    typedef std::map<std::string,std::chrono::time_point<std::chrono::system_clock>> RegionMap;
     RegionMap regions;
 };
 

--- a/code/RawLoader.cpp
+++ b/code/RawLoader.cpp
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "RawLoader.h"
 #include "ParsingUtils.h"
 #include "fast_atof.h"
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include "../include/assimp/IOSystem.hpp"
 #include "../include/assimp/DefaultLogger.hpp"
 #include "../include/assimp/scene.h"
@@ -99,7 +99,7 @@ const aiImporterDesc* RAWImporter::GetInfo () const
 void RAWImporter::InternReadFile( const std::string& pFile,
     aiScene* pScene, IOSystem* pIOHandler)
 {
-    boost::scoped_ptr<IOStream> file( pIOHandler->Open( pFile, "rb"));
+    std::unique_ptr<IOStream> file( pIOHandler->Open( pFile, "rb"));
 
     // Check whether we can read from the file
     if( file.get() == NULL) {

--- a/code/SMDLoader.cpp
+++ b/code/SMDLoader.cpp
@@ -52,7 +52,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "SkeletonMeshBuilder.h"
 #include "../include/assimp/Importer.hpp"
 #include "../include/assimp/IOSystem.hpp"
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include "../include/assimp/scene.h"
 #include "../include/assimp/DefaultLogger.hpp"
 
@@ -122,7 +122,7 @@ void SMDImporter::SetupProperties(const Importer* pImp)
 // Imports the given file into the given scene structure.
 void SMDImporter::InternReadFile( const std::string& pFile, aiScene* pScene, IOSystem* pIOHandler)
 {
-    boost::scoped_ptr<IOStream> file( pIOHandler->Open( pFile, "rb"));
+    std::unique_ptr<IOStream> file( pIOHandler->Open( pFile, "rb"));
 
     // Check whether we can read from the file
     if( file.get() == NULL) {

--- a/code/STEPFile.h
+++ b/code/STEPFile.h
@@ -41,7 +41,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef INCLUDED_AI_STEPFILE_H
 #define INCLUDED_AI_STEPFILE_H
 
-#include <boost/noncopyable.hpp>
 #include <bitset>
 #include <memory>
 #include <typeinfo>
@@ -589,13 +588,16 @@ namespace STEP {
     /** A LazyObject is created when needed. Before this happens, we just keep
        the text line that contains the object definition. */
     // -------------------------------------------------------------------------------
-    class LazyObject : public boost::noncopyable
+    class LazyObject
     {
         friend class DB;
     public:
 
         LazyObject(DB& db, uint64_t id, uint64_t line, const char* type,const char* args);
         ~LazyObject();
+
+        LazyObject( LazyObject const& ) = delete;
+        LazyObject operator=( LazyObject const& ) = delete;
 
     public:
 

--- a/code/STEPFile.h
+++ b/code/STEPFile.h
@@ -509,7 +509,7 @@ namespace STEP {
 
         static Object* Construct(const STEP::DB& db, const EXPRESS::LIST& params) {
             // make sure we don't leak if Fill() throws an exception
-            std::auto_ptr<TDerived> impl(new TDerived());
+            std::unique_ptr<TDerived> impl(new TDerived());
 
             // GenericFill<T> is undefined so we need to have a specialization
             const size_t num_args = GenericFill<TDerived>(db,params,&*impl);

--- a/code/STEPFile.h
+++ b/code/STEPFile.h
@@ -42,7 +42,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define INCLUDED_AI_STEPFILE_H
 
 #include <boost/noncopyable.hpp>
-#include <boost/foreach.hpp>
 #include <bitset>
 #include <memory>
 #include <typeinfo>
@@ -868,7 +867,7 @@ namespace STEP {
     public:
 
         ~DB() {
-            BOOST_FOREACH(ObjectMap::value_type& o, objects) {
+            for(ObjectMap::value_type& o : objects) {
                 delete o.second;
             }
         }
@@ -950,7 +949,7 @@ namespace STEP {
 
         // evaluate *all* entities in the file. this is a power test for the loader
         void EvaluateAll() {
-            BOOST_FOREACH(ObjectMap::value_type& e,objects) {
+            for(ObjectMap::value_type& e :objects) {
                 **e.second;
             }
             ai_assert(evaluated_count == objects.size());

--- a/code/STEPFile.h
+++ b/code/STEPFile.h
@@ -598,6 +598,8 @@ namespace STEP {
 
         LazyObject( LazyObject const& ) = delete;
         LazyObject operator=( LazyObject const& ) = delete;
+        LazyObject( LazyObject && ) = delete;
+        LazyObject operator=( LazyObject  && ) = delete;
 
     public:
 

--- a/code/STEPFile.h
+++ b/code/STEPFile.h
@@ -167,7 +167,7 @@ namespace STEP {
         {
         public:
 
-            typedef boost::shared_ptr<const DataType> Out;
+            typedef std::shared_ptr<const DataType> Out;
 
         public:
 
@@ -218,7 +218,7 @@ namespace STEP {
              *
              *  @throw SyntaxError
              */
-            static boost::shared_ptr<const EXPRESS::DataType> Parse(const char*& inout,
+            static std::shared_ptr<const EXPRESS::DataType> Parse(const char*& inout,
                 uint64_t line                           = SyntaxError::LINE_NOT_SPECIFIED,
                 const EXPRESS::ConversionSchema* schema = NULL);
 
@@ -338,7 +338,7 @@ namespace STEP {
         public:
 
             // access a particular list index, throw std::range_error for wrong indices
-            boost::shared_ptr<const DataType> operator[] (size_t index) const {
+            std::shared_ptr<const DataType> operator[] (size_t index) const {
                 return members[index];
             }
 
@@ -349,13 +349,13 @@ namespace STEP {
         public:
 
             /** @see DaraType::Parse */
-            static boost::shared_ptr<const EXPRESS::LIST> Parse(const char*& inout,
+            static std::shared_ptr<const EXPRESS::LIST> Parse(const char*& inout,
                 uint64_t line                           = SyntaxError::LINE_NOT_SPECIFIED,
                 const EXPRESS::ConversionSchema* schema = NULL);
 
 
         private:
-            typedef std::vector< boost::shared_ptr<const DataType> > MemberList;
+            typedef std::vector< std::shared_ptr<const DataType> > MemberList;
             MemberList members;
         };
 
@@ -670,12 +670,12 @@ namespace STEP {
     };
 
     template <typename T>
-    inline bool operator==( boost::shared_ptr<LazyObject> lo, T whatever ) {
+    inline bool operator==( std::shared_ptr<LazyObject> lo, T whatever ) {
         return *lo == whatever; // XXX use std::forward if we have 0x
     }
 
     template <typename T>
-    inline bool operator==( const std::pair<uint64_t, boost::shared_ptr<LazyObject> >& lo, T whatever ) {
+    inline bool operator==( const std::pair<uint64_t, std::shared_ptr<LazyObject> >& lo, T whatever ) {
         return *(lo.second) == whatever; // XXX use std::forward if we have 0x
     }
 
@@ -737,12 +737,12 @@ namespace STEP {
         typedef EXPRESS::ENTITY Type;
     };
 
-    template <> struct PickBaseType< boost::shared_ptr< const EXPRESS::DataType > >;
+    template <> struct PickBaseType< std::shared_ptr< const EXPRESS::DataType > >;
 
     // ------------------------------------------------------------------------------
     template <typename T>
     struct InternGenericConvert {
-        void operator()(T& out, const boost::shared_ptr< const EXPRESS::DataType >& in, const STEP::DB& /*db*/) {
+        void operator()(T& out, const std::shared_ptr< const EXPRESS::DataType >& in, const STEP::DB& /*db*/) {
             try{
                 out = dynamic_cast< const typename PickBaseType<T>::Type& > ( *in );
             }
@@ -753,15 +753,15 @@ namespace STEP {
     };
 
     template <>
-    struct InternGenericConvert< boost::shared_ptr< const EXPRESS::DataType > > {
-        void operator()(boost::shared_ptr< const EXPRESS::DataType >& out, const boost::shared_ptr< const EXPRESS::DataType >& in, const STEP::DB& /*db*/) {
+    struct InternGenericConvert< std::shared_ptr< const EXPRESS::DataType > > {
+        void operator()(std::shared_ptr< const EXPRESS::DataType >& out, const std::shared_ptr< const EXPRESS::DataType >& in, const STEP::DB& /*db*/) {
             out = in;
         }
     };
 
     template <typename T>
     struct InternGenericConvert< Maybe<T> > {
-        void operator()(Maybe<T>& out, const boost::shared_ptr< const EXPRESS::DataType >& in, const STEP::DB& db) {
+        void operator()(Maybe<T>& out, const std::shared_ptr< const EXPRESS::DataType >& in, const STEP::DB& db) {
             GenericConvert((T&)out,in,db);
             out.flag_valid();
         }
@@ -769,7 +769,7 @@ namespace STEP {
 
     template <typename T,uint64_t min_cnt, uint64_t max_cnt>
     struct InternGenericConvertList {
-        void operator()(ListOf<T, min_cnt, max_cnt>& out, const boost::shared_ptr< const EXPRESS::DataType >& inp_base, const STEP::DB& db) {
+        void operator()(ListOf<T, min_cnt, max_cnt>& out, const std::shared_ptr< const EXPRESS::DataType >& inp_base, const STEP::DB& db) {
 
             const EXPRESS::LIST* inp = dynamic_cast<const EXPRESS::LIST*>(inp_base.get());
             if (!inp) {
@@ -800,7 +800,7 @@ namespace STEP {
 
     template <typename T>
     struct InternGenericConvert< Lazy<T> > {
-        void operator()(Lazy<T>& out, const boost::shared_ptr< const EXPRESS::DataType >& in_base, const STEP::DB& db) {
+        void operator()(Lazy<T>& out, const std::shared_ptr< const EXPRESS::DataType >& in_base, const STEP::DB& db) {
             const EXPRESS::ENTITY* in = dynamic_cast<const EXPRESS::ENTITY*>(in_base.get());
             if (!in) {
                 throw TypeError("type error reading entity");
@@ -810,12 +810,12 @@ namespace STEP {
     };
 
     template <typename T1>
-    inline void GenericConvert(T1& a, const boost::shared_ptr< const EXPRESS::DataType >& b, const STEP::DB& db) {
+    inline void GenericConvert(T1& a, const std::shared_ptr< const EXPRESS::DataType >& b, const STEP::DB& db) {
         return InternGenericConvert<T1>()(a,b,db);
     }
 
     template <typename T1,uint64_t N1, uint64_t N2>
-    inline void GenericConvert(ListOf<T1,N1,N2>& a, const boost::shared_ptr< const EXPRESS::DataType >& b, const STEP::DB& db) {
+    inline void GenericConvert(ListOf<T1,N1,N2>& a, const std::shared_ptr< const EXPRESS::DataType >& b, const STEP::DB& db) {
         return InternGenericConvertList<T1,N1,N2>()(a,b,db);
     }
 
@@ -827,7 +827,7 @@ namespace STEP {
     // -------------------------------------------------------------------------------
     class DB
     {
-        friend DB* ReadFileHeader(boost::shared_ptr<IOStream> stream);
+        friend DB* ReadFileHeader(std::shared_ptr<IOStream> stream);
         friend void ReadFile(DB& db,const EXPRESS::ConversionSchema& scheme,
             const char* const* types_to_track, size_t len,
             const char* const* inverse_indices_to_track, size_t len2
@@ -857,7 +857,7 @@ namespace STEP {
 
     private:
 
-        DB(boost::shared_ptr<StreamReaderLE> reader)
+        DB(std::shared_ptr<StreamReaderLE> reader)
             : reader(reader)
             , splitter(*reader,true,true)
             , evaluated_count()
@@ -1012,7 +1012,7 @@ namespace STEP {
         RefMap refs;
         InverseWhitelist inv_whitelist;
 
-        boost::shared_ptr<StreamReaderLE> reader;
+        std::shared_ptr<StreamReaderLE> reader;
         LineSplitter splitter;
 
         uint64_t evaluated_count;

--- a/code/STEPFileEncoding.cpp
+++ b/code/STEPFileEncoding.cpp
@@ -45,7 +45,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "fast_atof.h"
 
 #include "../contrib/ConvertUTF/ConvertUTF.h"
-#include <boost/scoped_array.hpp>
+#include <memory>
 
 using namespace Assimp;
 
@@ -354,7 +354,7 @@ bool STEP::StringToUTF8(std::string& s)
                             }
 
                             const size_t count = (j-basei)/4;
-                            boost::scoped_array<UTF16> src(new UTF16[count]);
+                            std::unique_ptr<UTF16[]> src(new UTF16[count]);
 
                             const char* cur = s.c_str() + basei;
                             for (size_t k = 0; k < count; ++k, cur += 4) {
@@ -363,7 +363,7 @@ bool STEP::StringToUTF8(std::string& s)
                             }
 
                             const size_t dcount = count * 3; // this is enough to hold all possible outputs
-                            boost::scoped_array<UTF8> dest(new UTF8[dcount]);
+                            std::unique_ptr<UTF8[]> dest(new UTF8[dcount]);
 
                             const UTF16* srct = src.get();
                             UTF8* destt = dest.get();
@@ -387,7 +387,7 @@ bool STEP::StringToUTF8(std::string& s)
                             }
 
                             const size_t count = (j-basei)/8;
-                            boost::scoped_array<UTF32> src(new UTF32[count]);
+                            std::unique_ptr<UTF32[]> src(new UTF32[count]);
 
                             const char* cur = s.c_str() + basei;
                             for (size_t k = 0; k < count; ++k, cur += 8) {
@@ -398,7 +398,7 @@ bool STEP::StringToUTF8(std::string& s)
                             }
 
                             const size_t dcount = count * 5; // this is enough to hold all possible outputs
-                            boost::scoped_array<UTF8> dest(new UTF8[dcount]);
+                            std::unique_ptr<UTF8[]> dest(new UTF8[dcount]);
 
                             const UTF32* srct = src.get();
                             UTF8* destt = dest.get();

--- a/code/STEPFileReader.cpp
+++ b/code/STEPFileReader.cpp
@@ -88,7 +88,7 @@ STEP::TypeError::TypeError (const std::string& s,uint64_t entity /* = ENTITY_NOT
 STEP::DB* STEP::ReadFileHeader(boost::shared_ptr<IOStream> stream)
 {
     boost::shared_ptr<StreamReaderLE> reader = boost::shared_ptr<StreamReaderLE>(new StreamReaderLE(stream));
-    std::auto_ptr<STEP::DB> db = std::auto_ptr<STEP::DB>(new STEP::DB(reader));
+    std::unique_ptr<STEP::DB> db = std::unique_ptr<STEP::DB>(new STEP::DB(reader));
 
     LineSplitter& splitter = db->GetSplitter();
     if (!splitter || *splitter != "ISO-10303-21;") {

--- a/code/STEPFileReader.cpp
+++ b/code/STEPFileReader.cpp
@@ -47,7 +47,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "STEPFileEncoding.h"
 #include "TinyFormatter.h"
 #include "fast_atof.h"
-#include <boost/make_shared.hpp>
+#include <memory>
 
 
 using namespace Assimp;
@@ -85,9 +85,9 @@ STEP::TypeError::TypeError (const std::string& s,uint64_t entity /* = ENTITY_NOT
 
 
 // ------------------------------------------------------------------------------------------------
-STEP::DB* STEP::ReadFileHeader(boost::shared_ptr<IOStream> stream)
+STEP::DB* STEP::ReadFileHeader(std::shared_ptr<IOStream> stream)
 {
-    boost::shared_ptr<StreamReaderLE> reader = boost::shared_ptr<StreamReaderLE>(new StreamReaderLE(stream));
+    std::shared_ptr<StreamReaderLE> reader = std::shared_ptr<StreamReaderLE>(new StreamReaderLE(stream));
     std::unique_ptr<STEP::DB> db = std::unique_ptr<STEP::DB>(new STEP::DB(reader));
 
     LineSplitter& splitter = db->GetSplitter();
@@ -110,7 +110,7 @@ STEP::DB* STEP::ReadFileHeader(boost::shared_ptr<IOStream> stream)
         if (s.substr(0,11) == "FILE_SCHEMA") {
             const char* sz = s.c_str()+11;
             SkipSpaces(sz,&sz);
-            boost::shared_ptr< const EXPRESS::DataType > schema = EXPRESS::DataType::Parse(sz);
+            std::shared_ptr< const EXPRESS::DataType > schema = EXPRESS::DataType::Parse(sz);
 
             // the file schema should be a regular list entity, although it usually contains exactly one entry
             // since the list itself is contained in a regular parameter list, we actually have
@@ -300,7 +300,7 @@ void STEP::ReadFile(DB& db,const EXPRESS::ConversionSchema& scheme,
 }
 
 // ------------------------------------------------------------------------------------------------
-boost::shared_ptr<const EXPRESS::DataType> EXPRESS::DataType::Parse(const char*& inout,uint64_t line, const EXPRESS::ConversionSchema* schema /*= NULL*/)
+std::shared_ptr<const EXPRESS::DataType> EXPRESS::DataType::Parse(const char*& inout,uint64_t line, const EXPRESS::ConversionSchema* schema /*= NULL*/)
 {
     const char* cur = inout;
     SkipSpaces(&cur);
@@ -321,7 +321,7 @@ boost::shared_ptr<const EXPRESS::DataType> EXPRESS::DataType::Parse(const char*&
                 std::transform(s.begin(),s.end(),s.begin(),&ToLower<char> );
                 if (schema->IsKnownToken(s)) {
                     for(cur = t+1;*cur++ != '(';);
-                    const boost::shared_ptr<const EXPRESS::DataType> dt = Parse(cur);
+                    const std::shared_ptr<const EXPRESS::DataType> dt = Parse(cur);
                     inout = *cur ? cur+1 : cur;
                     return dt;
                 }
@@ -335,11 +335,11 @@ boost::shared_ptr<const EXPRESS::DataType> EXPRESS::DataType::Parse(const char*&
 
     if (*cur == '*' ) {
         inout = cur+1;
-        return boost::make_shared<EXPRESS::ISDERIVED>();
+        return std::make_shared<EXPRESS::ISDERIVED>();
     }
     else if (*cur == '$' ) {
         inout = cur+1;
-        return boost::make_shared<EXPRESS::UNSET>();
+        return std::make_shared<EXPRESS::UNSET>();
     }
     else if (*cur == '(' ) {
         // start of an aggregate, further parsing is done by the LIST factory constructor
@@ -355,11 +355,11 @@ boost::shared_ptr<const EXPRESS::DataType> EXPRESS::DataType::Parse(const char*&
             }
         }
         inout = cur+1;
-        return boost::make_shared<EXPRESS::ENUMERATION>(std::string(start, static_cast<size_t>(cur-start) ));
+        return std::make_shared<EXPRESS::ENUMERATION>(std::string(start, static_cast<size_t>(cur-start) ));
     }
     else if (*cur == '#' ) {
         // object reference
-        return boost::make_shared<EXPRESS::ENTITY>(strtoul10_64(++cur,&inout));
+        return std::make_shared<EXPRESS::ENTITY>(strtoul10_64(++cur,&inout));
     }
     else if (*cur == '\'' ) {
         // string literal
@@ -393,7 +393,7 @@ boost::shared_ptr<const EXPRESS::DataType> EXPRESS::DataType::Parse(const char*&
             DefaultLogger::get()->error("an error occurred reading escape sequences in ASCII text");
         }
 
-        return boost::make_shared<EXPRESS::STRING>(stemp);
+        return std::make_shared<EXPRESS::STRING>(stemp);
     }
     else if (*cur == '\"' ) {
         throw STEP::SyntaxError("binary data not supported yet",line);
@@ -406,7 +406,7 @@ boost::shared_ptr<const EXPRESS::DataType> EXPRESS::DataType::Parse(const char*&
         if (*cur == '.') {
             double f;
             inout = fast_atoreal_move<double>(start,f);
-            return boost::make_shared<EXPRESS::REAL>(f);
+            return std::make_shared<EXPRESS::REAL>(f);
         }
     }
 
@@ -419,14 +419,14 @@ boost::shared_ptr<const EXPRESS::DataType> EXPRESS::DataType::Parse(const char*&
         ++start;
     }
     int64_t num = static_cast<int64_t>( strtoul10_64(start,&inout) );
-    return boost::make_shared<EXPRESS::INTEGER>(neg?-num:num);
+    return std::make_shared<EXPRESS::INTEGER>(neg?-num:num);
 }
 
 
 // ------------------------------------------------------------------------------------------------
-boost::shared_ptr<const EXPRESS::LIST> EXPRESS::LIST::Parse(const char*& inout,uint64_t line, const EXPRESS::ConversionSchema* schema /*= NULL*/)
+std::shared_ptr<const EXPRESS::LIST> EXPRESS::LIST::Parse(const char*& inout,uint64_t line, const EXPRESS::ConversionSchema* schema /*= NULL*/)
 {
-    const boost::shared_ptr<EXPRESS::LIST> list = boost::make_shared<EXPRESS::LIST>();
+    const std::shared_ptr<EXPRESS::LIST> list = std::make_shared<EXPRESS::LIST>();
     EXPRESS::LIST::MemberList& members = list->members;
 
     const char* cur = inout;
@@ -522,7 +522,7 @@ void STEP::LazyObject::LazyInit() const
     }
 
     const char* acopy = args;
-    boost::shared_ptr<const EXPRESS::LIST> conv_args = EXPRESS::LIST::Parse(acopy,STEP::SyntaxError::LINE_NOT_SPECIFIED,&db.GetSchema());
+    std::shared_ptr<const EXPRESS::LIST> conv_args = EXPRESS::LIST::Parse(acopy,STEP::SyntaxError::LINE_NOT_SPECIFIED,&db.GetSchema());
     delete[] args;
     args = NULL;
 

--- a/code/STEPFileReader.h
+++ b/code/STEPFileReader.h
@@ -50,7 +50,7 @@ namespace STEP {
     // --------------------------------------------------------------------------
     // 1) read file header and return to caller, who checks if the
     //    file is of a supported schema ..
-    DB* ReadFileHeader(boost::shared_ptr<IOStream> stream);
+    DB* ReadFileHeader(std::shared_ptr<IOStream> stream);
     // --------------------------------------------------------------------------
     // 2) read the actual file contents using a user-supplied set of
     //    conversion functions to interpret the data.

--- a/code/STLExporter.cpp
+++ b/code/STLExporter.cpp
@@ -47,7 +47,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "../include/assimp/IOSystem.hpp"
 #include "../include/assimp/scene.h"
 #include "../include/assimp/Exporter.hpp"
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include "Exceptional.h"
 #include "ByteSwapper.h"
 
@@ -62,7 +62,7 @@ void ExportSceneSTL(const char* pFile,IOSystem* pIOSystem, const aiScene* pScene
     STLExporter exporter(pFile, pScene);
 
     // we're still here - export successfully completed. Write the file.
-    boost::scoped_ptr<IOStream> outfile (pIOSystem->Open(pFile,"wt"));
+    std::unique_ptr<IOStream> outfile (pIOSystem->Open(pFile,"wt"));
     if(outfile == NULL) {
         throw DeadlyExportError("could not open output .stl file: " + std::string(pFile));
     }
@@ -75,7 +75,7 @@ void ExportSceneSTLBinary(const char* pFile,IOSystem* pIOSystem, const aiScene* 
     STLExporter exporter(pFile, pScene, true);
 
     // we're still here - export successfully completed. Write the file.
-    boost::scoped_ptr<IOStream> outfile (pIOSystem->Open(pFile,"wb"));
+    std::unique_ptr<IOStream> outfile (pIOSystem->Open(pFile,"wb"));
     if(outfile == NULL) {
         throw DeadlyExportError("could not open output .stl file: " + std::string(pFile));
     }

--- a/code/STLLoader.cpp
+++ b/code/STLLoader.cpp
@@ -48,7 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "STLLoader.h"
 #include "ParsingUtils.h"
 #include "fast_atof.h"
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include "../include/assimp/IOSystem.hpp"
 #include "../include/assimp/scene.h"
 #include "../include/assimp/DefaultLogger.hpp"
@@ -172,7 +172,7 @@ void addFacesToMesh(aiMesh* pMesh)
 void STLImporter::InternReadFile( const std::string& pFile,
     aiScene* pScene, IOSystem* pIOHandler)
 {
-    boost::scoped_ptr<IOStream> file( pIOHandler->Open( pFile, "rb"));
+    std::unique_ptr<IOStream> file( pIOHandler->Open( pFile, "rb"));
 
     // Check whether we can read from the file
     if( file.get() == NULL) {

--- a/code/SplitByBoneCountProcess.cpp
+++ b/code/SplitByBoneCountProcess.cpp
@@ -48,9 +48,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "../include/assimp/DefaultLogger.hpp"
 
 #include <limits>
-#include <boost/format.hpp>
+#include "TinyFormatter.h"
 
 using namespace Assimp;
+using namespace Assimp::Formatter;
 
 // ------------------------------------------------------------------------------------------------
 // Constructor
@@ -95,7 +96,7 @@ void SplitByBoneCountProcess::Execute( aiScene* pScene)
 
     if( !isNecessary )
     {
-        DefaultLogger::get()->debug( boost::str( boost::format( "SplitByBoneCountProcess early-out: no meshes with more than %d bones.") % mMaxBoneCount));
+        DefaultLogger::get()->debug( format() << "SplitByBoneCountProcess early-out: no meshes with more than " << mMaxBoneCount << " bones." );
         return;
     }
 
@@ -143,7 +144,7 @@ void SplitByBoneCountProcess::Execute( aiScene* pScene)
     // recurse through all nodes and translate the node's mesh indices to fit the new mesh array
     UpdateNode( pScene->mRootNode);
 
-    DefaultLogger::get()->debug( boost::str( boost::format( "SplitByBoneCountProcess end: split %d meshes into %d submeshes.") % mSubMeshIndices.size() % meshes.size()));
+    DefaultLogger::get()->debug( format() << "SplitByBoneCountProcess end: split " << mSubMeshIndices.size() << " meshes into " << meshes.size() << " submeshes." );
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -234,7 +235,7 @@ void SplitByBoneCountProcess::SplitMesh( const aiMesh* pMesh, std::vector<aiMesh
         // create a new mesh to hold this subset of the source mesh
         aiMesh* newMesh = new aiMesh;
         if( pMesh->mName.length > 0 )
-            newMesh->mName.Set( boost::str( boost::format( "%s_sub%d") % pMesh->mName.data % poNewMeshes.size()));
+            newMesh->mName.Set( format() << pMesh->mName.data << "_sub" << poNewMeshes.size());
         newMesh->mMaterialIndex = pMesh->mMaterialIndex;
         newMesh->mPrimitiveTypes = pMesh->mPrimitiveTypes;
         poNewMeshes.push_back( newMesh);

--- a/code/StepExporter.cpp
+++ b/code/StepExporter.cpp
@@ -54,7 +54,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <set>
 #include <map>
 #include <list>
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include "Exceptional.h"
 #include "../include/assimp/IOSystem.hpp"
 #include "../include/assimp/scene.h"
@@ -102,7 +102,7 @@ void ExportSceneStep(const char* pFile,IOSystem* pIOSystem, const aiScene* pScen
     StepExporter iDoTheExportThing( pScene, pIOSystem, path, file, &props);
 
     // we're still here - export successfully completed. Write result to the given IOSYstem
-    boost::scoped_ptr<IOStream> outfile (pIOSystem->Open(pFile,"wt"));
+    std::unique_ptr<IOStream> outfile (pIOSystem->Open(pFile,"wt"));
     if(outfile == NULL) {
         throw DeadlyExportError("could not open output .stp file: " + std::string(pFile));
     }

--- a/code/StreamReader.h
+++ b/code/StreamReader.h
@@ -47,7 +47,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "ByteSwapper.h"
 #include "Exceptional.h"
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include "../include/assimp/IOStream.hpp"
 #include "Defines.h"
 
@@ -90,7 +90,7 @@ public:
      *    stream is in little endian byte order. Otherwise the
      *    endianness information is contained in the @c SwapEndianess
      *    template parameter and this parameter is meaningless.  */
-    StreamReader(boost::shared_ptr<IOStream> stream, bool le = false)
+    StreamReader(std::shared_ptr<IOStream> stream, bool le = false)
         : stream(stream)
         , le(le)
     {
@@ -100,7 +100,7 @@ public:
 
     // ---------------------------------------------------------------------
     StreamReader(IOStream* stream, bool le = false)
-        : stream(boost::shared_ptr<IOStream>(stream))
+        : stream(std::shared_ptr<IOStream>(stream))
         , le(le)
     {
         ai_assert(stream);
@@ -339,7 +339,7 @@ private:
 private:
 
 
-    boost::shared_ptr<IOStream> stream;
+    std::shared_ptr<IOStream> stream;
     int8_t *buffer, *current, *end, *limit;
     bool le;
 };

--- a/code/StreamWriter.h
+++ b/code/StreamWriter.h
@@ -48,7 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "ByteSwapper.h"
 #include "../include/assimp/IOStream.hpp"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <vector>
 
 namespace Assimp {
@@ -81,7 +81,7 @@ public:
      *    stream is in little endian byte order. Otherwise the
      *    endianness information is defined by the @c SwapEndianess
      *    template parameter and this parameter is meaningless.  */
-    StreamWriter(boost::shared_ptr<IOStream> stream, bool le = false)
+    StreamWriter(std::shared_ptr<IOStream> stream, bool le = false)
         : stream(stream)
         , le(le)
         , cursor()
@@ -92,7 +92,7 @@ public:
 
     // ---------------------------------------------------------------------
     StreamWriter(IOStream* stream, bool le = false)
-        : stream(boost::shared_ptr<IOStream>(stream))
+        : stream(std::shared_ptr<IOStream>(stream))
         , le(le)
         , cursor()
     {
@@ -212,7 +212,7 @@ private:
 
 private:
 
-    boost::shared_ptr<IOStream> stream;
+    std::shared_ptr<IOStream> stream;
     bool le;
 
     std::vector<uint8_t> buffer;

--- a/code/TriangulateProcess.cpp
+++ b/code/TriangulateProcess.cpp
@@ -64,7 +64,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "TriangulateProcess.h"
 #include "ProcessHelper.h"
 #include "PolyTools.h"
-#include <boost/scoped_array.hpp>
+#include <memory>
 
 //#define AI_BUILD_TRIANGULATE_COLOR_FACE_WINDING
 //#define AI_BUILD_TRIANGULATE_DEBUG_POLYS
@@ -191,8 +191,8 @@ bool TriangulateProcess::TriangulateMesh( aiMesh* pMesh)
 
     const aiVector3D* verts = pMesh->mVertices;
 
-    // use boost::scoped_array to avoid slow std::vector<bool> specialiations
-    boost::scoped_array<bool> done(new bool[max_out]);
+    // use std::unique_ptr to avoid slow std::vector<bool> specialiations
+    std::unique_ptr<bool[]> done(new bool[max_out]);
     for( unsigned int a = 0; a < pMesh->mNumFaces; a++) {
         aiFace& face = pMesh->mFaces[a];
 

--- a/code/UnrealLoader.cpp
+++ b/code/UnrealLoader.cpp
@@ -61,7 +61,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/IOSystem.hpp>
 #include <assimp/scene.h>
 
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 
 using namespace Assimp;
 
@@ -235,7 +235,7 @@ void UnrealImporter::InternReadFile( const std::string& pFile,
     nd->mName.Set("<UnrealRoot>");
 
     // we can live without the uc file if necessary
-    boost::scoped_ptr<IOStream> pb (pIOHandler->Open(uc_path));
+    std::unique_ptr<IOStream> pb (pIOHandler->Open(uc_path));
     if (pb.get())   {
 
         std::vector<char> _data;

--- a/code/ValidateDataStructure.cpp
+++ b/code/ValidateDataStructure.cpp
@@ -51,7 +51,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "BaseImporter.h"
 #include "fast_atof.h"
 #include "ProcessHelper.h"
-#include <boost/scoped_array.hpp>
+#include <memory>
 
 // CRT headers
 #include <stdarg.h>
@@ -463,7 +463,7 @@ void ValidateDSProcess::Validate( const aiMesh* pMesh)
             ReportError("aiMesh::mBones is NULL (aiMesh::mNumBones is %i)",
                 pMesh->mNumBones);
         }
-        boost::scoped_array<float> afSum(NULL);
+        std::unique_ptr<float[]> afSum(nullptr);
         if (pMesh->mNumVertices)
         {
             afSum.reset(new float[pMesh->mNumVertices]);

--- a/code/XFileExporter.cpp
+++ b/code/XFileExporter.cpp
@@ -51,7 +51,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "DefaultIOSystem.h"
 #include <ctime>
 #include <set>
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include "Exceptional.h"
 #include "../include/assimp/IOSystem.hpp"
 #include "../include/assimp/scene.h"
@@ -81,7 +81,7 @@ void ExportSceneXFile(const char* pFile,IOSystem* pIOSystem, const aiScene* pSce
     XFileExporter iDoTheExportThing( pScene, pIOSystem, path, file, &props);
 
     // we're still here - export successfully completed. Write result to the given IOSYstem
-    boost::scoped_ptr<IOStream> outfile (pIOSystem->Open(pFile,"wt"));
+    std::unique_ptr<IOStream> outfile (pIOSystem->Open(pFile,"wt"));
     if(outfile == NULL) {
         throw DeadlyExportError("could not open output .x file: " + std::string(pFile));
     }

--- a/code/XFileImporter.cpp
+++ b/code/XFileImporter.cpp
@@ -52,7 +52,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <memory>
 #include "../include/assimp/scene.h"
 #include "../include/assimp/DefaultLogger.hpp"
-#include <boost/format.hpp>
 #include "Defines.h"
 #include "TinyFormatter.h"
 #include <cctype>

--- a/code/XFileImporter.cpp
+++ b/code/XFileImporter.cpp
@@ -49,7 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "XFileParser.h"
 #include "ConvertToLHProcess.h"
 #include "../include/assimp/IOSystem.hpp"
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include "../include/assimp/scene.h"
 #include "../include/assimp/DefaultLogger.hpp"
 #include <boost/format.hpp>
@@ -111,7 +111,7 @@ const aiImporterDesc* XFileImporter::GetInfo () const
 void XFileImporter::InternReadFile( const std::string& pFile, aiScene* pScene, IOSystem* pIOHandler)
 {
     // read file into memory
-    boost::scoped_ptr<IOStream> file( pIOHandler->Open( pFile));
+    std::unique_ptr<IOStream> file( pIOHandler->Open( pFile));
     if( file.get() == NULL)
         throw DeadlyImportError( "Failed to open file " + pFile + ".");
 

--- a/code/XFileImporter.cpp
+++ b/code/XFileImporter.cpp
@@ -54,11 +54,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "../include/assimp/DefaultLogger.hpp"
 #include <boost/format.hpp>
 #include "Defines.h"
+#include "TinyFormatter.h"
 #include <cctype>
 
 
 
 using namespace Assimp;
+using namespace Assimp::Formatter;
 
 static const aiImporterDesc desc = {
     "Direct3D XFile Importer",
@@ -602,7 +604,7 @@ void XFileImporter::ConvertMaterials( aiScene* pScene, std::vector<XFile::Materi
 
       if( oldMat.sceneIndex == SIZE_MAX )
       {
-        DefaultLogger::get()->warn( boost::str( boost::format( "Could not resolve global material reference \"%s\"") % oldMat.mName));
+        DefaultLogger::get()->warn( format() << "Could not resolve global material reference \"" << oldMat.mName << "\"" );
         oldMat.sceneIndex = 0;
       }
 

--- a/code/XFileParser.cpp
+++ b/code/XFileParser.cpp
@@ -48,7 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "XFileHelper.h"
 #include "fast_atof.h"
 #include "Exceptional.h"
-#include <boost/format.hpp>
+#include "TinyFormatter.h"
 #include <boost/lexical_cast.hpp>
 #include "ByteSwapper.h"
 #include "../include/assimp/DefaultLogger.hpp"
@@ -56,6 +56,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using namespace Assimp;
 using namespace Assimp::XFile;
+using namespace Assimp::Formatter;
 
 #ifndef ASSIMP_BUILD_NO_COMPRESSED_X
 
@@ -129,8 +130,8 @@ XFileParser::XFileParser( const std::vector<char>& pBuffer)
         mIsBinaryFormat = true;
         compressed = true;
     }
-    else ThrowException( boost::str(boost::format("Unsupported xfile format '%c%c%c%c'")
-        % P[8] % P[9] % P[10] % P[11]));
+    else ThrowException( format() << "Unsupported xfile format '" <<
+       P[8] << P[9] << P[10] << P[11] << "'");
 
     // float size
     mBinaryFloatSize = (unsigned int)(P[12] - 48) * 1000
@@ -139,8 +140,7 @@ XFileParser::XFileParser( const std::vector<char>& pBuffer)
         + (unsigned int)(P[15] - 48);
 
     if( mBinaryFloatSize != 32 && mBinaryFloatSize != 64)
-        ThrowException( boost::str( boost::format( "Unknown float size %1% specified in xfile header.")
-            % mBinaryFloatSize));
+        ThrowException( format() << "Unknown float size " << mBinaryFloatSize << " specified in xfile header." );
 
     // The x format specifies size in bits, but we work in bytes
     mBinaryFloatSize /= 8;
@@ -467,7 +467,7 @@ void XFileParser::ParseDataObjectMesh( Mesh* pMesh)
     {
         unsigned int numIndices = ReadInt();
         if( numIndices < 3) {
-            ThrowException( boost::str( boost::format( "Invalid index count %1% for face %2%.") % numIndices % a));
+            ThrowException( format() << "Invalid index count " << numIndices << " for face " << a << "." );
         }
 
         // read indices
@@ -929,7 +929,7 @@ void XFileParser::ParseDataObjectAnimationKey( AnimBone* pAnimBone)
             }
 
             default:
-                ThrowException( boost::str( boost::format( "Unknown key type %1% in animation.") % keyType));
+                ThrowException( format() << "Unknown key type " << keyType << " in animation." );
                 break;
         } // end switch
 
@@ -1444,7 +1444,7 @@ AI_WONT_RETURN void XFileParser::ThrowException( const std::string& pText)
     if( mIsBinaryFormat)
         throw DeadlyImportError( pText);
     else
-        throw DeadlyImportError( boost::str( boost::format( "Line %d: %s") % mLineNumber % pText));
+        throw DeadlyImportError( format() << "Line " << mLineNumber << ": " << pText );
 }
 
 

--- a/code/XFileParser.cpp
+++ b/code/XFileParser.cpp
@@ -49,7 +49,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "fast_atof.h"
 #include "Exceptional.h"
 #include "TinyFormatter.h"
-#include <boost/lexical_cast.hpp>
 #include "ByteSwapper.h"
 #include "../include/assimp/DefaultLogger.hpp"
 
@@ -731,7 +730,7 @@ void XFileParser::ParseDataObjectMaterial( Material* pMaterial)
     std::string matName;
     readHeadOfDataObject( &matName);
     if( matName.empty())
-        matName = std::string( "material") + boost::lexical_cast<std::string>( mLineNumber);
+        matName = std::string( "material") + std::to_string( mLineNumber );
     pMaterial->mName = matName;
     pMaterial->mIsReference = false;
 

--- a/code/XGLLoader.cpp
+++ b/code/XGLLoader.cpp
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "StreamReader.h"
 #include "MemoryIOWrapper.h"
-#include <boost/scoped_ptr.hpp>
+#include <memory>
 #include "../include/assimp/mesh.h"
 #include "../include/assimp/scene.h"
 #include <cctype>
@@ -153,7 +153,7 @@ void XGLImporter::InternReadFile( const std::string& pFile,
 #endif
 
     scene = pScene;
-    boost::shared_ptr<IOStream> stream( pIOHandler->Open( pFile, "rb"));
+    std::shared_ptr<IOStream> stream( pIOHandler->Open( pFile, "rb"));
 
     // check whether we can read from the file
     if( stream.get() == NULL) {
@@ -165,7 +165,7 @@ void XGLImporter::InternReadFile( const std::string& pFile,
 #ifdef ASSIMP_BUILD_NO_COMPRESSED_XGL
         ThrowException("Cannot read ZGL file since Assimp was built without compression support");
 #else
-        boost::scoped_ptr<StreamReaderLE> raw_reader(new StreamReaderLE(stream));
+        std::unique_ptr<StreamReaderLE> raw_reader(new StreamReaderLE(stream));
 
         // build a zlib stream
         z_stream zstream;
@@ -214,7 +214,7 @@ void XGLImporter::InternReadFile( const std::string& pFile,
 
     // construct the irrXML parser
     CIrrXML_IOStreamReader st(stream.get());
-    boost::scoped_ptr<IrrXMLReader> read( createIrrXMLReader((IFileReadCallBack*) &st) );
+    std::unique_ptr<IrrXMLReader> read( createIrrXMLReader((IFileReadCallBack*) &st) );
     reader = read.get();
 
     // parse the XML file

--- a/code/XGLLoader.cpp
+++ b/code/XGLLoader.cpp
@@ -431,7 +431,7 @@ aiNode* XGLImporter::ReadObject(TempScope& scope, bool skipFirst, const char* cl
         }
 
     } catch(...) {
-        BOOST_FOREACH(aiNode* ch, children) {
+        for(aiNode* ch : children) {
             delete ch;
         }
         throw;
@@ -691,7 +691,7 @@ bool XGLImporter::ReadMesh(TempScope& scope)
 
     // finally extract output meshes and add them to the scope
     typedef std::pair<unsigned int, TempMaterialMesh> pairt;
-    BOOST_FOREACH(const pairt& p, bymat) {
+    for(const pairt& p : bymat) {
         aiMesh* const m  = ToOutputMesh(p.second);
         scope.meshes_linear.push_back(m);
 

--- a/code/XGLLoader.h
+++ b/code/XGLLoader.h
@@ -47,7 +47,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "BaseImporter.h"
 #include "irrXMLWrapper.h"
 #include "LogAux.h"
-#include <boost/foreach.hpp>
 #include "../include/assimp/material.h"
 #include "../include/assimp/Importer.hpp"
 #include "../include/assimp/mesh.h"
@@ -102,11 +101,11 @@ private:
 
         ~TempScope()
         {
-            BOOST_FOREACH(aiMesh* m, meshes_linear) {
+            for(aiMesh* m : meshes_linear) {
                 delete m;
             }
 
-            BOOST_FOREACH(aiMaterial* m, materials_linear) {
+            for(aiMaterial* m : materials_linear) {
                 delete m;
             }
 

--- a/code/glTFAsset.h
+++ b/code/glTFAsset.h
@@ -60,7 +60,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <rapidjson/error/en.h>
 
 #ifdef ASSIMP_API
-#   include "boost/shared_ptr.hpp"
+#   include <memory>
 #   include "DefaultIOSystem.h"
 #   include "ByteSwapper.h"
 #else
@@ -90,7 +90,7 @@ namespace glTF
 #ifdef ASSIMP_API
     using Assimp::IOStream;
     using Assimp::IOSystem;
-    using boost::shared_ptr;
+    using std::shared_ptr;
 #else
     using std::shared_ptr;
 
@@ -428,12 +428,12 @@ namespace glTF
         {
 
         };
-        
+
         struct Target
         {
 
         };
-        
+
         struct Sampler
         {
 
@@ -467,7 +467,7 @@ namespace glTF
         void Read(Value& obj, Asset& r);
 
         void LoadFromStream(IOStream& stream, size_t length = 0, size_t baseOffset = 0);
-        
+
         size_t AppendData(uint8_t* data, size_t length);
         void Grow(size_t amount);
 
@@ -476,7 +476,7 @@ namespace glTF
 
         void MarkAsSpecial()
             { mIsSpecial = true; }
-        
+
         bool IsSpecial() const
             { return mIsSpecial; }
     };
@@ -553,7 +553,7 @@ namespace glTF
 
         inline size_t GetDataLength() const
             { return mDataLength; }
-        
+
         inline const uint8_t* GetData() const
             { return mData; }
 

--- a/code/glTFAssetWriter.inl
+++ b/code/glTFAssetWriter.inl
@@ -330,7 +330,7 @@ namespace glTF {
     {
         bool isBinary = mAsset.extensionsUsed.KHR_binary_glTF;
 
-        boost::scoped_ptr<IOStream> outfile
+        std::unique_ptr<IOStream> outfile
             (mAsset.OpenFile(path, isBinary ? "wb" : "wt", true));
 
         if (outfile == 0) {

--- a/code/glTFExporter.cpp
+++ b/code/glTFExporter.cpp
@@ -54,7 +54,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/material.h>
 #include <assimp/scene.h>
 
-#include <boost/foreach.hpp>
 #include <boost/scoped_ptr.hpp>
 #include <boost/shared_ptr.hpp>
 
@@ -130,7 +129,7 @@ glTFExporter::glTFExporter(const char* filename, IOSystem* pIOSystem, const aiSc
 
 
 static void CopyValue(const aiMatrix4x4& v, glTF::mat4& o)
-{ 
+{
     o[ 0] = v.a1; o[ 1] = v.b1; o[ 2] = v.c1; o[ 3] = v.d1;
     o[ 4] = v.a2; o[ 5] = v.b2; o[ 6] = v.c2; o[ 7] = v.d2;
     o[ 8] = v.a3; o[ 9] = v.b3; o[10] = v.c3; o[11] = v.d3;
@@ -233,7 +232,7 @@ void glTFExporter::ExportMaterials()
     for (unsigned int i = 0; i < mScene->mNumMaterials; ++i) {
         const aiMaterial* mat = mScene->mMaterials[i];
 
-        
+
         std::string name;
         if (mat->Get(AI_MATKEY_NAME, aiName) == AI_SUCCESS) {
             name = aiName.C_Str();

--- a/code/glTFExporter.cpp
+++ b/code/glTFExporter.cpp
@@ -54,8 +54,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/material.h>
 #include <assimp/scene.h>
 
-#include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
+#include <memory>
 
 #include "glTFAssetWriter.h"
 
@@ -93,7 +93,7 @@ glTFExporter::glTFExporter(const char* filename, IOSystem* pIOSystem, const aiSc
     , mScene(pScene)
     , mProperties(pProperties)
 {
-    boost::scoped_ptr<Asset> asset(new glTF::Asset(pIOSystem));
+    std::unique_ptr<Asset> asset(new glTF::Asset(pIOSystem));
     mAsset = asset.get();
 
     if (isBinary) {

--- a/code/glTFExporter.h
+++ b/code/glTFExporter.h
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <vector>
 #include <map>
 
-#include "boost/scoped_ptr.hpp"
+#include <memory>
 
 
 struct aiScene;

--- a/code/glTFImporter.cpp
+++ b/code/glTFImporter.cpp
@@ -44,13 +44,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "StringComparison.h"
 
-#include "boost/scoped_ptr.hpp"
-
 #include <assimp/Importer.hpp>
 #include <assimp/scene.h>
 #include <assimp/ai_assert.h>
 #include <assimp/DefaultLogger.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include "glTFAsset.h"
 
@@ -76,7 +74,7 @@ static const aiImporterDesc desc = {
     "gltf glb"
 };
 
-glTFImporter::glTFImporter() 
+glTFImporter::glTFImporter()
 : BaseImporter()
 , meshOffsets()
 , embeddedTexIdxs()
@@ -103,7 +101,7 @@ bool glTFImporter::CanRead(const std::string& pFile, IOSystem* pIOHandler, bool 
     if ((checkSig || !extension.length()) && pIOHandler) {
         char buffer[4];
 
-        boost::scoped_ptr<IOStream> pStream(pIOHandler->Open(pFile));
+        std::unique_ptr<IOStream> pStream(pIOHandler->Open(pFile));
         if (pStream && pStream->Read(buffer, sizeof(buffer), 1) == 1) {
             if (memcmp(buffer, AI_GLB_MAGIC_NUMBER, sizeof(buffer)) == 0) {
                 return true; // Has GLB header
@@ -377,7 +375,7 @@ void glTFImporter::ImportMeshes(glTF::Asset& r)
     }
 
     meshOffsets.push_back(k);
-    
+
     CopyVector(meshes, mScene->mMeshes, mScene->mNumMeshes);
 }
 
@@ -394,7 +392,7 @@ void glTFImporter::ImportCameras(glTF::Asset& r)
         aiCamera* aicam = mScene->mCameras[i] = new aiCamera();
 
         if (cam.type == Camera::Perspective) {
-            
+
             aicam->mAspect        = cam.perspective.aspectRatio;
             aicam->mHorizontalFOV = cam.perspective.yfov * aicam->mAspect;
             aicam->mClipPlaneFar  = cam.perspective.zfar;
@@ -435,7 +433,7 @@ void glTFImporter::ImportLights(glTF::Asset& r)
         CopyValue(l.color, ail->mColorAmbient);
         CopyValue(l.color, ail->mColorDiffuse);
         CopyValue(l.color, ail->mColorSpecular);
-        
+
         ail->mAngleOuterCone = l.falloffAngle;
         ail->mAngleInnerCone = l.falloffExponent; // TODO fix this, it does not look right at all
 
@@ -598,7 +596,7 @@ void glTFImporter::ImportEmbeddedTextures(glTF::Asset& r)
 void glTFImporter::InternReadFile(const std::string& pFile, aiScene* pScene, IOSystem* pIOHandler) {
 
     this->mScene = pScene;
-    
+
     // read the asset file
     glTF::Asset asset(pIOHandler);
     asset.Load(pFile, GetExtension(pFile) == "glb");

--- a/code/irrXMLWrapper.h
+++ b/code/irrXMLWrapper.h
@@ -56,13 +56,13 @@ namespace Assimp    {
  *  Construct IrrXML-Reader in BaseImporter::InternReadFile():
  *  @code
  * // open the file
- * boost::scoped_ptr<IOStream> file( pIOHandler->Open( pFile));
+ * std::unique_ptr<IOStream> file( pIOHandler->Open( pFile));
  * if( file.get() == NULL) {
  *    throw DeadlyImportError( "Failed to open file " + pFile + ".");
  * }
  *
  * // generate a XML reader for it
- * boost::scoped_ptr<CIrrXML_IOStreamReader> mIOWrapper( new CIrrXML_IOStreamReader( file.get()));
+ * std::unique_ptr<CIrrXML_IOStreamReader> mIOWrapper( new CIrrXML_IOStreamReader( file.get()));
  * mReader = irr::io::createIrrXMLReader( mIOWrapper.get());
  * if( !mReader) {
  *    ThrowException( "xxxx: Unable to open file.");

--- a/doc/dox.h
+++ b/doc/dox.h
@@ -1680,7 +1680,7 @@ void xxxxImporter::GetExtensionList(std::set<std::string>& extensions)
 void xxxxImporter::InternReadFile( const std::string& pFile,
 	aiScene* pScene, IOSystem* pIOHandler)
 {
-	boost::scoped_ptr<IOStream> file( pIOHandler->Open( pFile, "rb"));
+	std::unique_ptr<IOStream> file( pIOHandler->Open( pFile, "rb"));
 
 	// Check whether we can read from the file
 	if( file.get() == NULL) {

--- a/include/assimp/defs.h
+++ b/include/assimp/defs.h
@@ -212,31 +212,16 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // "W8059 Packgr��e der Struktur ge�ndert"
 
 #endif
-    //////////////////////////////////////////////////////////////////////////
-    /* Define 'ASSIMP_BUILD_BOOST_WORKAROUND' to compile assimp
-     * without boost. This is done by using a few workaround
-     * classes and brings some limitations (e.g. some logging won't be done,
-     * the library won't utilize threads or be threadsafe at all).
-     * This implies the 'ASSIMP_BUILD_SINGLETHREADED' setting. */
-     //////////////////////////////////////////////////////////////////////////
-#ifdef ASSIMP_BUILD_BOOST_WORKAROUND
 
-    // threading support requires boost
-#ifndef ASSIMP_BUILD_SINGLETHREADED
-#   define ASSIMP_BUILD_SINGLETHREADED
-#endif
-
-#endif // !! ASSIMP_BUILD_BOOST_WORKAROUND
 
     //////////////////////////////////////////////////////////////////////////
     /* Define ASSIMP_BUILD_SINGLETHREADED to compile assimp
      * without threading support. The library doesn't utilize
-     * threads then and is itself not threadsafe.
-     * If this flag is specified boost::threads is *not* required. */
+     * threads then and is itself not threadsafe. */
     //////////////////////////////////////////////////////////////////////////
-#ifndef ASSIMP_BUILD_SINGLETHREADED
-#   define ASSIMP_BUILD_SINGLETHREADED
-#endif
+// #ifndef ASSIMP_BUILD_SINGLETHREADED
+// #   define ASSIMP_BUILD_SINGLETHREADED
+// #endif
 
 #if defined(_DEBUG) || ! defined(NDEBUG)
 #   define ASSIMP_BUILD_DEBUG

--- a/include/assimp/defs.h
+++ b/include/assimp/defs.h
@@ -219,9 +219,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
      * without threading support. The library doesn't utilize
      * threads then and is itself not threadsafe. */
     //////////////////////////////////////////////////////////////////////////
-// #ifndef ASSIMP_BUILD_SINGLETHREADED
-// #   define ASSIMP_BUILD_SINGLETHREADED
-// #endif
+#ifndef ASSIMP_BUILD_SINGLETHREADED
+#   define ASSIMP_BUILD_SINGLETHREADED
+#endif
 
 #if defined(_DEBUG) || ! defined(NDEBUG)
 #   define ASSIMP_BUILD_DEBUG

--- a/test/unit/utNoBoostTest.cpp
+++ b/test/unit/utNoBoostTest.cpp
@@ -44,13 +44,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define ASSIMP_FORCE_NOBOOST
 #include "BoostWorkaround/boost/format.hpp"
+#include "TinyFormatter.h"
 
 
 using namespace std;
 using namespace Assimp;
-
-using boost::format;
-using boost::str;
+using namespace Assimp::Formatter;
 
 // ------------------------------------------------------------------------------------------------
 TEST(NoBoostTest, testFormat)

--- a/tools/assimp_view/AnimEvaluator.cpp
+++ b/tools/assimp_view/AnimEvaluator.cpp
@@ -81,7 +81,7 @@ void AnimEvaluator::Evaluate( double pTime)
         {
             // Look for present frame number. Search from last position if time is after the last time, else from beginning
             // Should be much quicker than always looking from start for the average use case.
-            unsigned int frame = (time >= mLastTime) ? mLastPositions[a].get<0>() : 0;
+            unsigned int frame = (time >= mLastTime) ? std::get<0>(mLastPositions[a]) : 0;
             while( frame < channel->mNumPositionKeys - 1)
             {
                 if( time < channel->mPositionKeys[frame+1].mTime)
@@ -105,14 +105,14 @@ void AnimEvaluator::Evaluate( double pTime)
                 presentPosition = key.mValue;
             }
 
-            mLastPositions[a].get<0>() = frame;
+            std::get<0>(mLastPositions[a]) = frame;
         }
 
         // ******** Rotation *********
         aiQuaternion presentRotation( 1, 0, 0, 0);
         if( channel->mNumRotationKeys > 0)
         {
-            unsigned int frame = (time >= mLastTime) ? mLastPositions[a].get<1>() : 0;
+            unsigned int frame = (time >= mLastTime) ? std::get<1>(mLastPositions[a]) : 0;
             while( frame < channel->mNumRotationKeys - 1)
             {
                 if( time < channel->mRotationKeys[frame+1].mTime)
@@ -136,14 +136,14 @@ void AnimEvaluator::Evaluate( double pTime)
                 presentRotation = key.mValue;
             }
 
-            mLastPositions[a].get<1>() = frame;
+            std::get<1>(mLastPositions[a]) = frame;
         }
 
         // ******** Scaling **********
         aiVector3D presentScaling( 1, 1, 1);
         if( channel->mNumScalingKeys > 0)
         {
-            unsigned int frame = (time >= mLastTime) ? mLastPositions[a].get<2>() : 0;
+            unsigned int frame = (time >= mLastTime) ? std::get<2>(mLastPositions[a]) : 0;
             while( frame < channel->mNumScalingKeys - 1)
             {
                 if( time < channel->mScalingKeys[frame+1].mTime)
@@ -153,7 +153,7 @@ void AnimEvaluator::Evaluate( double pTime)
 
             // TODO: (thom) interpolation maybe? This time maybe even logarithmic, not linear
             presentScaling = channel->mScalingKeys[frame].mValue;
-            mLastPositions[a].get<2>() = frame;
+            std::get<2>(mLastPositions[a]) = frame;
         }
 
         // build a transformation matrix from it

--- a/tools/assimp_view/AnimEvaluator.cpp
+++ b/tools/assimp_view/AnimEvaluator.cpp
@@ -40,6 +40,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "assimp_view.h"
+#include <tuple>
 
 using namespace AssimpView;
 
@@ -49,7 +50,7 @@ AnimEvaluator::AnimEvaluator( const aiAnimation* pAnim)
 {
     mAnim = pAnim;
     mLastTime = 0.0;
-    mLastPositions.resize( pAnim->mNumChannels, boost::make_tuple( 0, 0, 0));
+    mLastPositions.resize( pAnim->mNumChannels, std::make_tuple( 0, 0, 0));
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/tools/assimp_view/AnimEvaluator.h
+++ b/tools/assimp_view/AnimEvaluator.h
@@ -44,6 +44,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define AV_ANIMEVALUATOR_H_INCLUDED
 
 #include <tuple>
+#include <vector>
 
 namespace AssimpView
 {

--- a/tools/assimp_view/AnimEvaluator.h
+++ b/tools/assimp_view/AnimEvaluator.h
@@ -43,7 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef AV_ANIMEVALUATOR_H_INCLUDED
 #define AV_ANIMEVALUATOR_H_INCLUDED
 
-#include <boost/tuple/tuple.hpp>
+#include <tuple>
 
 namespace AssimpView
 {
@@ -80,7 +80,7 @@ protected:
      * Useful to quickly find the corresponding frame for slightly increased time stamps
      */
     double mLastTime;
-    std::vector<boost::tuple<unsigned int, unsigned int, unsigned int> > mLastPositions;
+    std::vector<std::tuple<unsigned int, unsigned int, unsigned int> > mLastPositions;
 
     /** The array to store the transformations results of the evaluation */
     std::vector<aiMatrix4x4> mTransforms;


### PR DESCRIPTION
Resolves Issues:
  - #409
  - #825
  - #826 (used `std::to_string()`)
  - #827
  - #828 (used `std::unique_ptr<T[]>`)
  - #829

I did not remove the BoostWorkaround yet.