### PR TITLE
Fix PDB file installation in RelWithDebInfo configuration

### DIFF
--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -936,7 +936,7 @@ if(MSVC AND ASSIMP_INSTALL_PDB)
     DESTINATION ${ASSIMP_LIB_INSTALL_DIR}
     CONFIGURATIONS Debug
   )
-  install(FILES ${Assimp_BINARY_DIR}/code/RelWithDebInfo/assimp.pdb
+  install(FILES ${Assimp_BINARY_DIR}/code/RelWithDebInfo/assimp${LIBRARY_SUFFIX}.pdb
     DESTINATION ${ASSIMP_LIB_INSTALL_DIR}
     CONFIGURATIONS RelWithDebInfo
   )


### PR DESCRIPTION
When installing a RelWithDebInfo build using Visual Studio, the PDB file passed to install() cannot be found because it is missing the library suffix.