### PR TITLE
FBX importer: Use actual min/max of anim keys when start/stop time is missing

### DIFF
--- a/code/FBXConverter.cpp
+++ b/code/FBXConverter.cpp
@@ -61,6 +61,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <iterator>
 #include <vector>
 
+#include <stdint.h>
+
 namespace Assimp {
 namespace FBX {
 
@@ -2371,9 +2373,9 @@ void Converter::ConvertAnimationStack( const AnimationStack& st )
     bool has_local_startstop = start_time != 0 || stop_time != 0;
     if ( !has_local_startstop ) {
         // no time range given, so accept every keyframe and use the actual min/max time
-        // the numbers are INT64_MIN/MAX, the 20000 is for safety because GenerateNodeAnimations uses an epsilon of 10000
-        start_time = -9223372036854775807i64 + 20000;
-        stop_time = 9223372036854775807i64 - 20000;
+        // the 20000 is for safety because GenerateNodeAnimations uses an epsilon of 10000
+        start_time = INT64_MIN + 20000;
+        stop_time = INT64_MAX - 20000;
     }
 
     try {

--- a/code/FBXConverter.cpp
+++ b/code/FBXConverter.cpp
@@ -61,8 +61,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <iterator>
 #include <vector>
 
-#include <stdint.h>
-
 namespace Assimp {
 namespace FBX {
 
@@ -2373,9 +2371,9 @@ void Converter::ConvertAnimationStack( const AnimationStack& st )
     bool has_local_startstop = start_time != 0 || stop_time != 0;
     if ( !has_local_startstop ) {
         // no time range given, so accept every keyframe and use the actual min/max time
-        // the 20000 is for safety because GenerateNodeAnimations uses an epsilon of 10000
-        start_time = INT64_MIN + 20000;
-        stop_time = INT64_MAX - 20000;
+        // the numbers are INT64_MIN/MAX, the 20000 is for safety because GenerateNodeAnimations uses an epsilon of 10000
+        start_time = -9223372036854775807ll + 20000;
+        stop_time = 9223372036854775807ll - 20000;
     }
 
     try {

--- a/code/FBXConverter.cpp
+++ b/code/FBXConverter.cpp
@@ -2371,9 +2371,9 @@ void Converter::ConvertAnimationStack( const AnimationStack& st )
     bool has_local_startstop = start_time != 0 || stop_time != 0;
     if ( !has_local_startstop ) {
         // no time range given, so accept every keyframe and use the actual min/max time
-        // the +/- 20000 is a safety because GenerateNodeAnimations uses an epsilon of 10000
-        start_time = INT64_MIN + 20000;
-        stop_time = INT64_MAX - 20000;
+        // the numbers are INT64_MIN/MAX, the 20000 is for safety because GenerateNodeAnimations uses an epsilon of 10000
+        start_time = -9223372036854775807i64 + 20000;
+        stop_time = 9223372036854775807i64 - 20000;
     }
 
     try {


### PR DESCRIPTION
During testing our product I had to find out that some FBX exporters (confirmed with Cinema4D R18) don't fill out the LocalStart/LocalStop properties of an animation, resulting in assimp only importing the key frames at time index zero and discarding all others.

Fix: When LocalStart and LocalStop are both zero, just accept all key frames and calculate offset and duration from the actual min/max time of the imported keys.