### PR TITLE
Add all glTF data to single buffer

### DIFF
--- a/code/glTFExporter.cpp
+++ b/code/glTFExporter.cpp
@@ -267,6 +267,13 @@ void glTFExporter::ExportMaterials()
 
 void glTFExporter::ExportMeshes()
 {
+    std::string bufferId = mAsset->FindUniqueID("", "buffer");
+
+    Ref<Buffer> b = mAsset->GetBodyBuffer();
+    if (!b) {
+        b = mAsset->buffers.Create(bufferId);
+    }
+
     for (unsigned int i = 0; i < mScene->mNumMeshes; ++i) {
         const aiMesh* aim = mScene->mMeshes[i];
 
@@ -276,13 +283,6 @@ void glTFExporter::ExportMeshes()
         Mesh::Primitive& p = m->primitives.back();
 
         p.material = mAsset->materials.Get(aim->mMaterialIndex);
-
-        std::string bufferId = mAsset->FindUniqueID(meshId, "buffer");
-
-        Ref<Buffer> b = mAsset->GetBodyBuffer();
-        if (!b) {
-            b = mAsset->buffers.Create(bufferId);
-        }
 
         Ref<Accessor> v = ExportData(*mAsset, meshId, b, aim->mNumVertices, aim->mVertices, AttribType::VEC3, AttribType::VEC3, ComponentType_FLOAT);
         if (v) p.attributes.position.push_back(v);


### PR DESCRIPTION
Rather than creating one buffer per mesh, which is unnecessary, add all data to a single buffer.