### PR TITLE
Create the directory for the asset's extraction on Android

### DIFF
--- a/port/AndroidJNI/AndroidJNIIOSystem.cpp
+++ b/port/AndroidJNI/AndroidJNIIOSystem.cpp
@@ -46,7 +46,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <android/api-level.h>
 #if __ANDROID__ and __ANDROID_API__ > 9 and defined(AI_CONFIG_ANDROID_JNI_ASSIMP_MANAGER_SUPPORT)
 
+#include <libgen.h>
 #include <stdlib.h>
+#include <sys/stat.h>
 #include <android/log.h>
 #include <android/asset_manager.h>
 #include <android/asset_manager_jni.h>
@@ -101,6 +103,27 @@ void AndroidJNIIOSystem::AndroidActivityInit(ANativeActivity* activity)
 }
 
 // ------------------------------------------------------------------------------------------------
+// Create the directory for the extracted resource
+static int mkpath(std::string path, mode_t mode)
+{
+    if (mkdir(path.c_str(), mode) == -1) {
+        switch(errno) {
+            case ENOENT:
+                if (mkpath(path.substr(0, path.find_last_of('/')), mode) == -1)
+                    return -1;
+                else
+                    return mkdir(path.c_str(), mode);
+            case EEXIST:
+                return 0;
+            default:
+                return -1;
+        }
+    }
+
+    return 0;
+}
+
+// ------------------------------------------------------------------------------------------------
 // Extracts android asset
 bool AndroidJNIIOSystem::AndroidExtractAsset(std::string name)
 {
@@ -130,6 +153,15 @@ bool AndroidJNIIOSystem::AndroidExtractAsset(std::string name)
 
 		// Close
 		AAsset_close(asset);
+
+		// Prepare directory for output buffer
+		std::string directoryNewPath = newPath;
+		directoryNewPath = dirname(&directoryNewPath[0]);
+
+		if (mkpath(directoryNewPath, S_IRUSR | S_IWUSR | S_IXUSR) == -1) {
+			__android_log_print(ANDROID_LOG_ERROR, "assimp",
+					"Can not create the directory for the output file");
+		}
 
 		// Prepare output buffer
 		std::ofstream assetExtracted(newPath.c_str(),


### PR DESCRIPTION
We encountered a problem while using assimp on Android Nougat (but it may also happen with older versions, we don't know), so it's tied to the AndroidJNIIOSystem library. On Android, assimp creates a copy of the models on the filesystem (internal storage / data folder of the app), instead of loading them from the Android asset manager each time. 

When we tried to load a model that is located in a folder (or subfolder), assimp was not able to open the output file for extraction from the Android asset manager because the folder (or subfolder) did not exist yet in the app's data folder.

For example, if the model was `models/foo/bar.obj`, assimp will try to create the file `/data/user/0/com.app.sample/files/models/foo/bar.obj` directly without creating the corresponding directory structure.  

This patch adds the folder creation to the extraction mechanism.