### PR TITLE
Building own zlib on 64bit Linux shared library requires -fPIC for C compiler.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,9 @@ ENDIF()
 IF((CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX) AND NOT CMAKE_COMPILER_IS_MINGW)
   IF (BUILD_SHARED_LIBS AND CMAKE_SIZEOF_VOID_P EQUAL 8) # -fPIC is only required for shared libs on 64 bit
      SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+     IF(ASSIMP_BUILD_ZLIB)
+	     SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+     ENDIF()
   ENDIF()
   # hide all not-exported symbols
   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -Wall -std=c++0x" )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,9 +164,7 @@ ENDIF()
 IF((CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX) AND NOT CMAKE_COMPILER_IS_MINGW)
   IF (BUILD_SHARED_LIBS AND CMAKE_SIZEOF_VOID_P EQUAL 8) # -fPIC is only required for shared libs on 64 bit
      SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
-     IF(ASSIMP_BUILD_ZLIB)
-	     SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
-     ENDIF()
+     SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
   ENDIF()
   # hide all not-exported symbols
   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -Wall -std=c++0x" )

--- a/code/glTFAsset.inl
+++ b/code/glTFAsset.inl
@@ -40,6 +40,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "StringUtils.h"
 
+using namespace Assimp;
+
 namespace glTF {
 
 namespace {


### PR DESCRIPTION
Some of the files from the internally built zlib are too big to be placed in a .so when compiled without -fPIC on 64 bit platform. Tested on up to date Arch Linux, running virtualized on x86_64.

CMake 3.6.1
GNU make 4.2.1
gcc 6.1.1 20160802