### PR TITLE
Add support for reading texture coordinates from PLY meshes with properties named 'texture_u' and 'texture_v'

### DIFF
--- a/code/PlyParser.cpp
+++ b/code/PlyParser.cpp
@@ -196,11 +196,11 @@ PLY::ESemantic PLY::Property::ParseSemantic(const char* pCur,const char** pCurOu
         eOut = PLY::EST_Blue;
     }
     // NOTE: Blender3D exports texture coordinates as s,t tuples
-    else if (TokenMatch(pCur,"u",1) ||  TokenMatch(pCur,"s",1) || TokenMatch(pCur,"tx",2))
+    else if (TokenMatch(pCur,"u",1) ||  TokenMatch(pCur,"s",1) || TokenMatch(pCur,"tx",2) || TokenMatch(pCur,"texture_u",9))
     {
         eOut = PLY::EST_UTextureCoord;
     }
-    else if (TokenMatch(pCur,"v",1) ||  TokenMatch(pCur,"t",1) || TokenMatch(pCur,"ty",2))
+    else if (TokenMatch(pCur,"v",1) ||  TokenMatch(pCur,"t",1) || TokenMatch(pCur,"ty",2) || TokenMatch(pCur,"texture_v",9))
     {
         eOut = PLY::EST_VTextureCoord;
     }


### PR DESCRIPTION
Some PLY meshes (such as [JanMichael.zip](https://github.com/assimp/assimp/files/994204/JanMichael.zip) from [trn.io](http://trn.io/b/blEJaQKsLD/)) use `texture_u` and `texture_v` as their UV property names.  But OAI currently only detects properties named `u`/`v`, `s`/`t`, and `tx`/`ty`.  This patch adds `texture_u` and `texture_v`.