### PR TITLE
GLTF exporter: ensure buffer view byte offsets are correctly aligned

### DIFF
--- a/code/glTFExporter.cpp
+++ b/code/glTFExporter.cpp
@@ -185,8 +185,11 @@ inline Ref<Accessor> ExportData(Asset& a, std::string& meshName, Ref<Buffer>& bu
     unsigned int bytesPerComp = ComponentTypeSize(compType);
 
     size_t offset = buffer->byteLength;
+    // make sure offset is correctly byte-aligned, as required by spec
+    size_t padding = offset % bytesPerComp;
+    offset += padding;
     size_t length = count * numCompsOut * bytesPerComp;
-    buffer->Grow(length);
+    buffer->Grow(length + padding);
 
     // bufferView
     Ref<BufferView> bv = a.bufferViews.Create(a.FindUniqueID(meshName, "view"));


### PR DESCRIPTION
According to the GLTF spec, these buffer view offsets must be a multiple of the accessor's attribute type:
https://github.com/KhronosGroup/glTF/tree/master/specification/1.0#bufferview-and-accessor-byte-alignment

This sprung off of discussion at https://github.com/BabylonJS/Babylon.js/issues/2352.