### PR TITLE
glTF version

### DIFF
--- a/code/glTF2Asset.h
+++ b/code/glTF2Asset.h
@@ -177,7 +177,7 @@ namespace glTF2
     struct GLB_Header
     {
         uint8_t magic[4];     //!< Magic number: "glTF"
-        uint32_t version;     //!< Version number
+        float_t version;     //!< Version number
         uint32_t length;      //!< Total length of the Binary glTF, including header, scene, and body, in bytes
         uint32_t sceneLength; //!< Length, in bytes, of the glTF scene
         uint32_t sceneFormat; //!< Specifies the format of the glTF scene (see the SceneFormat enum)
@@ -1074,13 +1074,13 @@ namespace glTF2
             std::string version; //!< Specifies the target rendering API (default: "1.0.3")
         } profile; //!< Specifies the target rendering API and version, e.g., WebGL 1.0.3. (default: {})
 
-        int version; //!< The glTF format version
+        float version; //!< The glTF format version
 
         void Read(Document& doc);
 
         AssetMetadata()
             : premultipliedAlpha(false)
-            , version(0)
+            , version(0.)
         {
         }
     };

--- a/code/glTF2Asset.h
+++ b/code/glTF2Asset.h
@@ -177,7 +177,7 @@ namespace glTF2
     struct GLB_Header
     {
         uint8_t magic[4];     //!< Magic number: "glTF"
-        float_t version;     //!< Version number
+        uint32_t version;     //!< Version number
         uint32_t length;      //!< Total length of the Binary glTF, including header, scene, and body, in bytes
         uint32_t sceneLength; //!< Length, in bytes, of the glTF scene
         uint32_t sceneFormat; //!< Specifies the format of the glTF scene (see the SceneFormat enum)

--- a/code/glTF2Asset.h
+++ b/code/glTF2Asset.h
@@ -1080,7 +1080,7 @@ namespace glTF2
 
         AssetMetadata()
             : premultipliedAlpha(false)
-            , version(0.)
+            , version(0)
         {
         }
     };

