### PR TITLE
Fix OBJ parser mtllib statement parsing bug.

### DIFF
--- a/code/ObjFileParser.cpp
+++ b/code/ObjFileParser.cpp
@@ -185,7 +185,11 @@ void ObjFileParser::parseFile()
                 std::string name;
 
                 getName(m_DataIt, m_DataItEnd, name);
-                name = name.substr(0, name.find(" "));
+
+                size_t nextSpace = name.find(" ");
+                if (nextSpace != std::string::npos)
+                    name = name.substr(0, nextSpace);
+
                 if (name == "mg")
                     getGroupNumberAndResolution();
                 else if(name == "mtllib")

--- a/code/ObjFileParser.cpp
+++ b/code/ObjFileParser.cpp
@@ -182,9 +182,10 @@ void ObjFileParser::parseFile()
 
         case 'm': // Parse a material library or merging group ('mg')
             {
-				std::string name;
+                std::string name;
 
-				getName(m_DataIt, m_DataItEnd, name);
+                getName(m_DataIt, m_DataItEnd, name);
+                name = name.substr(0, name.find(" "));
                 if (name == "mg")
                     getGroupNumberAndResolution();
                 else if(name == "mtllib")


### PR DESCRIPTION
A previous commit used `getName` to parse lines beginning with 'm'. But since `getName` returns the whole line including spaces, the comparisons (e.g. `name == "mtllib"`) always fail, causing the line to be skipped.

In particular, any OBJ imported will be missing its material.

I added some additional parsing to get the correct behaviour back, but it might be best to revert the [commit](https://github.com/assimp/assimp/commit/0359ded94621a4bbba6a021ee5d62314916f6bd2) that introduced the problem.

Fixes #1041 