### PR TITLE
OBJParser: Support spaces in texture file names

### DIFF
--- a/code/ObjTools.h
+++ b/code/ObjTools.h
@@ -140,15 +140,13 @@ inline char_t getName( char_t it, char_t end, std::string &name )
     }
 
     char *pStart = &( *it );
-    while( !isEndOfBuffer( it, end ) && !IsLineEnd( *it ) && !IsSpaceOrNewLine( *it ) ) {
+    while( !isEndOfBuffer( it, end ) && !IsLineEnd( *it )) {
         ++it;
     }
 
-    /*while( isEndOfBuffer( it, end ) || IsLineEnd( *it ) || IsSpaceOrNewLine( *it ) ) {
+    while(IsSpace( *it ) ) {
         --it;
     }
-    ++it;
-    */
     // Get name
     // if there is no name, and the previous char is a separator, come back to start
     while (&(*it) < pStart) {


### PR DESCRIPTION
This patch allows embedded spaces in texture filenames found in MTL files. It only affects the OBJ parser.

Submitted by: Nola Donato nola.donato@samsung.com