### PR TITLE
Fix compile error with MSVC 2015

### DIFF
--- a/contrib/Open3DGC/o3dgcTimer.h
+++ b/contrib/Open3DGC/o3dgcTimer.h
@@ -26,7 +26,7 @@ THE SOFTWARE.
 
 #include "o3dgcCommon.h"
 
-#ifdef WIN32
+#ifdef _WIN32
 /* Thank you, Microsoft, for file WinDef.h with min/max redefinition. */
 #define NOMINMAX
 #include <windows.h>
@@ -42,7 +42,7 @@ THE SOFTWARE.
 
 namespace o3dgc
 {
-#ifdef WIN32
+#ifdef _WIN32
     class Timer
     {
     public: 


### PR DESCRIPTION
This patch fixes compilation with MSVC 2015.  WIN32 is not a preprocessor symbol that is defined by MSVC, but _WIN32 is.