### PR TITLE
glTF compact skins

### DIFF
--- a/code/glTFAsset.h
+++ b/code/glTFAsset.h
@@ -811,6 +811,8 @@ namespace glTF
         Ref<Skin>  skin;                          //!< The ID of the skin referenced by this node.
         std::string jointName;                    //!< Name used when this node is a joint in a skin.
 
+        Ref<Node> parent;                         //!< This is not part of the glTF specification. Used as a helper.
+
         Node() {}
         void Read(Value& obj, Asset& r);
     };

--- a/code/glTFExporter.cpp
+++ b/code/glTFExporter.cpp
@@ -446,10 +446,12 @@ void ExportSkin(Asset& mAsset, const aiMesh* aim, Ref<Mesh>& meshRef, Ref<Buffer
         Ref<Node> nodeRef = mAsset.nodes.Get(aib->mName.C_Str());
         nodeRef->jointName = nodeRef->id;  //"joint_" + std::to_string(idx_bone);
 
+        unsigned int jointNamesIndex;
         bool addJointToJointNames = true;
         for (int idx_joint = 0; idx_joint < skinRef->jointNames.size(); ++idx_joint) {
             if (skinRef->jointNames[idx_joint]->jointName.compare(nodeRef->jointName) == 0) {
                 addJointToJointNames = false;
+                jointNamesIndex = idx_joint;
             }
         }
 
@@ -460,6 +462,7 @@ void ExportSkin(Asset& mAsset, const aiMesh* aim, Ref<Mesh>& meshRef, Ref<Buffer
             aiMatrix4x4 tmpMatrix4;
             CopyValue(aib->mOffsetMatrix, tmpMatrix4);
             inverseBindMatricesData.push_back(tmpMatrix4);
+            jointNamesIndex = inverseBindMatricesData.size() - 1;
         }
 
         // aib->mWeights   =====>  vertexWeightData
@@ -470,7 +473,7 @@ void ExportSkin(Asset& mAsset, const aiMesh* aim, Ref<Mesh>& meshRef, Ref<Buffer
             // A vertex can only have at most four joint weights. Ignore all others.
             if (jointsPerVertex[vertexId] > 3) { continue; }
 
-            vertexJointData[vertexId][jointsPerVertex[vertexId]] = idx_bone;
+            vertexJointData[vertexId][jointsPerVertex[vertexId]] = jointNamesIndex;
             vertexWeightData[vertexId][jointsPerVertex[vertexId]] = vertWeight;
 
             jointsPerVertex[vertexId] += 1;
@@ -726,7 +729,6 @@ void glTFExporter::ExportMeshes()
     for (int idx_joint = 0; idx_joint < inverseBindMatricesData.size(); ++idx_joint) {
         CopyValue(inverseBindMatricesData[idx_joint], invBindMatrixData[idx_joint]);
     }
-
 
     Ref<Accessor> invBindMatrixAccessor = ExportData(*mAsset, skinName, b, inverseBindMatricesData.size(), invBindMatrixData, AttribType::MAT4, AttribType::MAT4, ComponentType_FLOAT);
     if (invBindMatrixAccessor) skinRef->inverseBindMatrices = invBindMatrixAccessor;

--- a/code/glTFExporter.cpp
+++ b/code/glTFExporter.cpp
@@ -713,7 +713,10 @@ void glTFExporter::ExportMeshes()
 	}// for (unsigned int i = 0; i < mScene->mNumMeshes; ++i)
 }
 
-
+/*
+ * Export the root node of the node hierarchy.
+ * Calls ExportNode for all children.
+ */
 unsigned int glTFExporter::ExportNodeHierarchy(const aiNode* n)
 {
     Ref<Node> node = mAsset->nodes.Create(mAsset->FindUniqueID(n->mName.C_Str(), "node"));
@@ -735,7 +738,10 @@ unsigned int glTFExporter::ExportNodeHierarchy(const aiNode* n)
     return node.GetIndex();
 }
 
-
+/*
+ * Export node and recursively calls ExportNode for all children.
+ * Since these nodes are not the root node, we also export the parent Ref<Node>
+ */
 unsigned int glTFExporter::ExportNode(const aiNode* n, Ref<Node>& parent)
 {
     Ref<Node> node = mAsset->nodes.Create(mAsset->FindUniqueID(n->mName.C_Str(), "node"));

--- a/code/glTFExporter.h
+++ b/code/glTFExporter.h
@@ -58,8 +58,12 @@ struct aiMaterial;
 
 namespace glTF
 {
+    template<class T>
+    class Ref;
+
     class Asset;
     struct TexProperty;
+    struct Node;
 }
 
 namespace Assimp
@@ -98,7 +102,8 @@ namespace Assimp
         void ExportMetadata();
         void ExportMaterials();
         void ExportMeshes();
-        unsigned int ExportNode(const aiNode* node);
+        unsigned int ExportNodeHierarchy(const aiNode* n);
+        unsigned int ExportNode(const aiNode* node, glTF::Ref<glTF::Node>& parent);
         void ExportScene();
         void ExportAnimations();
     };


### PR DESCRIPTION
This PR is in regard to skins in glTF export.

## FEATURES
* Iterating over the aiMeshes, all the bones are collected into one skin.
* `parent` node reference member is added to the glTF asset Node to help when traversing up the node hierarchy.
* A vertex can only have at most four joint weights. After the first four, all extras are ignored.

## TEST MODELS
| Model  | Export Success |
| ------------- | ------------- |
| `gltf/sampleModels/BoxAnimated`  | OK  |
| `gltf/sampleModels/RiggedSimple`  | OK  |
| `gltf/sampleModels/CesiumMilkTruck`  | OK  |
| `gltf/sampleModels/RiggedFigure`  | OK  |
| `gltf/sampleModels/CasiumMan`  | OK  |
| `gltf/sampleModels/Monster`  | OK  |
| `gltf/sampleModels/BrainStem`  | OK  |
| `robot` | OK  |


## ISSUES
* `glTFExporter.cpp` needs some code refactoring. Specifically, the `ExportSkins` procedure is intricately tied into the `ExportMeshes` function.
* The `Animations` and `Skins` need to be considered for compression lines 640 - 729.
* Seems to work well for scenes with one complex model. however I am not sure how it will perform for a scene with multiple complex models.
* I have been fixing the skins and animations on a model-by-model basis. Ideally I think there must be a more correct way to do this.