### PR TITLE
FIX: Fixed UB for aiMatrix4x4t<TReal>::operator[]

### DIFF
--- a/include/assimp/matrix4x4.inl
+++ b/include/assimp/matrix4x4.inl
@@ -243,8 +243,7 @@ inline TReal* aiMatrix4x4t<TReal>::operator[](unsigned int p_iIndex) {
         return NULL;
     }
 
-    // XXX this is UB. Has been for years. The fact that it works now does not make it better.
-    return &this->a1 + p_iIndex * 4;
+    return &(&a1)[p_iIndex];
 }
 
 // ----------------------------------------------------------------------------------------
@@ -254,8 +253,7 @@ inline const TReal* aiMatrix4x4t<TReal>::operator[](unsigned int p_iIndex) const
         return NULL;
     }
 
-    // XXX same
-    return &this->a1 + p_iIndex * 4;
+    return &(&a1)[p_iIndex];
 }
 
 // ----------------------------------------------------------------------------------------


### PR DESCRIPTION
I was trying to use the operator[] in my code but it did not work. I saw your comment and fixed the issue. See commit message. 