--- a/code/glTF2Asset.inl
+++ b/code/glTF2Asset.inl
@@ -1229,7 +1229,7 @@ inline void Scene::Read(Value& obj, Asset& r)
 inline void AssetMetadata::Read(Document& doc)
 {
     // read the version, etc.
-    float statedVersion = 0.;
+    float statedVersion = 0;
     if (Value* obj = FindObject(doc, "asset")) {
         ReadMember(*obj, "copyright", copyright);
         ReadMember(*obj, "generator", generator);
@@ -1245,12 +1245,12 @@ inline void AssetMetadata::Read(Document& doc)
 
     version = std::max(statedVersion, version);
 
-    if (version == 0.) {
+    if (version == 0) {
         // if missing version, we'll assume version 1.0...
-        version = 1.;
+        version = 1;
     }
 
-    if (version != 1.) {
+    if (version != 1) {
         char msg[128];
         ai_snprintf(msg, 128, "GLTF: Unsupported glTF version: %.1f", version);
         throw DeadlyImportError(msg);

--- a/code/glTF2Asset.inl
+++ b/code/glTF2Asset.inl
@@ -1229,7 +1229,7 @@ inline void Scene::Read(Value& obj, Asset& r)
 inline void AssetMetadata::Read(Document& doc)
 {
     // read the version, etc.
-    int statedVersion = 0;
+    float statedVersion = 0.;
     if (Value* obj = FindObject(doc, "asset")) {
         ReadMember(*obj, "copyright", copyright);
         ReadMember(*obj, "generator", generator);
@@ -1244,14 +1244,15 @@ inline void AssetMetadata::Read(Document& doc)
     }
 
     version = std::max(statedVersion, version);
-    if (version == 0) {
-        // if missing version, we'll assume version 1...
-        version = 1;
+
+    if (version == 0.) {
+        // if missing version, we'll assume version 1.0...
+        version = 1.;
     }
 
-    if (version != 1) {
+    if (version != 1.) {
         char msg[128];
-        ai_snprintf(msg, 128, "GLTF: Unsupported glTF version: %d", version);
+        ai_snprintf(msg, 128, "GLTF: Unsupported glTF version: %.1f", version);
         throw DeadlyImportError(msg);
     }
 }

--- a/code/glTF2AssetWriter.inl
+++ b/code/glTF2AssetWriter.inl
@@ -574,7 +574,7 @@ namespace glTF2 {
         GLB_Header header;
         memcpy(header.magic, AI_GLB_MAGIC_NUMBER, sizeof(header.magic));
 
-        header.version = 2.;
+        header.version = 2;
         AI_SWAP4(header.version);
 
         header.length = uint32_t(sizeof(header) + sceneLength + bodyLength);

--- a/code/glTF2AssetWriter.inl
+++ b/code/glTF2AssetWriter.inl
@@ -574,7 +574,7 @@ namespace glTF2 {
         GLB_Header header;
         memcpy(header.magic, AI_GLB_MAGIC_NUMBER, sizeof(header.magic));
 
-        header.version = 2;
+        header.version = 2.;
         AI_SWAP4(header.version);
 
         header.length = uint32_t(sizeof(header) + sceneLength + bodyLength);
@@ -600,7 +600,7 @@ namespace glTF2 {
         asset.SetObject();
         {
             char versionChar[10];
-            ai_snprintf(versionChar, sizeof(versionChar), "%d", mAsset.asset.version);
+            ai_snprintf(versionChar, sizeof(versionChar), "%.1f", mAsset.asset.version);
             asset.AddMember("version", Value(versionChar, mAl).Move(), mAl);
 
             asset.AddMember("generator", Value(mAsset.asset.generator, mAl).Move(), mAl);

--- a/code/glTF2Exporter.cpp
+++ b/code/glTF2Exporter.cpp
@@ -845,7 +845,7 @@ void glTF2Exporter::ExportScene()
 void glTF2Exporter::ExportMetadata()
 {
     AssetMetadata& asset = mAsset->asset;
-    asset.version = 2;
+    asset.version = 2.;
 
     char buffer[256];
     ai_snprintf(buffer, 256, "Open Asset Import Library (assimp v%d.%d.%d)",

--- a/code/glTF2Exporter.cpp
+++ b/code/glTF2Exporter.cpp
@@ -466,8 +466,8 @@ void ExportSkin(Asset& mAsset, const aiMesh* aimesh, Ref<Mesh>& meshRef, Ref<Buf
             float vertWeight      = aib->mWeights[idx_weights].mWeight;
 
             // A vertex can only have at most four joint weights. Ignore all others.
-            if (jointsPerVertex[vertexId] > 3) { 
-                continue; 
+            if (jointsPerVertex[vertexId] > 3) {
+                continue;
             }
 
             vertexJointData[vertexId][jointsPerVertex[vertexId]] = jointNamesIndex;
@@ -845,7 +845,7 @@ void glTF2Exporter::ExportScene()
 void glTF2Exporter::ExportMetadata()
 {
     AssetMetadata& asset = mAsset->asset;
-    asset.version = 2.;
+    asset.version = 2;
 
     char buffer[256];
     ai_snprintf(buffer, 256, "Open Asset Import Library (assimp v%d.%d.%d)",

--- a/code/glTFAsset.h
+++ b/code/glTFAsset.h
@@ -177,7 +177,7 @@ namespace glTF
     struct GLB_Header
     {
         uint8_t magic[4];     //!< Magic number: "glTF"
-        uint32_t version;     //!< Version number (always 1 as of the last update)
+        float_t version;     //!< Version number (always 1 as of the last update)
         uint32_t length;      //!< Total length of the Binary glTF, including header, scene, and body, in bytes
         uint32_t sceneLength; //!< Length, in bytes, of the glTF scene
         uint32_t sceneFormat; //!< Specifies the format of the glTF scene (see the SceneFormat enum)
@@ -1058,7 +1058,7 @@ namespace glTF
             std::string version; //!< Specifies the target rendering API (default: "1.0.3")
         } profile; //!< Specifies the target rendering API and version, e.g., WebGL 1.0.3. (default: {})
 
-        int version; //!< The glTF format version (should be 1)
+        float version; //!< The glTF format version (should be 1.0)
 
         void Read(Document& doc);
 

--- a/code/glTFAsset.h
+++ b/code/glTFAsset.h
@@ -177,7 +177,7 @@ namespace glTF
     struct GLB_Header
     {
         uint8_t magic[4];     //!< Magic number: "glTF"
-        float_t version;     //!< Version number (always 1 as of the last update)
+        uint32_t version;     //!< Version number (always 1 as of the last update)
         uint32_t length;      //!< Total length of the Binary glTF, including header, scene, and body, in bytes
         uint32_t sceneLength; //!< Length, in bytes, of the glTF scene
         uint32_t sceneFormat; //!< Specifies the format of the glTF scene (see the SceneFormat enum)

--- a/code/glTFAsset.inl
+++ b/code/glTFAsset.inl
@@ -1228,7 +1228,7 @@ inline void Scene::Read(Value& obj, Asset& r)
 inline void AssetMetadata::Read(Document& doc)
 {
     // read the version, etc.
-    float statedVersion = 0.;
+    float statedVersion = 0;
     if (Value* obj = FindObject(doc, "asset")) {
         ReadMember(*obj, "copyright", copyright);
         ReadMember(*obj, "generator", generator);
@@ -1243,12 +1243,12 @@ inline void AssetMetadata::Read(Document& doc)
     }
 
     version = std::max(statedVersion, version);
-    if (version == 0.) {
+    if (version == 0) {
         // if missing version, we'll assume version 1...
         version = 1;
     }
 
-    if (version != 1.) {
+    if (version != 1) {
         char msg[128];
         ai_snprintf(msg, 128, "GLTF: Unsupported glTF version: %.0f", version);
         throw DeadlyImportError(msg);

--- a/code/glTFAsset.inl
+++ b/code/glTFAsset.inl
@@ -1228,7 +1228,7 @@ inline void Scene::Read(Value& obj, Asset& r)
 inline void AssetMetadata::Read(Document& doc)
 {
     // read the version, etc.
-    int statedVersion = 0;
+    float statedVersion = 0.;
     if (Value* obj = FindObject(doc, "asset")) {
         ReadMember(*obj, "copyright", copyright);
         ReadMember(*obj, "generator", generator);
@@ -1243,14 +1243,14 @@ inline void AssetMetadata::Read(Document& doc)
     }
 
     version = std::max(statedVersion, version);
-    if (version == 0) {
+    if (version == 0.) {
         // if missing version, we'll assume version 1...
         version = 1;
     }
 
-    if (version != 1) {
+    if (version != 1.) {
         char msg[128];
-        ai_snprintf(msg, 128, "GLTF: Unsupported glTF version: %d", version);
+        ai_snprintf(msg, 128, "GLTF: Unsupported glTF version: %.0f", version);
         throw DeadlyImportError(msg);
     }
 }

--- a/code/glTFAssetWriter.inl
+++ b/code/glTFAssetWriter.inl
@@ -582,7 +582,7 @@ namespace glTF {
         GLB_Header header;
         memcpy(header.magic, AI_GLB_MAGIC_NUMBER, sizeof(header.magic));
 
-        header.version = 1.;
+        header.version = 1;
         AI_SWAP4(header.version);
 
         header.length = uint32_t(sizeof(header) + sceneLength + bodyLength);

--- a/code/glTFAssetWriter.inl
+++ b/code/glTFAssetWriter.inl
@@ -582,7 +582,7 @@ namespace glTF {
         GLB_Header header;
         memcpy(header.magic, AI_GLB_MAGIC_NUMBER, sizeof(header.magic));
 
-        header.version = 1;
+        header.version = 1.;
         AI_SWAP4(header.version);
 
         header.length = uint32_t(sizeof(header) + sceneLength + bodyLength);
@@ -608,7 +608,7 @@ namespace glTF {
         asset.SetObject();
         {
             char versionChar[10];
-            ai_snprintf(versionChar, sizeof(versionChar), "%d", mAsset.asset.version);
+            ai_snprintf(versionChar, sizeof(versionChar), "%.0f", mAsset.asset.version);
             asset.AddMember("version", Value(versionChar, mAl).Move(), mAl);
 
             asset.AddMember("generator", Value(mAsset.asset.generator, mAl).Move(), mAl);

--- a/code/glTFExporter.cpp
+++ b/code/glTFExporter.cpp
@@ -834,7 +834,7 @@ void glTFExporter::ExportScene()
 void glTFExporter::ExportMetadata()
 {
     glTF::AssetMetadata& asset = mAsset->asset;
-    asset.version = 1;
+    asset.version = 1.;
 
     char buffer[256];
     ai_snprintf(buffer, 256, "Open Asset Import Library (assimp v%d.%d.%d)",

--- a/code/glTFExporter.cpp
+++ b/code/glTFExporter.cpp
@@ -469,8 +469,8 @@ void ExportSkin(Asset& mAsset, const aiMesh* aimesh, Ref<Mesh>& meshRef, Ref<Buf
             float vertWeight      = aib->mWeights[idx_weights].mWeight;
 
             // A vertex can only have at most four joint weights. Ignore all others.
-            if (jointsPerVertex[vertexId] > 3) { 
-                continue; 
+            if (jointsPerVertex[vertexId] > 3) {
+                continue;
             }
 
             vertexJointData[vertexId][jointsPerVertex[vertexId]] = jointNamesIndex;
@@ -834,7 +834,7 @@ void glTFExporter::ExportScene()
 void glTFExporter::ExportMetadata()
 {
     glTF::AssetMetadata& asset = mAsset->asset;
-    asset.version = 1.;
+    asset.version = 1;
 
     char buffer[256];
     ai_snprintf(buffer, 256, "Open Asset Import Library (assimp v%d.%d.%d)",


### PR DESCRIPTION
Outputs the gltf asset field's version string in the pattern `/[0-9]+.[0-9+]/`, instead of an int, per [the GLTF spec](https://github.com/KhronosGroup/glTF/blob/master/specification/2.0/schema/asset.schema.json) and [validator](http://github.khronos.org/glTF-Validator)

