### PR TITLE
Allowing to enable building of zlib manually through CMake option.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Open Asset Import Library (assimp)
 # ----------------------------------------------------------------------
-# 
+#
 # Copyright (c) 2006-2016, assimp team
 # All rights reserved.
 #
@@ -175,7 +175,15 @@ ENDIF( CMAKE_COMPILER_IS_GNUCXX )
 
 # Search for external dependencies, and build them from source if not found
 # Search for zlib
-find_package(ZLIB)
+OPTION(ASSIMP_BUILD_ZLIB
+    "Build your own zlib"
+    OFF
+)
+
+IF ( NOT ASSIMP_BUILD_ZLIB )
+    find_package(ZLIB)
+ENDIF(ASSIMP_BUILD_ZLIB)
+
 IF( NOT ZLIB_FOUND )
   message(STATUS "compiling zlib from souces")
   include(CheckIncludeFile)
@@ -278,7 +286,7 @@ IF ( ASSIMP_BUILD_ASSIMP_TOOLS )
       ADD_SUBDIRECTORY( tools/assimp_view/ )
     ENDIF ( ASSIMP_BUILD_ASSIMP_VIEW )
   ENDIF ( WIN32 )
-  
+
   ADD_SUBDIRECTORY( tools/assimp_cmd/ )
 ENDIF ( ASSIMP_BUILD_ASSIMP_TOOLS )
 


### PR DESCRIPTION
Currently, `assimp`'s `cmake` automatically tries to find `zlib` and reverts to building an internal version if the library was not found. There is no easy option to force the internal build to go ahead. Preventing the `find_package(zlib)` call can also be useful to use another, externally build zlib version when embedding `assimp` into a larger project.