### PR TITLE
Fix static init ordering bug in OpenGEX importer

### DIFF
--- a/code/OpenGEXImporter.cpp
+++ b/code/OpenGEXImporter.cpp
@@ -52,8 +52,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <vector>
 
-static const std::string OpenGexExt = "ogex";
-
 static const aiImporterDesc desc = {
     "Open Game Engine Exchange",
     "",
@@ -64,7 +62,7 @@ static const aiImporterDesc desc = {
     0,
     0,
     0,
-    OpenGexExt.c_str()
+    "ogex"
 };
 
 namespace Grammar {
@@ -289,7 +287,7 @@ OpenGEXImporter::~OpenGEXImporter() {
 bool OpenGEXImporter::CanRead( const std::string &file, IOSystem *pIOHandler, bool checkSig ) const {
     bool canRead( false );
     if( !checkSig ) {
-        canRead = SimpleExtensionCheck( file, OpenGexExt.c_str() );
+        canRead = SimpleExtensionCheck( file, "ogex" );
     } else {
         static const char *token[] = { "Metric", "GeometryNode", "VertexArray (attrib", "IndexArray" };
         canRead = BaseImporter::SearchFileHeaderForToken( pIOHandler, file, token, 4 );


### PR DESCRIPTION
This fixes a bug that causes a crash when querying the list of supported extensions.

The original code attempts to static-initialise a POD structure using a value obtained from an `std::string`, but C++ guarantees that the dynamic initialisation of `std::string` happens *after* `desc` has been initialised in this case, so it would always initialise in the wrong order.

There is absolutely no purpose in keeping `OpenGexExt` as a statically initialised `std::string` object, so I just took it out, which fixed the crashes we were experiencing on load.