### PR TITLE
OBJParser: set material index when changing current material

### DIFF
--- a/code/ObjFileMtlImporter.cpp
+++ b/code/ObjFileMtlImporter.cpp
@@ -185,7 +185,7 @@ void ObjFileMtlImporter::load()
                     getFloatValue( m_pModel->m_pCurrentMaterial->alpha );
                     m_DataIt = skipLine<DataArrayIt>( m_DataIt, m_DataItEnd, m_uiLine );
                 }
-            }
+            }width * height * 4
             break;
 
         case 'N':
@@ -302,7 +302,8 @@ void ObjFileMtlImporter::createMaterial()
         // New Material created
         m_pModel->m_pCurrentMaterial = new ObjFile::Material();
         m_pModel->m_pCurrentMaterial->MaterialName.Set( name );
-        m_pModel->m_pCurrentMesh->m_uiMaterialIndex = m_pModel->m_MaterialLib.size();
+        if (m_pModel->m_pCurrentMesh)
+            m_pModel->m_pCurrentMesh->m_uiMaterialIndex = m_pModel->m_MaterialLib.size();
         m_pModel->m_MaterialLib.push_back( name );
         m_pModel->m_MaterialMap[ name ] = m_pModel->m_pCurrentMaterial;
     } else {

--- a/code/ObjFileMtlImporter.cpp
+++ b/code/ObjFileMtlImporter.cpp
@@ -302,6 +302,7 @@ void ObjFileMtlImporter::createMaterial()
         // New Material created
         m_pModel->m_pCurrentMaterial = new ObjFile::Material();
         m_pModel->m_pCurrentMaterial->MaterialName.Set( name );
+        m_pModel->m_pCurrentMesh->m_uiMaterialIndex = m_pModel->m_MaterialLib.size();
         m_pModel->m_MaterialLib.push_back( name );
         m_pModel->m_MaterialMap[ name ] = m_pModel->m_pCurrentMaterial;
     } else {


### PR DESCRIPTION
When a new material is parsed from the material library, the name of the current material is set but the old material index remains. This leaves an incorrect material index in the current mesh causing textures to not be associated with the right mesh. This patch updates the material index when changing the material name.

submitted by: Nola Donato nola.donato@samsung.com