### PR TITLE
cfileio: fix function typedefs to have struct/enum

### DIFF
--- a/include/assimp/cfileio.h
+++ b/include/assimp/cfileio.h
@@ -46,7 +46,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef AI_FILEIO_H_INC
 #define AI_FILEIO_H_INC
 
-#include "types.h"
+#include <assimp/types.h>
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -54,15 +54,15 @@ struct aiFileIO;
 struct aiFile;
 
 // aiFile callbacks
-typedef size_t   (*aiFileWriteProc) (C_STRUCT aiFile*,   const char*, size_t, size_t);
-typedef size_t   (*aiFileReadProc)  (C_STRUCT aiFile*,   char*, size_t,size_t);
-typedef size_t   (*aiFileTellProc)  (C_STRUCT aiFile*);
-typedef void     (*aiFileFlushProc) (C_STRUCT aiFile*);
-typedef aiReturn (*aiFileSeek)(C_STRUCT aiFile*, size_t, aiOrigin);
+typedef size_t          (*aiFileWriteProc) (C_STRUCT aiFile*,   const char*, size_t, size_t);
+typedef size_t          (*aiFileReadProc)  (C_STRUCT aiFile*,   char*, size_t,size_t);
+typedef size_t          (*aiFileTellProc)  (C_STRUCT aiFile*);
+typedef void            (*aiFileFlushProc) (C_STRUCT aiFile*);
+typedef C_ENUM aiReturn (*aiFileSeek)      (C_STRUCT aiFile*, size_t, C_ENUM aiOrigin);
 
 // aiFileIO callbacks
-typedef aiFile* (*aiFileOpenProc)  (C_STRUCT aiFileIO*, const char*, const char*);
-typedef void    (*aiFileCloseProc) (C_STRUCT aiFileIO*, C_STRUCT aiFile*);
+typedef C_STRUCT aiFile* (*aiFileOpenProc)  (C_STRUCT aiFileIO*, const char*, const char*);
+typedef void             (*aiFileCloseProc) (C_STRUCT aiFileIO*, C_STRUCT aiFile*);
 
 // Represents user-defined data
 typedef char* aiUserData;


### PR DESCRIPTION
Otherwise building with cfileio.h would result in:

/usr/include/assimp/cfileio.h:61:58: error: unknown type name ‘aiOrigin’
 typedef aiReturn (*aiFileSeek)(C_STRUCT aiFile*, size_t, aiOrigin);
                                                          ^~~~~~~~
/usr/include/assimp/cfileio.h:64:9: error: unknown type name ‘aiFile’
 typedef aiFile* (*aiFileOpenProc)  (C_STRUCT aiFileIO*, const char*, const char*);
         ^~~~~~
/usr/include/assimp/cfileio.h:122:5: error: unknown type name ‘aiFileSeek’
     aiFileSeek SeekProc;
     ^~~~~~~~~~