### PR TITLE
Fixed build error in ObjExporter :: GetMaterialLibFileName

### DIFF
--- a/code/ObjExporter.cpp
+++ b/code/ObjExporter.cpp
@@ -127,7 +127,7 @@ std::string ObjExporter :: GetMaterialLibFileName()
     // Remove existing .obj file extention so that the final material file name will be fileName.mtl and not fileName.obj.mtl
     size_t lastdot = filename.find_last_of('.');
     if (lastdot != std::string::npos)
-        filename = filename.substr(0, lastdot);
+        return filename.substr(0, lastdot) + MaterialExt;
 
     return filename + MaterialExt;
 }


### PR DESCRIPTION
The previous pull request had an error because the filename string was const and could not be changed. Sorry for that. This one fix that.