### PR TITLE
Fix compilation of iOS static libraries

### DIFF
--- a/contrib/rapidjson/include/rapidjson/document.h
+++ b/contrib/rapidjson/include/rapidjson/document.h
@@ -557,7 +557,7 @@ public:
             flags_ |= kIntFlag;
     }
 
-#if !defined(__x86_64__)
+#if !defined(__x86_64__) && !defined(__arm64__)
     //! Constructor for size_t value.
     explicit GenericValue( size_t u ) RAPIDJSON_NOEXCEPT : data_(), flags_( kNumberUintFlag ) {
         data_.n.u64 = u;

--- a/port/iOS/build.sh
+++ b/port/iOS/build.sh
@@ -22,6 +22,8 @@ CPP_DEV_TARGET_LIST=(miphoneos-version-min mios-simulator-version-min)
 CPP_DEV_TARGET=
 CPP_STD_LIB_LIST=(libc++ libstdc++)
 CPP_STD_LIB=
+CPP_STD_LIST=(c++03 c++11 c++14)
+CPP_STD=
 
 function join { local IFS="$1"; shift; echo "$*"; }
 
@@ -46,7 +48,7 @@ build_arch()
     export CFLAGS="-arch $1 -pipe -no-cpp-precomp -stdlib=$CPP_STD_LIB -isysroot $SDKROOT -$CPP_DEV_TARGET=$IOS_SDK_TARGET -I$SDKROOT/usr/include/"
     export LDFLAGS="-L$SDKROOT/usr/lib/"
     export CPPFLAGS=$CFLAGS
-    export CXXFLAGS=$CFLAGS
+    export CXXFLAGS="$CFLAGS -std=$CPP_STD"
 
     rm CMakeCache.txt
 
@@ -65,11 +67,16 @@ build_arch()
 echo "[!] $0 - assimp iOS build script"
 
 CPP_STD_LIB=${CPP_STD_LIB_LIST[0]}
+CPP_STD=${CPP_STD_LIST[0]}
 DEPLOY_ARCHS=${BUILD_ARCHS_ALL[*]}
 DEPLOY_FAT=1
 
 for i in "$@"; do
     case $i in
+    -s=*|--std=*)
+        CPP_STD=`echo $i | sed 's/[-a-zA-Z0-9]*=//'`
+        echo "[!] Selecting c++ standard: $CPP_STD"
+    ;;
     -l=*|--stdlib=*)
         CPP_STD_LIB=`echo $i | sed 's/[-a-zA-Z0-9]*=//'`
         echo "[!] Selecting c++ std lib: $CPP_STD_LIB"
@@ -85,7 +92,8 @@ for i in "$@"; do
     -h|--help)
         echo " - don't build fat library (--no-fat)."
         echo " - supported architectures (--archs):  $(echo $(join , ${BUILD_ARCHS_ALL[*]}) | sed 's/,/, /g')"
-        echo " - supported C++ STD libs. (--stdlib): $(echo $(join , ${CPP_STD_LIB_LIST[*]}) | sed 's/,/, /g')"
+        echo " - supported C++ STD libs (--stdlib): $(echo $(join , ${CPP_STD_LIB_LIST[*]}) | sed 's/,/, /g')"
+        echo " - supported C++ standards (--std): $(echo $(join , ${CPP_STD_LIST[*]}) | sed 's/,/, /g')"
         exit
     ;;
     *)


### PR DESCRIPTION
This fixes two different issues when generating iOS static libs.

1. Building for any targets using clang-703.0.31 failed with multiple errors. Using c++11 or c++14 as -std builds successfully for me. Added option to change the -std via command line, even though I still don't understand why c++03 is supposed to work.
2. Building for arm64 failed compilation due to duplicate constructors in rapidjson's document.h.

This is the command I used to build (from ports/iOS): $ ./build.sh --archs="x86_64 arm64"
Compiler version: Apple LLVM version 7.3.0 (clang-703.0.31)
