### PR TITLE
Import FindPkgMacros to main CMake Configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -187,6 +187,7 @@ endif()
 
 INCLUDE_DIRECTORIES( include )
 
+INCLUDE (FindPkgMacros)
 INCLUDE (PrecompiledHeader)
 
 # If this is an in-source build (CMAKE_SOURCE_DIR == CMAKE_BINARY_DIR),


### PR DESCRIPTION
Commit 125d2ab95581f23908d broke the build process when `-DASSIMP_BUILD_ZLIB=ON`. The main CMake task now uses a macro that is only imported if the FindZlib task is run first. This commit will allow builds with an internally built zlib to progress.