### PR TITLE
Disable Travis OS X build since it doesn't do anything currently

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ branches:
 
 os:
   - linux
-  - osx
 
 env:
   global:
@@ -50,10 +49,6 @@ matrix:
     - os: linux
       compiler: gcc
       env: LINUX=1 SHARED_BUILD=ON TRAVIS_NO_EXPORT=NO  ENABLE_COVERALLS=OFF
-    - os: osx
-      compiler: clang
-      osx_image: xcode8.3
-      env:
 
 install:
   - if [ $ANDROID ]; then wget -c http://dl.google.com/android/ndk/android-ndk-${PV}-${PLATF}.tar.bz2 && tar xf android-ndk-${PV}-${PLATF}.tar.bz2 ; fi


### PR DESCRIPTION
It doesn't actually build anything so it will always pass but the jobs are slow to start and delay the whole thing. Disable it for now. Also you should open an issue in case someone actually knows Travis/OSX and wants to fix it.