### PR TITLE
Export glTF buffer data in a separate .bin file

### DIFF
--- a/code/glTFAsset.h
+++ b/code/glTFAsset.h
@@ -489,6 +489,9 @@ namespace glTF
         bool IsSpecial() const
             { return mIsSpecial; }
 
+        std::string GetURI()
+            { return std::string(this->id) + ".bin"; }
+
         static const char* TranslateId(Asset& r, const char* id);
     };
 

--- a/code/glTFAssetWriter.h
+++ b/code/glTFAssetWriter.h
@@ -79,6 +79,7 @@ public:
     AssetWriter(Asset& asset);
 
     void WriteFile(const char* path);
+    void WriteGLBFile(const char* path);
 };
 
 }

--- a/code/glTFAssetWriter.inl
+++ b/code/glTFAssetWriter.inl
@@ -94,9 +94,6 @@ namespace glTF {
 
     inline void Write(Value& obj, Buffer& b, AssetWriter& w)
     {
-        std::string dataURI = "data:application/octet-stream;base64,";
-        Util::EncodeBase64(b.GetPointer(), b.byteLength, dataURI);
-
         const char* type;
         switch (b.type) {
             case Buffer::Type_text:
@@ -107,7 +104,7 @@ namespace glTF {
 
         obj.AddMember("byteLength", static_cast<uint64_t>(b.byteLength), w.mAl);
         obj.AddMember("type", StringRef(type), w.mAl);
-        obj.AddMember("uri", Value(dataURI, w.mAl).Move(), w.mAl);
+        obj.AddMember("uri", Value(b.GetURI(), w.mAl).Move(), w.mAl);
     }
 
     inline void Write(Value& obj, BufferView& bv, AssetWriter& w)
@@ -328,39 +325,61 @@ namespace glTF {
 
     inline void AssetWriter::WriteFile(const char* path)
     {
-        bool isBinary = mAsset.extensionsUsed.KHR_binary_glTF;
+        std::unique_ptr<IOStream> jsonOutFile(mAsset.OpenFile(path, "wt", true));
 
-        std::unique_ptr<IOStream> outfile
-            (mAsset.OpenFile(path, isBinary ? "wb" : "wt", true));
+        if (jsonOutFile == 0) {
+            throw DeadlyExportError("Could not open output file: " + std::string(path));
+        }
+
+        StringBuffer docBuffer;
+
+        PrettyWriter<StringBuffer> writer(docBuffer);
+        mDoc.Accept(writer);
+
+        if (jsonOutFile->Write(docBuffer.GetString(), docBuffer.GetSize(), 1) != 1) {
+            throw DeadlyExportError("Failed to write scene data!");
+        }
+
+        // Write buffer data to separate .bin files
+        for (unsigned int i = 0; i < mAsset.buffers.Size(); ++i) {
+            Ref<Buffer> b = mAsset.buffers.Get(i);
+
+            std::string binPath = b->GetURI();
+
+            std::unique_ptr<IOStream> binOutFile(mAsset.OpenFile(binPath, "wb", true));
+
+            if (binOutFile == 0) {
+                throw DeadlyExportError("Could not open output file: " + binPath);
+            }
+
+            if (b->byteLength > 0) {
+                if (binOutFile->Write(b->GetPointer(), b->byteLength, 1) != 1) {
+                    throw DeadlyExportError("Failed to write binary file: " + binPath);
+                }
+            }
+        }
+    }
+
+    inline void AssetWriter::WriteGLBFile(const char* path)
+    {
+        std::unique_ptr<IOStream> outfile(mAsset.OpenFile(path, "wb", true));
 
         if (outfile == 0) {
             throw DeadlyExportError("Could not open output file: " + std::string(path));
         }
 
-        if (isBinary) {
-            // we will write the header later, skip its size
-            outfile->Seek(sizeof(GLB_Header), aiOrigin_SET);
-        }
+        // we will write the header later, skip its size
+        outfile->Seek(sizeof(GLB_Header), aiOrigin_SET);
 
         StringBuffer docBuffer;
-
-        bool pretty = true; 
-        if (!isBinary && pretty) {
-            PrettyWriter<StringBuffer> writer(docBuffer);
-            mDoc.Accept(writer);
-        }
-        else {
-            Writer<StringBuffer> writer(docBuffer);
-            mDoc.Accept(writer);
-        }
+        Writer<StringBuffer> writer(docBuffer);
+        mDoc.Accept(writer);
 
         if (outfile->Write(docBuffer.GetString(), docBuffer.GetSize(), 1) != 1) {
-            throw DeadlyExportError("Failed to write scene data!"); 
+            throw DeadlyExportError("Failed to write scene data!");
         }
 
-        if (isBinary) {
-            WriteBinaryData(outfile.get(), docBuffer.GetSize());
-        }
+        WriteBinaryData(outfile.get(), docBuffer.GetSize());
     }
 
     inline void AssetWriter::WriteBinaryData(IOStream* outfile, size_t sceneLength)
@@ -384,7 +403,6 @@ namespace glTF {
                 }
             }
         }
-
 
         //
         // write the header

--- a/code/glTFExporter.cpp
+++ b/code/glTFExporter.cpp
@@ -80,20 +80,9 @@ namespace Assimp {
     // Worker function for exporting a scene to GLTF. Prototyped and registered in Exporter.cpp
     void ExportSceneGLTF(const char* pFile, IOSystem* pIOSystem, const aiScene* pScene, const ExportProperties* pProperties)
     {
-        aiScene* sceneCopy_tmp;
-        SceneCombiner::CopyScene(&sceneCopy_tmp, pScene);
-        std::unique_ptr<aiScene> sceneCopy(sceneCopy_tmp);
-
-        SplitLargeMeshesProcess_Triangle tri_splitter;
-        tri_splitter.SetLimit(0xffff);
-        tri_splitter.Execute(sceneCopy.get());
-
-        SplitLargeMeshesProcess_Vertex vert_splitter;
-        vert_splitter.SetLimit(0xffff);
-        vert_splitter.Execute(sceneCopy.get());
 
         // invoke the exporter
-        glTFExporter exporter(pFile, pIOSystem, sceneCopy.get(), pProperties, false);
+        glTFExporter exporter(pFile, pIOSystem, pScene, pProperties, false);
     }
 
     // ------------------------------------------------------------------------------------------------
@@ -112,9 +101,22 @@ glTFExporter::glTFExporter(const char* filename, IOSystem* pIOSystem, const aiSc
                            const ExportProperties* pProperties, bool isBinary)
     : mFilename(filename)
     , mIOSystem(pIOSystem)
-    , mScene(pScene)
     , mProperties(pProperties)
 {
+    aiScene* sceneCopy_tmp;
+    SceneCombiner::CopyScene(&sceneCopy_tmp, pScene);
+    std::unique_ptr<aiScene> sceneCopy(sceneCopy_tmp);
+
+    SplitLargeMeshesProcess_Triangle tri_splitter;
+    tri_splitter.SetLimit(0xffff);
+    tri_splitter.Execute(sceneCopy.get());
+
+    SplitLargeMeshesProcess_Vertex vert_splitter;
+    vert_splitter.SetLimit(0xffff);
+    vert_splitter.Execute(sceneCopy.get());
+
+    mScene = sceneCopy.get();
+
     std::unique_ptr<Asset> asset();
     mAsset.reset( new glTF::Asset( pIOSystem ) );
 


### PR DESCRIPTION
Changes:
* Export a `.bin` file containing buffer data, and reference that file in the `.gltf`, rather than embedding a base64 blob
* Factor GLB file logic out of `AssetWriter::WriteFile` into its own function
* Split meshes in constructor to cover GLB files
* use file name as base for buffer IDs (instead of 'buffer')