### PR TITLE
Fix glTF 2.0 multi-primitive support

### DIFF
--- a/code/glTF2Importer.cpp
+++ b/code/glTF2Importer.cpp
@@ -518,13 +518,22 @@ aiNode* ImportNode(aiScene* pScene, glTF2::Asset& r, std::vector<unsigned int>& 
     }
 
     if (node.mesh) {
-        ainode->mNumMeshes = 1;
-        ainode->mMeshes = new unsigned int[1];
 
-        int k = 0;
         int idx = node.mesh.GetIndex();
 
-        for (unsigned int j = meshOffsets[idx]; j < meshOffsets[idx + 1]; ++j, ++k) {
+        ai_assert(idx >= 0 && idx < meshOffsets.size());
+
+        unsigned int offBegin = meshOffsets[idx];
+        unsigned int offEnd = meshOffsets[idx + 1];
+        int k = 0;
+        
+        ai_assert(offEnd >= offBegin);
+
+        ainode->mNumMeshes = offEnd - offBegin;
+        ainode->mMeshes = new unsigned int[ainode->mNumMeshes];
+
+        for (unsigned int j = offBegin; j < offEnd; ++j, ++k) {
+            ai_assert(k < ainode->mNumMeshes);
             ainode->mMeshes[k] = j;
         }
     }


### PR DESCRIPTION
Previously, only one primitive was supported, in fact memory was corrupted
when more than one primitive was found per glTF mesh.

In this change, each primitive is unrolled as a new Assimp Mesh, resulting
in multiple Assimp meshes per node when multiple primitives exist per
glTF mesh. This is required in the general case, since glTF primitives can
have different material bindings and primitive modes.