### PR TITLE
Fix error when custom CMAKE_C_FLAGS is specified

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,7 +178,7 @@ ENDIF( UNIX )
 IF ((CMAKE_C_COMPILER_ID MATCHES "GNU") AND NOT CMAKE_COMPILER_IS_MINGW)
   # hide all not-exported symbols
   SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fvisibility=hidden -fPIC -Wall -std=c++0x")
-  SET(CMAKE_C_FLAGS ${CMAKE_C_FLAGS} -fPIC)
+  SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
   SET(LIBSTDC++_LIBRARIES -lstdc++)
 ELSEIF(MSVC)
   # enable multi-core compilation with MSVC


### PR DESCRIPTION
This fixes an error introduced by @heliocastro in #1255.  The CMAKE_C_FLAGS string was not quoted, causing CMake to insert a semicolon instead, which would cause a compiler error when additional CMAKE_C_FLAGS are specified.