### PR TITLE
Fixed Appveyor x64 builds

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,9 +28,16 @@ install:
 - call c:\projects\assimp\scripts\appveyor\compiler_setup.bat
 
 build_script:
- - cd c:\projects\assimp
- - cmake CMakeLists.txt -G "Visual Studio %Configuration%"
- - if "%platform%" EQU "x64" (msbuild /m /p:Configuration=Release /p:Platform="x64" Assimp.sln) else (msbuild /m /p:Configuration=Release /p:Platform="Win32" Assimp.sln)
+build_script:  
+- cmd: >-
+    cd c:\projects\assimp
+    if "%platform%" equ "x64" (
+      cmake CMakeLists.txt -G "Visual Studio %Configuration% Win64"
+      msbuild /m /p:Configuration=Release /p:Platform="x64" Assimp.sln
+    ) else (
+      cmake CMakeLists.txt -G "Visual Studio %Configuration%"
+      msbuild /m /p:Configuration=Release /p:Platform="Win32" Assimp.sln
+    ) 
 
 after_build:
   - 7z a assimp.7z c:\projects\assimp\bin\release\* c:\projects\assimp\lib\release\*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ install:
 build_script:
  - cd c:\projects\assimp
  - cmake CMakeLists.txt -G "Visual Studio %Configuration%"
- - msbuild /m /p:Configuration=Release /p:Platform="Win32" Assimp.sln
+ - if "%platform%" EQU "x64" (msbuild /m /p:Configuration=Release /p:Platform="x64" Assimp.sln) else (msbuild /m /p:Configuration=Release /p:Platform="Win32" Assimp.sln)
 
 after_build:
   - 7z a assimp.7z c:\projects\assimp\bin\release\* c:\projects\assimp\lib\release\*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,23 +28,11 @@ install:
 - call c:\projects\assimp\scripts\appveyor\compiler_setup.bat
 
 build_script:  
-- cmd: >-
-
-    cd c:\projects\assimp
-    
-    if "%platform%" equ "x64" (
-      
-      cmake CMakeLists.txt -G "Visual Studio %Configuration% Win64"
-      
-      msbuild /m /p:Configuration=Release /p:Platform="x64" Assimp.sln
-      
-    ) else (
-      
-      cmake CMakeLists.txt -G "Visual Studio %Configuration%"
-      
-      msbuild /m /p:Configuration=Release /p:Platform="Win32" Assimp.sln
-      
-    ) 
+- cd c:\projects\assimp
+- if "%platform%" equ "x64" (cmake CMakeLists.txt -G "Visual Studio %Configuration% Win64")
+- if "%platform%" equ "x86" (cmake CMakeLists.txt -G "Visual Studio %Configuration%")
+- if "%platform%" equ "x64" (msbuild /m /p:Configuration=Release /p:Platform="x64" Assimp.sln)
+- if "%platform%" equ "x86" (msbuild /m /p:Configuration=Release /p:Platform="Win32" Assimp.sln)
 
 after_build:
   - 7z a assimp.7z c:\projects\assimp\bin\release\* c:\projects\assimp\lib\release\*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,13 +29,21 @@ install:
 
 build_script:  
 - cmd: >-
+
     cd c:\projects\assimp
+    
     if "%platform%" equ "x64" (
+      
       cmake CMakeLists.txt -G "Visual Studio %Configuration% Win64"
+      
       msbuild /m /p:Configuration=Release /p:Platform="x64" Assimp.sln
+      
     ) else (
+      
       cmake CMakeLists.txt -G "Visual Studio %Configuration%"
+      
       msbuild /m /p:Configuration=Release /p:Platform="Win32" Assimp.sln
+      
     ) 
 
 after_build:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,6 @@ install:
 # Make compiler command line tools available
 - call c:\projects\assimp\scripts\appveyor\compiler_setup.bat
 
-build_script:
 build_script:  
 - cmd: >-
     cd c:\projects\assimp


### PR DESCRIPTION
I've noticed that the build script used by appveyor was always generating x86 binaries no matter what platform was defined. I fixed this in this PR. 

I made sure the generated DLL was indeed x64 by opening it in Depends then by using it from the Assimp-net wrapper.

You can check the generated binaries here: https://ci.appveyor.com/project/odalet/assimp/build/job/ulygh9s2j99sx9d8/artifacts

Hope this helps!