### PR TITLE
- Apply mechanism to decide use for IrrXML external or internal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,9 +174,11 @@ IF( UNIX )
 ENDIF( UNIX )
 
 
+# Grouped compiler settings
 IF ((CMAKE_C_COMPILER_ID MATCHES "GNU") AND NOT CMAKE_COMPILER_IS_MINGW)
   # hide all not-exported symbols
   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fvisibility=hidden -fPIC -Wall -std=c++0x" )
+  SET(LIBSTDC++_LIBRARIES -lstdc++)
 ELSEIF(MSVC)
   # enable multi-core compilation with MSVC
   add_compile_options(/MP)
@@ -236,9 +238,6 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/assimp-config.cmake"             "${C
 
 FIND_PACKAGE( DirectX )
 
-IF( CMAKE_COMPILER_IS_GNUCXX )
-  SET(LIBSTDC++_LIBRARIES -lstdc++)
-ENDIF( CMAKE_COMPILER_IS_GNUCXX )
 
 IF( BUILD_DOCS )
     add_subdirectory(doc)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,11 @@ OPTION ( ASSIMP_COVERALLS
    OFF
 )
 
+option ( SYSTEM_IRRXML
+    "Use system installed Irrlicht/IrrXML library."
+    OFF
+)
+
 OPTION ( BUILD_DOCS
    "Build documentation using Doxygen."
    OFF
@@ -169,18 +174,14 @@ IF( UNIX )
 ENDIF( UNIX )
 
 
-IF((CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX) AND NOT CMAKE_COMPILER_IS_MINGW)
-  IF (BUILD_SHARED_LIBS AND CMAKE_SIZEOF_VOID_P EQUAL 8) # -fPIC is only required for shared libs on 64 bit
-     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
-     SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
-  ENDIF()
+IF ((CMAKE_C_COMPILER_ID MATCHES "GNU") AND NOT CMAKE_COMPILER_IS_MINGW)
   # hide all not-exported symbols
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fvisibility=hidden -Wall -std=c++0x" )
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fvisibility=hidden -fPIC -Wall -std=c++0x" )
 ELSEIF(MSVC)
   # enable multi-core compilation with MSVC
   add_compile_options(/MP)
-ELSEIF ( "${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" )
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fvisibility=hidden -Wall -Wno-long-long -pedantic -std=c++11" )
+ELSEIF ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" )
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fvisibility=hidden -fPIC -Wall -Wno-long-long -pedantic -std=c++11" )
 ELSEIF( CMAKE_COMPILER_IS_MINGW )
   SET( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -Wall -Wno-long-long -pedantic -std=c++11" )
   add_definitions( -U__STRICT_ANSI__ )
@@ -242,6 +243,11 @@ ENDIF( CMAKE_COMPILER_IS_GNUCXX )
 IF( BUILD_DOCS )
     add_subdirectory(doc)
 ENDIF( BUILD_DOCS )
+
+# Look for system installed irrXML
+IF ( SYSTEM_IRRXML )
+    find_package( IrrXML REQUIRED )
+ENDIF( SYSTEM_IRRXML )
 
 # Search for external dependencies, and build them from source if not found
 # Search for zlib
@@ -336,6 +342,8 @@ IF (ASSIMP_BUILD_NONFREE_C4D_IMPORTER)
 ELSE (ASSIMP_BUILD_NONFREE_C4D_IMPORTER)
   ADD_DEFINITIONS( -DASSIMP_BUILD_NO_C4D_IMPORTER )
 ENDIF (ASSIMP_BUILD_NONFREE_C4D_IMPORTER)
+
+ADD_SUBDIRECTORY(contrib)
 
 ADD_SUBDIRECTORY( code/ )
 IF ( ASSIMP_BUILD_ASSIMP_TOOLS )

--- a/cmake-modules/FindIrrXML.cmake
+++ b/cmake-modules/FindIrrXML.cmake
@@ -1,0 +1,17 @@
+# Find IrrXMl from irrlicht project
+#
+# Find LibIrrXML headers and library
+#
+#   IRRXML_FOUND          - IrrXML found
+#   IRRXML_INCLUDE_DIR    - Headers location
+#   IRRXML_LIBRARY        - IrrXML main library
+
+find_path(IRRXML_INCLUDE_DIR irrXML.h
+    PATH_SUFFIXES include/irrlicht include/irrxml)
+find_library(IRRXML_LIBRARY IrrXML)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(IrrXML REQUIRED_VARS IRRXML_INCLUDE_DIR IRRXML_LIBRARY)
+
+
+mark_as_advanced(IRRXML_INCLUDE_DIR IRRXML_LIBRARY)

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -569,6 +569,9 @@ SET( PostProcessing_SRCS
 )
 SOURCE_GROUP( PostProcessing FILES ${PostProcessing_SRCS})
 
+SET( IrrXML_SRCS irrXMLWrapper.h )
+SOURCE_GROUP( IrrXML FILES ${IrrXML_SRCS})
+
 ADD_ASSIMP_IMPORTER( Q3D
   Q3DLoader.cpp
   Q3DLoader.h
@@ -680,18 +683,6 @@ SET( Extra_SRCS
   MD4FileData.h
 )
 SOURCE_GROUP( Extra FILES ${Extra_SRCS})
-
-SET( IrrXML_SRCS
-  irrXMLWrapper.h
-  ../contrib/irrXML/CXMLReaderImpl.h
-  ../contrib/irrXML/heapsort.h
-  ../contrib/irrXML/irrArray.h
-  ../contrib/irrXML/irrString.h
-  ../contrib/irrXML/irrTypes.h
-  ../contrib/irrXML/irrXML.cpp
-  ../contrib/irrXML/irrXML.h
-)
-SOURCE_GROUP( IrrXML FILES ${IrrXML_SRCS})
 
 SET( ConvertUTF_SRCS
   ../contrib/ConvertUTF/ConvertUTF.h
@@ -848,7 +839,8 @@ SET( assimp_src
 ADD_DEFINITIONS( -DOPENDDLPARSER_BUILD )
 
 INCLUDE_DIRECTORIES(
-  ../contrib/openddlparser/include
+    ${IRRXML_INCLUDE_DIR}
+    ../contrib/openddlparser/include
 )
 
 IF (ASSIMP_BUILD_NONFREE_C4D_IMPORTER)
@@ -858,7 +850,7 @@ ENDIF (ASSIMP_BUILD_NONFREE_C4D_IMPORTER)
 
 ADD_LIBRARY( assimp ${assimp_src} )
 
-TARGET_LINK_LIBRARIES(assimp ${ZLIB_LIBRARIES} ${OPENDDL_PARSER_LIBRARIES} )
+TARGET_LINK_LIBRARIES(assimp ${ZLIB_LIBRARIES} ${OPENDDL_PARSER_LIBRARIES} ${IRRXML_LIBRARY} )
 
 if(ANDROID AND ASSIMP_ANDROID_JNIIOSYSTEM)
   set(ASSIMP_ANDROID_JNIIOSYSTEM_PATH port/AndroidJNI)

--- a/code/irrXMLWrapper.h
+++ b/code/irrXMLWrapper.h
@@ -42,7 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define INCLUDED_AI_IRRXML_WRAPPER
 
 // some long includes ....
-#include "./../contrib/irrXML/irrXML.h"
+#include <irrXML.h>
 #include "./../include/assimp/IOStream.hpp"
 #include "BaseImporter.h"
 #include <vector>

--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -1,0 +1,4 @@
+# Compile internal irrXML only if system is not requested
+if( NOT SYSTEM_IRRXML )
+    add_subdirectory(irrXML)
+endif( NOT SYSTEM_IRRXML )

--- a/contrib/irrXML/CMakeLists.txt
+++ b/contrib/irrXML/CMakeLists.txt
@@ -1,0 +1,13 @@
+set( IrrXML_SRCS
+  CXMLReaderImpl.h
+  heapsort.h
+  irrArray.h
+  irrString.h
+  irrTypes.h
+  irrXML.cpp
+  irrXML.h
+)
+
+add_library(IrrXML STATIC ${IrrXML_SRCS})
+set(IRRXML_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}" CACHE INTERNAL "IrrXML_Include" )
+set(IRRXML_LIBRARY "IrrXML" CACHE INTERNAL "IrrXML" )


### PR DESCRIPTION
Several distributions usually decide for shared external libraries
instead of an usual embedded, for security reasons, duplicatiion issues.
This change enable the possibility to set SYSTEM_IRRXML=ON for detect
and build against a system installed irrxml.
By default, the internal copy is compiled.

Changes on build:
- Added a FindIrrXML cmake module.
- Moved the source recipe for proper CMakeLists inside contrib directory
- Includes aren't path based anymore, using the provided INCLUDE_DIR
- Compiler options are grouped in a single entry on main CMakeLists

Note: Current internal assimp irrXML is older than upstream irrlicht 1.8.4.
To enable usage of this version, code need to be patched.