### PR TITLE
Fixed library to use less memory when loading and processing models.

### DIFF
--- a/code/3DSConverter.cpp
+++ b/code/3DSConverter.cpp
@@ -388,10 +388,12 @@ void Discreet3DSImporter::ConvertMeshes(aiScene* pcOut)
 
             // convert vertices
             meshOut->mNumFaces = (unsigned int)aiSplit[p].size();
+            meshOut->mNumIndices = meshOut->mNumFaces * 3;
             meshOut->mNumVertices = meshOut->mNumFaces*3;
 
             // allocate enough storage for faces
             meshOut->mFaces = new aiFace[meshOut->mNumFaces];
+            meshOut->mIndices = new unsigned int[meshOut->mNumIndices];
             iFaceCnt += meshOut->mNumFaces;
 
             meshOut->mVertices = new aiVector3D[meshOut->mNumVertices];
@@ -405,7 +407,7 @@ void Discreet3DSImporter::ConvertMeshes(aiScene* pcOut)
                 unsigned int index = aiSplit[p][q];
                 aiFace& face = meshOut->mFaces[q];
 
-                face.mIndices = new unsigned int[3];
+                face.mIndices = q * 3;
                 face.mNumIndices = 3;
 
                 for (unsigned int a = 0; a < 3;++a,++base)
@@ -417,7 +419,7 @@ void Discreet3DSImporter::ConvertMeshes(aiScene* pcOut)
                     if ((*i).mTexCoords.size())
                         meshOut->mTextureCoords[0][base] = (*i).mTexCoords[idx];
 
-                    face.mIndices[a] = base;
+                    meshOut->mIndices[face.mIndices + a] = base;
                 }
             }
         }

--- a/code/3DSExporter.cpp
+++ b/code/3DSExporter.cpp
@@ -488,7 +488,7 @@ void Discreet3DSExporter::WriteMeshes()
 
                 for (unsigned int j = 0; j < 3; ++j) {
                     ai_assert(f.mIndices[j] <= 0xffff);
-                    writer.PutI2(static_cast<uint16_t>(f.mIndices[j]));
+                    writer.PutI2(static_cast<uint16_t>(mesh.mIndices[f.mIndices + j]));
                 }
 
                 // Edge visibility flag

--- a/code/ASELoader.cpp
+++ b/code/ASELoader.cpp
@@ -988,12 +988,14 @@ void ASEImporter::ConvertMeshes(ASE::Mesh& mesh, std::vector<aiMesh*>& avOutMesh
                 // convert vertices
                 p_pcOut->mNumVertices = (unsigned int)aiSplit[p].size()*3;
                 p_pcOut->mNumFaces = (unsigned int)aiSplit[p].size();
+                p_pcOut->mNumIndices = p_pcOut->mNumFaces * 3;
 
                 // receive output vertex weights
                 std::vector<std::pair<unsigned int, float> > *avOutputBones = NULL;
                 if (!mesh.mBones.empty())   {
                     avOutputBones = new std::vector<std::pair<unsigned int, float> >[mesh.mBones.size()];
                 }
+                p_pcOut->mIndices = new unsigned int[p_pcOut->mNumIndices];
 
                 // allocate enough storage for faces
                 p_pcOut->mFaces = new aiFace[p_pcOut->mNumFaces];
@@ -1006,7 +1008,7 @@ void ASEImporter::ConvertMeshes(ASE::Mesh& mesh, std::vector<aiMesh*>& avOutMesh
 
                         iIndex = aiSplit[p][q];
 
-                        p_pcOut->mFaces[q].mIndices = new unsigned int[3];
+                        p_pcOut->mFaces[q].mIndices = q * 3;
                         p_pcOut->mFaces[q].mNumIndices = 3;
 
                         for (unsigned int t = 0; t < 3;++t, ++iBase)    {
@@ -1030,7 +1032,7 @@ void ASEImporter::ConvertMeshes(ASE::Mesh& mesh, std::vector<aiMesh*>& avOutMesh
                                     }
                                 }
                             }
-                            p_pcOut->mFaces[q].mIndices[t] = iBase;
+                            p_pcOut->mIndices[p_pcOut->mFaces[q].mIndices + t] = iBase;
                         }
                     }
                 }
@@ -1125,10 +1127,12 @@ void ASEImporter::ConvertMeshes(ASE::Mesh& mesh, std::vector<aiMesh*>& avOutMesh
         if (mesh.mFaces.empty() || mesh.mPositions.empty()) {
             return;
         }
+        p_pcOut->mNumIndices = p_pcOut->mNumFaces * 3;
 
         // convert vertices
         p_pcOut->mNumVertices = (unsigned int)mesh.mPositions.size();
         p_pcOut->mNumFaces = (unsigned int)mesh.mFaces.size();
+        p_pcOut->mIndices = new unsigned int[p_pcOut->mNumIndices];
 
         // allocate enough storage for faces
         p_pcOut->mFaces = new aiFace[p_pcOut->mNumFaces];
@@ -1165,12 +1169,12 @@ void ASEImporter::ConvertMeshes(ASE::Mesh& mesh, std::vector<aiMesh*>& avOutMesh
         // copy faces
         for (unsigned int iFace = 0; iFace < p_pcOut->mNumFaces;++iFace)    {
             p_pcOut->mFaces[iFace].mNumIndices = 3;
-            p_pcOut->mFaces[iFace].mIndices = new unsigned int[3];
+            p_pcOut->mFaces[iFace].mIndices = iFace * 3;
 
             // copy indices
-            p_pcOut->mFaces[iFace].mIndices[0] = mesh.mFaces[iFace].mIndices[0];
-            p_pcOut->mFaces[iFace].mIndices[1] = mesh.mFaces[iFace].mIndices[1];
-            p_pcOut->mFaces[iFace].mIndices[2] = mesh.mFaces[iFace].mIndices[2];
+            p_pcOut->mIndices[p_pcOut->mFaces[iFace].mIndices + 0] = mesh.mFaces[iFace].mIndices[0];
+            p_pcOut->mIndices[p_pcOut->mFaces[iFace].mIndices + 1] = mesh.mFaces[iFace].mIndices[1];
+            p_pcOut->mIndices[p_pcOut->mFaces[iFace].mIndices + 2] = mesh.mFaces[iFace].mIndices[2];
         }
 
         // copy vertex bones

--- a/code/AssbinExporter.cpp
+++ b/code/AssbinExporter.cpp
@@ -472,7 +472,7 @@ inline size_t WriteArray(IOStream * stream, const T* in, unsigned int size)
                         hash = SuperFastHash(reinterpret_cast<const char*>(&tmp),sizeof tmp,hash);
                         for (unsigned int i = 0; i < f.mNumIndices; ++i) {
                             static_assert(AI_MAX_VERTICES <= 0xffffffff, "AI_MAX_VERTICES <= 0xffffffff");
-                            tmp = static_cast<uint32_t>( f.mIndices[i] );
+                            tmp = static_cast<uint32_t>( mesh->mIndices[f.mIndices + i] );
                             hash = SuperFastHash(reinterpret_cast<const char*>(&tmp),sizeof tmp,hash);
                         }
                     }
@@ -490,9 +490,9 @@ inline size_t WriteArray(IOStream * stream, const T* in, unsigned int size)
 
                     for (unsigned int a = 0; a < f.mNumIndices;++a) {
                         if (mesh->mNumVertices < (1u<<16)) {
-                            Write<uint16_t>(&chunk,f.mIndices[a]);
+                            Write<uint16_t>(&chunk, mesh->mIndices[f.mIndices + a]);
                         }
-                        else Write<unsigned int>(&chunk,f.mIndices[a]);
+                        else Write<unsigned int>(&chunk, mesh->mIndices[f.mIndices + a]);
                     }
                 }
             }

--- a/code/AssbinLoader.cpp
+++ b/code/AssbinLoader.cpp
@@ -347,24 +347,29 @@ void AssbinImporter::ReadBinaryMesh( IOStream * stream, aiMesh* mesh )
     {
         // if there are less than 2^16 vertices, we can simply use 16 bit integers ...
         mesh->mFaces = new aiFace[mesh->mNumFaces];
+        std::vector<unsigned int> indices;
         for (unsigned int i = 0; i < mesh->mNumFaces;++i) {
             aiFace& f = mesh->mFaces[i];
 
             static_assert(AI_MAX_FACE_INDICES <= 0xffff, "AI_MAX_FACE_INDICES <= 0xffff");
             f.mNumIndices = Read<uint16_t>(stream);
-            f.mIndices = new unsigned int[f.mNumIndices];
+            f.mIndices = (unsigned int)indices.size();
 
             for (unsigned int a = 0; a < f.mNumIndices;++a) {
                 if (mesh->mNumVertices < (1u<<16))
                 {
-                    f.mIndices[a] = Read<uint16_t>(stream);
+                    indices.push_back(Read<uint16_t>(stream));
                 }
                 else
                 {
-                    f.mIndices[a] = Read<unsigned int>(stream);
+                    indices.push_back(Read<unsigned int>(stream));
                 }
             }
         }
+
+        mesh->mNumIndices = (unsigned int)indices.size();
+        mesh->mIndices = new unsigned int[mesh->mNumIndices];
+        std::copy(indices.begin(), indices.end(), mesh->mIndices);
     }
 
     // write bones

--- a/code/AssxmlExporter.cpp
+++ b/code/AssxmlExporter.cpp
@@ -516,7 +516,7 @@ void WriteDump(const aiScene* scene, IOStream* io, bool shortened) {
                         "\t\t\t\t",f.mNumIndices);
 
                     for (unsigned int j = 0; j < f.mNumIndices;++j)
-                        ioprintf(io,"%i ",f.mIndices[j]);
+                        ioprintf(io,"%i ",mesh->mIndices[f.mIndices + j]);
 
                     ioprintf(io,"\n\t\t\t</Face>\n");
                 }

