### PR TITLE
Sort by primitive type before exporting as glTF

### DIFF
--- a/code/Exporter.cpp
+++ b/code/Exporter.cpp
@@ -139,9 +139,9 @@ Exporter::ExportFormatEntry gExporters[] =
 
 #ifndef ASSIMP_BUILD_NO_GLTF_EXPORTER
     Exporter::ExportFormatEntry( "gltf", "GL Transmission Format", "gltf", &ExportSceneGLTF,
-        aiProcess_JoinIdenticalVertices | aiProcess_Triangulate /*| aiProcess_SortByPType*/),
+        aiProcess_JoinIdenticalVertices | aiProcess_Triangulate | aiProcess_SortByPType),
     Exporter::ExportFormatEntry( "glb", "GL Transmission Format (binary)", "glb", &ExportSceneGLB,
-        aiProcess_JoinIdenticalVertices | aiProcess_Triangulate /*| aiProcess_SortByPType*/),
+        aiProcess_JoinIdenticalVertices | aiProcess_Triangulate | aiProcess_SortByPType),
 #endif
 
 #ifndef ASSIMP_BUILD_NO_ASSBIN_EXPORTER


### PR DESCRIPTION
Currently the glTF exporter [assumes](https://github.com/assimp/assimp/blob/master/code/glTFExporter.cpp#L382) that every face in a given mesh has the same number of indices. This assumption fails when a mesh contains e.g. both lines and triangles, and causes the exported geometry to be corrupted.

This change fixes that problem by setting `aiProcess_SortByPType` on the glTF exporter.

A potential alternative would be to separate mesh primitives by primitive type in the exporter itself.