### PR TITLE
Remove scaling of specular exponent in OBJFileImporter.cpp

### DIFF
--- a/code/ObjFileImporter.cpp
+++ b/code/ObjFileImporter.cpp
@@ -600,9 +600,6 @@ void ObjFileImporter::createMaterials(const ObjFile::Model* pModel, aiScene* pSc
 
         mat->AddProperty<int>( &sm, 1, AI_MATKEY_SHADING_MODEL);
 
-        // multiplying the specular exponent with 2 seems to yield better results
-        pCurrentMaterial->shineness *= 4.f;
-
         // Adding material colors
         mat->AddProperty( &pCurrentMaterial->ambient, 1, AI_MATKEY_COLOR_AMBIENT );
         mat->AddProperty( &pCurrentMaterial->diffuse, 1, AI_MATKEY_COLOR_DIFFUSE );


### PR DESCRIPTION
Currently the specular exponent in MTL files is being multiplied by 4 on import, causing imported models to be exponentially shinier than specified.

In addition, this scaling isn't matched in the exporter, so, for example, `assimp export my.obj my-new.obj` will yield a model with a much larger specular exponent than the original. Since Assimp isn't the only tool in our pipeline, this is causing us some headaches.

This was previously mentioned in #123, but not implemented. Is there any interest in revisiting this?