--- a/code/B3DImporter.cpp
+++ b/code/B3DImporter.cpp
@@ -378,6 +378,7 @@ void B3DImporter::ReadTRIS( int v0 ){
 
     int n_tris=ChunkSize()/12;
     aiFace *face=mesh->mFaces=new aiFace[n_tris];
+    mesh->mIndices = new unsigned int[n_tris * 3];
 
     for( int i=0;i<n_tris;++i ){
         int i0=ReadInt()+v0;
@@ -391,10 +392,10 @@ void B3DImporter::ReadTRIS( int v0 ){
             continue;
         }
         face->mNumIndices=3;
-        face->mIndices=new unsigned[3];
-        face->mIndices[0]=i0;
-        face->mIndices[1]=i1;
-        face->mIndices[2]=i2;
+        face->mIndices=i*3;
+        mesh->mIndices[face->mIndices + 0]=i0;
+        mesh->mIndices[face->mIndices + 1]=i1;
+        mesh->mIndices[face->mIndices + 2]=i2;
         ++mesh->mNumFaces;
         ++face;
     }
@@ -614,13 +615,13 @@ void B3DImporter::ReadBB3D( aiScene *scene ){
 
             for( int i=0;i<n_verts;i+=3 ){
                 for( int j=0;j<3;++j ){
-                    Vertex &v=_vertices[face->mIndices[j]];
+                    Vertex &v=_vertices[mesh->mIndices[face->mIndices + j]];
 
                     *mv++=v.vertex;
                     if( mn ) *mn++=v.normal;
                     if( mc ) *mc++=v.texcoords;
 
-                    face->mIndices[j]=i+j;
+                    mesh->mIndices[face->mIndices + j]=i+j;
 
                     for( int k=0;k<4;++k ){
                         if( !v.weights[k] ) break;

--- a/code/BlenderLoader.cpp
+++ b/code/BlenderLoader.cpp
@@ -849,8 +849,10 @@ void BlenderImporter::ConvertMesh(const Scene& /*in*/, const Object* /*obj*/, co
         out->mNormals  = new aiVector3D[per_mat_verts[it.first]];
 
         //out->mNumFaces = 0
+        //out->mNumIndices = 0
         //out->mNumVertices = 0
         out->mFaces = new aiFace[it.second]();
+        out->mIndices = new unsigned int[per_mat_verts[it.first]];
 
         // all submeshes created from this mesh are named equally. this allows
         // curious users to recover the original adjacency.
@@ -890,7 +892,8 @@ void BlenderImporter::ConvertMesh(const Scene& /*in*/, const Object* /*obj*/, co
         aiMesh* const out = temp[ mat_num_to_mesh_idx[ mf.mat_nr ] ];
         aiFace& f = out->mFaces[out->mNumFaces++];
 
-        f.mIndices = new unsigned int[ f.mNumIndices = mf.v4?4:3 ];
+        f.mNumIndices = mf.v4 ? 4 : 3;
+        f.mIndices = out->mNumIndices;
         aiVector3D* vo = out->mVertices + out->mNumVertices;
         aiVector3D* vn = out->mNormals + out->mNumVertices;
 
@@ -910,7 +913,7 @@ void BlenderImporter::ConvertMesh(const Scene& /*in*/, const Object* /*obj*/, co
         vn->x = v->no[0];
         vn->y = v->no[1];
         vn->z = v->no[2];
-        f.mIndices[0] = out->mNumVertices++;
+        out->mIndices[out->mNumIndices++] = out->mNumVertices++;
         ++vo;
         ++vn;
 
@@ -925,7 +928,7 @@ void BlenderImporter::ConvertMesh(const Scene& /*in*/, const Object* /*obj*/, co
         vn->x = v->no[0];
         vn->y = v->no[1];
         vn->z = v->no[2];
-        f.mIndices[1] = out->mNumVertices++;
+        out->mIndices[out->mNumIndices++] = out->mNumVertices++;
         ++vo;
         ++vn;
 
@@ -940,7 +943,7 @@ void BlenderImporter::ConvertMesh(const Scene& /*in*/, const Object* /*obj*/, co
         vn->x = v->no[0];
         vn->y = v->no[1];
         vn->z = v->no[2];
-        f.mIndices[2] = out->mNumVertices++;
+        out->mIndices[out->mNumIndices++] = out->mNumVertices++;
         ++vo;
         ++vn;
 
@@ -956,7 +959,7 @@ void BlenderImporter::ConvertMesh(const Scene& /*in*/, const Object* /*obj*/, co
             vn->x = v->no[0];
             vn->y = v->no[1];
             vn->z = v->no[2];
-            f.mIndices[3] = out->mNumVertices++;
+            out->mIndices[out->mNumIndices++] = out->mNumVertices++;
             ++vo;
             ++vn;
 
@@ -976,7 +979,8 @@ void BlenderImporter::ConvertMesh(const Scene& /*in*/, const Object* /*obj*/, co
         aiMesh* const out = temp[ mat_num_to_mesh_idx[ mf.mat_nr ] ];
         aiFace& f = out->mFaces[out->mNumFaces++];
 
-        f.mIndices = new unsigned int[ f.mNumIndices = mf.totloop ];
+        f.mNumIndices = mf.totloop;
+        f.mIndices = out->mNumIndices;
         aiVector3D* vo = out->mVertices + out->mNumVertices;
         aiVector3D* vn = out->mNormals + out->mNumVertices;
 
@@ -1001,7 +1005,7 @@ void BlenderImporter::ConvertMesh(const Scene& /*in*/, const Object* /*obj*/, co
             vn->x = v.no[0];
             vn->y = v.no[1];
             vn->z = v.no[2];
-            f.mIndices[j] = out->mNumVertices++;
+            out->mIndices[out->mNumIndices++] = out->mNumVertices++;
 
             ++vo;
             ++vn;

--- a/code/BlenderModifier.cpp
+++ b/code/BlenderModifier.cpp
@@ -255,7 +255,7 @@ void  BlenderModifier_Mirror :: DoIt(aiNode& out, ConversionData& conv_data,  co
             for( unsigned int i = 0; i < mesh->mNumFaces; i++) {
                 aiFace& face = mesh->mFaces[i];
                 for( unsigned int fi = 0; fi < face.mNumIndices / 2; ++fi)
-                    std::swap( face.mIndices[fi], face.mIndices[face.mNumIndices - 1 - fi]);
+                    std::swap( mesh->mIndices[face.mIndices + fi], mesh->mIndices[face.mIndices + face.mNumIndices - 1 - fi]);
             }
         }
 

--- a/code/COBLoader.cpp
+++ b/code/COBLoader.cpp
@@ -264,13 +264,15 @@ aiNode* COBImporter::BuildNodes(const Node& root,const Scene& scin,aiScene* fill
                     outmesh->mTextureCoords[0] = new aiVector3D[n];
 
                     outmesh->mFaces = new aiFace[reflist.second.size()]();
+                    outmesh->mIndices = new unsigned int[n];
                     for(Face* f : reflist.second) {
                         if (f->indices.empty()) {
                             continue;
                         }
 
                         aiFace& fout = outmesh->mFaces[outmesh->mNumFaces++];
-                        fout.mIndices = new unsigned int[f->indices.size()];
+                        fout.mIndices = outmesh->mNumIndices;
+                        outmesh->mNumIndices += f->indices.size();
 
                         for(VertexIndex& v : f->indices) {
                             if (v.pos_idx >= ndmesh.vertex_positions.size()) {
@@ -286,7 +288,7 @@ aiNode* COBImporter::BuildNodes(const Node& root,const Scene& scin,aiScene* fill
                                 0.f
                             );
 
-                            fout.mIndices[fout.mNumIndices++] = outmesh->mNumVertices++;
+                            outmesh->mIndices[fout.mIndices + fout.mNumIndices++] = outmesh->mNumVertices++;
                         }
                     }
                     outmesh->mMaterialIndex = fill->mNumMaterials;

--- a/code/CalcTangentsProcess.cpp
+++ b/code/CalcTangentsProcess.cpp
@@ -166,7 +166,7 @@ bool CalcTangentsProcess::ProcessMesh( aiMesh* pMesh, unsigned int meshIndex)
             // their tangent vectors are set to qnan.
             for (unsigned int i = 0; i < face.mNumIndices;++i)
             {
-                unsigned int idx = face.mIndices[i];
+                unsigned int idx = pMesh->mIndices[face.mIndices + i];
                 vertexDone  [idx] = true;
                 meshTang    [idx] = aiVector3D(qnan);
                 meshBitang  [idx] = aiVector3D(qnan);
@@ -178,7 +178,7 @@ bool CalcTangentsProcess::ProcessMesh( aiMesh* pMesh, unsigned int meshIndex)
         // triangle or polygon... we always use only the first three indices. A polygon
         // is supposed to be planar anyways....
         // FIXME: (thom) create correct calculation for multi-vertex polygons maybe?
-        const unsigned int p0 = face.mIndices[0], p1 = face.mIndices[1], p2 = face.mIndices[2];
+        const unsigned int p0 = pMesh->mIndices[face.mIndices + 0], p1 = pMesh->mIndices[face.mIndices + 1], p2 = pMesh->mIndices[face.mIndices + 2];
 
         // position differences p1->p2 and p1->p3
         aiVector3D v = meshPos[p1] - meshPos[p0], w = meshPos[p2] - meshPos[p0];
@@ -205,7 +205,7 @@ bool CalcTangentsProcess::ProcessMesh( aiMesh* pMesh, unsigned int meshIndex)
 
         // store for every vertex of that face
         for( unsigned int b = 0; b < face.mNumIndices; ++b ) {
-            unsigned int p = face.mIndices[b];
+            unsigned int p = pMesh->mIndices[face.mIndices + b];
 
             // project tangent and bitangent into the plane formed by the vertex' normal
             aiVector3D localTangent = tangent - meshNorm[p] * (tangent * meshNorm[p]);

--- a/code/ColladaExporter.cpp
+++ b/code/ColladaExporter.cpp
@@ -866,7 +866,7 @@ void ColladaExporter::WriteGeometry( size_t pIndex)
             const aiFace& face = mesh->mFaces[a];
             if (face.mNumIndices != 2) continue;
             for( size_t b = 0; b < face.mNumIndices; ++b )
-                mOutput << face.mIndices[b] << " ";
+                mOutput << mesh->mIndices[face.mIndices + b] << " ";
         }
         mOutput << "</p>" << endstr;
         PopTag();
@@ -901,7 +901,7 @@ void ColladaExporter::WriteGeometry( size_t pIndex)
             const aiFace& face = mesh->mFaces[a];
             if (face.mNumIndices < 3) continue;
             for( size_t b = 0; b < face.mNumIndices; ++b )
-                mOutput << face.mIndices[b] << " ";
+                mOutput << mesh->mIndices[face.mIndices + b] << " ";
         }
         mOutput << "</p>" << endstr;
         PopTag();

--- a/code/ColladaLoader.cpp
+++ b/code/ColladaLoader.cpp
@@ -635,15 +635,18 @@ aiMesh* ColladaLoader::CreateMesh( const ColladaParser& pParser, const Collada::
     // create faces. Due to the fact that each face uses unique vertices, we can simply count up on each vertex
     size_t vertex = 0;
     dstMesh->mNumFaces = pSubMesh.mNumFaces;
+    dstMesh->mNumIndices = std::accumulate(pSrcMesh->mFaceSize.begin(), pSrcMesh->mFaceSize.end(), 0);
     dstMesh->mFaces = new aiFace[dstMesh->mNumFaces];
-    for( size_t a = 0; a < dstMesh->mNumFaces; ++a)
+    dstMesh->mIndices = new unsigned int[dstMesh->mNumIndices];
+    for( size_t a = 0, curIndex = 0; a < dstMesh->mNumFaces; ++a)
     {
         size_t s = pSrcMesh->mFaceSize[ pStartFace + a];
         aiFace& face = dstMesh->mFaces[a];
         face.mNumIndices = s;
-        face.mIndices = new unsigned int[s];
+        face.mIndices = curIndex;
+        curIndex += face.mNumIndices;
         for( size_t b = 0; b < s; ++b)
-            face.mIndices[b] = vertex++;
+            dstMesh->mIndices[face.mIndices + b] = vertex++;
     }
 
     // create bones if given

--- a/code/ComputeUVMappingProcess.cpp
+++ b/code/ComputeUVMappingProcess.cpp
@@ -129,23 +129,23 @@ void RemoveUVSeams (aiMesh* mesh, aiVector3D* out)
         // lies on a UV seam should work for most cases.
         for (unsigned int n = 0; n < face.mNumIndices;++n)
         {
-            if (out[face.mIndices[n]].x < LOWER_LIMIT)
+            if (out[mesh->mIndices[face.mIndices + n]].x < LOWER_LIMIT)
             {
                 small = n;
 
                 // If we have a U value very close to 0 we can't
                 // round the others to 0, too.
-                if (out[face.mIndices[n]].x <= LOWER_EPSILON)
+                if (out[mesh->mIndices[face.mIndices + n]].x <= LOWER_EPSILON)
                     zero = true;
                 else round_to_zero = true;
             }
-            if (out[face.mIndices[n]].x > UPPER_LIMIT)
+            if (out[mesh->mIndices[face.mIndices + n]].x > UPPER_LIMIT)
             {
                 large = n;
 
                 // If we have a U value very close to 1 we can't
                 // round the others to 1, too.
-                if (out[face.mIndices[n]].x >= UPPER_EPSILON)
+                if (out[mesh->mIndices[face.mIndices + n]].x >= UPPER_EPSILON)
                     one = true;
             }
         }
@@ -155,13 +155,13 @@ void RemoveUVSeams (aiMesh* mesh, aiVector3D* out)
             {
                 // If the u value is over the upper limit and no other u
                 // value of that face is 0, round it to 0
-                if (out[face.mIndices[n]].x > UPPER_LIMIT && !zero)
-                    out[face.mIndices[n]].x = 0.0;
+                if (out[mesh->mIndices[face.mIndices + n]].x > UPPER_LIMIT && !zero)
+                    out[mesh->mIndices[face.mIndices + n]].x = 0.f;
 
                 // If the u value is below the lower limit and no other u
                 // value of that face is 1, round it to 1
-                else if (out[face.mIndices[n]].x < LOWER_LIMIT && !one)
-                    out[face.mIndices[n]].x = 1.0;
+                else if (out[mesh->mIndices[face.mIndices + n]].x < LOWER_LIMIT && !one)
+                    out[mesh->mIndices[face.mIndices + n]].x = 1.f;
 
                 // The face contains both 0 and 1 as UV coords. This can occur
                 // for faces which have an edge that lies directly on the seam.
@@ -170,10 +170,10 @@ void RemoveUVSeams (aiMesh* mesh, aiVector3D* out)
                 // to which side we must round to.
                 else if (one && zero)
                 {
-                    if (round_to_zero && out[face.mIndices[n]].x >=  UPPER_EPSILON)
-                        out[face.mIndices[n]].x = 0.0;
-                    else if (!round_to_zero && out[face.mIndices[n]].x <= LOWER_EPSILON)
-                        out[face.mIndices[n]].x = 1.0;
+                    if (round_to_zero && out[mesh->mIndices[face.mIndices + n]].x >=  UPPER_EPSILON)
+                        out[mesh->mIndices[face.mIndices + n]].x = 0.f;
+                    else if (!round_to_zero && out[mesh->mIndices[face.mIndices + n]].x <= LOWER_EPSILON)
+                        out[mesh->mIndices[face.mIndices + n]].x = 1.f;
                 }
             }
         }

--- a/code/ConvertToLHProcess.cpp
+++ b/code/ConvertToLHProcess.cpp
@@ -324,7 +324,7 @@ void FlipWindingOrderProcess::ProcessMesh( aiMesh* pMesh)
     {
         aiFace& face = pMesh->mFaces[a];
         for( unsigned int b = 0; b < face.mNumIndices / 2; b++)
-            std::swap( face.mIndices[b], face.mIndices[ face.mNumIndices - 1 - b]);
+            std::swap( pMesh->mIndices[face.mIndices + b], pMesh->mIndices[face.mIndices + face.mNumIndices - 1 - b]);
     }
 }
 

--- a/code/D3MFImporter.cpp
+++ b/code/D3MFImporter.cpp
@@ -235,36 +235,35 @@ private:
     void ImportTriangles(aiMesh* mesh)
     {
          std::vector<aiFace> faces;         
+         std::vector<unsigned int> indices;
 
 
          while(ReadToEndElement(D3MF::XmlTag::triangles))
          {
              if(xmlReader->getNodeName() == D3MF::XmlTag::triangle)
              {
-                 faces.push_back(ReadTriangle());
+                 aiFace face;
+
+                 face.mNumIndices = 3;
+                 face.mIndices = static_cast<unsigned int>(indices.size());
+                 indices.push_back(static_cast<unsigned int>(std::atoi(xmlReader->getAttributeValue(D3MF::XmlTag::v1.c_str()))));
+                 indices.push_back(static_cast<unsigned int>(std::atoi(xmlReader->getAttributeValue(D3MF::XmlTag::v2.c_str()))));
+                 indices.push_back(static_cast<unsigned int>(std::atoi(xmlReader->getAttributeValue(D3MF::XmlTag::v3.c_str()))));
+
+                 faces.push_back(face);
              }
          }
 
         mesh->mNumFaces = static_cast<unsigned int>(faces.size());
         mesh->mFaces = new aiFace[mesh->mNumFaces];
+        mesh->mNumIndices = static_cast<unsigned int>(indices.size());
+        mesh->mIndices = new unsigned int[mesh->mNumIndices];
         mesh->mPrimitiveTypes = aiPrimitiveType_TRIANGLE;
 
 
         std::copy(faces.begin(), faces.end(), mesh->mFaces);
+        std::copy(indices.begin(), indices.end(), mesh->mIndices);
 
-    }
-
-    aiFace ReadTriangle()
-    {
-        aiFace face;
-
-        face.mNumIndices = 3;
-        face.mIndices = new unsigned int[face.mNumIndices];
-        face.mIndices[0] = static_cast<unsigned int>(std::atoi(xmlReader->getAttributeValue(D3MF::XmlTag::v1.c_str())));
-        face.mIndices[1] = static_cast<unsigned int>(std::atoi(xmlReader->getAttributeValue(D3MF::XmlTag::v2.c_str())));
-        face.mIndices[2] = static_cast<unsigned int>(std::atoi(xmlReader->getAttributeValue(D3MF::XmlTag::v3.c_str())));
-
-        return face;
     }
 
 private:

--- a/code/DXFLoader.cpp
+++ b/code/DXFLoader.cpp
@@ -302,9 +302,11 @@ void DXFImporter::ConvertMeshes(aiScene* pScene, DXF::FileData& output)
         aiVector3D* verts = mesh->mVertices = new aiVector3D[cvert];
         aiColor4D* colors = mesh->mColors[0] = new aiColor4D[cvert];
         aiFace* faces = mesh->mFaces = new aiFace[cface];
+        mesh->mIndices = new unsigned int[cvert];
 
         mesh->mNumVertices = cvert;
         mesh->mNumFaces = cface;
+        mesh->mNumIndices = cvert;
 
         unsigned int prims = 0;
         unsigned int overall_indices = 0;
@@ -313,10 +315,10 @@ void DXFImporter::ConvertMeshes(aiScene* pScene, DXF::FileData& output)
             std::vector<unsigned int>::const_iterator it = pl->indices.begin();
             for(unsigned int facenumv : pl->counts) {
                 aiFace& face = *faces++;
-                face.mIndices = new unsigned int[face.mNumIndices = facenumv];
+                face.mIndices = overall_indices;
 
                 for (unsigned int i = 0; i < facenumv; ++i) {
-                    face.mIndices[i] = overall_indices++;
+                    mesh->mIndices[face.mIndices + i] = overall_indices++;
 
                     ai_assert(pl->positions.size() == pl->colors.size());
                     if (*it >= pl->positions.size()) {

--- a/code/DeboneProcess.cpp
+++ b/code/DeboneProcess.cpp
@@ -229,10 +229,10 @@ bool DeboneProcess::ConsiderMesh(const aiMesh* pMesh)
 
     if(isInterstitialRequired) {
         for(unsigned int i=0;i<pMesh->mNumFaces;i++) {
-            unsigned int v = vertexBones[pMesh->mFaces[i].mIndices[0]];
+            unsigned int v = vertexBones[pMesh->mIndices[pMesh->mFaces[i].mIndices + 0]];
 
             for(unsigned int j=1;j<pMesh->mFaces[i].mNumIndices;j++) {
-                unsigned int w = vertexBones[pMesh->mFaces[i].mIndices[j]];
+                unsigned int w = vertexBones[pMesh->mIndices[pMesh->mFaces[i].mIndices + j]];
 
                 if(v!=w)    {
                     if(v<pMesh->mNumBones) isBoneNecessary[v] = true;
@@ -303,10 +303,10 @@ void DeboneProcess::SplitMesh( const aiMesh* pMesh, std::vector< std::pair< aiMe
     for(unsigned int i=0;i<pMesh->mNumFaces;i++) {
         unsigned int nInterstitial = 1;
 
-        unsigned int v = vertexBones[pMesh->mFaces[i].mIndices[0]];
+        unsigned int v = vertexBones[pMesh->mIndices[pMesh->mFaces[i].mIndices + 0]];
 
         for(unsigned int j=1;j<pMesh->mFaces[i].mNumIndices;j++) {
-            unsigned int w = vertexBones[pMesh->mFaces[i].mIndices[j]];
+            unsigned int w = vertexBones[pMesh->mIndices[pMesh->mFaces[i].mIndices + j]];
 
             if(v!=w)    {
                 if(v<pMesh->mNumBones) isBoneNecessary[v] = true;

--- a/code/Exporter.cpp
+++ b/code/Exporter.cpp
@@ -279,7 +279,7 @@ bool IsVerboseFormat(const aiMesh* mesh)
     for(unsigned int i = 0; i < mesh->mNumFaces; ++i) {
         const aiFace& f = mesh->mFaces[i];
         for(unsigned int j = 0; j < f.mNumIndices; ++j) {
-            if(++seen[f.mIndices[j]] == 2) {
+            if(++seen[mesh->mIndices[f.mIndices + j]] == 2) {
                 // found a duplicate index
                 return false;
             }

--- a/code/FBXConverter.cpp
+++ b/code/FBXConverter.cpp
@@ -1286,8 +1286,6 @@ unsigned int Converter::ConvertMeshSingleMaterial( const MeshGeometry& mesh, con
         if ( uvs.empty() ) {
             break;
         }
-        out_mesh->mNumIndices = std::accumulate(faces.begin(), faces.end(), 0);
-        out_mesh->mIndices = new unsigned int[out_mesh->mNumIndices];
 
         aiVector3D* out_uv = out_mesh->mTextureCoords[ i ] = new aiVector3D[ vertices.size() ];
         for( const aiVector2D& v : uvs ) {

--- a/code/FBXConverter.cpp
+++ b/code/FBXConverter.cpp
@@ -1209,12 +1209,14 @@ unsigned int Converter::ConvertMeshSingleMaterial( const MeshGeometry& mesh, con
     // generate dummy faces
     out_mesh->mNumFaces = static_cast<unsigned int>( faces.size() );
     aiFace* fac = out_mesh->mFaces = new aiFace[ faces.size() ]();
+    out_mesh->mNumIndices = std::accumulate(faces.begin(), faces.end(), 0);
+    out_mesh->mIndices = new unsigned int[out_mesh->mNumIndices];
 
     unsigned int cursor = 0;
     for( unsigned int pcount : faces ) {
         aiFace& f = *fac++;
         f.mNumIndices = pcount;
-        f.mIndices = new unsigned int[ pcount ];
+        f.mIndices = cursor;
         switch ( pcount )
         {
         case 1:
@@ -1231,7 +1233,7 @@ unsigned int Converter::ConvertMeshSingleMaterial( const MeshGeometry& mesh, con
             break;
         }
         for ( unsigned int i = 0; i < pcount; ++i ) {
-            f.mIndices[ i ] = cursor++;
+            out_mesh->mIndices[ f.mIndices + i ] = cursor++;
         }
     }
 
@@ -1284,6 +1286,8 @@ unsigned int Converter::ConvertMeshSingleMaterial( const MeshGeometry& mesh, con
         if ( uvs.empty() ) {
             break;
         }
+        out_mesh->mNumIndices = std::accumulate(faces.begin(), faces.end(), 0);
+        out_mesh->mIndices = new unsigned int[out_mesh->mNumIndices];
 
         aiVector3D* out_uv = out_mesh->mTextureCoords[ i ] = new aiVector3D[ vertices.size() ];
         for( const aiVector2D& v : uvs ) {
@@ -1383,6 +1387,9 @@ unsigned int Converter::ConvertMeshMultiMaterial( const MeshGeometry& mesh, cons
     out_mesh->mNumFaces = count_faces;
     aiFace* fac = out_mesh->mFaces = new aiFace[ count_faces ]();
 
+    out_mesh->mNumIndices = count_vertices;
+    out_mesh->mIndices = new unsigned int[ count_vertices ];
+
 
     // allocate normals
     const std::vector<aiVector3D>& normals = mesh.GetNormals();
@@ -1459,7 +1466,7 @@ unsigned int Converter::ConvertMeshMultiMaterial( const MeshGeometry& mesh, cons
         aiFace& f = *fac++;
 
         f.mNumIndices = pcount;
-        f.mIndices = new unsigned int[ pcount ];
+        f.mIndices = cursor;
         switch ( pcount )
         {
         case 1:
@@ -1476,7 +1483,7 @@ unsigned int Converter::ConvertMeshMultiMaterial( const MeshGeometry& mesh, cons
             break;
         }
         for ( unsigned int i = 0; i < pcount; ++i, ++cursor, ++in_cursor ) {
-            f.mIndices[ i ] = cursor;
+            out_mesh->mIndices[ f.mIndices + i ] = cursor;
 
             if ( reverseMapping.size() ) {
                 reverseMapping[ cursor ] = in_cursor;

--- a/code/FindDegenerates.cpp
+++ b/code/FindDegenerates.cpp
@@ -119,21 +119,21 @@ void FindDegeneratesProcess::ExecuteOnMesh( aiMesh* mesh)
 
             for (unsigned int t = i+1; t < limit; ++t)
             {
-                if (mesh->mVertices[face.mIndices[i]] == mesh->mVertices[face.mIndices[t]])
+                if (mesh->mVertices[mesh->mIndices[face.mIndices + i]] == mesh->mVertices[mesh->mIndices[face.mIndices + t]])
                 {
                     // we have found a matching vertex position
                     // remove the corresponding index from the array
                     --face.mNumIndices;--limit;
                     for (unsigned int m = t; m < face.mNumIndices; ++m)
                     {
-                        face.mIndices[m] = face.mIndices[m+1];
+                        mesh->mIndices[face.mIndices + m] = mesh->mIndices[face.mIndices + m+1];
                     }
                     --t;
 
                     // NOTE: we set the removed vertex index to an unique value
                     // to make sure the developer gets notified when his
                     // application attemps to access this data.
-                    face.mIndices[face.mNumIndices] = 0xdeadbeef;
+                    mesh->mIndices[face.mIndices + face.mNumIndices] = 0xdeadbeef;
 
                     if(first)
                     {
@@ -185,13 +185,12 @@ evil_jump_outside:
                 if (&face_src != &face_dest) {
                     // clear source
                     face_src.mNumIndices = 0;
-                    face_src.mIndices = NULL;
+                    face_src.mIndices = 0;
                 }
             }
             else {
                 // Otherwise delete it if we don't need this face
-                delete[] face_src.mIndices;
-                face_src.mIndices = NULL;
+                face_src.mIndices = 0;
                 face_src.mNumIndices = 0;
             }
         }

--- a/code/FindInstancesProcess.cpp
+++ b/code/FindInstancesProcess.cpp
@@ -225,11 +225,11 @@ void FindInstancesProcess::Execute( aiScene* pScene)
                         for (unsigned int tt = 0; tt < orig->mNumFaces;++tt) {
                             aiFace& f = orig->mFaces[tt];
                             for (unsigned int nn = 0; nn < f.mNumIndices;++nn)
-                                ftbl_orig[f.mIndices[nn]] = tt;
+                                ftbl_orig[orig->mIndices[f.mIndices + nn]] = tt;
 
                             aiFace& f2 = inst->mFaces[tt];
                             for (unsigned int nn = 0; nn < f2.mNumIndices;++nn)
-                                ftbl_inst[f2.mIndices[nn]] = tt;
+                                ftbl_inst[inst->mIndices[f2.mIndices + nn]] = tt;
                         }
                         if (0 != ::memcmp(ftbl_inst.get(),ftbl_orig.get(),orig->mNumVertices*sizeof(unsigned int)))
                             continue;

--- a/code/FindInvalidDataProcess.cpp
+++ b/code/FindInvalidDataProcess.cpp
@@ -346,7 +346,7 @@ int FindInvalidDataProcess::ProcessMesh (aiMesh* pMesh)
         const aiFace& f = pMesh->mFaces[m];
 
         for (unsigned int i = 0; i < f.mNumIndices;++i) {
-            dirtyMask[f.mIndices[i]] = false;
+            dirtyMask[pMesh->mIndices[f.mIndices + i]] = false;
         }
     }
 
@@ -386,10 +386,10 @@ int FindInvalidDataProcess::ProcessMesh (aiMesh* pMesh)
                     const aiFace& f = pMesh->mFaces[m];
 
                     if (f.mNumIndices < 3)  {
-                        dirtyMask[f.mIndices[0]] = true;
+                        dirtyMask[pMesh->mIndices[f.mIndices + 0]] = true;
 
                         if (f.mNumIndices == 2) {
-                            dirtyMask[f.mIndices[1]] = true;
+                            dirtyMask[pMesh->mIndices[f.mIndices + 1]] = true;
                         }
                     }
                 }

--- a/code/FixNormalsStep.cpp
+++ b/code/FixNormalsStep.cpp
@@ -172,7 +172,7 @@ bool FixInfacingNormalsProcess::ProcessMesh( aiMesh* pcMesh, unsigned int index)
         {
             aiFace& face = pcMesh->mFaces[i];
             for( unsigned int b = 0; b < face.mNumIndices / 2; b++)
-                std::swap( face.mIndices[b], face.mIndices[ face.mNumIndices - 1 - b]);
+                std::swap( pcMesh->mIndices[face.mIndices + b], pcMesh->mIndices[face.mIndices + face.mNumIndices - 1 - b]);
         }
         return true;
     }

--- a/code/GenFaceNormalsProcess.cpp
+++ b/code/GenFaceNormalsProcess.cpp
@@ -125,18 +125,18 @@ bool GenFaceNormalsProcess::GenMeshFaceNormals (aiMesh* pMesh)
         if (face.mNumIndices < 3)   {
             // either a point or a line -> no well-defined normal vector
             for (unsigned int i = 0;i < face.mNumIndices;++i) {
-                pMesh->mNormals[face.mIndices[i]] = aiVector3D(qnan);
+                pMesh->mNormals[pMesh->mIndices[face.mIndices + i]] = aiVector3D(qnan);
             }
             continue;
         }
 
-        const aiVector3D* pV1 = &pMesh->mVertices[face.mIndices[0]];
-        const aiVector3D* pV2 = &pMesh->mVertices[face.mIndices[1]];
-        const aiVector3D* pV3 = &pMesh->mVertices[face.mIndices[face.mNumIndices-1]];
+        const aiVector3D* pV1 = &pMesh->mVertices[pMesh->mIndices[face.mIndices + 0]];
+        const aiVector3D* pV2 = &pMesh->mVertices[pMesh->mIndices[face.mIndices + 1]];
+        const aiVector3D* pV3 = &pMesh->mVertices[pMesh->mIndices[face.mIndices + face.mNumIndices-1]];
         const aiVector3D vNor = ((*pV2 - *pV1) ^ (*pV3 - *pV1)).Normalize();
 
         for (unsigned int i = 0;i < face.mNumIndices;++i) {
-            pMesh->mNormals[face.mIndices[i]] = vNor;
+            pMesh->mNormals[pMesh->mIndices[face.mIndices + i]] = vNor;
         }
     }
     return true;

--- a/code/GenVertexNormalsProcess.cpp
+++ b/code/GenVertexNormalsProcess.cpp
@@ -134,19 +134,19 @@ bool GenVertexNormalsProcess::GenMeshVertexNormals (aiMesh* pMesh, unsigned int 
         {
             // either a point or a line -> no normal vector
             for (unsigned int i = 0;i < face.mNumIndices;++i) {
-                pMesh->mNormals[face.mIndices[i]] = aiVector3D(qnan);
+                pMesh->mNormals[pMesh->mIndices[face.mIndices + i]] = aiVector3D(qnan);
             }
 
             continue;
         }
 
-        const aiVector3D* pV1 = &pMesh->mVertices[face.mIndices[0]];
-        const aiVector3D* pV2 = &pMesh->mVertices[face.mIndices[1]];
-        const aiVector3D* pV3 = &pMesh->mVertices[face.mIndices[face.mNumIndices-1]];
+        const aiVector3D* pV1 = &pMesh->mVertices[pMesh->mIndices[face.mIndices + 0]];
+        const aiVector3D* pV2 = &pMesh->mVertices[pMesh->mIndices[face.mIndices + 1]];
+        const aiVector3D* pV3 = &pMesh->mVertices[pMesh->mIndices[face.mIndices + face.mNumIndices-1]];
         const aiVector3D vNor = ((*pV2 - *pV1) ^ (*pV3 - *pV1));
 
         for (unsigned int i = 0;i < face.mNumIndices;++i) {
-            pMesh->mNormals[face.mIndices[i]] = vNor;
+            pMesh->mNormals[pMesh->mIndices[face.mIndices + i]] = vNor;
         }
     }
 

--- a/code/HMPLoader.cpp
+++ b/code/HMPLoader.cpp
@@ -386,6 +386,8 @@ void HMPImporter::CreateOutputFaceList(unsigned int width,unsigned int height)
     // Allocate enough storage
     pcMesh->mNumFaces = (width-1) * (height-1);
     pcMesh->mFaces = new aiFace[pcMesh->mNumFaces];
+    pcMesh->mNumIndices = pcMesh->mNumFaces * 4;
+    pcMesh->mIndices = new unsigned int[pcMesh->mNumIndices];
 
     pcMesh->mNumVertices   = pcMesh->mNumFaces*4;
     aiVector3D* pcVertices = new aiVector3D[pcMesh->mNumVertices];
@@ -403,7 +405,7 @@ void HMPImporter::CreateOutputFaceList(unsigned int width,unsigned int height)
     for (unsigned int y = 0; y < height-1;++y)  {
         for (unsigned int x = 0; x < width-1;++x,++pcFaceOut)   {
             pcFaceOut->mNumIndices = 4;
-            pcFaceOut->mIndices = new unsigned int[4];
+            pcFaceOut->mIndices = ((y * (width - 1)) + x) * 4;
 
             *pcVertOut++ = pcMesh->mVertices[y*width+x];
             *pcVertOut++ = pcMesh->mVertices[(y+1)*width+x];
@@ -425,7 +427,7 @@ void HMPImporter::CreateOutputFaceList(unsigned int width,unsigned int height)
             }
 
             for (unsigned int i = 0; i < 4;++i)
-                pcFaceOut->mIndices[i] = iCurrent++;
+                pcMesh->mIndices[pcFaceOut->mIndices + i] = iCurrent++;
         }
     }
     delete[] pcMesh->mVertices;

--- a/code/IFCUtil.cpp
+++ b/code/IFCUtil.cpp
@@ -85,6 +85,8 @@ aiMesh* TempMesh::ToMesh()
     // and build up faces
     mesh->mNumFaces = static_cast<unsigned int>(vertcnt.size());
     mesh->mFaces = new aiFace[mesh->mNumFaces];
+    mesh->mNumIndices = std::accumulate(vertcnt.begin(), vertcnt.end(), 0);
+    mesh->mIndices = new unsigned int[mesh->mNumIndices];
 
     for(unsigned int i = 0,n=0, acc = 0; i < mesh->mNumFaces; ++n) {
         aiFace& f = mesh->mFaces[i];
@@ -94,9 +96,9 @@ aiMesh* TempMesh::ToMesh()
         }
 
         f.mNumIndices = vertcnt[n];
-        f.mIndices = new unsigned int[f.mNumIndices];
+        f.mIndices = acc;
         for(unsigned int a = 0; a < f.mNumIndices; ++a) {
-            f.mIndices[a] = acc++;
+            mesh->mIndices[f.mIndices + a] = acc++;
         }
 
         ++i;

--- a/code/IRRLoader.cpp
+++ b/code/IRRLoader.cpp
@@ -153,15 +153,17 @@ aiMesh* IRRImporter::BuildSingleQuadMesh(const SkyboxVertex& v1,
 
     out->mPrimitiveTypes = aiPrimitiveType_POLYGON;
     out->mNumFaces = 1;
+    out->mNumIndices = 4;
 
     // build the face
     out->mFaces    = new aiFace[1];
+    out->mIndices  = new unsigned int[4];
     aiFace& face   = out->mFaces[0];
 
     face.mNumIndices = 4;
-    face.mIndices    = new unsigned int[4];
+    face.mIndices    = 0;
     for (unsigned int i = 0; i < 4;++i)
-        face.mIndices[i] = i;
+        out->mIndices[i] = i;
 
     out->mNumVertices = 4;
 

--- a/code/IRRMeshLoader.cpp
+++ b/code/IRRMeshLoader.cpp
@@ -273,6 +273,9 @@ void IRRMeshImporter::InternReadFile( const std::string& pFile,
                     continue;
                 }
 
+                curMesh->mNumIndices = curMesh->mNumFaces * 3;
+                curMesh->mIndices = new unsigned int[curMesh->mNumIndices];
+
                 if (curMesh->mNumVertices % 3)  {
                     DefaultLogger::get()->warn("IRRMESH: Number if indices isn't divisible by 3");
                 }
@@ -430,16 +433,16 @@ void IRRMeshImporter::InternReadFile( const std::string& pFile,
                     }
                     if (!curIdx)    {
                         curFace->mNumIndices = 3;
-                        curFace->mIndices = new unsigned int[3];
+                        curFace->mIndices = (unsigned int)(curFace - curMesh->mFaces) * 3;
                     }
+
+                    curMesh->mIndices[curFace->mIndices + curIdx] = total++;
 
                     unsigned int idx = strtoul10(sz,&sz);
                     if (idx >= curVertices.size())  {
                         DefaultLogger::get()->error("IRRMESH: Index out of range");
                         idx = 0;
                     }
-
-                    curFace->mIndices[curIdx] = total++;
 
                     *pcV++ = curVertices[idx];
                     if (pcN)*pcN++ = curNormals[idx];

--- a/code/ImproveCacheLocality.cpp
+++ b/code/ImproveCacheLocality.cpp
@@ -160,7 +160,7 @@ float ImproveCacheLocalityProcess::ProcessMesh( aiMesh* pMesh, unsigned int mesh
                 bool bInCache = false;
 
                 for (unsigned int* pp = piFIFOStack;pp < piCurEnd;++pp) {
-                    if (*pp == pcFace->mIndices[qq])    {
+                    if (*pp == pMesh->mIndices[pcFace->mIndices + qq])    {
                         // the vertex is in cache
                         bInCache = true;
                         break;
@@ -171,7 +171,7 @@ float ImproveCacheLocalityProcess::ProcessMesh( aiMesh* pMesh, unsigned int mesh
                     if (piCurEnd == piCur) {
                         piCur = piFIFOStack;
                     }
-                    *piCur++ = pcFace->mIndices[qq];
+                    *piCur++ = pMesh->mIndices[pcFace->mIndices + qq];
                 }
             }
         }
@@ -190,7 +190,7 @@ float ImproveCacheLocalityProcess::ProcessMesh( aiMesh* pMesh, unsigned int mesh
     }
 
     // first we need to build a vertex-triangle adjacency list
-    VertexTriangleAdjacency adj(pMesh->mFaces,pMesh->mNumFaces, pMesh->mNumVertices,true);
+    VertexTriangleAdjacency adj(pMesh, pMesh->mFaces,pMesh->mNumFaces, pMesh->mNumVertices,true);
 
     // build a list to store per-vertex caching time stamps
     unsigned int* const piCachingStamps = new unsigned int[pMesh->mNumVertices];
@@ -273,7 +273,7 @@ float ImproveCacheLocalityProcess::ProcessMesh( aiMesh* pMesh, unsigned int mesh
 
                 // so iterate through all vertices of the current triangle
                 const aiFace* pcFace = &pMesh->mFaces[ fidx ];
-                for (unsigned int* p = pcFace->mIndices, *p2 = pcFace->mIndices+3;p != p2;++p)  {
+                for (unsigned int* p = pMesh->mIndices + pcFace->mIndices, *p2 = pMesh->mIndices + pcFace->mIndices+3;p != p2;++p)  {
                     const unsigned int dp = *p;
 
                     // the current vertex won't have any free triangles after this step
@@ -372,9 +372,9 @@ float ImproveCacheLocalityProcess::ProcessMesh( aiMesh* pMesh, unsigned int mesh
     // sort the output index buffer back to the input array
     piCSIter = piIBOutput;
     for (aiFace* pcFace = pMesh->mFaces; pcFace != pcEnd;++pcFace)  {
-        pcFace->mIndices[0] = *piCSIter++;
-        pcFace->mIndices[1] = *piCSIter++;
-        pcFace->mIndices[2] = *piCSIter++;
+        pMesh->mIndices[pcFace->mIndices + 0] = *piCSIter++;
+        pMesh->mIndices[pcFace->mIndices + 1] = *piCSIter++;
+        pMesh->mIndices[pcFace->mIndices + 2] = *piCSIter++;
     }
 
     // delete temporary storage

--- a/code/JoinVerticesProcess.cpp
+++ b/code/JoinVerticesProcess.cpp
@@ -351,7 +351,7 @@ int JoinVerticesProcess::ProcessMesh( aiMesh* pMesh, unsigned int meshIndex)
     {
         aiFace& face = pMesh->mFaces[a];
         for( unsigned int b = 0; b < face.mNumIndices; b++) {
-            face.mIndices[b] = replaceIndex[face.mIndices[b]] & ~0x80000000;
+            pMesh->mIndices[face.mIndices + b] = replaceIndex[pMesh->mIndices[face.mIndices + b]] & ~0x80000000;
         }
     }
 

--- a/code/LWOBLoader.cpp
+++ b/code/LWOBLoader.cpp
@@ -128,7 +128,7 @@ void LWOImporter::LoadLWOBPolygons(unsigned int length)
 
         mCurLayer->mFaces.resize(iNumFaces);
         FaceList::iterator it = mCurLayer->mFaces.begin();
-        CopyFaceIndicesLWOB(it,cursor,end);
+        CopyFaceIndicesLWOB(it,mCurLayer->mIndices,cursor,end);
     }
 }
 
@@ -164,6 +164,7 @@ void LWOImporter::CountVertsAndFacesLWOB(unsigned int& verts, unsigned int& face
 
 // ------------------------------------------------------------------------------------------------
 void LWOImporter::CopyFaceIndicesLWOB(FaceList::iterator& it,
+    IndicesList& indices,
     LE_NCONST uint16_t*& cursor,
     const uint16_t* const end,
     unsigned int max)
@@ -180,13 +181,13 @@ void LWOImporter::CopyFaceIndicesLWOB(FaceList::iterator& it,
             {
                 break;
             }
-            face.mIndices = new unsigned int[face.mNumIndices];
+            face.mIndices = indices.size();
             for (unsigned int i = 0; i < face.mNumIndices;++i)
             {
-                unsigned int & mi = face.mIndices[i];
                 uint16_t index;
                 ::memcpy(&index, cursor++, 2);
-                mi = index;
+                indices.push_back(index);
+                unsigned int & mi = indices.back();
                 if (mi > mCurLayer->mTempPoints.size())
                 {
                     DefaultLogger::get()->warn("LWOB: face index is out of range");
@@ -206,7 +207,7 @@ void LWOImporter::CopyFaceIndicesLWOB(FaceList::iterator& it,
             ::memcpy(&numPolygons, cursor++, 2);
             if (cursor < end)
             {
-                CopyFaceIndicesLWOB(it,cursor,end,numPolygons);
+                CopyFaceIndicesLWOB(it, indices,cursor,end,numPolygons);
             }
         }
         face.surfaceIndex = surface-1;

--- a/code/LWOFileData.h
+++ b/code/LWOFileData.h
@@ -619,6 +619,7 @@ struct Surface
 // some typedefs ... to make life with loader monsters like this easier
 typedef std::vector <   aiVector3D      >   PointList;
 typedef std::vector <   LWO::Face       >   FaceList;
+typedef std::vector <   unsigned int    >   IndicesList;
 typedef std::vector <   LWO::Surface    >   SurfaceList;
 typedef std::vector <   std::string     >   TagList;
 typedef std::vector <   unsigned int    >   TagMappingTable;
@@ -668,6 +669,9 @@ struct Layer
 
     /** Temporary face list from the file*/
     FaceList mFaces;
+
+    /** Temprorary indices list from the file*/
+    IndicesList mIndices;
 
     /** Current face indexing offset from the beginning of the buffers*/
     unsigned int mFaceIDXOfs;

--- a/code/LWOLoader.h
+++ b/code/LWOLoader.h
@@ -229,11 +229,13 @@ private:
     /** Read vertices and faces in a LWOB/LWO2 file
     */
     void CopyFaceIndicesLWO2(LWO::FaceList::iterator& it,
+        LWO::IndicesList& indices,
         uint16_t*& cursor,
         const uint16_t* const end);
 
     // -------------------------------------------------------------------
     void CopyFaceIndicesLWOB(LWO::FaceList::iterator& it,
+        LWO::IndicesList& indices,
         LE_NCONST uint16_t*& cursor,
         const uint16_t* const end,
         unsigned int max = UINT_MAX);

--- a/code/LWOMaterial.cpp
+++ b/code/LWOMaterial.cpp
@@ -421,7 +421,7 @@ void LWOImporter::FindUVChannels(LWO::Surface& surf,
             LWO::Face& face = layer.mFaces[*it];
 
             for (unsigned int n = 0; n < face.mNumIndices; ++n) {
-                unsigned int idx = face.mIndices[n];
+                unsigned int idx = layer.mIndices.size();
 
                 if (uv.abAssigned[idx] && ((aiVector2D*)&uv.rawData[0])[idx] != aiVector2D()) {
 
@@ -495,7 +495,7 @@ void LWOImporter::FindVCChannels(const LWO::Surface& surf, LWO::SortedRep& sorte
                 const LWO::Face& face = layer.mFaces[*it];
 
                 for (unsigned int n = 0; n < face.mNumIndices; ++n) {
-                    unsigned int idx = face.mIndices[n];
+                    unsigned int idx = layer.mIndices[face.mIndices + n];
 
                     if (vc.abAssigned[idx] && ((aiColor4D*)&vc.rawData[0])[idx] != aiColor4D(0.0,0.0,0.0,1.0)) {
                         if (next >= AI_MAX_NUMBER_OF_COLOR_SETS) {

--- a/code/MD2Loader.cpp
+++ b/code/MD2Loader.cpp
@@ -312,6 +312,8 @@ void MD2Importer::InternReadFile( const std::string& pFile,
 
     pcMesh->mNumFaces = m_pcHeader->numTriangles;
     pcMesh->mFaces = new aiFace[m_pcHeader->numTriangles];
+    pcMesh->mNumIndices = pcMesh->mNumFaces * 3;
+    pcMesh->mIndices = new unsigned int[pcMesh->mNumIndices];
 
     // allocate output storage
     pcMesh->mNumVertices = (unsigned int)pcMesh->mNumFaces*3;
@@ -399,7 +401,7 @@ void MD2Importer::InternReadFile( const std::string& pFile,
 
     for (unsigned int i = 0; i < (unsigned int)m_pcHeader->numTriangles;++i)    {
         // Allocate the face
-        pScene->mMeshes[0]->mFaces[i].mIndices = new unsigned int[3];
+        pScene->mMeshes[0]->mFaces[i].mIndices = i * 3;
         pScene->mMeshes[0]->mFaces[i].mNumIndices = 3;
 
         // copy texture coordinates
@@ -449,7 +451,7 @@ void MD2Importer::InternReadFile( const std::string& pFile,
                 pcOut.x = pcTexCoords[iIndex].s / fDivisorU;
                 pcOut.y = 1.f-pcTexCoords[iIndex].t / fDivisorV;
             }
-            pScene->mMeshes[0]->mFaces[i].mIndices[c] = iCurrent;
+            pScene->mMeshes[0]->mIndices[pScene->mMeshes[0]->mFaces[i].mIndices + c] = iCurrent;
         }
     }
 }

--- a/code/MD3Loader.cpp
+++ b/code/MD3Loader.cpp
@@ -990,7 +990,9 @@ void MD3Importer::InternReadFile( const std::string& pFile,
 
         pcMesh->mNumVertices        = pcSurfaces->NUM_TRIANGLES*3;
         pcMesh->mNumFaces           = pcSurfaces->NUM_TRIANGLES;
+        pcMesh->mNumIndices         = pcMesh->mNumFaces * 3;
         pcMesh->mFaces              = new aiFace[pcSurfaces->NUM_TRIANGLES];
+        pcMesh->mIndices            = new unsigned int[pcMesh->mNumIndices];
         pcMesh->mNormals            = new aiVector3D[pcMesh->mNumVertices];
         pcMesh->mVertices           = new aiVector3D[pcMesh->mNumVertices];
         pcMesh->mTextureCoords[0]   = new aiVector3D[pcMesh->mNumVertices];
@@ -999,12 +1001,12 @@ void MD3Importer::InternReadFile( const std::string& pFile,
         // Fill in all triangles
         unsigned int iCurrent = 0;
         for (unsigned int i = 0; i < (unsigned int)pcSurfaces->NUM_TRIANGLES;++i)   {
-            pcMesh->mFaces[i].mIndices = new unsigned int[3];
+            pcMesh->mFaces[i].mIndices = i * 3;
             pcMesh->mFaces[i].mNumIndices = 3;
 
             //unsigned int iTemp = iCurrent;
             for (unsigned int c = 0; c < 3;++c,++iCurrent)  {
-                pcMesh->mFaces[i].mIndices[c] = iCurrent;
+                pcMesh->mIndices[pcMesh->mFaces[i].mIndices + c] = iCurrent;
 
                 // Read vertices
                 aiVector3D& vec = pcMesh->mVertices[iCurrent];
@@ -1026,7 +1028,7 @@ void MD3Importer::InternReadFile( const std::string& pFile,
             }
             // Flip face order if necessary
             if (!shader || shader->cull == Q3Shader::CULL_CW) {
-                std::swap(pcMesh->mFaces[i].mIndices[2],pcMesh->mFaces[i].mIndices[1]);
+                std::swap(pcMesh->mIndices[pcMesh->mFaces[i].mIndices + 2], pcMesh->mIndices[pcMesh->mFaces[i].mIndices + 1]);
             }
             pcTriangles++;
         }

--- a/code/MD5Loader.cpp
+++ b/code/MD5Loader.cpp
@@ -240,19 +240,19 @@ void MD5Importer::MakeDataUnique (MD5::MeshDesc& meshSrc)
     for (FaceList::const_iterator iter = meshSrc.mFaces.begin(),iterEnd = meshSrc.mFaces.end();iter != iterEnd;++iter){
         const aiFace& face = *iter;
         for (unsigned int i = 0; i < 3;++i) {
-            if (face.mIndices[0] >= meshSrc.mVertices.size()) {
+            if (meshSrc.mIndices[face.mIndices + 0] >= meshSrc.mVertices.size()) {
                 throw DeadlyImportError("MD5MESH: Invalid vertex index");
             }
 
-            if (abHad[face.mIndices[i]])    {
+            if (abHad[meshSrc.mIndices[face.mIndices + i]])    {
                 // generate a new vertex
-                meshSrc.mVertices[iNewIndex] = meshSrc.mVertices[face.mIndices[i]];
-                face.mIndices[i] = iNewIndex++;
+                meshSrc.mVertices[iNewIndex] = meshSrc.mVertices[meshSrc.mIndices[face.mIndices + i]];
+                meshSrc.mIndices[face.mIndices + i] = iNewIndex++;
             }
-            else abHad[face.mIndices[i]] = true;
+            else abHad[meshSrc.mIndices[face.mIndices + i]] = true;
         }
         // swap face order
-        std::swap(face.mIndices[0],face.mIndices[2]);
+        std::swap(meshSrc.mIndices[face.mIndices + 0], meshSrc.mIndices[face.mIndices + 2]);
     }
 }
 

--- a/code/MD5Parser.cpp
+++ b/code/MD5Parser.cpp
@@ -319,10 +319,11 @@ MD5MeshParser::MD5MeshParser(SectionList& mSections)
                         desc.mFaces.resize(idx+1);
 
                     aiFace& face = desc.mFaces[idx];
-                    face.mIndices = new unsigned int[face.mNumIndices = 3];
+                    face.mNumIndices = 3;
+                    face.mIndices = (unsigned int)desc.mIndices.size();
                     for (unsigned int i = 0; i < 3;++i) {
                         AI_MD5_SKIP_SPACES();
-                        face.mIndices[i] = strtoul10(sz,&sz);
+                        desc.mIndices.push_back(strtoul10(sz,&sz));
                     }
                 }
                 // weight attribute

--- a/code/MD5Parser.h
+++ b/code/MD5Parser.h
@@ -228,6 +228,7 @@ struct WeightDesc
 
 typedef std::vector< WeightDesc > WeightList;
 typedef std::vector< aiFace > FaceList;
+typedef std::vector< unsigned int > IndicesList;
 
 // ---------------------------------------------------------------------------
 /** Represents a mesh in a MD5 file
@@ -242,6 +243,9 @@ struct MeshDesc
 
     //! Faces of the mesh
     FaceList mFaces;
+
+    //! Indices of the mesh
+    IndicesList mIndices;
 
     //! Name of the shader (=texture) to be assigned to the mesh
     aiString mShader;

--- a/code/MDCLoader.cpp
+++ b/code/MDCLoader.cpp
@@ -278,6 +278,7 @@ void MDCImporter::InternReadFile(
         aiMesh* pcMesh = pScene->mMeshes[iNum++] = new aiMesh();
 
         pcMesh->mNumFaces = pcSurface->ulNumTriangles;
+        pcMesh->mNumIndices = pcMesh->mNumFaces * 3;
         pcMesh->mNumVertices = pcMesh->mNumFaces * 3;
 
         // store the name of the surface for use as node name.
@@ -303,6 +304,8 @@ void MDCImporter::InternReadFile(
         }
         // otherwise assign a reference to the default material
         else pcMesh->mMaterialIndex = iDefaultMatIndex;
+        unsigned int pcIndicesCur = 0;
+        pcMesh->mIndices = new unsigned int[pcMesh->mNumIndices];
 
         // allocate output storage for the mesh
         aiVector3D* pcVertCur   = pcMesh->mVertices         = new aiVector3D[pcMesh->mNumVertices];
@@ -378,7 +381,8 @@ void MDCImporter::InternReadFile(
         {
             const unsigned int iOutIndex = iFace*3;
             pcFaceCur->mNumIndices = 3;
-            pcFaceCur->mIndices = new unsigned int[3];
+            pcFaceCur->mIndices = pcIndicesCur;
+            pcIndicesCur += 3;
 
             for (unsigned int iIndex = 0; iIndex < 3;++iIndex,
                 ++pcVertCur,++pcUVCur,++pcNorCur)
@@ -416,9 +420,9 @@ void MDCImporter::InternReadFile(
             }
 
             // swap the face order - DX to OGL
-            pcFaceCur->mIndices[0] = iOutIndex + 2;
-            pcFaceCur->mIndices[1] = iOutIndex + 1;
-            pcFaceCur->mIndices[2] = iOutIndex + 0;
+            pcMesh->mIndices[pcFaceCur->mIndices + 0] = iOutIndex + 2;
+            pcMesh->mIndices[pcFaceCur->mIndices + 1] = iOutIndex + 1;
+            pcMesh->mIndices[pcFaceCur->mIndices + 2] = iOutIndex + 0;
         }
 
         pcSurface =  new ((int8_t*)pcSurface + pcSurface->ulOffsetEnd) MDC::Surface;

--- a/code/MDLLoader.cpp
+++ b/code/MDLLoader.cpp
@@ -446,9 +446,11 @@ void MDLImporter::InternReadFile_Quake1( )
     pcMesh->mPrimitiveTypes = aiPrimitiveType_TRIANGLE;
     pcMesh->mNumVertices = pcHeader->num_tris * 3;
     pcMesh->mNumFaces = pcHeader->num_tris;
+    pcMesh->mNumIndices = pcMesh->mNumFaces * 3;
     pcMesh->mVertices = new aiVector3D[pcMesh->mNumVertices];
     pcMesh->mTextureCoords[0] = new aiVector3D[pcMesh->mNumVertices];
     pcMesh->mFaces = new aiFace[pcMesh->mNumFaces];
+    pcMesh->mIndices = new unsigned int[pcMesh->mNumIndices];
     pcMesh->mNormals = new aiVector3D[pcMesh->mNumVertices];
     pcMesh->mNumUVComponents[0] = 2;
 
@@ -465,13 +467,13 @@ void MDLImporter::InternReadFile_Quake1( )
     unsigned int iCurrent = 0;
     for (unsigned int i = 0; i < (unsigned int) pcHeader->num_tris;++i)
     {
-        pcMesh->mFaces[i].mIndices = new unsigned int[3];
+        pcMesh->mFaces[i].mIndices = i * 3;
         pcMesh->mFaces[i].mNumIndices = 3;
 
         unsigned int iTemp = iCurrent;
         for (unsigned int c = 0; c < 3;++c,++iCurrent)
         {
-            pcMesh->mFaces[i].mIndices[c] = iCurrent;
+            pcMesh->mIndices[pcMesh->mFaces[i].mIndices + c] = iCurrent;
 
             // read vertices
             unsigned int iIndex = pcTriangles->vertex[c];
@@ -510,9 +512,9 @@ void MDLImporter::InternReadFile_Quake1( )
             pcMesh->mTextureCoords[0][iCurrent].y = 1.0f-(t + 0.5f) / pcHeader->skinheight;
 
         }
-        pcMesh->mFaces[i].mIndices[0] = iTemp+2;
-        pcMesh->mFaces[i].mIndices[1] = iTemp+1;
-        pcMesh->mFaces[i].mIndices[2] = iTemp+0;
+        pcMesh->mIndices[pcMesh->mFaces[i].mIndices + 0] = iTemp+2;
+        pcMesh->mIndices[pcMesh->mFaces[i].mIndices + 1] = iTemp+1;
+        pcMesh->mIndices[pcMesh->mFaces[i].mIndices + 2] = iTemp+0;
         pcTriangles++;
     }
     return;
@@ -642,7 +644,9 @@ void MDLImporter::InternReadFile_3DGS_MDL345( )
 
     pcMesh->mNumVertices = pcHeader->num_tris * 3;
     pcMesh->mNumFaces = pcHeader->num_tris;
+    pcMesh->mNumIndices = pcMesh->mNumFaces * 3;
     pcMesh->mFaces = new aiFace[pcMesh->mNumFaces];
+    pcMesh->mIndices = new unsigned int[pcMesh->mNumIndices];
 
     // there won't be more than one mesh inside the file
     pScene->mRootNode = new aiNode();
@@ -680,7 +684,7 @@ void MDLImporter::InternReadFile_3DGS_MDL345( )
         // now iterate through all triangles
         unsigned int iCurrent = 0;
         for (unsigned int i = 0; i < (unsigned int) pcHeader->num_tris;++i) {
-            pcMesh->mFaces[i].mIndices = new unsigned int[3];
+            pcMesh->mFaces[i].mIndices = i * 3;
             pcMesh->mFaces[i].mNumIndices = 3;
 
             unsigned int iTemp = iCurrent;
@@ -713,9 +717,9 @@ void MDLImporter::InternReadFile_3DGS_MDL345( )
                         pcTexCoords,pcTriangles->index_uv[c]);
                 }
             }
-            pcMesh->mFaces[i].mIndices[0] = iTemp+2;
-            pcMesh->mFaces[i].mIndices[1] = iTemp+1;
-            pcMesh->mFaces[i].mIndices[2] = iTemp+0;
+            pcMesh->mIndices[pcMesh->mFaces[i].mIndices + 0] = iTemp+2;
+            pcMesh->mIndices[pcMesh->mFaces[i].mIndices + 1] = iTemp+1;
+            pcMesh->mIndices[pcMesh->mFaces[i].mIndices + 2] = iTemp+0;
             pcTriangles++;
         }
 
@@ -735,7 +739,7 @@ void MDLImporter::InternReadFile_3DGS_MDL345( )
         // now iterate through all triangles
         unsigned int iCurrent = 0;
         for (unsigned int i = 0; i < (unsigned int) pcHeader->num_tris;++i) {
-            pcMesh->mFaces[i].mIndices = new unsigned int[3];
+            pcMesh->mFaces[i].mIndices = i * 3;
             pcMesh->mFaces[i].mNumIndices = 3;
 
             unsigned int iTemp = iCurrent;
@@ -768,9 +772,9 @@ void MDLImporter::InternReadFile_3DGS_MDL345( )
                         pcTexCoords,pcTriangles->index_uv[c]);
                 }
             }
-            pcMesh->mFaces[i].mIndices[0] = iTemp+2;
-            pcMesh->mFaces[i].mIndices[1] = iTemp+1;
-            pcMesh->mFaces[i].mIndices[2] = iTemp+0;
+            pcMesh->mIndices[pcMesh->mFaces[i].mIndices + 0] = iTemp+2;
+            pcMesh->mIndices[pcMesh->mFaces[i].mIndices + 1] = iTemp+1;
+            pcMesh->mIndices[pcMesh->mFaces[i].mIndices + 2] = iTemp+0;
             pcTriangles++;
         }
     }
@@ -1832,7 +1836,9 @@ void MDLImporter::GenerateOutputMeshes_3DGS_MDL7(
 
             // allocate output storage
             pcMesh->mNumFaces = (unsigned int)splitGroupData.aiSplit[i]->size();
+            pcMesh->mNumIndices = pcMesh->mNumFaces * 3;
             pcMesh->mFaces = new aiFace[pcMesh->mNumFaces];
+            pcMesh->mIndices = new unsigned int[pcMesh->mNumIndices];
 
             pcMesh->mNumVertices = pcMesh->mNumFaces*3;
             pcMesh->mVertices = new aiVector3D[pcMesh->mNumVertices];
@@ -1851,7 +1857,7 @@ void MDLImporter::GenerateOutputMeshes_3DGS_MDL7(
             unsigned int iCurrent = 0;
             for (unsigned int iFace = 0; iFace < pcMesh->mNumFaces;++iFace) {
                 pcMesh->mFaces[iFace].mNumIndices = 3;
-                pcMesh->mFaces[iFace].mIndices = new unsigned int[3];
+                pcMesh->mFaces[iFace].mIndices = iFace * 3;
 
                 unsigned int iSrcFace = splitGroupData.aiSplit[i]->operator[](iFace);
                 const MDL::IntFace_MDL7& oldFace = groupData.pcFaces[iSrcFace];
@@ -1869,7 +1875,7 @@ void MDLImporter::GenerateOutputMeshes_3DGS_MDL7(
                             pcMesh->mTextureCoords[1][iCurrent] = groupData.vTextureCoords2[iIndex];
                         }
                     }
-                    pcMesh->mFaces[iFace].mIndices[c] = iCurrent++;
+                    pcMesh->mIndices[pcMesh->mFaces[iFace].mIndices + c] = iCurrent++;
                 }
             }
 

--- a/code/MS3DLoader.cpp
+++ b/code/MS3DLoader.cpp
@@ -484,6 +484,7 @@ void MS3DImporter::InternReadFile( const std::string& pFile,
         m->mPrimitiveTypes = aiPrimitiveType_TRIANGLE;
 
         m->mFaces = new aiFace[m->mNumFaces = g.triangles.size()];
+        m->mIndices = new unsigned int[m->mNumIndices = m->mNumFaces * 3];
         m->mNumVertices = m->mNumFaces*3;
 
         // storage for vertices - verbose format, as requested by the postprocessing pipeline
@@ -502,7 +503,8 @@ void MS3DImporter::InternReadFile( const std::string& pFile,
             }
 
             TempTriangle& t = triangles[g.triangles[i]];
-            f.mIndices = new unsigned int[f.mNumIndices=3];
+            f.mNumIndices = 3;
+            f.mIndices = n;
 
             for (unsigned int i = 0; i < 3; ++i,++n) {
                 if (t.indices[i]>vertices.size()) {
@@ -527,7 +529,7 @@ void MS3DImporter::InternReadFile( const std::string& pFile,
 
                 m->mNormals[n] = t.normals[i];
                 m->mTextureCoords[0][n] = aiVector3D(t.uv[i].x,1.f-t.uv[i].y,0.0);
-                f.mIndices[i] = n;
+                m->mIndices[f.mIndices + i] = n;
             }
         }
 

--- a/code/MakeVerboseFormat.cpp
+++ b/code/MakeVerboseFormat.cpp
@@ -130,7 +130,7 @@ bool MakeVerboseFormatProcess::MakeVerboseFormat(aiMesh* pcMesh)
                 for (unsigned int a = 0;  a < pcMesh->mBones[i]->mNumWeights;a++)
                 {
                     const aiVertexWeight& w = pcMesh->mBones[i]->mWeights[a];
-                    if(pcFace->mIndices[q] == w.mVertexId)
+                    if(pcMesh->mIndices[pcFace->mIndices + q] == w.mVertexId)
                     {
                         aiVertexWeight wNew;
                         wNew.mVertexId = iIndex;
@@ -140,31 +140,31 @@ bool MakeVerboseFormatProcess::MakeVerboseFormat(aiMesh* pcMesh)
                 }
             }
 
-            pvPositions[iIndex] = pcMesh->mVertices[pcFace->mIndices[q]];
+            pvPositions[iIndex] = pcMesh->mVertices[pcMesh->mIndices[pcFace->mIndices + q]];
 
             if (pcMesh->HasNormals())
             {
-                pvNormals[iIndex] = pcMesh->mNormals[pcFace->mIndices[q]];
+                pvNormals[iIndex] = pcMesh->mNormals[pcMesh->mIndices[pcFace->mIndices + q]];
             }
             if (pcMesh->HasTangentsAndBitangents())
             {
-                pvTangents[iIndex] = pcMesh->mTangents[pcFace->mIndices[q]];
-                pvBitangents[iIndex] = pcMesh->mBitangents[pcFace->mIndices[q]];
+                pvTangents[iIndex] = pcMesh->mTangents[pcMesh->mIndices[pcFace->mIndices + q]];
+                pvBitangents[iIndex] = pcMesh->mBitangents[pcMesh->mIndices[pcFace->mIndices + q]];
             }
 
             unsigned int p = 0;
             while (pcMesh->HasTextureCoords(p))
             {
-                apvTextureCoords[p][iIndex] = pcMesh->mTextureCoords[p][pcFace->mIndices[q]];
+                apvTextureCoords[p][iIndex] = pcMesh->mTextureCoords[p][pcMesh->mIndices[pcFace->mIndices + q]];
                 ++p;
             }
             p = 0;
             while (pcMesh->HasVertexColors(p))
             {
-                apvColorSets[p][iIndex] = pcMesh->mColors[p][pcFace->mIndices[q]];
+                apvColorSets[p][iIndex] = pcMesh->mColors[p][pcMesh->mIndices[pcFace->mIndices + q]];
                 ++p;
             }
-            pcFace->mIndices[q] = iIndex;
+            pcMesh->mIndices[pcFace->mIndices + q] = iIndex;
         }
     }
 

--- a/code/NDOLoader.cpp
+++ b/code/NDOLoader.cpp
@@ -261,10 +261,13 @@ void NDOImporter::InternReadFile( const std::string& pFile,
 
         vertices.clear();
         vertices.reserve(4 * face_table.size()); // arbitrarily chosen
+        indices.clear();
+        indices.reserve(4 * face_table.size()); // arbitrarily chosen
         for(FaceTable::value_type& v : face_table) {
             indices.clear();
 
             aiFace& f = *faces++;
+            f.mIndices = indices.size();
 
             const unsigned int key = v.first;
             unsigned int cur_edge = v.second;
@@ -287,12 +290,14 @@ void NDOImporter::InternReadFile( const std::string& pFile,
                 }
             }
 
-            f.mIndices = new unsigned int[f.mNumIndices = indices.size()];
-            std::copy(indices.begin(),indices.end(),f.mIndices);
+            f.mNumIndices = (indices.size() - f.mIndices);
         }
 
         mesh->mVertices = new aiVector3D[mesh->mNumVertices = vertices.size()];
         std::copy(vertices.begin(),vertices.end(),mesh->mVertices);
+
+        mesh->mIndices = new unsigned int[mesh->mNumIndices = indices.size()];
+        std::copy(indices.begin(), indices.end(), mesh->mIndices);
 
         if (mesh->mNumVertices) {
             pScene->mMeshes[pScene->mNumMeshes] = mesh;

--- a/code/OFFLoader.cpp
+++ b/code/OFFLoader.cpp
@@ -195,6 +195,10 @@ void OFFImporter::InternReadFile( const std::string& pFile,
     std::vector<aiVector3D> verts;
     verts.reserve(mesh->mNumVertices);
 
+    // allocate storage for the output indices
+    mesh->mIndices = new unsigned int[mesh->mNumIndices = mesh->mNumVertices];
+    unsigned int indices = 0;
+
     // second: now parse all face indices
     buffer = old;
     faces = mesh->mFaces;
@@ -208,7 +212,8 @@ void OFFImporter::InternReadFile( const std::string& pFile,
         if(!(idx) || idx > 9)
             continue;
 
-        faces->mIndices = new unsigned int [faces->mNumIndices];
+        faces->mIndices = indices;
+        indices += faces->mNumIndices;
         for (unsigned int m = 0; m < faces->mNumIndices;++m)
         {
             SkipSpaces(&sz);
@@ -218,7 +223,7 @@ void OFFImporter::InternReadFile( const std::string& pFile,
                 DefaultLogger::get()->error("OFF: Vertex index is out of range");
                 idx = numVertices-1;
             }
-            faces->mIndices[m] = p++;
+            mesh->mIndices[faces->mIndices + m] = p++;
             verts.push_back(tempPositions[idx]);
         }
         ++i;

--- a/code/ObjExporter.cpp
+++ b/code/ObjExporter.cpp
@@ -322,7 +322,7 @@ void ObjExporter::AddMesh(const aiString& name, const aiMesh* m, const aiMatrix4
         face.indices.resize(f.mNumIndices);
 
         for(unsigned int a = 0; a < f.mNumIndices; ++a) {
-            const unsigned int idx = f.mIndices[a];
+            const unsigned int idx = m->mIndices[f.mIndices + a];
 
             aiVector3D vert = mat * m->mVertices[idx];
             face.indices[a].vp = vpMap.getIndex(vert);

--- a/code/ObjFileData.h
+++ b/code/ObjFileData.h
@@ -63,11 +63,14 @@ struct Face
     //! Primitive type
     aiPrimitiveType m_PrimitiveType;
     //! Vertex indices
-    IndexArray *m_pVertices;
+    unsigned int m_numVertices;
+    unsigned int m_Vertices;
     //! Normal indices
-    IndexArray *m_pNormals;
+    unsigned int m_numNormals;
+    unsigned int m_Normals;
     //! Texture coordinates indices
-    IndexArray *m_pTexturCoords;
+    unsigned int m_numTexturCoords;
+    unsigned int m_TexturCoords;
     //! Pointer to assigned material
     Material *m_pMaterial;
 
@@ -75,31 +78,27 @@ struct Face
     //! \param  pVertices   Pointer to assigned vertex indexbuffer
     //! \param  pNormals    Pointer to assigned normals indexbuffer
     //! \param  pTexCoords  Pointer to assigned texture indexbuffer
-    Face( std::vector<unsigned int> *pVertices,
-            std::vector<unsigned int> *pNormals,
-            std::vector<unsigned int> *pTexCoords,
+    Face( unsigned int numVertices,
+            unsigned int Vertices,
+            unsigned int numNormals,
+            unsigned int Normals,
+            unsigned int numTexturCoords,
+            unsigned int TexturCoords,
             aiPrimitiveType pt = aiPrimitiveType_POLYGON) :
         m_PrimitiveType( pt ),
-        m_pVertices( pVertices ),
-        m_pNormals( pNormals ),
-        m_pTexturCoords( pTexCoords ),
+        m_numVertices(numVertices),
+        m_Vertices(Vertices),
+        m_numNormals(numNormals),
+        m_Normals(Normals),
+        m_numTexturCoords(numTexturCoords),
+        m_TexturCoords(TexturCoords),
         m_pMaterial( 0L )
     {
         // empty
     }
 
     //! \brief  Destructor
-    ~Face()
-    {
-        delete m_pVertices;
-        m_pVertices = NULL;
-
-        delete m_pNormals;
-        m_pNormals = NULL;
-
-        delete m_pTexturCoords;
-        m_pTexturCoords = NULL;
-    }
+    ~Face() {}
 };
 
 // ------------------------------------------------------------------------------------------------
@@ -229,7 +228,13 @@ struct Mesh {
     /// The name for the mesh
     std::string m_name;
     /// Array with pointer to all stored faces
-    std::vector<Face*> m_Faces;
+    std::vector<Face> m_Faces;
+    ///	Vertex indices
+    std::vector<unsigned int> m_Vertices;
+    ///	Normal indices
+    std::vector<unsigned int> m_Normals;
+    ///	Texture coordinates indices
+    std::vector<unsigned int> m_TexturCoords;
     /// Assigned material
     Material *m_pMaterial;
     /// Number of stored indices.
@@ -254,14 +259,7 @@ struct Mesh {
     }
 
     /// Destructor
-    ~Mesh()
-    {
-        for (std::vector<Face*>::iterator it = m_Faces.begin();
-            it != m_Faces.end(); ++it)
-        {
-            delete *it;
-        }
-    }
+    ~Mesh() {}
 };
 
 // ------------------------------------------------------------------------------------------------

--- a/code/OgreStructs.h
+++ b/code/OgreStructs.h
@@ -636,6 +636,7 @@ public:
     uint32_t faceCount;
 
     std::vector<aiFace> faces;
+    std::vector<unsigned int> indices;
 };
 
 /// Ogre XML SubMesh

--- a/code/OgreXmlSerializer.cpp
+++ b/code/OgreXmlSerializer.cpp
@@ -579,10 +579,10 @@ void OgreXmlSerializer::ReadSubMesh(MeshXml *mesh)
             {
                 aiFace face;
                 face.mNumIndices = 3;
-                face.mIndices = new unsigned int[3];
-                face.mIndices[0] = ReadAttribute<uint32_t>(anV1);
-                face.mIndices[1] = ReadAttribute<uint32_t>(anV2);
-                face.mIndices[2] = ReadAttribute<uint32_t>(anV3);
+                face.mIndices = submesh->indexData->indices.size();
+                submesh->indexData->indices.push_back(ReadAttribute<uint32_t>(anV1));
+                submesh->indexData->indices.push_back(ReadAttribute<uint32_t>(anV2));
+                submesh->indexData->indices.push_back(ReadAttribute<uint32_t>(anV3));
 
                 /// @todo Support quads if Ogre even supports them in XML (I'm not sure but I doubt it)
                 if (!quadWarned && HasAttribute(anV4)) {

--- a/code/OpenGEXImporter.cpp
+++ b/code/OpenGEXImporter.cpp
@@ -124,7 +124,7 @@ namespace Grammar {
         MaterialToken,
         ColorToken,
         ParamToken,
-        TextureToken, 
+        TextureToken,
         AttenToken
     };
 
@@ -235,7 +235,7 @@ OpenGEXImporter::VertexContainer::VertexContainer()
 OpenGEXImporter::VertexContainer::~VertexContainer() {
     delete[] m_vertices;
     delete[] m_normals;
-    
+
     for(auto &texcoords : m_textureCoords) {
         delete [] texcoords;
     }
@@ -411,7 +411,7 @@ void OpenGEXImporter::handleNodes( DDLNode *node, aiScene *pScene ) {
             case Grammar::ColorToken:
                 handleColorNode( *it, pScene );
                 break;
-            
+
             case Grammar::ParamToken:
                 handleParamNode( *it, pScene );
                 break;
@@ -477,7 +477,7 @@ void OpenGEXImporter::handleNameNode( DDLNode *node, aiScene *pScene ) {
         }
 
         const std::string name( val->getString() );
-        if( m_tokenType == Grammar::GeometryNodeToken || m_tokenType == Grammar::LightNodeToken  
+        if( m_tokenType == Grammar::GeometryNodeToken || m_tokenType == Grammar::LightNodeToken
                 || m_tokenType == Grammar::CameraNodeToken ) {
             m_currentNode->mName.Set( name.c_str() );
         } else if( m_tokenType == Grammar::MaterialToken ) {
@@ -513,7 +513,7 @@ void OpenGEXImporter::handleObjectRefNode( DDLNode *node, aiScene *pScene ) {
 
     std::vector<std::string> objRefNames;
     getRefNames( node, objRefNames );
-    
+
     // when we are dealing with a geometry node prepare the mesh cache
     if ( m_tokenType == Grammar::GeometryNodeToken ) {
         m_currentNode->mNumMeshes = objRefNames.size();
@@ -594,7 +594,7 @@ void OpenGEXImporter::handleGeometryObject( DDLNode *node, aiScene *pScene ) {
 //------------------------------------------------------------------------------------------------
 void OpenGEXImporter::handleCameraObject( ODDLParser::DDLNode *node, aiScene *pScene ) {
     // parameters will be parsed normally in the tree, so just go for it
-   
+
     handleNodes( node, pScene );
 }
 
@@ -833,6 +833,8 @@ void OpenGEXImporter::handleIndexArrayNode( ODDLParser::DDLNode *node, aiScene *
     const size_t numItems( countDataArrayListItems( vaList ) );
     m_currentMesh->mNumFaces = numItems;
     m_currentMesh->mFaces = new aiFace[ numItems ];
+    m_currentMesh->mNumIndices = numItems * 3;
+    m_currentMesh->mIndices = new unsigned int[m_currentMesh->mNumIndices];
     m_currentMesh->mNumVertices = numItems * 3;
     m_currentMesh->mVertices = new aiVector3D[ m_currentMesh->mNumVertices ];
     bool hasNormalCoords( false );
@@ -850,7 +852,7 @@ void OpenGEXImporter::handleIndexArrayNode( ODDLParser::DDLNode *node, aiScene *
     for( size_t i = 0; i < m_currentMesh->mNumFaces; i++ ) {
         aiFace &current(  m_currentMesh->mFaces[ i ] );
         current.mNumIndices = 3;
-        current.mIndices = new unsigned int[ current.mNumIndices ];
+        current.mIndices = index;
         Value *next( vaList->m_dataList );
         for( size_t indices = 0; indices < current.mNumIndices; indices++ ) {
             const int idx( next->getUnsignedInt32() );
@@ -866,7 +868,7 @@ void OpenGEXImporter::handleIndexArrayNode( ODDLParser::DDLNode *node, aiScene *
                 aiVector3D &tex = ( m_currentVertices.m_textureCoords[ 0 ][ idx ] );
                 m_currentMesh->mTextureCoords[ 0 ][ index ].Set( tex.x, tex.y, tex.z );
             }
-            current.mIndices[ indices ] = index;
+            m_currentMesh->mIndices[ current.mIndices + indices ] = index;
             index++;
 
             next = next->m_next;
@@ -1127,7 +1129,7 @@ void OpenGEXImporter::pushNode( aiNode *node, aiScene *pScene ) {
     if ( NULL == node ) {
         return;
     }
-        
+
     ChildInfo *info( nullptr );
     if( m_nodeStack.empty() ) {
         node->mParent = pScene->mRootNode;

--- a/code/PlyExporter.cpp
+++ b/code/PlyExporter.cpp
@@ -358,7 +358,7 @@ void PlyExporter::WriteMeshIndices(const aiMesh* m, unsigned int offset)
         const aiFace& f = m->mFaces[i];
         mOutput << f.mNumIndices << " ";
         for(unsigned int c = 0; c < f.mNumIndices; ++c) {
-            mOutput << (f.mIndices[c] + offset) << (c == f.mNumIndices-1 ? endl : " ");
+            mOutput << (m->mIndices[f.mIndices + c] + offset) << (c == f.mNumIndices-1 ? endl : " ");
         }
     }
 }
@@ -372,7 +372,7 @@ void WriteMeshIndicesBinary_Generic(const aiMesh* m, unsigned int offset, std::o
         NumIndicesType numIndices = static_cast<NumIndicesType>(f.mNumIndices);
         output.write(reinterpret_cast<const char*>(&numIndices), sizeof(NumIndicesType));
         for (unsigned int c = 0; c < f.mNumIndices; ++c) {
-            IndexType index = f.mIndices[c] + offset;
+            IndexType index = m->mIndices[f.mIndices + c] + offset;
             output.write(reinterpret_cast<const char*>(&index), sizeof(IndexType));
         }
     }

--- a/code/PlyLoader.cpp
+++ b/code/PlyLoader.cpp
@@ -343,20 +343,28 @@ void PLYImporter::ConvertMeshes(std::vector<PLY::Face>* avFaces,
             if (!avNormals->empty())
                 p_pcOut->mNormals = new aiVector3D[iNum];
 
+            for (std::vector<unsigned int>::const_iterator i = aiSplit[p].begin(); i != aiSplit[p].end(); ++i)
+            {
+                p_pcOut->mNumIndices += (unsigned int)(*avFaces)[*i].mIndices.size();
+            }
+            p_pcOut->mIndices = new unsigned int[p_pcOut->mNumIndices];
+
             // add all faces
             iNum = 0;
             unsigned int iVertex = 0;
+            unsigned int iIndices = 0;
             for (std::vector<unsigned int>::const_iterator i =  aiSplit[p].begin();
                 i != aiSplit[p].end();++i,++iNum)
             {
-                p_pcOut->mFaces[iNum].mNumIndices = (unsigned int)(*avFaces)[*i].mIndices.size();
-                p_pcOut->mFaces[iNum].mIndices = new unsigned int[p_pcOut->mFaces[iNum].mNumIndices];
+                p_pcOut->mFaces[iNum].mNumIndices = (unsigned int)(*avFaces)[*i].mIndices.size(); 
+                p_pcOut->mFaces[iNum].mIndices = iIndices;
+                iIndices += p_pcOut->mFaces[iNum].mNumIndices;
 
                 // build an unique set of vertices/colors for this face
                 for (unsigned int q = 0; q <  p_pcOut->mFaces[iNum].mNumIndices;++q)
                 {
-                    p_pcOut->mFaces[iNum].mIndices[q] = iVertex;
-                    const size_t idx = ( *avFaces )[ *i ].mIndices[ q ];
+                    p_pcOut->mIndices[p_pcOut->mFaces[iNum].mIndices + q] = iVertex;
+                    const size_t idx = p_pcOut->mIndices[p_pcOut->mFaces[iNum].mIndices + q];
                     if( idx >= ( *avPositions ).size() ) {
                         // out of border
                         continue;

--- a/code/PretransformVertices.h
+++ b/code/PretransformVertices.h
@@ -114,6 +114,7 @@ private:
         unsigned int iMat,
         unsigned int iVFormat,
         unsigned int* piFaces,
+        unsigned int* piIndices,
         unsigned int* piVertices);
 
     // -------------------------------------------------------------------
@@ -122,7 +123,7 @@ private:
         unsigned int iMat,
         unsigned int iVFormat,
         aiMesh* pcMeshOut,
-        unsigned int aiCurrent[2],
+        unsigned int aiCurrent[3],
         unsigned int* num_refs);
 
     // -------------------------------------------------------------------

--- a/code/Q3BSPFileImporter.cpp
+++ b/code/Q3BSPFileImporter.cpp
@@ -373,7 +373,9 @@ aiNode *Q3BSPFileImporter::CreateTopology( const Q3BSP::Q3BSPModel *pModel,
     pMesh->mPrimitiveTypes = aiPrimitiveType_TRIANGLE;
 
     pMesh->mFaces = new aiFace[ numTriangles ];
+    pMesh->mIndices = new unsigned int[ numTriangles * 3 ];
     pMesh->mNumFaces = numTriangles;
+    pMesh->mNumIndices = numTriangles * 3;
 
     pMesh->mNumVertices = numVerts;
     pMesh->mVertices = new aiVector3D[ numVerts ];
@@ -429,7 +431,7 @@ void Q3BSPFileImporter::createTriangleTopology( const Q3BSP::Q3BSPModel *pModel,
     }
 
     m_pCurrentFace->mNumIndices = 3;
-    m_pCurrentFace->mIndices = new unsigned int[ m_pCurrentFace->mNumIndices ];
+    m_pCurrentFace->mIndices = (rFaceIdx - 1) * 3;
 
     size_t idx = 0;
     for ( size_t i = 0; i < (size_t) pQ3BSPFace->iNumOfFaceVerts; i++ )
@@ -454,7 +456,7 @@ void Q3BSPFileImporter::createTriangleTopology( const Q3BSP::Q3BSPModel *pModel,
         pMesh->mTextureCoords[ 0 ][ rVertIdx ].Set( pVertex->vTexCoord.x, pVertex->vTexCoord.y, 0.0f );
         pMesh->mTextureCoords[ 1 ][ rVertIdx ].Set( pVertex->vLightmap.x, pVertex->vLightmap.y, 0.0f );
 
-        m_pCurrentFace->mIndices[ idx ] = rVertIdx;
+        pMesh->mIndices[m_pCurrentFace->mIndices + idx ] = rVertIdx;
         rVertIdx++;
 
         idx++;
@@ -465,7 +467,7 @@ void Q3BSPFileImporter::createTriangleTopology( const Q3BSP::Q3BSPModel *pModel,
             if ( NULL != m_pCurrentFace )
             {
                 m_pCurrentFace->mNumIndices = 3;
-                m_pCurrentFace->mIndices = new unsigned int[ 3 ];
+                m_pCurrentFace->mIndices = (rFaceIdx - 1) * 3;
             }
         }
     }

--- a/code/Q3DLoader.cpp
+++ b/code/Q3DLoader.cpp
@@ -507,6 +507,15 @@ outer:
         }
         else uv = NULL;
 
+        for (FaceIdxArray::const_iterator it = fidx[i].begin(), end = fidx[i].end(); it != end; ++it)
+        {
+            Mesh& m = meshes[(*it).first];
+            Face& face = m.faces[(*it).second];
+
+            mesh->mNumIndices += (unsigned int)face.indices.size();
+        }
+        mesh->mIndices = new unsigned int[mesh->mNumIndices];
+
         // Build the final array
         unsigned int cnt = 0;
         for (FaceIdxArray::const_iterator it = fidx[i].begin(),end = fidx[i].end();
@@ -515,7 +524,7 @@ outer:
             Mesh& m    = meshes[(*it).first];
             Face& face = m.faces[(*it).second];
             faces->mNumIndices = (unsigned int)face.indices.size();
-            faces->mIndices = new unsigned int [faces->mNumIndices];
+            faces->mIndices = cnt;
 
 
             aiVector3D faceNormal;
@@ -568,7 +577,7 @@ outer:
                 }
 
                 // setup the new vertex index
-                faces->mIndices[n] = cnt;
+                mesh->mIndices[faces->mIndices + n] = cnt;
             }
 
         }

--- a/code/RawLoader.cpp
+++ b/code/RawLoader.cpp
@@ -293,14 +293,16 @@ void RAWImporter::InternReadFile( const std::string& pFile,
             // generate triangles
             ai_assert(0 == mesh->mNumVertices % 3);
             aiFace* fc = mesh->mFaces = new aiFace[ mesh->mNumFaces = mesh->mNumVertices/3 ];
+            mesh->mIndices = new unsigned int[mesh->mNumIndices = mesh->mNumFaces * 3];
             aiFace* const fcEnd = fc + mesh->mNumFaces;
             unsigned int n = 0;
             while (fc != fcEnd)
             {
                 aiFace& f = *fc++;
-                f.mIndices = new unsigned int[f.mNumIndices = 3];
+                f.mNumIndices = 3;
+                f.mIndices = n;
                 for (unsigned int m = 0; m < 3;++m)
-                    f.mIndices[m] = n++;
+                    mesh->mIndices[f.mIndices + m] = n++;
             }
 
             // generate a material for the mesh

--- a/code/SIBImporter.cpp
+++ b/code/SIBImporter.cpp
@@ -509,6 +509,7 @@ struct TempMesh
     std::vector<aiVector3D> nrm;
     std::vector<aiVector3D> uv;
     std::vector<aiFace> faces;
+    std::vector<unsigned int> indices;
 };
 
 static void ReadShape(SIB* sib, StreamReaderLE* stream)
@@ -582,11 +583,11 @@ static void ReadShape(SIB* sib, StreamReaderLE* stream)
 
         aiFace face;
         face.mNumIndices = *idx++;
-        face.mIndices = new unsigned[face.mNumIndices];
+        face.mIndices = dest.indices.size();
         for (unsigned pt=0;pt<face.mNumIndices;pt++,idx+=N)
         {
             size_t vtxIdx = dest.vtx.size();
-            face.mIndices[pt] = vtxIdx;
+            dest.indices.push_back(vtxIdx);
 
             // De-index it. We don't need to validate here as
             // we did it when creating the data.
@@ -623,6 +624,8 @@ static void ReadShape(SIB* sib, StreamReaderLE* stream)
         mesh->mName = name;
         mesh->mNumFaces = src.faces.size();
         mesh->mFaces = new aiFace[mesh->mNumFaces];
+        mesh->mNumIndices = src.indices.size();
+        mesh->mIndices = new unsigned int[mesh->mNumIndices];
         mesh->mNumVertices = src.vtx.size();
         mesh->mVertices = new aiVector3D[mesh->mNumVertices];
         mesh->mNormals = new aiVector3D[mesh->mNumVertices];
@@ -639,6 +642,10 @@ static void ReadShape(SIB* sib, StreamReaderLE* stream)
         for (unsigned i=0;i<mesh->mNumFaces;i++)
         {
             mesh->mFaces[i] = src.faces[i];
+        }
+        for (unsigned i=0;i<mesh->mNumIndices;i++)
+        {
+            mesh->mIndices[i] = src.indices[i];
         }
 
         sib->meshes.push_back(mesh);

--- a/code/SMDLoader.cpp
+++ b/code/SMDLoader.cpp
@@ -297,6 +297,7 @@ void SMDImporter::CreateOutputMeshes()
         pcMesh->mPrimitiveTypes = aiPrimitiveType_TRIANGLE;
         pcMesh->mNumVertices = (unsigned int)aaiFaces[i].size()*3;
         pcMesh->mNumFaces = (unsigned int)aaiFaces[i].size();
+        pcMesh->mNumIndices = (unsigned int)aaiFaces[i].size();
         pcMesh->mMaterialIndex = i;
 
         // storage for bones
@@ -313,6 +314,7 @@ void SMDImporter::CreateOutputMeshes()
 
         // allocate storage
         pcMesh->mFaces = new aiFace[pcMesh->mNumFaces];
+        pcMesh->mIndices = new unsigned int[pcMesh->mNumIndices];
         aiVector3D* pcNormals = pcMesh->mNormals = new aiVector3D[pcMesh->mNumVertices];
         aiVector3D* pcVerts = pcMesh->mVertices = new aiVector3D[pcMesh->mNumVertices];
 
@@ -326,7 +328,7 @@ void SMDImporter::CreateOutputMeshes()
         iNum = 0;
         for (unsigned int iFace = 0; iFace < pcMesh->mNumFaces;++iFace)
         {
-            pcMesh->mFaces[iFace].mIndices = new unsigned int[3];
+            pcMesh->mFaces[iFace].mIndices = iFace * 3;
             pcMesh->mFaces[iFace].mNumIndices = 3;
 
             // fill the vertices
@@ -404,7 +406,7 @@ void SMDImporter::CreateOutputMeshes()
                             TempWeightListEntry(iNum,1.0f-fSum));
                     }
                 }
-                pcMesh->mFaces[iFace].mIndices[iVert] = iNum++;
+                pcMesh->mIndices[pcMesh->mFaces[iFace].mIndices + iVert] = iNum++;
             }
         }
 

--- a/code/STLExporter.cpp
+++ b/code/STLExporter.cpp
@@ -133,14 +133,14 @@ void STLExporter :: WriteMesh(const aiMesh* m)
         aiVector3D nor;
         if (m->mNormals) {
             for(unsigned int a = 0; a < f.mNumIndices; ++a) {
-                nor += m->mNormals[f.mIndices[a]];
+                nor += m->mNormals[m->mIndices[f.mIndices + a]];
             }
             nor.Normalize();
         }
         mOutput << " facet normal " << nor.x << " " << nor.y << " " << nor.z << endl;
         mOutput << "  outer loop" << endl;
         for(unsigned int a = 0; a < f.mNumIndices; ++a) {
-            const aiVector3D& v  = m->mVertices[f.mIndices[a]];
+            const aiVector3D& v  = m->mVertices[m->mIndices[f.mIndices + a]];
             mOutput << "  vertex " << v.x << " " << v.y << " " << v.z << endl;
         }
 
@@ -158,7 +158,7 @@ void STLExporter :: WriteMeshBinary(const aiMesh* m)
         aiVector3D nor;
         if (m->mNormals) {
             for(unsigned int a = 0; a < f.mNumIndices; ++a) {
-                nor += m->mNormals[f.mIndices[a]];
+                nor += m->mNormals[m->mIndices[f.mIndices + a]];
             }
             nor.Normalize();
         }
@@ -166,7 +166,7 @@ void STLExporter :: WriteMeshBinary(const aiMesh* m)
         AI_SWAP4(nx); AI_SWAP4(ny); AI_SWAP4(nz);
         mOutput.write((char *)&nx, 4); mOutput.write((char *)&ny, 4); mOutput.write((char *)&nz, 4);
         for(unsigned int a = 0; a < f.mNumIndices; ++a) {
-            const aiVector3D& v  = m->mVertices[f.mIndices[a]];
+            const aiVector3D& v  = m->mVertices[m->mIndices[f.mIndices + a]];
             ai_real vx = v.x, vy = v.y, vz = v.z;
             AI_SWAP4(vx); AI_SWAP4(vy); AI_SWAP4(vz);
             mOutput.write((char *)&vx, 4); mOutput.write((char *)&vy, 4); mOutput.write((char *)&vz, 4);

--- a/code/STLLoader.cpp
+++ b/code/STLLoader.cpp
@@ -156,12 +156,14 @@ const aiImporterDesc* STLImporter::GetInfo () const {
 void addFacesToMesh(aiMesh* pMesh)
 {
     pMesh->mFaces = new aiFace[pMesh->mNumFaces];
+    pMesh->mIndices = new unsigned int[pMesh->mNumIndices = pMesh->mNumFaces * 3];
     for (unsigned int i = 0, p = 0; i < pMesh->mNumFaces;++i)    {
 
         aiFace& face = pMesh->mFaces[i];
-        face.mIndices = new unsigned int[face.mNumIndices = 3];
+        face.mNumIndices = 3;
+        face.mIndices = i;
         for (unsigned int o = 0; o < 3;++o,++p) {
-            face.mIndices[o] = p;
+            pMesh->mIndices[face.mIndices + o] = p;
         }
     }
 }

--- a/code/SceneCombiner.cpp
+++ b/code/SceneCombiner.cpp
@@ -870,7 +870,7 @@ void SceneCombiner::MergeMeshes(aiMesh** _out,unsigned int /*flags*/,
                 if (ofs)    {
                     // add the offset to the vertex
                     for (unsigned int q = 0; q < face.mNumIndices; ++q)
-                        face.mIndices[q] += ofs;
+                        (*it)->mIndices[face.mIndices + q] += ofs;
                 }
                 face.mIndices = NULL;
             }
@@ -1061,11 +1061,7 @@ void SceneCombiner::Copy     (aiMesh** _dest, const aiMesh* src)
 
     // make a deep copy of all faces
     GetArrayCopy(dest->mFaces,dest->mNumFaces);
-    for (unsigned int i = 0; i < dest->mNumFaces;++i)
-    {
-        aiFace& f = dest->mFaces[i];
-        GetArrayCopy(f.mIndices,f.mNumIndices);
-    }
+    GetArrayCopy(dest->mIndices,dest->mNumIndices);
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/code/SkeletonMeshBuilder.cpp
+++ b/code/SkeletonMeshBuilder.cpp
@@ -217,15 +217,17 @@ aiMesh* SkeletonMeshBuilder::CreateMesh()
     // add faces
     mesh->mNumFaces = mFaces.size();
     mesh->mFaces = new aiFace[mesh->mNumFaces];
+    mesh->mNumIndices = mesh->mNumFaces * 3;
+    mesh->mIndices = new unsigned int[mesh->mNumIndices];
     for( unsigned int a = 0; a < mesh->mNumFaces; a++)
     {
         const Face& inface = mFaces[a];
         aiFace& outface = mesh->mFaces[a];
         outface.mNumIndices = 3;
-        outface.mIndices = new unsigned int[3];
-        outface.mIndices[0] = inface.mIndices[0];
-        outface.mIndices[1] = inface.mIndices[1];
-        outface.mIndices[2] = inface.mIndices[2];
+        outface.mIndices = a * 3;
+        mesh->mIndices[outface.mIndices + 0] = inface.mIndices[0];
+        mesh->mIndices[outface.mIndices + 1] = inface.mIndices[1];
+        mesh->mIndices[outface.mIndices + 2] = inface.mIndices[2];
 
         // Compute per-face normals ... we don't want the bones to be smoothed ... they're built to visualize
         // the skeleton, so it's good if there's a visual difference to the rest of the geometry

--- a/code/SortByPTypeProcess.cpp
+++ b/code/SortByPTypeProcess.cpp
@@ -232,6 +232,8 @@ void SortByPTypeProcess::Execute( aiScene* pScene)
             // allocate output storage
             out->mNumFaces = aiNumPerPType[real];
             aiFace* outFaces = out->mFaces = new aiFace[out->mNumFaces];
+            out->mNumIndices = mesh->mNumIndices;
+            out->mIndices = new unsigned int[out->mNumIndices];
 
             out->mNumVertices = (3 == real ? numPolyVerts : out->mNumFaces * (real+1));
 
@@ -288,9 +290,9 @@ void SortByPTypeProcess::Execute( aiScene* pScene)
                 outFaces->mNumIndices = in.mNumIndices;
                 outFaces->mIndices    = in.mIndices;
 
-                for (unsigned int q = 0; q < in.mNumIndices; ++q)
+                for (unsigned int q = 0; q < outFaces->mNumIndices; ++q)
                 {
-                    unsigned int idx = in.mIndices[q];
+                    unsigned int idx = mesh->mIndices[outFaces->mIndices + q];
 
                     // process all bones of this index
                     if (avw)
@@ -327,7 +329,7 @@ void SortByPTypeProcess::Execute( aiScene* pScene)
                         *cols[pp]++ = mesh->mColors[pp][idx];
                     }
 
-                    in.mIndices[q] = outIdx++;
+                    out->mIndices[outFaces->mIndices + q] = outIdx++;
                 }
 
                 in.mIndices = NULL;

--- a/code/StandardShapes.cpp
+++ b/code/StandardShapes.cpp
@@ -144,13 +144,15 @@ aiMesh* StandardShapes::MakeMesh(const std::vector<aiVector3D>& positions,
 
     out->mNumFaces = (unsigned int)positions.size() / numIndices;
     out->mFaces = new aiFace[out->mNumFaces];
+    out->mNumIndices = positions.size();
+    out->mIndices = new unsigned int[out->mNumIndices];
     for (unsigned int i = 0, a = 0; i < out->mNumFaces;++i)
     {
         aiFace& f = out->mFaces[i];
         f.mNumIndices = numIndices;
-        f.mIndices = new unsigned int[numIndices];
+        f.mIndices = numIndices * i;
         for (unsigned int i = 0; i < numIndices;++i,++a)
-            f.mIndices[i] = a;
+            out->mIndices[f.mIndices + i] = a;
     }
     out->mNumVertices = (unsigned int)positions.size();
     out->mVertices = new aiVector3D[out->mNumVertices];

--- a/code/StepExporter.cpp
+++ b/code/StepExporter.cpp
@@ -286,9 +286,9 @@ void StepExporter::WriteFile()
 
             if (face->mNumIndices != 3) continue;
 
-            aiVector3D* v1 = &(mesh->mVertices[face->mIndices[0]]);
-            aiVector3D* v2 = &(mesh->mVertices[face->mIndices[1]]);
-            aiVector3D* v3 = &(mesh->mVertices[face->mIndices[2]]);
+            aiVector3D* v1 = &(mesh->mVertices[mesh->mIndices[face->mIndices + 0]]);
+            aiVector3D* v2 = &(mesh->mVertices[mesh->mIndices[face->mIndices + 1]]);
+            aiVector3D* v3 = &(mesh->mVertices[mesh->mIndices[face->mIndices + 2]]);
             aiVector3D dv12 = *v2 - *v1;
             aiVector3D dv23 = *v3 - *v2;
             aiVector3D dv31 = *v1 - *v3;
@@ -308,9 +308,9 @@ void StepExporter::WriteFile()
                 fColor.r = 0.0;
                 fColor.g = 0.0;
                 fColor.b = 0.0;
-                fColor += mesh->mColors[0][face->mIndices[0]];
-                fColor += mesh->mColors[0][face->mIndices[1]];
-                fColor += mesh->mColors[0][face->mIndices[2]];
+                fColor += mesh->mColors[0][mesh->mIndices[face->mIndices + 0]];
+                fColor += mesh->mColors[0][mesh->mIndices[face->mIndices + 1]];
+                fColor += mesh->mColors[0][mesh->mIndices[face->mIndices + 2]];
                 fColor /= 3.0f;
             }
 

--- a/code/TerragenLoader.cpp
+++ b/code/TerragenLoader.cpp
@@ -216,6 +216,7 @@ void TerragenImporter::InternReadFile( const std::string& pFile,
 
             // We return quads
             aiFace* f = m->mFaces = new aiFace[m->mNumFaces = (x-1)*(y-1)];
+            m->mIndices = new unsigned int[m->mNumIndices = m->mNumFaces * 4];
             aiVector3D* pv = m->mVertices = new aiVector3D[m->mNumVertices = m->mNumFaces*4];
 
             aiVector3D *uv( NULL );
@@ -247,9 +248,10 @@ void TerragenImporter::InternReadFile( const std::string& pFile,
                     }
 
                     // make indices
-                    f->mIndices = new unsigned int[f->mNumIndices = 4];
+                    f->mNumIndices = 4;
+                    f->mIndices = ((x - 1) * yy + xx) * 4;
                     for (unsigned int i = 0; i < 4;++i)
-                        f->mIndices[i] = t++;
+                        m->mIndices[f->mIndices + i] = t++;
                 }
             }
 

--- a/code/UnrealLoader.cpp
+++ b/code/UnrealLoader.cpp
@@ -361,6 +361,7 @@ void UnrealImporter::InternReadFile( const std::string& pFile,
 
         const unsigned int num = materials[i].numFaces;
         m->mFaces            = new aiFace     [num];
+        m->mIndices          = new unsigned int [num*3];
         m->mVertices         = new aiVector3D [num*3];
         m->mTextureCoords[0] = new aiVector3D [num*3];
 
@@ -421,10 +422,12 @@ void UnrealImporter::InternReadFile( const std::string& pFile,
 
         aiMesh* mesh = pScene->mMeshes[nt-materials.begin()];
         aiFace& f    = mesh->mFaces[mesh->mNumFaces++];
-        f.mIndices   = new unsigned int[f.mNumIndices = 3];
-
+        f.mIndices   = mesh->mNumIndices;
+        f.mNumIndices = 3;
+        mesh->mNumIndices += 3;
+        
         for (unsigned int i = 0; i < 3;++i,mesh->mNumVertices++) {
-            f.mIndices[i] = mesh->mNumVertices;
+            mesh->mIndices[f.mIndices + i] = mesh->mNumVertices;
 
             mesh->mVertices[mesh->mNumVertices] = vertices[ tri.mVertex[i] ];
             mesh->mTextureCoords[0][mesh->mNumVertices] = aiVector3D( tri.mTex[i][0] / 255.f, 1.f - tri.mTex[i][1] / 255.f, 0.f);

--- a/code/ValidateDataStructure.cpp
+++ b/code/ValidateDataStructure.cpp
@@ -362,14 +362,16 @@ void ValidateDSProcess::Validate( const aiMesh* pMesh)
                 break;
             };
         }
-
-        if (!face.mIndices)
-            ReportError("aiMesh::mFaces[%i].mIndices is NULL",i);
     }
 
     // positions must always be there ...
     if (!pMesh->mNumVertices || (!pMesh->mVertices && !mScene->mFlags)) {
         ReportError("The mesh contains no vertices");
+    }
+
+    // indices must always be there ...
+    if (!pMesh->mNumIndices || (!pMesh->mIndices && !mScene->mFlags)) {
+        ReportError("The mesh contains no indices");
     }
 
     if (pMesh->mNumVertices > AI_MAX_VERTICES) {
@@ -402,18 +404,18 @@ void ValidateDSProcess::Validate( const aiMesh* pMesh)
 
         for (unsigned int a = 0; a < face.mNumIndices;++a)
         {
-            if (face.mIndices[a] >= pMesh->mNumVertices)    {
-                ReportError("aiMesh::mFaces[%i]::mIndices[%i] is out of range",i,a);
+            if (pMesh->mIndices[face.mIndices + a] >= pMesh->mNumVertices)    {
+                ReportError("aiMesh::mIndices[aiMesh::mFaces[%i]::mIndices + %i] is out of range",i,a);
             }
             // the MSB flag is temporarily used by the extra verbose
-            // mode to tell us that the JoinVerticesProcess might have
+            // mode to tell us that the JoinVerticesProcess might have 
             // been executed already.
-            if ( !(this->mScene->mFlags & AI_SCENE_FLAGS_NON_VERBOSE_FORMAT ) && abRefList[face.mIndices[a]])
+            if ( !(this->mScene->mFlags & AI_SCENE_FLAGS_NON_VERBOSE_FORMAT ) && abRefList[pMesh->mIndices[face.mIndices + a]])
             {
                 ReportError("aiMesh::mVertices[%i] is referenced twice - second "
-                    "time by aiMesh::mFaces[%i]::mIndices[%i]",face.mIndices[a],i,a);
+                    "time by aiMesh::mIndices[aiMesh::mFaces[%i]::mIndices + %i]", pMesh->mIndices[face.mIndices + a],i,a);
             }
-            abRefList[face.mIndices[a]] = true;
+            abRefList[pMesh->mIndices[face.mIndices + a]] = true;
         }
     }
 

--- a/code/VertexTriangleAdjacency.cpp
+++ b/code/VertexTriangleAdjacency.cpp
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using namespace Assimp;
 
 // ------------------------------------------------------------------------------------------------
-VertexTriangleAdjacency::VertexTriangleAdjacency(aiFace *pcFaces,
+VertexTriangleAdjacency::VertexTriangleAdjacency(aiMesh *pcMesh, aiFace *pcFaces,
     unsigned int iNumFaces,
     unsigned int iNumVertices /*= 0*/,
     bool bComputeNumTriangles /*= false*/)
@@ -61,9 +61,9 @@ VertexTriangleAdjacency::VertexTriangleAdjacency(aiFace *pcFaces,
 
         for (aiFace* pcFace = pcFaces; pcFace != pcFaceEnd; ++pcFace)   {
             ai_assert(3 == pcFace->mNumIndices);
-            iNumVertices = std::max(iNumVertices,pcFace->mIndices[0]);
-            iNumVertices = std::max(iNumVertices,pcFace->mIndices[1]);
-            iNumVertices = std::max(iNumVertices,pcFace->mIndices[2]);
+            iNumVertices = std::max(iNumVertices,pcMesh->mIndices[pcFace->mIndices + 0]);
+            iNumVertices = std::max(iNumVertices,pcMesh->mIndices[pcFace->mIndices + 1]);
+            iNumVertices = std::max(iNumVertices,pcMesh->mIndices[pcFace->mIndices + 2]);
         }
     }
 
@@ -90,9 +90,9 @@ VertexTriangleAdjacency::VertexTriangleAdjacency(aiFace *pcFaces,
     // first pass: compute the number of faces referencing each vertex
     for (aiFace* pcFace = pcFaces; pcFace != pcFaceEnd; ++pcFace)
     {
-        pi[pcFace->mIndices[0]]++;
-        pi[pcFace->mIndices[1]]++;
-        pi[pcFace->mIndices[2]]++;
+        pi[pcMesh->mIndices[pcFace->mIndices + 0]]++;
+        pi[pcMesh->mIndices[pcFace->mIndices + 1]]++;
+        pi[pcMesh->mIndices[pcFace->mIndices + 2]]++;
     }
 
     // second pass: compute the final offset table
@@ -111,13 +111,13 @@ VertexTriangleAdjacency::VertexTriangleAdjacency(aiFace *pcFaces,
     iSum = 0;
     for (aiFace* pcFace = pcFaces; pcFace != pcFaceEnd; ++pcFace,++iSum)    {
 
-        unsigned int idx = pcFace->mIndices[0];
+        unsigned int idx = pcMesh->mIndices[pcFace->mIndices + 0];
         mAdjacencyTable[pi[idx]++] = iSum;
 
-        idx = pcFace->mIndices[1];
+        idx = pcMesh->mIndices[pcFace->mIndices + 1];
         mAdjacencyTable[pi[idx]++] = iSum;
 
-        idx = pcFace->mIndices[2];
+        idx = pcMesh->mIndices[pcFace->mIndices + 2];
         mAdjacencyTable[pi[idx]++] = iSum;
     }
     // fourth pass: undo the offset computations made during the third pass

--- a/code/VertexTriangleAdjacency.h
+++ b/code/VertexTriangleAdjacency.h
@@ -71,7 +71,7 @@ public:
      *  @param bComputeNumTriangles If you want the class to compute
      *    a list containing the number of referenced triangles per vertex
      *    per vertex - pass true.  */
-    VertexTriangleAdjacency(aiFace* pcFaces,unsigned int iNumFaces,
+    VertexTriangleAdjacency(aiMesh *pcMesh, aiFace* pcFaces,unsigned int iNumFaces,
         unsigned int iNumVertices = 0,
         bool bComputeNumTriangles = true);
 

--- a/code/XFileExporter.cpp
+++ b/code/XFileExporter.cpp
@@ -348,7 +348,7 @@ void XFileExporter::WriteMesh(aiMesh* mesh)
         //for(int b = face.mNumIndices - 1; b >= 0 ; --b)
         for(size_t b = 0; b < face.mNumIndices ; ++b)
         {
-            mOutput << face.mIndices[b];
+            mOutput << mesh->mIndices[face.mIndices + b];
             //if (b > 0)
             if (b<face.mNumIndices-1)
                 mOutput << ",";
@@ -425,7 +425,7 @@ void XFileExporter::WriteMesh(aiMesh* mesh)
             //for(int b = face.mNumIndices-1; b >= 0 ; --b)
             for(size_t b = 0; b < face.mNumIndices ; ++b)
             {
-                mOutput << face.mIndices[b];
+                mOutput << mesh->mIndices[face.mIndices + b];
                 //if (b > 0)
                 if (b<face.mNumIndices-1)
                     mOutput << ",";

--- a/code/XFileImporter.cpp
+++ b/code/XFileImporter.cpp
@@ -301,6 +301,12 @@ void XFileImporter::CreateMeshes( aiScene* pScene, aiNode* pNode, const std::vec
 
             // name
             mesh->mName.Set(sourceMesh->mName);
+            // indices
+            for (unsigned int c = 0; c < faces.size(); ++c)
+            {
+                mesh->mNumIndices += sourceMesh->mPosFaces[faces[c]].mIndices.size();
+            }
+            mesh->mIndices = new unsigned int[mesh->mNumIndices];
 
             // normals?
             if( sourceMesh->mNormals.size() > 0)
@@ -331,12 +337,12 @@ void XFileImporter::CreateMeshes( aiScene* pScene, aiNode* pNode, const std::vec
                 // create face. either triangle or triangle fan depending on the index count
                 aiFace& df = mesh->mFaces[c]; // destination face
                 df.mNumIndices = (unsigned int)pf.mIndices.size();
-                df.mIndices = new unsigned int[ df.mNumIndices];
+                df.mIndices = newIndex;
 
                 // collect vertex data for indices of this face
                 for( unsigned int d = 0; d < df.mNumIndices; d++)
                 {
-                    df.mIndices[d] = newIndex;
+                    mesh->mIndices[df.mIndices + d] = newIndex;
                     orgPoints[newIndex] = pf.mIndices[d];
 
                     // Position

--- a/code/XGLLoader.cpp
+++ b/code/XGLLoader.cpp
@@ -54,6 +54,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/scene.h>
 #include <cctype>
 #include <memory>
+#include <numeric>
 
 using namespace Assimp;
 using namespace irr;
@@ -553,14 +554,15 @@ aiMesh* XGLImporter::ToOutputMesh(const TempMaterialMesh& m)
 
     mesh->mNumFaces =  static_cast<unsigned int>(m.vcounts.size());
     mesh->mFaces = new aiFace[m.vcounts.size()];
+    mesh->mNumIndices = std::accumulate(m.vcounts.begin(), m.vcounts.end(), 0);
+    mesh->mIndices = new unsigned int[mesh->mNumIndices];
 
     unsigned int idx = 0;
     for(unsigned int i = 0; i < mesh->mNumFaces; ++i) {
         aiFace& f = mesh->mFaces[i];
         f.mNumIndices = m.vcounts[i];
-        f.mIndices = new unsigned int[f.mNumIndices];
         for(unsigned int c = 0; c < f.mNumIndices; ++c) {
-            f.mIndices[c] = idx++;
+            mesh->mIndices[f.mIndices + c] = idx++;
         }
     }
 

--- a/code/glTFExporter.cpp
+++ b/code/glTFExporter.cpp
@@ -289,7 +289,7 @@ void glTFExporter::ExportMeshes()
             indices.resize(aim->mNumFaces * nIndicesPerFace);
             for (size_t i = 0; i < aim->mNumFaces; ++i) {
                 for (size_t j = 0; j < nIndicesPerFace; ++j) {
-                    indices[i*nIndicesPerFace + j] = uint16_t(aim->mFaces[i].mIndices[j]);
+                    indices[i*nIndicesPerFace + j] = uint16_t(aim->mIndices[aim->mFaces[i].mIndices + j]);
                 }
             }
             p.indices = ExportData(*mAsset, meshId, b, unsigned(indices.size()), &indices[0], AttribType::SCALAR, AttribType::SCALAR, ComponentType_UNSIGNED_SHORT, true);

--- a/include/assimp/mesh.h
+++ b/include/assimp/mesh.h
@@ -129,27 +129,24 @@ struct aiFace
     //! The maximum value for this member is #AI_MAX_FACE_INDICES.
     unsigned int mNumIndices;
 
-    //! Pointer to the indices array. Size of the array is given in numIndices.
-    unsigned int* mIndices;
+    //! Index to the indices array.
+    unsigned int mIndices;
 
 #ifdef __cplusplus
 
     //! Default constructor
     aiFace()
       : mNumIndices( 0 )
-      , mIndices( NULL )
+      , mIndices( 0 )
     {
     }
 
     //! Default destructor. Delete the index array
-    ~aiFace()
-    {
-        delete [] mIndices;
-    }
+    ~aiFace() { }
 
     //! Copy constructor. Copy the index array
     aiFace( const aiFace& o)
-      : mIndices( NULL )
+      : mIndices( 0 )
     {
         *this = o;
     }
@@ -160,15 +157,8 @@ struct aiFace
         if (&o == this)
             return *this;
 
-        delete[] mIndices;
         mNumIndices = o.mNumIndices;
-        if (mNumIndices) {
-            mIndices = new unsigned int[mNumIndices];
-            ::memcpy( mIndices, o.mIndices, mNumIndices * sizeof( unsigned int));
-        }
-        else {
-            mIndices = NULL;
-        }
+        mIndices = o.mIndices;
         return *this;
     }
 
@@ -177,12 +167,7 @@ struct aiFace
     bool operator== (const aiFace& o) const
     {
         if (mIndices == o.mIndices)return true;
-        else if (mIndices && mNumIndices == o.mNumIndices)
-        {
-            for (unsigned int i = 0;i < this->mNumIndices;++i)
-                if (mIndices[i] != o.mIndices[i])return false;
-            return true;
-        }
+        else if (mNumIndices == o.mNumIndices)return true;
         return false;
     }
 
@@ -568,6 +553,16 @@ struct aiMesh
     */
     C_STRUCT aiFace* mFaces;
 
+    /** The number of indices this mesh contains.
+    */
+    unsigned int mNumIndices;
+
+    /** The indices of this mesh.
+    * The faces contain an index and length for looking up in
+    * this array.
+    */
+    unsigned int* mIndices;
+
     /** The number of bones this mesh contains.
     * Can be 0, in which case the mBones array is NULL.
     */
@@ -621,6 +616,8 @@ struct aiMesh
         , mTangents( NULL )
         , mBitangents( NULL )
         , mFaces( NULL )
+        , mNumIndices( 0 )
+        , mIndices( NULL )
         , mNumBones( 0 )
         , mBones( NULL )
         , mMaterialIndex( 0 )
@@ -667,6 +664,7 @@ struct aiMesh
         }
 
         delete [] mFaces;
+        delete [] mIndices;
     }
 
     //! Check whether the mesh contains positions. Provided no special

--- a/test/unit/utFindDegenerates.cpp
+++ b/test/unit/utFindDegenerates.cpp
@@ -65,6 +65,9 @@ void FindDegeneratesProcessTest::SetUp()
     mesh->mNumFaces = 1000;
     mesh->mFaces = new aiFace[1000];
 
+    mesh->mNumIndices = 5000*2;
+    mesh->mIndices = new unsigned int[5000*2];
+
     mesh->mNumVertices = 5000*2;
     mesh->mVertices = new aiVector3D[5000*2];
 
@@ -75,28 +78,29 @@ void FindDegeneratesProcessTest::SetUp()
     mesh->mPrimitiveTypes = aiPrimitiveType_LINE | aiPrimitiveType_POINT |
     aiPrimitiveType_POLYGON | aiPrimitiveType_TRIANGLE;
 
-    unsigned int numOut = 0, numFaces = 0;
+    unsigned int numOut = 0, numFaces = 0, numIndices = 0;
     for (unsigned int i = 0; i < 1000; ++i) {
         aiFace& f = mesh->mFaces[i];
-    f.mNumIndices = (i % 5)+1; // between 1 and 5
-    f.mIndices = new unsigned int[f.mNumIndices];
-    bool had = false;
-    for (unsigned int n = 0; n < f.mNumIndices;++n) {
-        // FIXME
+        f.mNumIndices = (i % 5)+1; // between 1 and 5
+        f.mIndices = numIndices;
+        numIndices += f.mNumIndices;
+        bool had = false;
+        for (unsigned int n = 0; n < f.mNumIndices;++n) {
+            // FIXME
 #if 0
-        // some duplicate indices
-        if ( n && n == (i / 200)+1) {
-            f.mIndices[n] = f.mIndices[n-1];
-            had = true;
-        }
-        // and some duplicate vertices
+            // some duplicate indices
+            if ( n && n == (i / 200)+1) {
+                mesh->mIndices[f.mIndices+n] = mesh->mIndices[f.mIndices+n-1];
+                had = true;
+            }
+            // and some duplicate vertices
 #endif
-        if (n && i % 2 && 0 == n % 2) {
-            f.mIndices[n] = f.mIndices[n-1]+5000;
-            had = true;
-        }
-        else {
-            f.mIndices[n] = numOut++;
+            if (n && i % 2 && 0 == n % 2) {
+                mesh->mIndices[f.mIndices+n] = mesh->mIndices[f.mIndices+n-1]+5000;
+                had = true;
+            }
+            else {
+                mesh->mIndices[f.mIndices+n] = numOut++;
             }
         }
         if (!had)

--- a/test/unit/utGenNormals.cpp
+++ b/test/unit/utGenNormals.cpp
@@ -63,10 +63,13 @@ void GenNormalsTest::SetUp()
     pcMesh->mPrimitiveTypes = aiPrimitiveType_TRIANGLE;
     pcMesh->mNumFaces = 1;
     pcMesh->mFaces = new aiFace[1];
-    pcMesh->mFaces[0].mIndices = new unsigned int[pcMesh->mFaces[0].mNumIndices = 3];
-    pcMesh->mFaces[0].mIndices[0] = 0;
-    pcMesh->mFaces[0].mIndices[1] = 1;
-    pcMesh->mFaces[0].mIndices[2] = 1;
+    pcMesh->mFaces[0].mNumIndices = 3;
+    pcMesh->mFaces[0].mIndices = 0;
+    pcMesh->mNumIndices = 3;
+    pcMesh->mIndices = new unsigned int[pcMesh->mNumIndices];
+    pcMesh->mIndices[pcMesh->mFaces[0].mIndices + 0] = 0;
+    pcMesh->mIndices[pcMesh->mFaces[0].mIndices + 1] = 1;
+    pcMesh->mIndices[pcMesh->mFaces[0].mIndices + 2] = 1;
     pcMesh->mNumVertices = 3;
     pcMesh->mVertices = new aiVector3D[3];
     pcMesh->mVertices[0] = aiVector3D(0.0f,1.0f,6.0f);

--- a/test/unit/utJoinVertices.cpp
+++ b/test/unit/utJoinVertices.cpp
@@ -82,12 +82,15 @@ void JoinVerticesTest::SetUp()
     // generate faces - each vertex is referenced once
     pcMesh->mNumFaces = 300;
     pcMesh->mFaces = new aiFace[300];
+    pcMesh->mNumIndices = pcMesh->mNumFaces * 3;
+    pcMesh->mIndices = new unsigned int[pcMesh->mNumIndices];
     for (unsigned int i = 0,p = 0; i < 300;++i)
     {
         aiFace& face = pcMesh->mFaces[i];
-        face.mIndices = new unsigned int[ face.mNumIndices = 3 ];
+        face.mNumIndices = 3;
+        face.mIndices = i * 3;
         for (unsigned int a = 0; a < 3;++a)
-            face.mIndices[a] = p++;
+            pcMesh->mIndices[face.mIndices + a] = p++;
     }
 
     // generate extra members - set them to zero to make sure they're identical

--- a/test/unit/utPretransformVertices.cpp
+++ b/test/unit/utPretransformVertices.cpp
@@ -99,11 +99,13 @@ void PretransformVerticesTest::SetUp()
 
         mesh->mPrimitiveTypes = aiPrimitiveType_POINT;
         mesh->mFaces = new aiFace[ mesh->mNumFaces = 10+i ];
+        mesh->mIndices = new unsigned int[mesh->mNumIndices = mesh->mNumFaces];
         mesh->mVertices = new aiVector3D[mesh->mNumVertices = mesh->mNumFaces];
         for (unsigned int a = 0; a < mesh->mNumFaces; ++a ) {
             aiFace& f = mesh->mFaces[a];
-            f.mIndices = new unsigned int [f.mNumIndices = 1];
-            f.mIndices[0] = a*3;
+            f.mNumIndices = 1;
+            f.mIndices = a;
+            mesh->mIndices[f.mIndices + 0] = a*3;
 
             mesh->mVertices[a] = aiVector3D((float)i,(float)a,0.f);
         }

--- a/test/unit/utSortByPType.cpp
+++ b/test/unit/utSortByPType.cpp
@@ -106,7 +106,9 @@ void SortByPTypeProcessTest::SetUp()
     {
         aiMesh* mesh = scene->mMeshes[i] = new aiMesh();
         mesh->mNumFaces = 1000;
+        mesh->mNumIndices = mesh->mNumFaces * 5;
         aiFace* faces =  mesh->mFaces = new aiFace[1000];
+        mesh->mIndices = new unsigned int[mesh->mNumIndices];
         aiVector3D* pv = mesh->mVertices = new aiVector3D[mesh->mNumFaces*5];
         aiVector3D* pn = mesh->mNormals = new aiVector3D[mesh->mNumFaces*5];
 
@@ -135,10 +137,10 @@ void SortByPTypeProcessTest::SetUp()
                 if(five)++faces->mNumIndices;
                 five = !five;
             }
-            faces->mIndices = new unsigned int[faces->mNumIndices];
+            faces->mIndices = n;
             for (unsigned int q = 0; q <faces->mNumIndices;++q,++n)
             {
-                faces->mIndices[q] = n;
+                mesh->mIndices[faces->mIndices + q] = n;
                 float f = (float)remaining[idx];
 
                 // (the values need to be unique - otherwise all degenerates would be removed)

--- a/test/unit/utSplitLargeMeshes.cpp
+++ b/test/unit/utSplitLargeMeshes.cpp
@@ -92,16 +92,18 @@ TEST_F(SplitLargeMeshesTest, testVertexSplit)
 
      pcMesh1->mNumFaces = pcMesh1->mNumVertices / 3;
      pcMesh1->mFaces = new aiFace[pcMesh1->mNumFaces];
+     pcMesh1->mNumIndices = pcMesh1->mNumFaces * 3;
+     pcMesh1->mIndices = new unsigned int[pcMesh1->mNumIndices];
 
      unsigned int qq = 0;
      for (unsigned int i = 0; i < pcMesh1->mNumFaces;++i)
      {
          aiFace& face = pcMesh1->mFaces[i];
          face.mNumIndices = 3;
-         face.mIndices = new unsigned int[3];
-         face.mIndices[0] = qq++;
-         face.mIndices[1] = qq++;
-         face.mIndices[2] = qq++;
+         face.mIndices = i * 3;
+         pcMesh1->mIndices[face.mIndices + 0] = qq++;
+         pcMesh1->mIndices[face.mIndices + 1] = qq++;
+         pcMesh1->mIndices[face.mIndices + 2] = qq++;
      }
 
 
@@ -137,15 +139,17 @@ TEST_F(SplitLargeMeshesTest, testTriangleSplit)
 
     pcMesh2->mNumFaces = 10000;
     pcMesh2->mFaces = new aiFace[pcMesh2->mNumFaces];
+    pcMesh2->mNumIndices = pcMesh2->mNumFaces * 3;
+    pcMesh2->mIndices = new unsigned int[pcMesh2->mNumIndices];
 
     for (unsigned int i = 0; i < pcMesh2->mNumFaces;++i)
     {
         aiFace& face = pcMesh2->mFaces[i];
         face.mNumIndices = 3;
-        face.mIndices = new unsigned int[3];
-        face.mIndices[0] = (unsigned int)((rand() / (float)RAND_MAX) * pcMesh2->mNumVertices);
-        face.mIndices[1] = (unsigned int)((rand() / (float)RAND_MAX) * pcMesh2->mNumVertices);
-        face.mIndices[2] = (unsigned int)((rand() / (float)RAND_MAX) * pcMesh2->mNumVertices);
+        face.mIndices = i * 3;
+        pcMesh2->mIndices[face.mIndices + 0] = (unsigned int)((rand() / (float)RAND_MAX) * pcMesh2->mNumVertices);
+        pcMesh2->mIndices[face.mIndices + 1] = (unsigned int)((rand() / (float)RAND_MAX) * pcMesh2->mNumVertices);
+        pcMesh2->mIndices[face.mIndices + 2] = (unsigned int)((rand() / (float)RAND_MAX) * pcMesh2->mNumVertices);
     }
 
     // the number of faces shouldn't change

--- a/test/unit/utTriangulate.cpp
+++ b/test/unit/utTriangulate.cpp
@@ -67,6 +67,8 @@ void TriangulateProcessTest::SetUp()
 
     pcMesh->mNumFaces = 1000;
     pcMesh->mFaces = new aiFace[1000];
+    pcMesh->mNumIndices = 10000;
+    pcMesh->mIndices = new unsigned int[10000];
     pcMesh->mVertices = new aiVector3D[10000];
 
     pcMesh->mPrimitiveTypes = aiPrimitiveType_POINT | aiPrimitiveType_LINE |
@@ -84,10 +86,10 @@ void TriangulateProcessTest::SetUp()
 
             if (10 == q)q = 4;
         }
-        face.mIndices = new unsigned int[face.mNumIndices];
+        face.mIndices = m * 10;
         for (unsigned int p = 0; p < face.mNumIndices; ++p)
         {
-            face.mIndices[p] = pcMesh->mNumVertices;
+            pcMesh->mIndices[face.mIndices + p] = pcMesh->mNumVertices;
 
         // construct fully convex input data in ccw winding, xy plane
             aiVector3D& v = pcMesh->mVertices[pcMesh->mNumVertices++];
@@ -126,7 +128,7 @@ TEST_F(TriangulateProcessTest, testTriangulation)
 
                 for (unsigned int qqq = 0; qqq < face.mNumIndices; ++qqq)
                 {
-                    ait[face.mIndices[qqq]-idx] = true;
+                    ait[pcMesh->mIndices[face.mIndices + qqq]-idx] = true;
                 }
             }
             for (std::vector<bool>::const_iterator it = ait.begin(); it != ait.end(); ++it)
@@ -143,7 +145,7 @@ TEST_F(TriangulateProcessTest, testTriangulation)
 
             for (unsigned int i = 0; i < face.mNumIndices; ++i,++idx)
             {
-                EXPECT_EQ(idx, face.mIndices[i]);
+                EXPECT_EQ(idx, pcMesh->mIndices[face.mIndices + i]);
             }
         }
     }

--- a/tools/assimp_cmd/WriteDumb.cpp
+++ b/tools/assimp_cmd/WriteDumb.cpp
@@ -424,7 +424,7 @@ uint32_t WriteBinaryMesh(const aiMesh* mesh)
 				hash = SuperFastHash(reinterpret_cast<const char*>(&tmp),sizeof tmp,hash);
 				for (unsigned int i = 0; i < f.mNumIndices; ++i) {
 					static_assert(AI_MAX_VERTICES <= 0xffffffff, "AI_MAX_VERTICES <= 0xffffffff");
-					tmp = static_cast<uint32_t>( f.mIndices[i] );
+					tmp = static_cast<uint32_t>( mesh->mIndices[f.mIndices+i] );
 					hash = SuperFastHash(reinterpret_cast<const char*>(&tmp),sizeof tmp,hash);
 				}
 			}
@@ -442,9 +442,9 @@ uint32_t WriteBinaryMesh(const aiMesh* mesh)
 
 			for (unsigned int a = 0; a < f.mNumIndices;++a) {
 				if (mesh->mNumVertices < (1u<<16)) {
-					len += Write<uint16_t>(f.mIndices[a]);
+					len += Write<uint16_t>(mesh->mIndices[f.mIndices+a]);
 				}
-				else len += Write<unsigned int>(f.mIndices[a]);
+				else len += Write<unsigned int>(mesh->mIndices[f.mIndices+a]);
 			}
 		}
 	}
@@ -1185,7 +1185,7 @@ void WriteDump(const aiScene* scene, FILE* out, const char* src, const char* cmd
 						"\t\t\t\t",f.mNumIndices);
 
 					for (unsigned int j = 0; j < f.mNumIndices;++j)
-						fprintf(out,"%u ",f.mIndices[j]);
+						fprintf(out,"%u ",mesh->mIndices[f.mIndices+j]);
 
 					fprintf(out,"\n\t\t\t</Face>\n");
 				}

--- a/tools/assimp_view/MeshRenderer.cpp
+++ b/tools/assimp_view/MeshRenderer.cpp
@@ -108,7 +108,7 @@ int CMeshRenderer::DrawSorted(unsigned int iIndex,const aiMatrix4x4& mWorld)
         float fDist = 0.0f;
         for (unsigned int c = 0; c < 3;++c)
         {
-            aiVector3D vPos = pcMesh->mVertices[pcFace->mIndices[c]];
+            aiVector3D vPos = pcMesh->mVertices[pcMesh->mIndices[pcFace->mIndices+c]];
             vPos -= vLocalCamera;
             fDist += vPos.SquareLength();
         }
@@ -129,9 +129,9 @@ int CMeshRenderer::DrawSorted(unsigned int iIndex,const aiMatrix4x4& mWorld)
             i != smap.end();++i)
         {
             const aiFace* pcFace =  &pcMesh->mFaces[(*i).second];
-            *aiIndices++ = (uint16_t)pcFace->mIndices[0];
-            *aiIndices++ = (uint16_t)pcFace->mIndices[1];
-            *aiIndices++ = (uint16_t)pcFace->mIndices[2];
+            *aiIndices++ = (uint16_t)pcMesh->mIndices[pcFace->mIndices+0];
+            *aiIndices++ = (uint16_t)pcMesh->mIndices[pcFace->mIndices+1];
+            *aiIndices++ = (uint16_t)pcMesh->mIndices[pcFace->mIndices+2];
         }
     }
     else if (D3DFMT_INDEX32 == sDesc.Format)
@@ -144,9 +144,9 @@ int CMeshRenderer::DrawSorted(unsigned int iIndex,const aiMatrix4x4& mWorld)
             i != smap.end();++i)
         {
             const aiFace* pcFace =  &pcMesh->mFaces[(*i).second];
-            *aiIndices++ = (uint32_t)pcFace->mIndices[0];
-            *aiIndices++ = (uint32_t)pcFace->mIndices[1];
-            *aiIndices++ = (uint32_t)pcFace->mIndices[2];
+            *aiIndices++ = (uint32_t)pcMesh->mIndices[pcFace->mIndices+0];
+            *aiIndices++ = (uint32_t)pcMesh->mIndices[pcFace->mIndices+1];
+            *aiIndices++ = (uint32_t)pcMesh->mIndices[pcFace->mIndices+2];
         }
     }
     pcHelper->piIB->Unlock();

--- a/tools/assimp_view/assimp_view.cpp
+++ b/tools/assimp_view/assimp_view.cpp
@@ -534,7 +534,7 @@ int CreateAssetData()
             {
                 for (unsigned int a = 0; a < nidx;++a)
                 {
-                    *pbData++ = mesh->mFaces[x].mIndices[a];
+                    *pbData++ = mesh->mIndices[mesh->mFaces[x].mIndices+a];
                 }
             }
         }
@@ -560,7 +560,7 @@ int CreateAssetData()
             {
                 for (unsigned int a = 0; a < nidx;++a)
                 {
-                    *pbData++ = (uint16_t)mesh->mFaces[x].mIndices[a];
+                    *pbData++ = (uint16_t)mesh->mIndices[mesh->mFaces[x].mIndices+a];
                 }
             }
         }


### PR DESCRIPTION
This is a pretty big change, but it removes all of the mini-allocations that occurred for indices. These mini-allocations would result in excessive memory usage, at least on Windows (potentially not an issue on Windows 10 though). Resolves #944
