### PR TITLE
Fixed no member named 'atop' in global namespace issue for Android ND…

### DIFF
--- a/code/StringUtils.h
+++ b/code/StringUtils.h
@@ -42,6 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <sstream>
 #include <stdarg.h>
+#include <cstdlib>
 
 ///	@fn		ai_snprintf
 ///	@brief	The portable version of the function snprintf ( C99 standard ), which works on visual studio compilers 2013 and earlier.


### PR DESCRIPTION
Fixed compilation error for Android NDK platform (gnu-libstdc++, 4.9) 

> error: no member named 'atof' in the global namespace
>           val = static_cast< float >( ::atof( begin ) );
>           val = static_cast< float >( ::atof( token.c_str() ) );