### PR TITLE
Replace use of nullptr in headers with NULL

### DIFF
--- a/include/assimp/anim.h
+++ b/include/assimp/anim.h
@@ -377,9 +377,9 @@ struct aiAnimation {
     : mDuration(-1.)
     , mTicksPerSecond(0.)
     , mNumChannels(0)
-    , mChannels(nullptr)
+    , mChannels(NULL)
     , mNumMeshChannels(0)
-    , mMeshChannels(nullptr) {
+    , mMeshChannels(NULL) {
         // empty
     }
 

--- a/include/assimp/metadata.h
+++ b/include/assimp/metadata.h
@@ -187,7 +187,7 @@ struct aiMetadata {
     static inline
     aiMetadata *Alloc( unsigned int numProperties ) {
         if ( 0 == numProperties ) {
-            return nullptr;
+            return NULL;
         }
 
         aiMetadata *data = new aiMetadata;


### PR DESCRIPTION
It's fine if assimp uses nullptr internally, but not all projects that use it compile in C++11 mode, so this patch removes the 3 occurrences of nullptr from the public headers.

This allows projects that use assimp to build in C++03 mode.