### PR TITLE
Revert "Installing assimp library as well"

### DIFF
--- a/port/PyAssimp/pyassimp/helper.py
+++ b/port/PyAssimp/pyassimp/helper.py
@@ -8,7 +8,6 @@ import os
 import ctypes
 from ctypes import POINTER
 import operator
-import sys
 
 try: import numpy
 except: numpy = None
@@ -40,9 +39,7 @@ elif os.name=='nt':
     for dir_candidate in path_dirs:
         if 'assimp' in dir_candidate.lower():
             additional_dirs.append(dir_candidate)
-
-additional_dirs += sys.path
-
+            
 #print(additional_dirs)
 def vec2tuple(x):
     """ Converts a VECTOR3D to a Tuple """

--- a/port/PyAssimp/setup.py
+++ b/port/PyAssimp/setup.py
@@ -9,7 +9,5 @@ setup(name='pyassimp',
       url='https://github.com/assimp/assimp',
       packages=['pyassimp'],
       data_files=[('share/pyassimp', ['README.md']),
-                  ('share/examples/pyassimp', ['scripts/' + f for f in os.listdir('scripts/')]),
-                  ('lib/', [f for f in os.listdir('../../lib') if os.path.isfile(f)])],
-      requires=['numpy']
+                  ('share/examples/pyassimp', ['scripts/' + f for f in os.listdir('scripts/')])], requires=['numpy']
       )


### PR DESCRIPTION
This reverts commit 33bd5cfcfb0f27794a333273b20b60a7a550d184.

Installing the assimp library from setup.py is *not* a good idea as
it will break every packaging effort.

Besides, the original commit relies on an hard-coded path to find the
library that may not exist.