### PR TITLE
Fix incorrect truncation of binary URI in glTF exporter

### DIFF
--- a/code/glTFExporter.cpp
+++ b/code/glTFExporter.cpp
@@ -511,7 +511,7 @@ void glTFExporter::ExportMeshes()
     // Variables needed for compression. END.
 
     std::string fname = std::string(mFilename);
-    std::string bufferIdPrefix = fname.substr(0, fname.find("."));
+    std::string bufferIdPrefix = fname.substr(0, fname.rfind(".gltf"));
     std::string bufferId = mAsset->FindUniqueID("", bufferIdPrefix.c_str());
 
     Ref<Buffer> b = mAsset->GetBodyBuffer();


### PR DESCRIPTION
Currently the glTF exporter generates a path for the binary file by searching for the first occurrence of `"."` in the glTF's file name, and replacing that and everything following it with a string of the form `"\d+.bin"`. This can fail if, for example, the file name is a path of the form `/path/to/my.dir/example.gltf`. In such cases, the binary's URI will be of the form `/path/to/my.bin`, which is incorrect.

This patch instead looks for the last occurrence of the string ".gltf" in the file name, using that as a base for the binary's URI. It will still fail on an input of the form `/path/to/my.gltf.files/example.xgltf`, again generating a binary URI like `/path/to/my.bin`. This seems like an unlikely case, but it may be worth handling as well.