### PR TITLE
AMF Postprocessed Metadata given type bool regardless of original type

### DIFF
--- a/code/AMFImporter_Postprocess.cpp
+++ b/code/AMFImporter_Postprocess.cpp
@@ -352,7 +352,7 @@ void AMFImporter::Postprocess_AddMetadata(const std::list<CAMFImporter_NodeEleme
 
 		for(const CAMFImporter_NodeElement_Metadata& metadata: pMetadataList)
 		{
-			pSceneNode.mMetaData->Set(meta_idx++, metadata.Type, metadata.Value.c_str());
+			pSceneNode.mMetaData->Set(meta_idx++, metadata.Type, aiString(metadata.Value));
 		}
 	}// if(pMetadataList.size() > 0)
 }


### PR DESCRIPTION
Fixed a bug in the AMF Importer Postprocessing where metadata would be incorrectly recorded as having type bool for all entries.
The warning originally surfaced inside of metadata.h, which indicated the original const char* was being interpreted as a bool, rather than an aiString as was obviously intended.