### PR TITLE
Fix compiling problems under VS2017.3.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,6 +148,12 @@ find_package(OpenMP)
 if (OPENMP_FOUND)
     SET (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
     SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+
+    IF(MSVC)
+        IF(MSVC_VERSION GREATER 1910)
+            SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zc:twoPhase-")
+        ENDIF()
+    ENDIF()
 endif()
 
 CONFIGURE_FILE(

--- a/code/X3DImporter.cpp
+++ b/code/X3DImporter.cpp
@@ -95,8 +95,8 @@ struct WordIterator: public std::iterator<std::input_iterator_tag, const char*> 
         end_ = other.end_;
         return *this;
     }
-    bool operator==(WordIterator &other) const { return start_ == other.start_; }
-    bool operator!=(WordIterator &other) const { return start_ != other.start_; }
+    bool operator==(const WordIterator &other) const { return start_ == other.start_; }
+    bool operator!=(const WordIterator &other) const { return start_ != other.start_; }
     WordIterator &operator++() {
         start_ += strcspn(start_, whitespace);
         start_ += strspn(start_, whitespace);


### PR DESCRIPTION
1. WordIterator's operator== and operator!= must take const WordIterator& as parameter type.
2. OpenMP doesn't work with new two phase lookups. Need to disable twoPhase.