### PR TITLE
Debian fixes 4.0.1

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,3 +13,10 @@ CHANGES text eol=lf
 CREDITS text eol=lf
 LICENSE text eol=lf
 Readme.md text eol=lf
+# make sure that repo-specific settings (.gitignore, CI-setup,...)
+# are excluded from the source-package generated via 'git archive'
+.git*      	export-ignore
+/.travis*	export-ignore
+/.coveralls*	export-ignore
+appveyor.yml	export-ignore
+

--- a/code/PlyLoader.cpp
+++ b/code/PlyLoader.cpp
@@ -538,7 +538,7 @@ void PLYImporter::LoadFace(const PLY::Element* pcElement, const PLY::ElementInst
   ai_assert(NULL != instElement);
 
   if (mGeneratedMesh == NULL)
-    throw DeadlyImportError("Invalid .ply file: Vertices shoud be declared before faces");
+    throw DeadlyImportError("Invalid .ply file: Vertices should be declared before faces");
 
   bool bOne = false;
 

--- a/port/PyAssimp/setup.py
+++ b/port/PyAssimp/setup.py
@@ -8,6 +8,9 @@ setup(name='pyassimp',
       description='Python bindings for the Open Asset Import Library (ASSIMP)',
       url='https://github.com/assimp/assimp',
       packages=['pyassimp'],
-      data_files=[('share/pyassimp', ['README.md']),
-                  ('share/examples/pyassimp', ['scripts/' + f for f in os.listdir('scripts/')])], requires=['numpy']
+      data_files=[
+                  ('share/pyassimp', ['README.md']),
+                  ('share/examples/pyassimp', ['scripts/' + f for f in os.listdir('scripts/')])
+                 ],
+      requires=['numpy']
       )


### PR DESCRIPTION
these are fixes from the Debian package:

- spelling fix should be self-explanatory
- pyassimp: in Debian we are patching passimp/setup.py to not include any data, as we are including the data by other means, as the setup.py installs them to the "wrong" place (from Debian's POV). this patch makes the Debian specific patch a little easier to handle.