### PR TITLE
Clean up some more GCC warnings

### DIFF
--- a/code/BlenderDNA.h
+++ b/code/BlenderDNA.h
@@ -253,7 +253,7 @@ public:
      *  a compiler complain is the result.
      *  @param dest Destination value to be written
      *  @param db File database, including input stream. */
-    template <typename T> inline void Convert (T& dest, const FileDatabase& db) const;
+    template <typename T> void Convert (T& dest, const FileDatabase& db) const;
 
     // --------------------------------------------------------
     // generic converter

--- a/code/ColladaLoader.cpp
+++ b/code/ColladaLoader.cpp
@@ -674,7 +674,7 @@ aiMesh* ColladaLoader::CreateMesh( const ColladaParser& pParser, const Collada::
     // create morph target meshes if any
     std::vector<aiMesh*> targetMeshes;
     std::vector<float> targetWeights;
-    Collada::MorphMethod method;
+    Collada::MorphMethod method = Collada::Normalized;
 
     for(std::map<std::string, Collada::Controller>::const_iterator it = pParser.mControllerLibrary.begin();
         it != pParser.mControllerLibrary.end(); it++)

--- a/code/FIReader.cpp
+++ b/code/FIReader.cpp
@@ -168,7 +168,7 @@ struct FIBase64ValueImpl: public FIBase64Value {
         if (!strValueValid) {
             strValueValid = true;
             std::ostringstream os;
-            uint8_t c1, c2;
+            uint8_t c1 = 0, c2;
             int imod3 = 0;
             std::vector<uint8_t>::size_type valueSize = value.size();
             for (std::vector<uint8_t>::size_type i = 0; i < valueSize; ++i) {

--- a/code/PlyLoader.cpp
+++ b/code/PlyLoader.cpp
@@ -170,9 +170,10 @@ void PLYImporter::InternReadFile(const std::string& pFile,
   std::vector<char> headerCheck;
   streamedBuffer.getNextLine(headerCheck);
 
-  if ((headerCheck.size() >= 3) && (headerCheck[0] != 'P' && headerCheck[0] != 'p') ||
-    (headerCheck[1] != 'L' && headerCheck[1] != 'l') ||
-    (headerCheck[2] != 'Y' && headerCheck[2] != 'y'))
+  if ((headerCheck.size() < 3) ||
+      (headerCheck[0] != 'P' && headerCheck[0] != 'p') ||
+      (headerCheck[1] != 'L' && headerCheck[1] != 'l') ||
+      (headerCheck[2] != 'Y' && headerCheck[2] != 'y') )
   {
     streamedBuffer.close();
     throw DeadlyImportError("Invalid .ply file: Magic number \'ply\' is no there");

--- a/code/glTF2Exporter.cpp
+++ b/code/glTF2Exporter.cpp
@@ -541,7 +541,7 @@ void ExportSkin(Asset& mAsset, const aiMesh* aimesh, Ref<Mesh>& meshRef, Ref<Buf
         Ref<Node> nodeRef = mAsset.nodes.Get(aib->mName.C_Str());
         nodeRef->jointName = nodeRef->name;
 
-        unsigned int jointNamesIndex;
+        unsigned int jointNamesIndex = 0;
         bool addJointToJointNames = true;
         for ( unsigned int idx_joint = 0; idx_joint < skinRef->jointNames.size(); ++idx_joint) {
             if (skinRef->jointNames[idx_joint]->jointName.compare(nodeRef->jointName) == 0) {

--- a/code/glTFExporter.cpp
+++ b/code/glTFExporter.cpp
@@ -444,7 +444,7 @@ void ExportSkin(Asset& mAsset, const aiMesh* aimesh, Ref<Mesh>& meshRef, Ref<Buf
         Ref<Node> nodeRef = mAsset.nodes.Get(aib->mName.C_Str());
         nodeRef->jointName = nodeRef->id;
 
-        unsigned int jointNamesIndex;
+        unsigned int jointNamesIndex = 0;
         bool addJointToJointNames = true;
         for ( unsigned int idx_joint = 0; idx_joint < skinRef->jointNames.size(); ++idx_joint) {
             if (skinRef->jointNames[idx_joint]->jointName.compare(nodeRef->jointName) == 0) {


### PR DESCRIPTION
Mostly simple stuff. The only one which should change behavior is in PLY loader. The previous version could fail on malformed files where the header wasn't complete.