### PR TITLE
Low performance in OptimizeMeshesProcess with huge number of meshes

### DIFF
--- a/code/OptimizeMeshes.cpp
+++ b/code/OptimizeMeshes.cpp
@@ -181,11 +181,8 @@ void OptimizeMeshesProcess::ProcessNode( aiNode* pNode)
                     verts += mScene->mMeshes[am]->mNumVertices;
                     faces += mScene->mMeshes[am]->mNumFaces;
 
+                    pNode->mMeshes[a] = pNode->mMeshes[pNode->mNumMeshes - 1];
                     --pNode->mNumMeshes;
-                    for( unsigned int n = a; n < pNode->mNumMeshes; ++n ) {
-                        pNode->mMeshes[ n ] = pNode->mMeshes[ n + 1 ];
-                    }
-
                     --a;
                 }
             }


### PR DESCRIPTION
Maybe we don't need to shift every mesh 1 position every time we find a match to join meshes. 

I was working with a 3dmodel really huge (>600k meshes), and it took like 2 minutes only with this step , using release flags. Those 2 minutes were like 95% of the whole process.

Here is a grab from the problem:

> 
> Debug, T992: START `postprocess`
> Debug, T992: OptimizeMeshesProcess begin
> Info,  T992: OptimizeMeshesProcess finished. Input meshes: 615321, Output meshes: 10
> Debug, T992: END   `postprocess`, dt= 123.334 s
> 

And the same process after patching this change:

> Debug, T9772: START `postprocess`
> Debug, T9772: OptimizeMeshesProcess begin
> Info,  T9772: OptimizeMeshesProcess finished. Input meshes: 615321, Output meshes: 10
> Debug, T9772: END   `postprocess`, dt= 1.2176 s

Regards,


