### PR TITLE
closes https://github.com/assimp/assimp/issues/967: add unzip include path

### DIFF
--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -722,6 +722,7 @@ if (UNZIP_FOUND)
   SET (unzip_compile_SRCS "")
 else (UNZIP_FOUND)
   SET (unzip_compile_SRCS ${unzip_SRCS})
+  INCLUDE_DIRECTORIES( "../contrib/unzip/" )
 endif (UNZIP_FOUND)
 
 MESSAGE(STATUS "Enabled formats:${ASSIMP_IMPORTERS_ENABLED}")


### PR DESCRIPTION
When using the internal version of unzip we need to add the unzip folder to the includes.