### PR TITLE
Properly export COLLADA <transparency> value

### DIFF
--- a/code/ColladaExporter.cpp
+++ b/code/ColladaExporter.cpp
@@ -691,7 +691,7 @@ void ColladaExporter::WriteMaterials()
 
     materials[a].shininess.exist = mat->Get( AI_MATKEY_SHININESS, materials[a].shininess.value) == aiReturn_SUCCESS;
     materials[a].transparency.exist = mat->Get( AI_MATKEY_OPACITY, materials[a].transparency.value) == aiReturn_SUCCESS;
-    materials[a].transparency.value = 1 - materials[a].transparency.value;
+    materials[a].transparency.value = materials[a].transparency.value;
     materials[a].index_refraction.exist = mat->Get( AI_MATKEY_REFRACTI, materials[a].index_refraction.value) == aiReturn_SUCCESS;
   }
 


### PR DESCRIPTION
This value is handled properly on import, but is inverted in the exporter. Since the default interpretation of this value is such that 0.0 is fully transparent and 1.0 fully opaque, which matches how the importer stores the value, inverting it on export is incorrect.

For example, running `assimp export my.dae my-new.dae` where `my.dae` is in `A_ONE` mode for transparency (the default), will yield a .dae with the transparency inverted from the original. You can also see this happening when converting e.g. OBJs to COLLADA.