### PR TITLE
Fix compiler cpp std version

### DIFF
--- a/port/iOS/build.sh
+++ b/port/iOS/build.sh
@@ -22,7 +22,7 @@ CPP_DEV_TARGET_LIST=(miphoneos-version-min mios-simulator-version-min)
 CPP_DEV_TARGET=
 CPP_STD_LIB_LIST=(libc++ libstdc++)
 CPP_STD_LIB=
-CPP_STD_LIST=(c++03 c++11 c++14)
+CPP_STD_LIST=(c++11 c++14)
 CPP_STD=
 
 function join { local IFS="$1"; shift; echo "$*"; }


### PR DESCRIPTION
```
In file included from ~/assimp/code/Importer.cpp:76:
~/assimp/code/Profiler.h:92:83: error: a space is required between consecutive right angle brackets (use '> >')
    typedef std::map<std::string,std::chrono::time_point<std::chrono::system_clock>> RegionMap;
                                                                                  ^~
                                                                                  > >
~/assimp/code/Profiler.h:86:9: warning: 'auto' type specifier is a C++11 extension [-Wc++11-extensions]
        auto elapsedSeconds = std::chrono::system_clock::now() - regions[region];
        ^
[ 16%] Building CXX object code/CMakeFiles/assimp.dir/StandardShapes.cpp.o
1 warning and 1 error generated.
make[3]: *** [code/CMakeFiles/assimp.dir/Importer.cpp.o] Error 1
make[3]: *** Waiting for unfinished jobs....
In file included from ~/assimp/code/ImporterRegistry.cpp:150:
~/assimp/code/OpenGEXImporter.h:155:54: warning: deleted function definitions are a C++11 extension [-Wc++11-extensions]
        VertexContainer( const VertexContainer & ) = delete;
                                                     ^
~/assimp/code/OpenGEXImporter.h:156:67: warning: deleted function definitions are a C++11 extension [-Wc++11-extensions]
        VertexContainer &operator = ( const VertexContainer & ) = delete;
                                                                  ^
~/assimp/code/OpenGEXImporter.h:172:38: warning: deleted function definitions are a C++11 extension [-Wc++11-extensions]
        RefInfo( const RefInfo & ) = delete;
                                     ^
~/assimp/code/OpenGEXImporter.h:173:51: warning: deleted function definitions are a C++11 extension [-Wc++11-extensions]
        RefInfo &operator = ( const RefInfo & ) = delete;
                                                  ^
In file included from ~/assimp/code/ImporterRegistry.cpp:171:
~/assimp/code/XGLLoader.h:105:27: warning: range-based for loop is a C++11 extension [-Wc++11-extensions]
            for(aiMesh* m : meshes_linear) {
                          ^
~/assimp/code/XGLLoader.h:109:31: warning: range-based for loop is a C++11 extension [-Wc++11-extensions]
            for(aiMaterial* m : materials_linear) {
                              ^
6 warnings generated.
make[2]: *** [code/CMakeFiles/assimp.dir/all] Error 2
make[1]: *** [code/CMakeFiles/assimp.dir/rule] Error 2
make: *** [assimp] Error 2
```
There's list loop enumerations causing warnings and incompatible template code which may cause compile errors due to different compilers which corresponding to code:

```c++
for(aiMaterial* m : materials_linear) {
                              ^
```

and

```c++
 typedef std::map<std::string,std::chrono::time_point<std::chrono::system_clock>> RegionMap;
                                                                                  ^~
                                                                                  > >
```

