### PR TITLE
[One-Line-Change] Fix config.h not being found during cmake --build . --target install

### DIFF
--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -59,7 +59,7 @@ SET( PUBLIC_HEADERS
   ${HEADER_PATH}/camera.h
   ${HEADER_PATH}/color4.h
   ${HEADER_PATH}/color4.inl
-  ${HEADER_PATH}/config.h
+  ${CMAKE_BINARY_DIR}/include/assimp/config.h
   ${HEADER_PATH}/defs.h
   ${HEADER_PATH}/cfileio.h
   ${HEADER_PATH}/light.h


### PR DESCRIPTION
Hi everybody!

Thank you for maintaining this amazing project 👍 During compilation I found a tiny little bug, here is my fix. A different way to fix it would be setting a different output of for the configure_file command in the root CMakeLists.txt (I'd say having the generated files separated from the hand-written ones is slightly cleaner, though).

Cheers!
Jonathan.