### PR TITLE
{D3MF} Move #ifndefs before #includes

### DIFF
--- a/code/D3MFImporter.cpp
+++ b/code/D3MFImporter.cpp
@@ -38,6 +38,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------
 */
 
+#ifndef ASSIMP_BUILD_NO_3MF_IMPORTER
+
 #include "D3MFImporter.h"
 
 #include <assimp/scene.h>
@@ -58,8 +60,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <memory>
 
 #include <assimp/ai_assert.h>
-
-#ifndef ASSIMP_BUILD_NO_3MF_IMPORTER
 
 #include "D3MFOpcPackage.h"
 #include <contrib/unzip/unzip.h>

--- a/code/D3MFOpcPackage.cpp
+++ b/code/D3MFOpcPackage.cpp
@@ -38,6 +38,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------
 */
 
+#ifndef ASSIMP_BUILD_NO_3MF_IMPORTER
 
 #include "D3MFOpcPackage.h"
 #include "Exceptional.h"
@@ -53,8 +54,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <algorithm>
 #include <cassert>
 #include <cstdlib>
-
-#ifndef ASSIMP_BUILD_NO_3MF_IMPORTER
 
 #include <contrib/unzip/unzip.h>
 


### PR DESCRIPTION
(Pointed out by Antti Määttä in Qt code review.)