### PR TITLE
Elapsed seconds not shown correctly

### DIFF
--- a/code/Profiler.h
+++ b/code/Profiler.h
@@ -84,7 +84,7 @@ public:
             return;
         }
 
-        auto elapsedSeconds = std::chrono::system_clock::now() - regions[region];
+        std::chrono::duration<double> elapsedSeconds = std::chrono::system_clock::now() - regions[region];
         DefaultLogger::get()->debug((format("END   `"),region,"`, dt= ", elapsedSeconds.count()," s"));
     }
 


### PR DESCRIPTION
I was getting this kind of message, instead of seconds when debugging:

Debug, T9224: END postprocess, dt= 11717743 s

Just changed that 'auto' with std::chrono::duration<double>, and it seems to be working:

 Debug, T9772: END   `postprocess`, dt= 1.2176 s