### PR TITLE
Fixed compiler error on clang 4.0 running on OSX

### DIFF
--- a/code/glTFExporter.cpp
+++ b/code/glTFExporter.cpp
@@ -582,7 +582,7 @@ void glTFExporter::ExportMeshes()
 		if (v) p.attributes.position.push_back(v);
 
 		/******************** Normals ********************/
-		if(comp_allow && (aim->mNormals > 0)) idx_srcdata_normal = b->byteLength;// Store index of normals array.
+		if(comp_allow && (aim->mNormals != 0)) idx_srcdata_normal = b->byteLength;// Store index of normals array.
 
 		Ref<Accessor> n = ExportData(*mAsset, meshId, b, aim->mNumVertices, aim->mNormals, AttribType::VEC3, AttribType::VEC3, ComponentType_FLOAT);
 		if (n) p.attributes.normal.push_back(n);


### PR DESCRIPTION
glTFExporter.cpp:585:35: error: ordered comparison between pointer and zero ('aiVector3D *'
      (aka 'aiVector3t<float> *') and 'int')
                if(comp_allow && (aim->mNormals > 0)) idx_srcdata_normal = b->byteLength;// Store index of normals array.