### PR TITLE
Added 'joint' node type to Collada export

### DIFF
--- a/code/ColladaExporter.cpp
+++ b/code/ColladaExporter.cpp
@@ -1016,7 +1016,7 @@ void ColladaExporter::WriteSceneLibrary()
 
     // start recursive write at the root node
     for( size_t a = 0; a < mScene->mRootNode->mNumChildren; ++a )
-        WriteNode( mScene->mRootNode->mChildren[a]);
+        WriteNode( mScene, mScene->mRootNode->mChildren[a]);
 
     PopTag();
     mOutput << startstr << "</visual_scene>" << endstr;
@@ -1025,10 +1025,25 @@ void ColladaExporter::WriteSceneLibrary()
 }
 
 // ------------------------------------------------------------------------------------------------
+// Helper to find a bone by name in the scene
+aiBone* findBone( const aiScene* scene, const char * name) {
+    for (size_t m=0; m<scene->mNumMeshes; m++) {
+        aiMesh * mesh = scene->mMeshes[m];
+        for (size_t b=0; b<mesh->mNumBones; b++) {
+            aiBone * bone = mesh->mBones[b];
+            if (0 == strcmp(name, bone->mName.C_Str())) {
+                return bone;
+            }
+        }
+    }
+    return NULL;
+}
+
+// ------------------------------------------------------------------------------------------------
 // Recursively writes the given node
-void ColladaExporter::WriteNode(aiNode* pNode)
+void ColladaExporter::WriteNode( const aiScene* pScene, aiNode* pNode)
 {
-    // the must have a name
+    // the node must have a name
     if (pNode->mName.length == 0)
     {
         std::stringstream ss;
@@ -1036,8 +1051,21 @@ void ColladaExporter::WriteNode(aiNode* pNode)
         pNode->mName.Set(ss.str());
     }
 
+    // If the node is associated with a bone, it is a joint node (JOINT)
+    // otherwise it is a normal node (NODE)
+    const char * node_type;
+    if (NULL == findBone(pScene, pNode->mName.C_Str())) {
+        node_type = "NODE";
+    } else {
+        node_type = "JOINT";
+    }
+
     const std::string node_name_escaped = XMLEscape(pNode->mName.data);
-    mOutput << startstr << "<node id=\"" << node_name_escaped << "\" name=\"" << node_name_escaped << "\">" << endstr;
+    mOutput << startstr 
+            << "<node id=\"" << node_name_escaped 
+            << "\" name=\"" << node_name_escaped 
+            << "\" type=\"" << node_type
+            << "\">" << endstr;
     PushTag();
 
     // write transformation - we can directly put the matrix there
@@ -1102,7 +1130,7 @@ void ColladaExporter::WriteNode(aiNode* pNode)
 
     // recurse into subnodes
     for( size_t a = 0; a < pNode->mNumChildren; ++a )
-        WriteNode( pNode->mChildren[a]);
+        WriteNode( pScene, pNode->mChildren[a]);
 
     PopTag();
     mOutput << startstr << "</node>" << endstr;

--- a/code/ColladaExporter.h
+++ b/code/ColladaExporter.h
@@ -114,7 +114,7 @@ protected:
     void WriteSceneLibrary();
 
     /// Recursively writes the given node
-    void WriteNode( aiNode* pNode);
+    void WriteNode( const aiScene* scene, aiNode* pNode);
 
     /// Enters a new xml element, which increases the indentation
     void PushTag() { startstr.append( "  "); }


### PR DESCRIPTION
Allows skeleton information to be exported to Collada by adding the node 'type' field with options 'NODE" and 'JOINT'.