### PR TITLE
Allow to enable importers in a whitelist manner

### DIFF
--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -187,10 +187,16 @@ IF ( ASSIMP_BUILD_NONFREE_C4D_IMPORTER )
   SOURCE_GROUP( C4D FILES ${C4D_SRCS})
 ENDIF ( ASSIMP_BUILD_NONFREE_C4D_IMPORTER )
 
+# if this variable is set to TRUE, the user can manually disable importers by setting
+# ASSIMP_BUILD_XXX_IMPORTER to FALSE for each importer
+# if this variable is set to FALSE, the user can manually enable importers by setting
+# ASSIMP_BUILD_XXX_IMPORTER to TRUE for each importer
+OPTION(ASSIMP_BUILD_ALL_IMPORTERS_BY_DEFAULT "default value of all ASSIMP_BUILD_XXX_IMPORTER value" TRUE)
+
 # macro to add the CMake Option ADD_ASSIMP_IMPORTER_<name> which enables compile of loader
 # this way selective loaders can be compiled (reduces filesize + compile time)
 MACRO(ADD_ASSIMP_IMPORTER name)
-  OPTION(ASSIMP_BUILD_${name}_IMPORTER "build the ${name} importer" TRUE)
+  OPTION(ASSIMP_BUILD_${name}_IMPORTER "build the ${name} importer" ${ASSIMP_BUILD_ALL_IMPORTERS_BY_DEFAULT})
   IF(ASSIMP_BUILD_${name}_IMPORTER)
     LIST(APPEND ASSIMP_LOADER_SRCS ${ARGN})
     SET(ASSIMP_IMPORTERS_ENABLED "${ASSIMP_IMPORTERS_ENABLED} ${name}")

--- a/code/ImporterRegistry.cpp
+++ b/code/ImporterRegistry.cpp
@@ -46,6 +46,9 @@ directly (unless you are adding new loaders), instead use the
 corresponding preprocessor flag to selectively disable formats.
 */
 
+#include <vector>
+#include "BaseImporter.h"
+
 // ------------------------------------------------------------------------------------------------
 // Importers
 // (include_new_importers_here)


### PR DESCRIPTION
In the case when we want to build assimp with only a few importers (let's say less than 10), it would be shorter to specify the importers in a whitelist manner, instead of disabling every other importer but the 10 we want.

The feature works like that:

```sh
cmake \
  -DASSIMP_BUILD_ALL_IMPORTERS_BY_DEFAULT=OFF \
  -DASSIMP_NO_EXPORT=ON \
  -DASSIMP_BUILD_3DS_IMPORTER=ON \
  -DASSIMP_BUILD_FBX_IMPORTER=ON \
  -DASSIMP_BUILD_OBJ_IMPORTER=ON \
  -DASSIMP_BUILD_COLLADA_IMPORTER=ON;
# that's all!
```

The new flag here is `ASSIMP_BUILD_ALL_IMPORTERS_BY_DEFAULT` which is documented in the `CMakeLists.txt` (by default it is TRUE, which mimics the current behavior).

The change in `code/ImporterRegistry.cpp` was because of a fun edge case when no importer was set, which resulted in missing include directives.