### PR TITLE
Use Assimp namespace to fix build for big-endian architectures

### DIFF
--- a/code/glTFAsset.inl
+++ b/code/glTFAsset.inl
@@ -40,6 +40,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "StringUtils.h"
 
+using namespace Assimp;
+
 namespace glTF {
 
 namespace {


### PR DESCRIPTION
This package failed to build for big-endian architectures with the following error:

> In file included from /«PKGBUILDDIR»/code/glTFAsset.h:65:0,
                 from /«PKGBUILDDIR»/code/glTFImporter.cpp:55:
/«PKGBUILDDIR»/code/glTFAsset.inl: In member function 'void glTF::Asset::ReadBinaryHeader(Assimp::IOStream&)':
/«PKGBUILDDIR»/code/ByteSwapper.h:217:24: error: 'ByteSwap' has not been declared
 #   define AI_SWAP4(p) ByteSwap::Swap4(&(p))
                        ^
/«PKGBUILDDIR»/code/glTFAsset.inl:906:5: note: in expansion of macro 'AI_SWAP4'
     AI_SWAP4(header.version);
     ^~~~~~~~
/«PKGBUILDDIR»/code/ByteSwapper.h:217:24: error: 'ByteSwap' has not been declared
 #   define AI_SWAP4(p) ByteSwap::Swap4(&(p))
                        ^
/«PKGBUILDDIR»/code/glTFAsset.inl:912:5: note: in expansion of macro 'AI_SWAP4'
     AI_SWAP4(header.sceneFormat);
     ^~~~~~~~
/«PKGBUILDDIR»/code/ByteSwapper.h:217:24: error: 'ByteSwap' has not been declared
 #   define AI_SWAP4(p) ByteSwap::Swap4(&(p))
                        ^
/«PKGBUILDDIR»/code/glTFAsset.inl:917:5: note: in expansion of macro 'AI_SWAP4'
     AI_SWAP4(header.length);
     ^~~~~~~~
/«PKGBUILDDIR»/code/ByteSwapper.h:217:24: error: 'ByteSwap' has not been declared
 #   define AI_SWAP4(p) ByteSwap::Swap4(&(p))
                        ^
/«PKGBUILDDIR»/code/glTFAsset.inl:918:5: note: in expansion of macro 'AI_SWAP4'
     AI_SWAP4(header.sceneLength);
     ^~~~~~~~
/«PKGBUILDDIR»/code/glTFAssetWriter.inl: In member function 'void glTF::AssetWriter::WriteBinaryData(Assimp::IOStream*, size_t)':
/«PKGBUILDDIR»/code/ByteSwapper.h:217:24: error: 'ByteSwap' has not been declared
 #   define AI_SWAP4(p) ByteSwap::Swap4(&(p))
                        ^
/«PKGBUILDDIR»/code/glTFAssetWriter.inl:397:9: note: in expansion of macro 'AI_SWAP4'
         AI_SWAP4(header.version);
         ^~~~~~~~
/«PKGBUILDDIR»/code/ByteSwapper.h:217:24: error: 'ByteSwap' has not been declared
 #   define AI_SWAP4(p) ByteSwap::Swap4(&(p))
                        ^
/«PKGBUILDDIR»/code/glTFAssetWriter.inl:400:9: note: in expansion of macro 'AI_SWAP4'
         AI_SWAP4(header.length);
         ^~~~~~~~
/«PKGBUILDDIR»/code/ByteSwapper.h:217:24: error: 'ByteSwap' has not been declared
 #   define AI_SWAP4(p) ByteSwap::Swap4(&(p))
                        ^
/«PKGBUILDDIR»/code/glTFAssetWriter.inl:403:9: note: in expansion of macro 'AI_SWAP4'
         AI_SWAP4(header.sceneLength);
         ^~~~~~~~
/«PKGBUILDDIR»/code/ByteSwapper.h:217:24: error: 'ByteSwap' has not been declared
 #   define AI_SWAP4(p) ByteSwap::Swap4(&(p))
                        ^
/«PKGBUILDDIR»/code/glTFAssetWriter.inl:406:9: note: in expansion of macro 'AI_SWAP4'
         AI_SWAP4(header.sceneFormat);
         ^~~~~~~~

Macros aren't namespaced, pre-processor knows nothing about namespaces.
AI_SWAP4(p) is just replaced with ByteSwap::Swap4(&(p)) function call, because
of a missing namespace the compiler can't find the ByteSwap class.

Bug with proposed solution is reported on Debian: https://bugs.debian.org/834717