### PR TITLE
Fixes a few build issues with MSVC 2015 and gcc

### DIFF
--- a/code/PlyExporter.cpp
+++ b/code/PlyExporter.cpp
@@ -56,11 +56,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 //using namespace Assimp;
 namespace Assimp    {
 
-// make sure typeof returns consistent output across different platforms
+// make sure type_of returns consistent output across different platforms
 // also consider using: typeid(VAR).name()
-template <typename T> const char* typeof(T&) { return "unknown"; }
-template<> const char* typeof(float&) { return "float"; }
-template<> const char* typeof(double&) { return "double"; }
+template <typename T> const char* type_of(T&) { return "unknown"; }
+template<> const char* type_of(float&) { return "float"; }
+template<> const char* type_of(double&) { return "double"; }
 
 // ------------------------------------------------------------------------------------------------
 // Worker function for exporting a scene to PLY. Prototyped and registered in Exporter.cpp
@@ -146,7 +146,7 @@ PlyExporter::PlyExporter(const char* _filename, const aiScene* pScene, bool bina
     //       definitely not good to always write float even if we might have double precision
 
     ai_real tmp = 0.0;
-    const char * typeName = typeof(tmp);
+    const char * typeName = type_of(tmp);
 
     mOutput << "element vertex " << vertices << endl;
     mOutput << "property " << typeName << " x" << endl;

--- a/include/assimp/types.h
+++ b/include/assimp/types.h
@@ -216,7 +216,7 @@ struct aiColor3D
 
     /** Check whether a color is black */
     bool IsBlack() const {
-        static const ai_real epsilon = 10e-3;
+        static const ai_real epsilon = ai_real(10e-3);
         return std::fabs( r ) < epsilon && std::fabs( g ) < epsilon && std::fabs( b ) < epsilon;
     }
 


### PR DESCRIPTION
There are still a whole bunch of `conversion from 'double' to 'ai_real', possible loss of data` warnings on MSVC2015, but the first commit fix already removes many.
The second fix a prevent a collision with the gcc "keyword" `typeof` by renaming it to `type_of`.