### PR TITLE
Fix blender vertex colors being negative, and fix blender vertex colors scaling to be 0 to 1

### DIFF
--- a/code/BlenderDNA.inl
+++ b/code/BlenderDNA.inl
@@ -532,7 +532,7 @@ template <typename T> struct signless;
 template <> struct signless<char> {typedef unsigned char type;};
 template <> struct signless<short> {typedef unsigned short type;};
 template <> struct signless<int> {typedef unsigned int type;};
-
+template <> struct signless<unsigned char> { typedef unsigned char type; };
 template <typename T>
 struct static_cast_silent {
     template <typename V>
@@ -613,6 +613,22 @@ template <> inline void Structure :: Convert<char>   (char& dest,const FileDatab
     }
     ConvertDispatcher(dest,*this,db);
 }
+
+// ------------------------------------------------------------------------------------------------
+template <> inline void Structure::Convert<unsigned char>(unsigned char& dest, const FileDatabase& db) const
+{
+	// automatic rescaling from char to float and vice versa (seems useful for RGB colors)
+	if (name == "float") {
+		dest = static_cast<unsigned char>(db.reader->GetF4() * 255.f);
+		return;
+	}
+	else if (name == "double") {
+		dest = static_cast<unsigned char>(db.reader->GetF8() * 255.f);
+		return;
+	}
+	ConvertDispatcher(dest, *this, db);
+}
+
 
 // ------------------------------------------------------------------------------------------------
 template <> inline void Structure :: Convert<float>  (float& dest,const FileDatabase& db) const

--- a/code/BlenderLoader.cpp
+++ b/code/BlenderLoader.cpp
@@ -1118,7 +1118,7 @@ void BlenderImporter::ConvertMesh(const Scene& /*in*/, const Object* /*obj*/, co
             const aiFace& f = out->mFaces[out->mNumFaces++];
 
             aiColor4D* vo = &out->mColors[0][out->mNumVertices];
-			const ai_real scaleZeroToOne = 1.f / 255.f;
+			const ai_real scaleZeroToOne = 1.f/255.f;
             for (unsigned int j = 0; j < f.mNumIndices; ++j,++vo,++out->mNumVertices) {
                 const MLoopCol& col = mesh->mloopcol[v.loopstart + j];
                 vo->r = ai_real(col.r) * scaleZeroToOne;

--- a/code/BlenderLoader.cpp
+++ b/code/BlenderLoader.cpp
@@ -1118,13 +1118,13 @@ void BlenderImporter::ConvertMesh(const Scene& /*in*/, const Object* /*obj*/, co
             const aiFace& f = out->mFaces[out->mNumFaces++];
 
             aiColor4D* vo = &out->mColors[0][out->mNumVertices];
-			const float scaleZeroToOne = 1.f / 255.f;
+			const ai_real scaleZeroToOne = 1.f / 255.f;
             for (unsigned int j = 0; j < f.mNumIndices; ++j,++vo,++out->mNumVertices) {
                 const MLoopCol& col = mesh->mloopcol[v.loopstart + j];
-                vo->r = float(col.r) * scaleZeroToOne;
-                vo->g = float(col.g) * scaleZeroToOne;
-                vo->b = float(col.b) * scaleZeroToOne;
-                vo->a = float(col.a) * scaleZeroToOne;
+                vo->r = ai_real(col.r) * scaleZeroToOne;
+                vo->g = ai_real(col.g) * scaleZeroToOne;
+                vo->b = ai_real(col.b) * scaleZeroToOne;
+                vo->a = ai_real(col.a) * scaleZeroToOne;
             }
 
         }

--- a/code/BlenderLoader.cpp
+++ b/code/BlenderLoader.cpp
@@ -1118,12 +1118,13 @@ void BlenderImporter::ConvertMesh(const Scene& /*in*/, const Object* /*obj*/, co
             const aiFace& f = out->mFaces[out->mNumFaces++];
 
             aiColor4D* vo = &out->mColors[0][out->mNumVertices];
+			const float scaleZeroToOne = 1.f / 255.f;
             for (unsigned int j = 0; j < f.mNumIndices; ++j,++vo,++out->mNumVertices) {
                 const MLoopCol& col = mesh->mloopcol[v.loopstart + j];
-                vo->r = col.r;
-                vo->g = col.g;
-                vo->b = col.b;
-                vo->a = col.a;
+                vo->r = float(col.r) * scaleZeroToOne;
+                vo->g = float(col.g) * scaleZeroToOne;
+                vo->b = float(col.b) * scaleZeroToOne;
+                vo->a = float(col.a) * scaleZeroToOne;
             }
 
         }

--- a/code/BlenderScene.h
+++ b/code/BlenderScene.h
@@ -175,7 +175,7 @@ struct MLoopUV : ElemBase {
 // -------------------------------------------------------------------------------
 // Note that red and blue are not swapped, as with MCol
 struct MLoopCol : ElemBase {
-    char r, g, b, a;
+	unsigned char r, g, b, a;
 };
 
 // -------------------------------------------------------------------------------

--- a/contrib/openddlparser/code/OpenDDLExport.cpp
+++ b/contrib/openddlparser/code/OpenDDLExport.cpp
@@ -280,7 +280,7 @@ bool OpenDDLExport::writeValueType( Value::ValueType type, size_t numItems, std:
         statement += "[";
         char buffer[ 256 ];
         ::memset( buffer, '\0', 256 * sizeof( char ) );
-        sprintf( buffer, "%d", numItems );
+        sprintf( buffer, "%d", int(numItems) );
         statement += buffer;
         statement += "]";
     }


### PR DESCRIPTION
Blender vertex color was importing as negative values. This was because it was being converted to a signed char. Needed to be unsigned.

Also aiColor4 specifies that the color will be 0 to 1, but blender importer was dumping out -128 to +127. Rescaled it so that it is now 0 to 1