### PR TITLE
Fixed parsing ASE MESH_CFACE

### DIFF
--- a/code/ASEParser.cpp
+++ b/code/ASEParser.cpp
@@ -1858,7 +1858,7 @@ void Parser::ParseLV3MeshCFaceListBlock(unsigned int iNumFaces, ASE::Mesh& mesh)
             ++filePtr;
 
             // Face entry
-            if (TokenMatch(filePtr,"MESH_CFACE" ,11))
+            if (TokenMatch(filePtr,"MESH_CFACE" ,10))
             {
                 unsigned int aiValues[3];
                 unsigned int iIndex = 0;


### PR DESCRIPTION
Stumbled upon this while trying to use vertex colors in ASE files.