### PR TITLE
Elapsed seconds not shown shown correctly

### DIFF
--- a/code/OptimizeMeshes.cpp
+++ b/code/OptimizeMeshes.cpp
@@ -181,11 +181,8 @@ void OptimizeMeshesProcess::ProcessNode( aiNode* pNode)
                     verts += mScene->mMeshes[am]->mNumVertices;
                     faces += mScene->mMeshes[am]->mNumFaces;
 
+                    pNode->mMeshes[a] = pNode->mMeshes[pNode->mNumMeshes - 1];
                     --pNode->mNumMeshes;
-                    for( unsigned int n = a; n < pNode->mNumMeshes; ++n ) {
-                        pNode->mMeshes[ n ] = pNode->mMeshes[ n + 1 ];
-                    }
-
                     --a;
                 }
             }

--- a/code/Profiler.h
+++ b/code/Profiler.h
@@ -84,7 +84,7 @@ public:
             return;
         }
 
-        auto elapsedSeconds = std::chrono::system_clock::now() - regions[region];
+        std::chrono::duration<double> elapsedSeconds = std::chrono::system_clock::now() - regions[region];
         DefaultLogger::get()->debug((format("END   `"),region,"`, dt= ", elapsedSeconds.count()," s"));
     }
 


### PR DESCRIPTION
Regarding Profiler.h, I was getting this kind of message, instead of seconds:

Debug, T9224: END   `postprocess`, dt= 11717743 s