### PR TITLE
MSVC14 x64 /bigobj missing causes compile error

### DIFF
--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -463,7 +463,7 @@ ADD_ASSIMP_IMPORTER( IFC
   STEPFileEncoding.h
 )
 if (MSVC AND ASSIMP_BUILD_IFC_IMPORTER)
-  set_source_files_properties(IFCReaderGen.cpp PROPERTIES COMPILE_FLAGS "/bigobj")
+  set_source_files_properties(IFCReaderGen1.cpp IFCReaderGen2.cpp PROPERTIES COMPILE_FLAGS "/bigobj")
 endif (MSVC AND ASSIMP_BUILD_IFC_IMPORTER)
 
 ADD_ASSIMP_IMPORTER( XGL


### PR DESCRIPTION
Fixed a compile error on MSVC14 x64 caused by the /bigobj flag failing to be set
for the 1 and 2-suffixed versions introduced in
commit 0a25b076b8968b7ea2aa96d7d1b4381be2d72ce6.