### PR TITLE
glTF: Read and write transparency values

### DIFF
--- a/code/glTFAsset.inl
+++ b/code/glTFAsset.inl
@@ -696,6 +696,7 @@ inline void Material::Read(Value& material, Asset& r)
         ReadMaterialProperty(r, *values, "diffuse", this->diffuse);
         ReadMaterialProperty(r, *values, "specular", this->specular);
 
+        ReadMember(*values, "transparency", transparency);
         ReadMember(*values, "shininess", shininess);
     }
 

--- a/code/glTFAssetWriter.inl
+++ b/code/glTFAssetWriter.inl
@@ -171,6 +171,9 @@ namespace glTF {
             WriteColorOrTex(v, m.specular, "specular", w.mAl);
             WriteColorOrTex(v, m.emission, "emission", w.mAl);
 
+            if (m.transparent)
+                v.AddMember("transparency", m.transparency, w.mAl);
+
             v.AddMember("shininess", m.shininess, w.mAl);
         }
         obj.AddMember("values", v, w.mAl);

--- a/code/glTFExporter.cpp
+++ b/code/glTFExporter.cpp
@@ -274,6 +274,8 @@ void glTFExporter::ExportMaterials()
         GetMatColorOrTex(mat, m->specular, AI_MATKEY_COLOR_SPECULAR, aiTextureType_SPECULAR);
         GetMatColorOrTex(mat, m->emission, AI_MATKEY_COLOR_EMISSIVE, aiTextureType_EMISSIVE);
 
+        m->transparent = mat->Get(AI_MATKEY_OPACITY, m->transparency) == aiReturn_SUCCESS && m->transparency != 1.0;
+
         GetMatScalar(mat, m->shininess, AI_MATKEY_SHININESS);
     }
 }


### PR DESCRIPTION
Currently, `Material.transparency` is ignored by the importer and exporter for glTF.
NOTE: the transparency is only exported if it's different from the default value of `1.0`.