### PR TITLE
setting default export precision to 17 for all exporters

### DIFF
--- a/code/ColladaExporter.cpp
+++ b/code/ColladaExporter.cpp
@@ -94,7 +94,7 @@ ColladaExporter::ColladaExporter( const aiScene* pScene, IOSystem* pIOSystem, co
 {
     // make sure that all formatting happens using the standard, C locale and not the user's current locale
     mOutput.imbue( std::locale("C") );
-    mOutput.precision(17);
+    mOutput.precision(16);
 
     mScene = pScene;
     mSceneOwned = false;

--- a/code/ColladaExporter.cpp
+++ b/code/ColladaExporter.cpp
@@ -94,6 +94,7 @@ ColladaExporter::ColladaExporter( const aiScene* pScene, IOSystem* pIOSystem, co
 {
     // make sure that all formatting happens using the standard, C locale and not the user's current locale
     mOutput.imbue( std::locale("C") );
+    mOutput.precision(17);
 
     mScene = pScene;
     mSceneOwned = false;
@@ -1061,9 +1062,9 @@ void ColladaExporter::WriteNode( const aiScene* pScene, aiNode* pNode)
     }
 
     const std::string node_name_escaped = XMLEscape(pNode->mName.data);
-    mOutput << startstr 
-            << "<node id=\"" << node_name_escaped 
-            << "\" name=\"" << node_name_escaped 
+    mOutput << startstr
+            << "<node id=\"" << node_name_escaped
+            << "\" name=\"" << node_name_escaped
             << "\" type=\"" << node_type
             << "\">" << endstr;
     PushTag();

--- a/code/ObjExporter.cpp
+++ b/code/ObjExporter.cpp
@@ -94,7 +94,9 @@ ObjExporter :: ObjExporter(const char* _filename, const aiScene* pScene)
     // make sure that all formatting happens using the standard, C locale and not the user's current locale
     const std::locale& l = std::locale("C");
     mOutput.imbue(l);
+    mOutput.precision(17);
     mOutputMat.imbue(l);
+    mOutputMat.precision(17);
 
     WriteGeometryFile();
     WriteMaterialFile();

--- a/code/ObjExporter.cpp
+++ b/code/ObjExporter.cpp
@@ -94,9 +94,9 @@ ObjExporter :: ObjExporter(const char* _filename, const aiScene* pScene)
     // make sure that all formatting happens using the standard, C locale and not the user's current locale
     const std::locale& l = std::locale("C");
     mOutput.imbue(l);
-    mOutput.precision(17);
+    mOutput.precision(16);
     mOutputMat.imbue(l);
-    mOutputMat.precision(17);
+    mOutputMat.precision(16);
 
     WriteGeometryFile();
     WriteMaterialFile();

--- a/code/PlyExporter.cpp
+++ b/code/PlyExporter.cpp
@@ -99,7 +99,7 @@ PlyExporter::PlyExporter(const char* _filename, const aiScene* pScene, bool bina
     // make sure that all formatting happens using the standard, C locale and not the user's current locale
     const std::locale& l = std::locale("C");
     mOutput.imbue(l);
-    mOutput.precision(17);
+    mOutput.precision(16);
 
     unsigned int faces = 0u, vertices = 0u, components = 0u;
     for (unsigned int i = 0; i < pScene->mNumMeshes; ++i) {

--- a/code/PlyExporter.cpp
+++ b/code/PlyExporter.cpp
@@ -99,6 +99,7 @@ PlyExporter::PlyExporter(const char* _filename, const aiScene* pScene, bool bina
     // make sure that all formatting happens using the standard, C locale and not the user's current locale
     const std::locale& l = std::locale("C");
     mOutput.imbue(l);
+    mOutput.precision(17);
 
     unsigned int faces = 0u, vertices = 0u, components = 0u;
     for (unsigned int i = 0; i < pScene->mNumMeshes; ++i) {

--- a/code/STLExporter.cpp
+++ b/code/STLExporter.cpp
@@ -94,6 +94,7 @@ STLExporter :: STLExporter(const char* _filename, const aiScene* pScene, bool bi
     // make sure that all formatting happens using the standard, C locale and not the user's current locale
     const std::locale& l = std::locale("C");
     mOutput.imbue(l);
+    mOutput.precision(17);
     if (binary) {
         char buf[80] = {0} ;
         buf[0] = 'A'; buf[1] = 's'; buf[2] = 's'; buf[3] = 'i'; buf[4] = 'm'; buf[5] = 'p';

--- a/code/STLExporter.cpp
+++ b/code/STLExporter.cpp
@@ -94,7 +94,7 @@ STLExporter :: STLExporter(const char* _filename, const aiScene* pScene, bool bi
     // make sure that all formatting happens using the standard, C locale and not the user's current locale
     const std::locale& l = std::locale("C");
     mOutput.imbue(l);
-    mOutput.precision(17);
+    mOutput.precision(16);
     if (binary) {
         char buf[80] = {0} ;
         buf[0] = 'A'; buf[1] = 's'; buf[2] = 's'; buf[3] = 'i'; buf[4] = 'm'; buf[5] = 'p';

--- a/code/StepExporter.cpp
+++ b/code/StepExporter.cpp
@@ -146,6 +146,7 @@ StepExporter::StepExporter(const aiScene* pScene, IOSystem* pIOSystem, const std
 
     // make sure that all formatting happens using the standard, C locale and not the user's current locale
     mOutput.imbue( std::locale("C") );
+    mOutput.precision(17);
 
     // start writing
     WriteFile();
@@ -158,7 +159,9 @@ void StepExporter::WriteFile()
     // see http://shodhganga.inflibnet.ac.in:8080/jspui/bitstream/10603/14116/11/11_chapter%203.pdf
     // note, that all realnumber values must be comma separated in x files
     mOutput.setf(std::ios::fixed);
-    mOutput.precision(16); // precission for double
+    // precission for double
+    // see http://stackoverflow.com/questions/554063/how-do-i-print-a-double-value-with-full-precision-using-cout
+    mOutput.precision(17);
 
     // standard color
     aiColor4D fColor;
@@ -365,4 +368,3 @@ void StepExporter::WriteFile()
 
 #endif
 #endif
-

--- a/code/StepExporter.cpp
+++ b/code/StepExporter.cpp
@@ -146,7 +146,7 @@ StepExporter::StepExporter(const aiScene* pScene, IOSystem* pIOSystem, const std
 
     // make sure that all formatting happens using the standard, C locale and not the user's current locale
     mOutput.imbue( std::locale("C") );
-    mOutput.precision(17);
+    mOutput.precision(16);
 
     // start writing
     WriteFile();
@@ -161,7 +161,7 @@ void StepExporter::WriteFile()
     mOutput.setf(std::ios::fixed);
     // precission for double
     // see http://stackoverflow.com/questions/554063/how-do-i-print-a-double-value-with-full-precision-using-cout
-    mOutput.precision(17);
+    mOutput.precision(16);
 
     // standard color
     aiColor4D fColor;

--- a/code/XFileExporter.cpp
+++ b/code/XFileExporter.cpp
@@ -104,7 +104,7 @@ XFileExporter::XFileExporter(const aiScene* pScene, IOSystem* pIOSystem, const s
 {
     // make sure that all formatting happens using the standard, C locale and not the user's current locale
     mOutput.imbue( std::locale("C") );
-    mOutput.precision(17);
+    mOutput.precision(16);
 
     // start writing
     WriteFile();
@@ -125,7 +125,7 @@ void XFileExporter::WriteFile()
 {
     // note, that all realnumber values must be comma separated in x files
     mOutput.setf(std::ios::fixed);
-    mOutput.precision(17); // precission for double
+    mOutput.precision(16); // precission for double
 
     // entry of writing the file
     WriteHeader();

--- a/code/XFileExporter.cpp
+++ b/code/XFileExporter.cpp
@@ -104,6 +104,7 @@ XFileExporter::XFileExporter(const aiScene* pScene, IOSystem* pIOSystem, const s
 {
     // make sure that all formatting happens using the standard, C locale and not the user's current locale
     mOutput.imbue( std::locale("C") );
+    mOutput.precision(17);
 
     // start writing
     WriteFile();
@@ -124,7 +125,7 @@ void XFileExporter::WriteFile()
 {
     // note, that all realnumber values must be comma separated in x files
     mOutput.setf(std::ios::fixed);
-    mOutput.precision(16); // precission for double
+    mOutput.precision(17); // precission for double
 
     // entry of writing the file
     WriteHeader();
@@ -529,4 +530,3 @@ void XFileExporter::writePath(aiString path)
 
 #endif
 #endif
-


### PR DESCRIPTION
It appears like a good idea to increase the export precision to a consistent number (discussed below), so (`stl`, `obj`, `ply`, etc) exporters are not cutting values of the models. Currently, some exporters did define higher precisions, but most did not - this will fix that and ensure you don't loose too much precision upon export. _It may be a good idea to also allow double precision in general (#638)._

_from: http://stackoverflow.com/questions/554063/how-do-i-print-a-double-value-with-full-precision-using-cout_

> The precision needs to be 17 (or std::numeric_limits<double>::digits10 + 2) because 2 extra digits are needed when converting from decimal back to the binary representation to ensure the value is rounded to the same original value. Here is a paper with some details: http://docs.oracle.com/cd/E19957-01/806-3568/ncg_goldberg.html
> 
> [C++11 introduces max_digits10](http://www2.open-std.org/JTC1/SC22/WG21/docs/papers/2005/n1822.pdf) to denote the same.

