### PR TITLE
Issue 1059

### DIFF
--- a/code/IOStreamBuffer.h
+++ b/code/IOStreamBuffer.h
@@ -230,8 +230,6 @@ template<class T>
 inline
 bool IOStreamBuffer<T>::getNextLine( std::vector<T> &buffer ) {
     buffer.resize( m_cacheSize );
-    //::memset( &buffer[ 0 ], '\n', m_cacheSize );
-
     if ( m_cachePos == m_cacheSize || 0 == m_filePos ) {
         if ( !readNextBlock() ) {
             return false;

--- a/code/IOStreamBuffer.h
+++ b/code/IOStreamBuffer.h
@@ -230,7 +230,7 @@ template<class T>
 inline
 bool IOStreamBuffer<T>::getNextLine( std::vector<T> &buffer ) {
     buffer.resize( m_cacheSize );
-    ::memset( &buffer[ 0 ], '\n', m_cacheSize );
+    //::memset( &buffer[ 0 ], '\n', m_cacheSize );
 
     if ( m_cachePos == m_cacheSize || 0 == m_filePos ) {
         if ( !readNextBlock() ) {
@@ -248,6 +248,7 @@ bool IOStreamBuffer<T>::getNextLine( std::vector<T> &buffer ) {
             }
         }
     }
+    buffer[ i ] = '\n';
     m_cachePos++;
 
     return true;

--- a/test/unit/utTypes.cpp
+++ b/test/unit/utTypes.cpp
@@ -43,6 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/types.h>
 
 using namespace Assimp;
+
 class utTypes : public ::testing::Test {
     // empty
 };


### PR DESCRIPTION
Fix obj-performance issue:
- memset will be used to set linebuffer-cache to \n.
- Fix is to set only the last one after end of line was found.