### PR TITLE
Fix obj .mtl file loading

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ OPTION( ASSIMP_BUILD_ZLIB
 )
 option( ASSIMP_BUILD_ASSIMP_TOOLS
   "If the supplementary tools for Assimp are built in addition to the library."
-  ON
+  OFF 
 )
 option ( ASSIMP_BUILD_SAMPLES
   "If the official samples are built as well (needs Glut)."
@@ -74,7 +74,7 @@ option ( ASSIMP_BUILD_SAMPLES
 )
 OPTION ( ASSIMP_BUILD_TESTS
   "If the test suite for Assimp is built in addition to the library."
-  ON
+  OFF 
 )
 IF(MSVC)
   set (CMAKE_PREFIX_PATH "D:\\libs\\devil")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ OPTION( ASSIMP_BUILD_ZLIB
 )
 option( ASSIMP_BUILD_ASSIMP_TOOLS
   "If the supplementary tools for Assimp are built in addition to the library."
-  OFF 
+  ON
 )
 option ( ASSIMP_BUILD_SAMPLES
   "If the official samples are built as well (needs Glut)."
@@ -74,7 +74,7 @@ option ( ASSIMP_BUILD_SAMPLES
 )
 OPTION ( ASSIMP_BUILD_TESTS
   "If the test suite for Assimp is built in addition to the library."
-  OFF 
+  ON
 )
 IF(MSVC)
   set (CMAKE_PREFIX_PATH "D:\\libs\\devil")

--- a/code/BaseImporter.cpp
+++ b/code/BaseImporter.cpp
@@ -481,7 +481,7 @@ namespace Assimp
         BatchLoader::PropertyMap map;
         unsigned int id;
 
-        bool operator== (const std::string& f) {
+        bool operator== (const std::string& f) const {
             return file == f;
         }
     };
@@ -489,13 +489,22 @@ namespace Assimp
 
 // ------------------------------------------------------------------------------------------------
 // BatchLoader::pimpl data structure
-struct Assimp::BatchData
-{
-    BatchData()
-        : pIOSystem()
-        , pImporter()
-        , next_id(0xffff)
-    {}
+struct Assimp::BatchData {
+    BatchData( IOSystem* pIO, bool validate )
+    : pIOSystem( pIO )
+    , pImporter( nullptr )
+    , next_id(0xffff)
+    , validate( validate ) {
+        ai_assert( NULL != pIO );
+        
+        pImporter = new Importer();
+        pImporter->SetIOHandler( pIO );
+    }
+
+    ~BatchData() {
+        pImporter->SetIOHandler( NULL ); /* get pointer back into our possession */
+        delete pImporter;
+    }
 
     // IO system to be used for all imports
     IOSystem* pIOSystem;
@@ -511,53 +520,59 @@ struct Assimp::BatchData
 
     // Id for next item
     unsigned int next_id;
+
+    // Validation enabled state
+    bool validate;
 };
 
+typedef std::list<LoadRequest>::iterator LoadReqIt;
+
 // ------------------------------------------------------------------------------------------------
-BatchLoader::BatchLoader(IOSystem* pIO)
+BatchLoader::BatchLoader(IOSystem* pIO, bool validate )
 {
     ai_assert(NULL != pIO);
 
-    data = new BatchData();
-    data->pIOSystem = pIO;
-
-    data->pImporter = new Importer();
-    data->pImporter->SetIOHandler(data->pIOSystem);
+    m_data = new BatchData( pIO, validate );
 }
 
 // ------------------------------------------------------------------------------------------------
 BatchLoader::~BatchLoader()
 {
-    // delete all scenes wthat have not been polled by the user
-    for (std::list<LoadRequest>::iterator it = data->requests.begin();it != data->requests.end(); ++it) {
-
+    // delete all scenes what have not been polled by the user
+    for ( LoadReqIt it = m_data->requests.begin();it != m_data->requests.end(); ++it) {
         delete (*it).scene;
     }
-    data->pImporter->SetIOHandler(NULL); /* get pointer back into our possession */
-    delete data->pImporter;
-    delete data;
+    delete m_data;
 }
 
+// ------------------------------------------------------------------------------------------------
+void BatchLoader::setValidation( bool enabled ) {
+    m_data->validate = enabled;
+}
 
 // ------------------------------------------------------------------------------------------------
-unsigned int BatchLoader::AddLoadRequest    (const std::string& file,
+bool BatchLoader::getValidation() const {
+    return m_data->validate;
+}
+
+// ------------------------------------------------------------------------------------------------
+unsigned int BatchLoader::AddLoadRequest(const std::string& file,
     unsigned int steps /*= 0*/, const PropertyMap* map /*= NULL*/)
 {
     ai_assert(!file.empty());
 
     // check whether we have this loading request already
-    std::list<LoadRequest>::iterator it;
-    for (it = data->requests.begin();it != data->requests.end(); ++it)  {
-
+    for ( LoadReqIt it = m_data->requests.begin();it != m_data->requests.end(); ++it)  {
         // Call IOSystem's path comparison function here
-        if (data->pIOSystem->ComparePaths((*it).file,file)) {
-
+        if ( m_data->pIOSystem->ComparePaths((*it).file,file)) {
             if (map) {
-                if (!((*it).map == *map))
+                if ( !( ( *it ).map == *map ) ) {
                     continue;
+                }
             }
-            else if (!(*it).map.empty())
+            else if ( !( *it ).map.empty() ) {
                 continue;
+            }
 
             (*it).refCnt++;
             return (*it).id;
@@ -565,20 +580,18 @@ unsigned int BatchLoader::AddLoadRequest    (const std::string& file,
     }
 
     // no, we don't have it. So add it to the queue ...
-    data->requests.push_back(LoadRequest(file,steps,map,data->next_id));
-    return data->next_id++;
+    m_data->requests.push_back(LoadRequest(file,steps,map, m_data->next_id));
+    return m_data->next_id++;
 }
 
 // ------------------------------------------------------------------------------------------------
-aiScene* BatchLoader::GetImport     (unsigned int which)
+aiScene* BatchLoader::GetImport( unsigned int which )
 {
-    for (std::list<LoadRequest>::iterator it = data->requests.begin();it != data->requests.end(); ++it) {
-
+    for ( LoadReqIt it = m_data->requests.begin();it != m_data->requests.end(); ++it) {
         if ((*it).id == which && (*it).loaded)  {
-
             aiScene* sc = (*it).scene;
             if (!(--(*it).refCnt))  {
-                data->requests.erase(it);
+                m_data->requests.erase(it);
             }
             return sc;
         }
@@ -590,14 +603,15 @@ aiScene* BatchLoader::GetImport     (unsigned int which)
 void BatchLoader::LoadAll()
 {
     // no threaded implementation for the moment
-    for (std::list<LoadRequest>::iterator it = data->requests.begin();it != data->requests.end(); ++it) {
+    for ( LoadReqIt it = m_data->requests.begin();it != m_data->requests.end(); ++it) {
         // force validation in debug builds
         unsigned int pp = (*it).flags;
-#ifdef ASSIMP_BUILD_DEBUG
-        pp |= aiProcess_ValidateDataStructure;
-#endif
+        if ( m_data->validate ) {
+            pp |= aiProcess_ValidateDataStructure;
+        }
+
         // setup config properties if necessary
-        ImporterPimpl* pimpl = data->pImporter->Pimpl();
+        ImporterPimpl* pimpl = m_data->pImporter->Pimpl();
         pimpl->mFloatProperties  = (*it).map.floats;
         pimpl->mIntProperties    = (*it).map.ints;
         pimpl->mStringProperties = (*it).map.strings;
@@ -608,8 +622,8 @@ void BatchLoader::LoadAll()
             DefaultLogger::get()->info("%%% BEGIN EXTERNAL FILE %%%");
             DefaultLogger::get()->info("File: " + (*it).file);
         }
-        data->pImporter->ReadFile((*it).file,pp);
-        (*it).scene = data->pImporter->GetOrphanedScene();
+        m_data->pImporter->ReadFile((*it).file,pp);
+        (*it).scene = m_data->pImporter->GetOrphanedScene();
         (*it).loaded = true;
 
         DefaultLogger::get()->info("%%% END EXTERNAL FILE %%%");

--- a/code/BaseImporter.h
+++ b/code/BaseImporter.h
@@ -347,7 +347,12 @@ public: // static utilities
     static void ConvertUTF8toISO8859_1(
         std::string& data);
 
-    enum TextFileMode { ALLOW_EMPTY, FORBID_EMPTY };
+    // -------------------------------------------------------------------
+    /// @brief  Enum to define, if empty files are ok or not.
+    enum TextFileMode { 
+        ALLOW_EMPTY,
+        FORBID_EMPTY 
+    };
 
     // -------------------------------------------------------------------
     /** Utility for text file loaders which copies the contents of the
@@ -382,14 +387,10 @@ public: // static utilities
         }
     }
 
-    
-
 protected:
-
-    /** Error description in case there was one. */
+    /// Error description in case there was one.
     std::string m_ErrorText;
-
-    /** Currently set progress handler */
+    /// Currently set progress handler.
     ProgressHandler* m_progress;
 };
 

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -184,62 +184,21 @@ IF ( ASSIMP_BUILD_NONFREE_C4D_IMPORTER )
   SOURCE_GROUP( C4D FILES ${C4D_SRCS})
 ENDIF ( ASSIMP_BUILD_NONFREE_C4D_IMPORTER )
 
-# This option allows to select whether to build all the importers and then
-# manually select which ones not to build (old behaviour), or if to
-# exclude all importers from build and manually select the ones to actually
-# build.
-# By default, exclude all importers and manually select which ones to use.
-# 
-# To have all importers excluded, simply do not set this option in the parent
-# CmakeLists. Then, set the option for the importer(s) needed in the parent
-# CMakeLists, e.g.:
-#    OPTION(ASSIMP_BUILD_OBJ_IMPORTER "" TRUE)
-#
-# To have assimp build all the importers, set the option to true, then manually
-# exclude which importers you don't need, e.g.:
-#    OPTION(ASSIMP_BUILD_OBJ_IMPORTER "" FALSE)
-#
-# NOTE: In order to use this method of exclusion, the tools build must be disabled;
-# their code references certain importers/exporters which would be excluded.
-# If you need the tools, either manually add the importers/exporters the code
-# references (you will see linkage errors), or just enable the build of all the
-# importers as explained above.
-OPTION(ASSIMP_BUILD_ALL_AND_EXCLUDE "Build all importers and select which ones
-			 to not build" FALSE)
-IF(ASSIMP_BUILD_ALL_AND_EXCLUDE)
-	# macro to add the CMake Option ADD_ASSIMP_IMPORTER_<name> which enables compile of loader
-	# this way selective loaders can be compiled (reduces filesize + compile time)
-	MACRO(ADD_ASSIMP_IMPORTER name)
-		OPTION(ASSIMP_BUILD_${name}_IMPORTER "build the ${name} importer" TRUE)
-		IF(ASSIMP_BUILD_${name}_IMPORTER)
-			LIST(APPEND ASSIMP_LOADER_SRCS ${ARGN})
-			SET(ASSIMP_IMPORTERS_ENABLED "${ASSIMP_IMPORTERS_ENABLED} ${name}")
-			SET(${name}_SRCS ${ARGN})
-			SOURCE_GROUP(${name} FILES ${ARGN})
-		ELSE()
-			SET(${name}_SRC "")
-			SET(ASSIMP_IMPORTERS_DISABLED "${ASSIMP_IMPORTERS_DISABLED} ${name}")
-			add_definitions(-DASSIMP_BUILD_NO_${name}_IMPORTER)
-		ENDIF()
-	ENDMACRO()
-ELSE(ASSIMP_BUILD_ALL_AND_EXCLUDE)
-	MACRO(ADD_ASSIMP_IMPORTER name)
-		OPTION(ASSIMP_BUILD_${name}_IMPORTER "build the ${name} importer" FALSE)
-		MESSAGE(STATUS "Setting false for ${name}")
-		IF(ASSIMP_BUILD_${name}_IMPORTER)
-			LIST(APPEND ASSIMP_LOADER_SRCS ${ARGN})
-			SET(ASSIMP_IMPORTERS_ENABLED "${ASSIMP_IMPORTERS_ENABLED} ${name}")
-			SET(${name}_SRCS ${ARGN})
-			SOURCE_GROUP(${name} FILES ${ARGN})
-			MESSAGE(STATUS "Setting true for ${name}")
-		ELSE()
-			SET(${name}_SRC "")
-			SET(ASSIMP_IMPORTERS_DISABLED "${ASSIMP_IMPORTERS_DISABLED} ${name}")
-			add_definitions(-DASSIMP_BUILD_NO_${name}_IMPORTER)
-			MESSAGE(STATUS "Setting false for ${name}")
-		ENDIF()
-	ENDMACRO()
-ENDIF(ASSIMP_BUILD_ALL_AND_EXCLUDE)
+# macro to add the CMake Option ADD_ASSIMP_IMPORTER_<name> which enables compile of loader
+# this way selective loaders can be compiled (reduces filesize + compile time)
+MACRO(ADD_ASSIMP_IMPORTER name)
+  OPTION(ASSIMP_BUILD_${name}_IMPORTER "build the ${name} importer" TRUE)
+  IF(ASSIMP_BUILD_${name}_IMPORTER)
+    LIST(APPEND ASSIMP_LOADER_SRCS ${ARGN})
+    SET(ASSIMP_IMPORTERS_ENABLED "${ASSIMP_IMPORTERS_ENABLED} ${name}")
+    SET(${name}_SRCS ${ARGN})
+    SOURCE_GROUP(${name} FILES ${ARGN})
+  ELSE()
+    SET(${name}_SRC "")
+    SET(ASSIMP_IMPORTERS_DISABLED "${ASSIMP_IMPORTERS_DISABLED} ${name}")
+    add_definitions(-DASSIMP_BUILD_NO_${name}_IMPORTER)
+  ENDIF()
+ENDMACRO()
 
 SET(ASSIMP_LOADER_SRCS "")
 SET(ASSIMP_IMPORTERS_ENABLED "") # list of enabled importers

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -184,21 +184,62 @@ IF ( ASSIMP_BUILD_NONFREE_C4D_IMPORTER )
   SOURCE_GROUP( C4D FILES ${C4D_SRCS})
 ENDIF ( ASSIMP_BUILD_NONFREE_C4D_IMPORTER )
 
-# macro to add the CMake Option ADD_ASSIMP_IMPORTER_<name> which enables compile of loader
-# this way selective loaders can be compiled (reduces filesize + compile time)
-MACRO(ADD_ASSIMP_IMPORTER name)
-  OPTION(ASSIMP_BUILD_${name}_IMPORTER "build the ${name} importer" TRUE)
-  IF(ASSIMP_BUILD_${name}_IMPORTER)
-    LIST(APPEND ASSIMP_LOADER_SRCS ${ARGN})
-    SET(ASSIMP_IMPORTERS_ENABLED "${ASSIMP_IMPORTERS_ENABLED} ${name}")
-    SET(${name}_SRCS ${ARGN})
-    SOURCE_GROUP(${name} FILES ${ARGN})
-  ELSE()
-    SET(${name}_SRC "")
-    SET(ASSIMP_IMPORTERS_DISABLED "${ASSIMP_IMPORTERS_DISABLED} ${name}")
-    add_definitions(-DASSIMP_BUILD_NO_${name}_IMPORTER)
-  ENDIF()
-ENDMACRO()
+# This option allows to select whether to build all the importers and then
+# manually select which ones not to build (old behaviour), or if to
+# exclude all importers from build and manually select the ones to actually
+# build.
+# By default, exclude all importers and manually select which ones to use.
+# 
+# To have all importers excluded, simply do not set this option in the parent
+# CmakeLists. Then, set the option for the importer(s) needed in the parent
+# CMakeLists, e.g.:
+#    OPTION(ASSIMP_BUILD_OBJ_IMPORTER "" TRUE)
+#
+# To have assimp build all the importers, set the option to true, then manually
+# exclude which importers you don't need, e.g.:
+#    OPTION(ASSIMP_BUILD_OBJ_IMPORTER "" FALSE)
+#
+# NOTE: In order to use this method of exclusion, the tools build must be disabled;
+# their code references certain importers/exporters which would be excluded.
+# If you need the tools, either manually add the importers/exporters the code
+# references (you will see linkage errors), or just enable the build of all the
+# importers as explained above.
+OPTION(ASSIMP_BUILD_ALL_AND_EXCLUDE "Build all importers and select which ones
+			 to not build" FALSE)
+IF(ASSIMP_BUILD_ALL_AND_EXCLUDE)
+	# macro to add the CMake Option ADD_ASSIMP_IMPORTER_<name> which enables compile of loader
+	# this way selective loaders can be compiled (reduces filesize + compile time)
+	MACRO(ADD_ASSIMP_IMPORTER name)
+		OPTION(ASSIMP_BUILD_${name}_IMPORTER "build the ${name} importer" TRUE)
+		IF(ASSIMP_BUILD_${name}_IMPORTER)
+			LIST(APPEND ASSIMP_LOADER_SRCS ${ARGN})
+			SET(ASSIMP_IMPORTERS_ENABLED "${ASSIMP_IMPORTERS_ENABLED} ${name}")
+			SET(${name}_SRCS ${ARGN})
+			SOURCE_GROUP(${name} FILES ${ARGN})
+		ELSE()
+			SET(${name}_SRC "")
+			SET(ASSIMP_IMPORTERS_DISABLED "${ASSIMP_IMPORTERS_DISABLED} ${name}")
+			add_definitions(-DASSIMP_BUILD_NO_${name}_IMPORTER)
+		ENDIF()
+	ENDMACRO()
+ELSE(ASSIMP_BUILD_ALL_AND_EXCLUDE)
+	MACRO(ADD_ASSIMP_IMPORTER name)
+		OPTION(ASSIMP_BUILD_${name}_IMPORTER "build the ${name} importer" FALSE)
+		MESSAGE(STATUS "Setting false for ${name}")
+		IF(ASSIMP_BUILD_${name}_IMPORTER)
+			LIST(APPEND ASSIMP_LOADER_SRCS ${ARGN})
+			SET(ASSIMP_IMPORTERS_ENABLED "${ASSIMP_IMPORTERS_ENABLED} ${name}")
+			SET(${name}_SRCS ${ARGN})
+			SOURCE_GROUP(${name} FILES ${ARGN})
+			MESSAGE(STATUS "Setting true for ${name}")
+		ELSE()
+			SET(${name}_SRC "")
+			SET(ASSIMP_IMPORTERS_DISABLED "${ASSIMP_IMPORTERS_DISABLED} ${name}")
+			add_definitions(-DASSIMP_BUILD_NO_${name}_IMPORTER)
+			MESSAGE(STATUS "Setting false for ${name}")
+		ENDIF()
+	ENDMACRO()
+ENDIF(ASSIMP_BUILD_ALL_AND_EXCLUDE)
 
 SET(ASSIMP_LOADER_SRCS "")
 SET(ASSIMP_IMPORTERS_ENABLED "") # list of enabled importers

--- a/code/Importer.h
+++ b/code/Importer.h
@@ -39,6 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 /** @file Importer.h mostly internal stuff for use by #Assimp::Importer */
+#pragma once
 #ifndef INCLUDED_AI_IMPORTER_H
 #define INCLUDED_AI_IMPORTER_H
 
@@ -133,12 +134,11 @@ struct BatchData;
  *  could, this has not yet been implemented at the moment).
  *
  *  @note The class may not be used by more than one thread*/
-class BatchLoader
+class ASSIMP_API BatchLoader
 {
     // friend of Importer
 
 public:
-
     //! @cond never
     // -------------------------------------------------------------------
     /** Wraps a full list of configuration properties for an importer.
@@ -162,15 +162,29 @@ public:
     //! @endcond
 
 public:
-
-
     // -------------------------------------------------------------------
     /** Construct a batch loader from a given IO system to be used
-     *  to access external files */
-    explicit BatchLoader(IOSystem* pIO);
+     *  to access external files 
+     */
+    explicit BatchLoader(IOSystem* pIO, bool validate = false );
+
+    // -------------------------------------------------------------------
+    /** The class destructor.
+     */
     ~BatchLoader();
 
-
+    // -------------------------------------------------------------------
+    /** Sets the validation step. True for enable validation during postprocess.
+     *  @param  enable  True for validation.
+     */
+    void setValidation( bool enabled );
+    
+    // -------------------------------------------------------------------
+    /** Returns the current validation step.
+     *  @return The current validation step.
+     */
+    bool getValidation() const;
+    
     // -------------------------------------------------------------------
     /** Add a new file to the list of files to be loaded.
      *  @param file File to be loaded
@@ -185,7 +199,6 @@ public:
         const PropertyMap* map = NULL
         );
 
-
     // -------------------------------------------------------------------
     /** Get an imported scene.
      *  This polls the import from the internal request list.
@@ -199,20 +212,16 @@ public:
         unsigned int which
         );
 
-
     // -------------------------------------------------------------------
     /** Waits until all scenes have been loaded. This returns
      *  immediately if no scenes are queued.*/
     void LoadAll();
 
 private:
-
     // No need to have that in the public API ...
-    BatchData* data;
+    BatchData *m_data;
 };
 
-}
+} // Namespace Assimp
 
-
-
-#endif
+#endif // INCLUDED_AI_IMPORTER_H

--- a/code/ObjFileParser.cpp
+++ b/code/ObjFileParser.cpp
@@ -178,7 +178,7 @@ void ObjFileParser::parseFile( IOStreamBuffer<char> &streamBuffer ) {
             {
                 std::string name;
 
-                getName(m_DataIt, m_DataItEnd, name);
+                getNameNoSpace(m_DataIt, m_DataItEnd, name);
 
                 size_t nextSpace = name.find(" ");
                 if (nextSpace != std::string::npos)

--- a/code/ObjTools.h
+++ b/code/ObjTools.h
@@ -165,6 +165,47 @@ inline char_t getName( char_t it, char_t end, std::string &name )
     return it;
 }
 
+/** @brief  Get a name from the current line. Do not preserve space
+ *    in the middle, but trim it at the end.
+ *  @param  it      set to current position
+ *  @param  end     set to end of scratch buffer for readout
+ *  @param  name    Separated name
+ *  @return Current-iterator with new position
+ */
+template<class char_t>
+inline char_t getNameNoSpace( char_t it, char_t end, std::string &name )
+{
+    name = "";
+    if( isEndOfBuffer( it, end ) ) {
+        return end;
+    }
+
+    char *pStart = &( *it );
+    while( !isEndOfBuffer( it, end ) && !IsLineEnd( *it )
+          && !IsSpaceOrNewLine( *it ) ) {
+        ++it;
+    }
+
+    while( isEndOfBuffer( it, end ) || IsLineEnd( *it )
+          || IsSpaceOrNewLine( *it ) ) {
+        --it;
+    }
+    ++it;
+
+    // Get name
+    // if there is no name, and the previous char is a separator, come back to start
+    while (&(*it) < pStart) {
+        ++it;
+    }
+    std::string strName( pStart, &(*it) );
+    if ( strName.empty() )
+        return it;
+    else
+        name = strName;
+
+    return it;
+}
+
 /** @brief  Get next word from given line
  *  @param  it      set to current position
  *  @param  end     set to end of scratch buffer for readout

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -55,7 +55,9 @@ SOURCE_GROUP( unit FILES
 )
 
 SET( TEST_SRCS
+  unit/TestIOSystem.h
   unit/AssimpAPITest.cpp
+  unit/utBatchLoader.cpp
   unit/utBlenderIntermediate.cpp
   unit/utBlendImportAreaLight.cpp
   unit/utBlendImportMaterials.cpp

--- a/test/unit/TestIOSystem.h
+++ b/test/unit/TestIOSystem.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "UnitTestPCH.h"
+
+#include <assimp/IOSystem.hpp>
+
+using namespace std;
+using namespace Assimp;
+
+static const string Sep = "/";
+class TestIOSystem : public IOSystem {
+public:
+    TestIOSystem() : IOSystem() {}
+    virtual ~TestIOSystem() {}
+    virtual bool Exists( const char* ) const {
+        return true;
+    }
+    virtual char getOsSeparator() const {
+        return Sep[ 0 ];
+    }
+
+    virtual IOStream* Open( const char* pFile, const char* pMode = "rb" ) {
+        return NULL;
+    }
+
+    virtual void Close( IOStream* pFile ) {
+        // empty
+    }
+};

--- a/test/unit/utBatchLoader.cpp
+++ b/test/unit/utBatchLoader.cpp
@@ -39,41 +39,40 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ---------------------------------------------------------------------------
 */
 #include "UnitTestPCH.h"
+#include "Importer.h"
 #include "TestIOSystem.h"
 
-#include <assimp/IOSystem.hpp>
+using namespace ::Assimp;
 
-using namespace std;
-using namespace Assimp;
-
-class IOSystemTest : public ::testing::Test {
+class BatchLoaderTest : public ::testing::Test {
 public:
-    virtual void SetUp() { 
-        pImp = new TestIOSystem(); 
+    virtual void SetUp() {
+        m_io = new TestIOSystem();
     }
-    
-    virtual void TearDown() { 
-        delete pImp; 
+
+    virtual void TearDown() {
+        delete m_io;
     }
 
 protected:
-    TestIOSystem* pImp;
+    TestIOSystem* m_io;
 };
 
-/*
-virtual bool PushDirectory( const std::string &path );
-virtual const std::string &CurrentDirectory() const;
-virtual bool PopDirectory();
-*/
+TEST_F( BatchLoaderTest, createTest ) {
+    bool ok( true );
+    try {
+        BatchLoader loader( m_io );
+    } catch ( ... ) {
+        ok = false;
+    }
+}
 
-TEST_F( IOSystemTest, accessDirectoryStackTest ) {
-    EXPECT_FALSE( pImp->PopDirectory() );
-    EXPECT_EQ( 0, pImp->StackSize() );
-    EXPECT_FALSE( pImp->PushDirectory( "" ) );
-    std::string path = "test/";
-    EXPECT_TRUE( pImp->PushDirectory( path ) );
-    EXPECT_EQ( 1, pImp->StackSize() );
-    EXPECT_EQ( path, pImp->CurrentDirectory() );
-    EXPECT_TRUE( pImp->PopDirectory() );
-    EXPECT_EQ( 0, pImp->StackSize() );
+TEST_F( BatchLoaderTest, validateAccessTest ) {
+    BatchLoader loader1( m_io );
+    EXPECT_FALSE( loader1.getValidation() );
+    loader1.setValidation( true );
+    EXPECT_TRUE( loader1.getValidation() );
+
+    BatchLoader loader2( m_io, true );
+    EXPECT_TRUE( loader2.getValidation() );
 }

--- a/test/unit/utImporter.cpp
+++ b/test/unit/utImporter.cpp
@@ -270,3 +270,5 @@ TEST_F(ImporterTest, testMultipleReads)
     EXPECT_TRUE(pImp->ReadFile(ASSIMP_TEST_MODELS_DIR "/X/BCN_Epileptic.X",flags));
     //EXPECT_TRUE(pImp->ReadFile(ASSIMP_TEST_MODELS_DIR "/X/dwarf.x",flags)); # is in nonbsd
 }
+
+// ------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Fix the obj file loader by adding a new method which allows
a name to be read considering the space in the middle between two
words and use that for parsing the "mtlib" line in the .obj file
parsing method.

Before, the method used in the obj parsing function would have
returned the string "mtlib NAME_OF_MTL" instead of "mtlib" only,
which resulted in the .mtl file being never parsed.