### PR TITLE
Set UVW index material properties for OBJ files.

### DIFF
--- a/code/ObjFileImporter.cpp
+++ b/code/ObjFileImporter.cpp
@@ -614,9 +614,12 @@ void ObjFileImporter::createMaterials(const ObjFile::Model* pModel, aiScene* pSc
         mat->AddProperty( &pCurrentMaterial->ior, 1, AI_MATKEY_REFRACTI );
 
         // Adding textures
+        const int uvwIndex = 0;
+
         if ( 0 != pCurrentMaterial->texture.length )
         {
             mat->AddProperty( &pCurrentMaterial->texture, AI_MATKEY_TEXTURE_DIFFUSE(0));
+            mat->AddProperty( &uvwIndex, 1, AI_MATKEY_UVWSRC_DIFFUSE(0) );
             if (pCurrentMaterial->clamp[ObjFile::Material::TextureDiffuseType])
             {
                 addTextureMappingModeProperty(mat, aiTextureType_DIFFUSE);
@@ -626,6 +629,7 @@ void ObjFileImporter::createMaterials(const ObjFile::Model* pModel, aiScene* pSc
         if ( 0 != pCurrentMaterial->textureAmbient.length )
         {
             mat->AddProperty( &pCurrentMaterial->textureAmbient, AI_MATKEY_TEXTURE_AMBIENT(0));
+            mat->AddProperty( &uvwIndex, 1, AI_MATKEY_UVWSRC_AMBIENT(0) );
             if (pCurrentMaterial->clamp[ObjFile::Material::TextureAmbientType])
             {
                 addTextureMappingModeProperty(mat, aiTextureType_AMBIENT);
@@ -633,11 +637,15 @@ void ObjFileImporter::createMaterials(const ObjFile::Model* pModel, aiScene* pSc
         }
 
         if ( 0 != pCurrentMaterial->textureEmissive.length )
+        {
             mat->AddProperty( &pCurrentMaterial->textureEmissive, AI_MATKEY_TEXTURE_EMISSIVE(0));
+            mat->AddProperty( &uvwIndex, 1, AI_MATKEY_UVWSRC_EMISSIVE(0) );
+        }
 
         if ( 0 != pCurrentMaterial->textureSpecular.length )
         {
             mat->AddProperty( &pCurrentMaterial->textureSpecular, AI_MATKEY_TEXTURE_SPECULAR(0));
+            mat->AddProperty( &uvwIndex, 1, AI_MATKEY_UVWSRC_SPECULAR(0) );
             if (pCurrentMaterial->clamp[ObjFile::Material::TextureSpecularType])
             {
                 addTextureMappingModeProperty(mat, aiTextureType_SPECULAR);
@@ -647,6 +655,7 @@ void ObjFileImporter::createMaterials(const ObjFile::Model* pModel, aiScene* pSc
         if ( 0 != pCurrentMaterial->textureBump.length )
         {
             mat->AddProperty( &pCurrentMaterial->textureBump, AI_MATKEY_TEXTURE_HEIGHT(0));
+            mat->AddProperty( &uvwIndex, 1, AI_MATKEY_UVWSRC_HEIGHT(0) );
             if (pCurrentMaterial->clamp[ObjFile::Material::TextureBumpType])
             {
                 addTextureMappingModeProperty(mat, aiTextureType_HEIGHT);
@@ -656,6 +665,7 @@ void ObjFileImporter::createMaterials(const ObjFile::Model* pModel, aiScene* pSc
         if ( 0 != pCurrentMaterial->textureNormal.length )
         {
             mat->AddProperty( &pCurrentMaterial->textureNormal, AI_MATKEY_TEXTURE_NORMALS(0));
+            mat->AddProperty( &uvwIndex, 1, AI_MATKEY_UVWSRC_NORMALS(0) );
             if (pCurrentMaterial->clamp[ObjFile::Material::TextureNormalType])
             {
                 addTextureMappingModeProperty(mat, aiTextureType_NORMALS);
@@ -672,6 +682,7 @@ void ObjFileImporter::createMaterials(const ObjFile::Model* pModel, aiScene* pSc
             for( unsigned i = 0; i < count; i++ )
             {
                 mat->AddProperty(&pCurrentMaterial->textureReflection[i], AI_MATKEY_TEXTURE_REFLECTION(i));
+                mat->AddProperty( &uvwIndex, 1, AI_MATKEY_UVWSRC_REFLECTION(i) );
 
                 if(pCurrentMaterial->clamp[type])
                     addTextureMappingModeProperty(mat, aiTextureType_REFLECTION, 1, i);
@@ -681,6 +692,7 @@ void ObjFileImporter::createMaterials(const ObjFile::Model* pModel, aiScene* pSc
         if ( 0 != pCurrentMaterial->textureDisp.length )
         {
             mat->AddProperty( &pCurrentMaterial->textureDisp, AI_MATKEY_TEXTURE_DISPLACEMENT(0) );
+            mat->AddProperty( &uvwIndex, 1, AI_MATKEY_UVWSRC_DISPLACEMENT(0) );
             if (pCurrentMaterial->clamp[ObjFile::Material::TextureDispType])
             {
                 addTextureMappingModeProperty(mat, aiTextureType_DISPLACEMENT);
@@ -690,6 +702,7 @@ void ObjFileImporter::createMaterials(const ObjFile::Model* pModel, aiScene* pSc
         if ( 0 != pCurrentMaterial->textureOpacity.length )
         {
             mat->AddProperty( &pCurrentMaterial->textureOpacity, AI_MATKEY_TEXTURE_OPACITY(0));
+            mat->AddProperty( &uvwIndex, 1, AI_MATKEY_UVWSRC_OPACITY(0) );
             if (pCurrentMaterial->clamp[ObjFile::Material::TextureOpacityType])
             {
                 addTextureMappingModeProperty(mat, aiTextureType_OPACITY);
@@ -699,6 +712,7 @@ void ObjFileImporter::createMaterials(const ObjFile::Model* pModel, aiScene* pSc
         if ( 0 != pCurrentMaterial->textureSpecularity.length )
         {
             mat->AddProperty( &pCurrentMaterial->textureSpecularity, AI_MATKEY_TEXTURE_SHININESS(0));
+            mat->AddProperty( &uvwIndex, 1, AI_MATKEY_UVWSRC_SHININESS(0) );
             if (pCurrentMaterial->clamp[ObjFile::Material::TextureSpecularityType])
             {
                 addTextureMappingModeProperty(mat, aiTextureType_SHININESS);


### PR DESCRIPTION
After importing an OBJ file, clients cannot not get the UVW index associated with a texture by using `material.Get(AI_MATKEY_UVWSRC(type, i), uvw_index);` because the property is never set by the importer. This change should fix that.