### PR TITLE
Re-enabling PACK_STRUCT for MDL files.

### DIFF
--- a/code/MDLFileData.h
+++ b/code/MDLFileData.h
@@ -164,7 +164,7 @@ struct Header {
 
     //! Could be the total size of the file (and not a float)
     float size;
-} /* PACK_STRUCT */;
+} PACK_STRUCT;
 
 
 // -------------------------------------------------------------------------------------
@@ -223,7 +223,7 @@ struct Header_MDL7 {
 
     //! Size of the Frame_MDL7 data structure used in the file
     uint16_t frame_stc_size;
-} /* PACK_STRUCT */;
+} PACK_STRUCT;
 
 
 // -------------------------------------------------------------------------------------
@@ -242,7 +242,7 @@ struct Bone_MDL7 {
 
     //! Optional name of the bone
     char name[1 /* DUMMY SIZE */];
-} /* PACK_STRUCT */;
+} PACK_STRUCT;
 
 #if (!defined AI_MDL7_BONE_STRUCT_SIZE__NAME_IS_20_CHARS)
 #   define AI_MDL7_BONE_STRUCT_SIZE__NAME_IS_20_CHARS (16 + 20)
@@ -290,7 +290,7 @@ struct Group_MDL7 {
 
     //! Number of frames
     int32_t numframes;
-} /* PACK_STRUCT */;
+} PACK_STRUCT;
 
 #define AI_MDL7_SKINTYPE_MIPFLAG                0x08
 #define AI_MDL7_SKINTYPE_MATERIAL               0x10
@@ -312,7 +312,7 @@ struct Deformer_MDL7 {
     int32_t group_index;
     int32_t elements;
     int32_t deformerdata_size;
-} /* PACK_STRUCT */;
+} PACK_STRUCT;
 
 
 // -------------------------------------------------------------------------------------
@@ -324,7 +324,7 @@ struct DeformerElement_MDL7 {
     int32_t element_index;
     char    element_name[AI_MDL7_MAX_BONENAMESIZE];
     int32_t weights;
-} /* PACK_STRUCT */;
+} PACK_STRUCT;
 
 // -------------------------------------------------------------------------------------
 /** \struct DeformerWeight_MDL7
@@ -334,7 +334,7 @@ struct DeformerWeight_MDL7 {
     //! for deformer_typ==0 (==bones) index == vertex index
     int32_t index;
     float   weight;
-} /* PACK_STRUCT */;
+} PACK_STRUCT;
 
 // don't know why this was in the original headers ...
 typedef int32_t MD7_MATERIAL_ASCDEFSIZE;
@@ -345,7 +345,7 @@ typedef int32_t MD7_MATERIAL_ASCDEFSIZE;
  */
 struct ColorValue_MDL7 {
     float r,g,b,a;
-} /* PACK_STRUCT */;
+} PACK_STRUCT;
 
 // -------------------------------------------------------------------------------------
 /** \struct Material_MDL7
@@ -366,7 +366,7 @@ struct Material_MDL7 {
 
     //! Phong power
     float           Power;
-} /* PACK_STRUCT */;
+} PACK_STRUCT;
 
 // -------------------------------------------------------------------------------------
 /** \struct Skin
@@ -388,7 +388,7 @@ struct Skin {
 
     //! Texture data
     uint8_t *data;
-} /* PACK_STRUCT */;
+} PACK_STRUCT;
 
 
 // -------------------------------------------------------------------------------------
@@ -399,7 +399,7 @@ struct Skin {
 struct Skin_MDL5 {
     int32_t size, width, height;
     uint8_t *data;
-} /* PACK_STRUCT */;
+} PACK_STRUCT;
 
 // maximum length of texture file name
 #if (!defined AI_MDL7_MAX_TEXNAMESIZE)
