### PR TITLE
Fix location of config.h

### DIFF
--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -59,7 +59,7 @@ SET( PUBLIC_HEADERS
   ${HEADER_PATH}/camera.h
   ${HEADER_PATH}/color4.h
   ${HEADER_PATH}/color4.inl
-  ${CMAKE_BINARY_DIR}/include/assimp/config.h
+  ${CMAKE_CURRENT_BINARY_DIR}/../include/assimp/config.h
   ${HEADER_PATH}/defs.h
   ${HEADER_PATH}/cfileio.h
   ${HEADER_PATH}/light.h


### PR DESCRIPTION
This change makes possible to use assimp as subdirectory in another cmake project. 