### PR TITLE
Parse homogeneous vertex coordinates in OBJs

### DIFF
--- a/code/ObjFileParser.cpp
+++ b/code/ObjFileParser.cpp
@@ -140,6 +140,9 @@ void ObjFileParser::parseFile()
                     if (numComponents == 3) {
                         // read in vertex definition
                         getVector3(m_pModel->m_Vertices);
+                    } else if (numComponents == 4) {
+                        // read in vertex definition (homogeneous coords)
+                        getHomogeneousVector3(m_pModel->m_Vertices);
                     } else if (numComponents == 6) {
                         // read vertex and vertex-color
                         getTwoVectors3(m_pModel->m_Vertices, m_pModel->m_VertexColors);
@@ -317,6 +320,26 @@ void ObjFileParser::getVector3( std::vector<aiVector3D> &point3d_array ) {
     z = ( ai_real ) fast_atof( m_buffer );
 
     point3d_array.push_back( aiVector3D( x, y, z ) );
+    m_DataIt = skipLine<DataArrayIt>( m_DataIt, m_DataItEnd, m_uiLine );
+}
+
+void ObjFileParser::getHomogeneousVector3( std::vector<aiVector3D> &point3d_array ) {
+    ai_real x, y, z, w;
+    copyNextWord(m_buffer, Buffersize);
+    x = (ai_real) fast_atof(m_buffer);
+
+    copyNextWord(m_buffer, Buffersize);
+    y = (ai_real) fast_atof(m_buffer);
+
+    copyNextWord( m_buffer, Buffersize );
+    z = ( ai_real ) fast_atof( m_buffer );
+
+    copyNextWord( m_buffer, Buffersize );
+    w = ( ai_real ) fast_atof( m_buffer );
+
+    ai_assert( w != 0 );
+
+    point3d_array.push_back( aiVector3D( x/w, y/w, z/w ) );
     m_DataIt = skipLine<DataArrayIt>( m_DataIt, m_DataItEnd, m_uiLine );
 }
 

--- a/code/ObjFileParser.h
+++ b/code/ObjFileParser.h
@@ -89,6 +89,8 @@ private:
     void getVector( std::vector<aiVector3D> &point3d_array );
     /// Stores the following 3d vector.
     void getVector3( std::vector<aiVector3D> &point3d_array );
+    /// Stores the following homogeneous vector as a 3D vector
+    void getHomogeneousVector3( std::vector<aiVector3D> &point3d_array );
     /// Stores the following two 3d vectors on the line.
     void getTwoVectors3( std::vector<aiVector3D> &point3d_array_a, std::vector<aiVector3D> &point3d_array_b );
     /// Stores the following 3d vector.


### PR DESCRIPTION
This change allows import of OBJ files that define vertex positions in homogeneous coordinates (as allowed by the [OBJ spec](http://www.martinreddy.net/gfx/3d/OBJ.spec)).