### PR TITLE
fix SceneCombiner copy of aiNode not setting mParent field

### DIFF
--- a/code/SceneCombiner.cpp
+++ b/code/SceneCombiner.cpp
@@ -1211,6 +1211,11 @@ void SceneCombiner::Copy     (aiNode** _dest, const aiNode* src)
     // and reallocate all arrays
     GetArrayCopy( dest->mMeshes, dest->mNumMeshes );
     CopyPtrArray( dest->mChildren, src->mChildren,dest->mNumChildren);
+
+	// need to set the mParent fields to the created aiNode.
+	for( unsigned int i = 0; i < dest->mNumChildren; i ++ ) {
+		dest->mChildren[i]->mParent = dest;
+	}
 }
 
 // ------------------------------------------------------------------------------------------------


### PR DESCRIPTION
After performing a deep copy of a scene, the mParent fields of the nodes of the new scene were pointing to the nodes of the original scene.