### PR TITLE
Fix glTF2 alphaMode storage and reading

### DIFF
--- a/code/glTF2Exporter.cpp
+++ b/code/glTF2Exporter.cpp
@@ -424,20 +424,11 @@ void glTF2Exporter::ExportMaterials()
         mat->Get(AI_MATKEY_TWOSIDED, m->doubleSided);
         mat->Get(AI_MATKEY_GLTF_ALPHACUTOFF, m->alphaCutoff);
 
-        bool foundAlphaMode = false;
-        for (size_t i = 0; i < mat->mNumProperties; ++i) {
-            aiMaterialProperty *prop = mat->mProperties[i];
-            if (prop->mKey != aiString("$mat.gltf.alphaMode"))
-                continue;
+        aiString alphaMode;
 
-            std::string alphaMode;
-            for (size_t c = 0; c < prop->mDataLength; ++c)
-                alphaMode += prop->mData[c];
-            m->alphaMode = alphaMode;
-            foundAlphaMode = true;
-        }
-
-        if (!foundAlphaMode) {
+        if (mat->Get(AI_MATKEY_GLTF_ALPHAMODE, alphaMode) == AI_SUCCESS) {
+            m->alphaMode = alphaMode.C_Str();
+        } else {
             float opacity;
 
             if (mat->Get(AI_MATKEY_OPACITY, opacity) == AI_SUCCESS) {

--- a/code/glTF2Importer.cpp
+++ b/code/glTF2Importer.cpp
@@ -239,7 +239,9 @@ void glTF2Importer::ImportMaterials(glTF2::Asset& r)
         SetMaterialColorProperty(r, mat.emissiveFactor, aimat, AI_MATKEY_COLOR_EMISSIVE);
 
         aimat->AddProperty(&mat.doubleSided, 1, AI_MATKEY_TWOSIDED);
-        aimat->AddProperty(&mat.alphaMode, 1, AI_MATKEY_GLTF_ALPHAMODE);
+
+        aiString alphaMode(mat.alphaMode);
+        aimat->AddProperty(&alphaMode, AI_MATKEY_GLTF_ALPHAMODE);
         aimat->AddProperty(&mat.alphaCutoff, 1, AI_MATKEY_GLTF_ALPHACUTOFF);
 
         //pbrSpecularGlossiness


### PR DESCRIPTION
alphaMode is now converted from a std::string to an aiString and back to std::string, since aiString is easier to store and retrieve from aiMaterial properties than std::string

Fixes issues of alphaMode being written out as `\fOPAQUE\0\0\0\0\0\0…`