### PR TITLE
Update 3DSLoader.cpp

### DIFF
--- a/code/3DSLoader.cpp
+++ b/code/3DSLoader.cpp
@@ -1381,7 +1381,7 @@ void Discreet3DSImporter::ParseColorChunk( aiColor3D* out, bool acceptPercent )
         bGamma = true;
 
     case Discreet3DS::CHUNK_RGBF:
-        if (sizeof(ai_real) * 3 > diff)   {
+        if (sizeof(float) * 3 > diff)   {
             *out = clrError;
             return;
         }


### PR DESCRIPTION
Fixed reading of CHUNK_RGBF. If reading performs on x32 platform then reading will be executed right, but on x64 wrong because it will read 8 bytes instead 4. 