### PR TITLE
Update STLLoader.cpp

### DIFF
--- a/code/STLLoader.cpp
+++ b/code/STLLoader.cpp
@@ -274,7 +274,7 @@ void STLImporter::LoadASCIIFile()
         }
         else pScene->mRootNode->mName.Set("<STL_ASCII>");
 
-        unsigned int faceVertexCounter = 0;
+        unsigned int faceVertexCounter = 3;
         for ( ;; )
         {
             // go to the next token


### PR DESCRIPTION
If `faceVertexCounter` does not start equal 3, then at line 291 you will get always a warning (only one, but still..)