@@ -416,7 +416,7 @@ struct Skin_MDL7 {
     int32_t         width;
     int32_t         height;
     char            texture_name[AI_MDL7_MAX_TEXNAMESIZE];
-} /* PACK_STRUCT */;
+} PACK_STRUCT;
 
 // -------------------------------------------------------------------------------------
 /** \struct RGB565
@@ -426,7 +426,7 @@ struct RGB565 {
     uint16_t r : 5;
     uint16_t g : 6;
     uint16_t b : 5;
-} /* PACK_STRUCT */;
+} PACK_STRUCT;
 
 // -------------------------------------------------------------------------------------
 /** \struct ARGB4
@@ -455,7 +455,7 @@ struct GroupSkin {
 
     //! Data of each image
     uint8_t **data;
-} /* PACK_STRUCT */;
+} PACK_STRUCT;
 
 // -------------------------------------------------------------------------------------
 /** \struct TexCoord
@@ -470,7 +470,7 @@ struct TexCoord {
 
     //! Texture coordinate in the ty direction
     int32_t t;
-} /* PACK_STRUCT */;
+} PACK_STRUCT;
 
 // -------------------------------------------------------------------------------------
 /** \struct TexCoord_MDL3
@@ -482,7 +482,7 @@ struct TexCoord_MDL3 {
 
     //! position, vertically in range 0..skinheight-1
     int16_t v;
-} /* PACK_STRUCT */;
+} PACK_STRUCT;
 
 // -------------------------------------------------------------------------------------
 /** \struct TexCoord_MDL7
@@ -494,7 +494,7 @@ struct TexCoord_MDL7 {
 
     //! position, vertically in range 0..1
     float v;
-} /* PACK_STRUCT */;
+} PACK_STRUCT;
 
 // -------------------------------------------------------------------------------------
 /** \struct SkinSet_MDL7
@@ -510,7 +510,7 @@ struct SkinSet_MDL7
 
     //! Material index
     int32_t     material;    // size 4
-} /* PACK_STRUCT */;
+} PACK_STRUCT;
 
 // -------------------------------------------------------------------------------------
 /** \struct Triangle
@@ -523,7 +523,7 @@ struct Triangle
 
     //! Vertex indices
     int32_t vertex[3];
-} /* PACK_STRUCT */;
+} PACK_STRUCT;
 
 // -------------------------------------------------------------------------------------
 /** \struct Triangle_MDL3
@@ -536,7 +536,7 @@ struct Triangle_MDL3
 
     //! Index of 3 skin vertices in range 0..numskinverts
     uint16_t index_uv[3];
-} /* PACK_STRUCT */;
+} PACK_STRUCT;
 
 // -------------------------------------------------------------------------------------
 /** \struct Triangle_MDL7
@@ -549,7 +549,7 @@ struct Triangle_MDL7
 
     //! Two skinsets. The second will be used for multi-texturing
     SkinSet_MDL7  skinsets[2];
-} /* PACK_STRUCT */;
+} PACK_STRUCT;
 
 #if (!defined AI_MDL7_TRIANGLE_STD_SIZE_ONE_UV)
 #   define AI_MDL7_TRIANGLE_STD_SIZE_ONE_UV (6+sizeof(SkinSet_MDL7)-sizeof(uint32_t))
@@ -577,7 +577,7 @@ struct Vertex
 {
     uint8_t v[3];
     uint8_t normalIndex;
-} /* PACK_STRUCT */;
+} PACK_STRUCT;
 
 
 // -------------------------------------------------------------------------------------
@@ -603,7 +603,7 @@ struct Vertex_MDL7
         uint8_t norm162index;
         float norm[3];
     };
-} /* PACK_STRUCT */;
+} PACK_STRUCT;
 
 // -------------------------------------------------------------------------------------
 /** \struct BoneTransform_MDL7
@@ -620,7 +620,7 @@ struct BoneTransform_MDL7
     //! I HATE 3DGS AND THE SILLY DEVELOPER WHO DESIGNED
     //! THIS STUPID FILE FORMAT!
     int8_t _unused_[2];
-} /* PACK_STRUCT */;
+} PACK_STRUCT;
 
 
 #define AI_MDL7_MAX_FRAMENAMESIZE       16
@@ -654,7 +654,7 @@ struct SimpleFrame
 
     //! Vertex list of the frame
     Vertex *verts;
-} /* PACK_STRUCT */;
+} PACK_STRUCT;
 
 // -------------------------------------------------------------------------------------
 /** \struct Frame
@@ -667,7 +667,7 @@ struct Frame
 
     //! Frame data
     SimpleFrame frame;
-} /* PACK_STRUCT */;
+} PACK_STRUCT;
 
 
 // -------------------------------------------------------------------------------------
@@ -684,7 +684,7 @@ struct SimpleFrame_MDLn_SP
 
     //! Vertex list of the frame
     Vertex_MDL4 *verts;
-} /* PACK_STRUCT */;
+} PACK_STRUCT;
 
 // -------------------------------------------------------------------------------------
 /** \struct GroupFrame
@@ -706,7 +706,7 @@ struct GroupFrame
 
     //! List of single frames
     SimpleFrame *frames;
-} /* PACK_STRUCT */;
+} PACK_STRUCT;
 
 #include "./../include/assimp/Compiler/poppack1.h"
 


### PR DESCRIPTION
When using this compiler:

    Apple LLVM version 7.3.0 (clang-703.0.31)
    Target: x86_64-apple-darwin15.4.0
    Thread model: posix

The MDL::Frame is aligned in 8-byte boundaries instead of 4. This generates this error when loading old Quake 1 MDL files:

    ERROR: Failed to load file: Invalid MDL file. The file is too small
    or contains invalid data (File: MDLLoader.cpp Line: 422)

It seems this error was introduced by commit bd2af6591f20fd8777332d510056a037fbfa0df5 due to compilation warnings.