### PR TITLE
Fixes parameters to pyassimp.load

### DIFF
--- a/port/PyAssimp/scripts/3d_viewer.py
+++ b/port/PyAssimp/scripts/3d_viewer.py
@@ -679,7 +679,7 @@ class PyAssimp3DViewer:
         logger.info("Loading model:" + path + "...")
 
         if postprocess:
-            self.scene = pyassimp.load(path, postprocess)
+            self.scene = pyassimp.load(path, processing=postprocess)
         else:
             self.scene = pyassimp.load(path)
         logger.info("Done.")

--- a/port/PyAssimp/scripts/fixed_pipeline_3d_viewer.py
+++ b/port/PyAssimp/scripts/fixed_pipeline_3d_viewer.py
@@ -98,7 +98,7 @@ class GLRenderer():
         logger.info("Loading model:" + path + "...")
 
         if postprocess:
-            self.scene = pyassimp.load(path, postprocess)
+            self.scene = pyassimp.load(path, processing=postprocess)
         else:
             self.scene = pyassimp.load(path)
         logger.info("Done.")

--- a/port/PyAssimp/scripts/sample.py
+++ b/port/PyAssimp/scripts/sample.py
@@ -20,7 +20,7 @@ def recur_node(node,level = 0):
 
 def main(filename=None):
 
-    scene = pyassimp.load(filename, pyassimp.postprocess.aiProcess_Triangulate)
+    scene = pyassimp.load(filename, processing=pyassimp.postprocess.aiProcess_Triangulate)
     
     #the model we load
     print("MODEL:" + filename)


### PR DESCRIPTION
Commit 704e57db4ee640262b8b20f4b687c15231d64354 changed the order of the parameters to `pyassimp.load`.  The new order groups `filename` and `file_type` which is preferable, but the samples and other calls to `load` still point to the old order.  This fixes that with named arguments where necessary.