### PR TITLE
glTF2 primitives fixes

### DIFF
--- a/code/glTF2Asset.h
+++ b/code/glTF2Asset.h
@@ -781,7 +781,7 @@ namespace glTF2
     struct Node : public Object
     {
         std::vector< Ref<Node> > children;
-        Ref<Mesh> mesh;
+        std::vector< Ref<Mesh> > meshes;
 
         Nullable<mat4> matrix;
         Nullable<vec3> translation;

--- a/code/glTF2Asset.inl
+++ b/code/glTF2Asset.inl
@@ -934,10 +934,7 @@ inline void Node::Read(Value& obj, Asset& r)
     }
 
     if (Value* mesh = FindUInt(obj, "mesh")) {
-        //unsigned numMeshes = (unsigned)meshes->Size();
         unsigned numMeshes = 1;
-
-        //std::vector<unsigned int> meshList;
 
         this->meshes.reserve(numMeshes);
 

--- a/code/glTF2Asset.inl
+++ b/code/glTF2Asset.inl
@@ -934,9 +934,16 @@ inline void Node::Read(Value& obj, Asset& r)
     }
 
     if (Value* mesh = FindUInt(obj, "mesh")) {
+        //unsigned numMeshes = (unsigned)meshes->Size();
+        unsigned numMeshes = 1;
+
+        //std::vector<unsigned int> meshList;
+
+        this->meshes.reserve(numMeshes);
+
         Ref<Mesh> meshRef = r.meshes.Retrieve((*mesh).GetUint());
 
-        if (meshRef) this->mesh = meshRef;
+        if (meshRef) this->meshes.push_back(meshRef);
     }
 
     if (Value* camera = FindUInt(obj, "camera")) {

--- a/code/glTF2AssetWriter.inl
+++ b/code/glTF2AssetWriter.inl
@@ -417,9 +417,7 @@ namespace glTF2 {
 
         AddRefsVector(obj, "children", n.children, w.mAl);
 
-        if (n.mesh) {
-            obj.AddMember("mesh", n.mesh->index, w.mAl);
-        }
+        AddRefsVector(obj, "meshes", n.meshes, w.mAl);
 
         AddRefsVector(obj, "skeletons", n.skeletons, w.mAl);
 

--- a/code/glTF2AssetWriter.inl
+++ b/code/glTF2AssetWriter.inl
@@ -417,7 +417,9 @@ namespace glTF2 {
 
         AddRefsVector(obj, "children", n.children, w.mAl);
 
-        AddRefsVector(obj, "meshes", n.meshes, w.mAl);
+        if (!n.meshes.empty()) {
+            obj.AddMember("mesh", n.meshes[0]->index, w.mAl);
+        }
 
         AddRefsVector(obj, "skeletons", n.skeletons, w.mAl);
 

--- a/code/glTF2Exporter.cpp
+++ b/code/glTF2Exporter.cpp
@@ -479,14 +479,14 @@ bool FindMeshNode(Ref<Node>& nodeIn, Ref<Node>& meshNode, std::string meshID)
 {
     for (unsigned int i = 0; i < nodeIn->meshes.size(); ++i) {
         if (meshID.compare(nodeIn->meshes[i]->id) == 0) {
-          meshNode = nodeIn;
-          return true;
+            meshNode = nodeIn;
+            return true;
         }
     }
 
     for (unsigned int i = 0; i < nodeIn->children.size(); ++i) {
         if(FindMeshNode(nodeIn->children[i], meshNode, meshID)) {
-          return true;
+            return true;
         }
     }
 

--- a/code/glTF2Exporter.cpp
+++ b/code/glTF2Exporter.cpp
@@ -110,6 +110,7 @@ glTF2Exporter::glTF2Exporter(const char* filename, IOSystem* pIOSystem, const ai
     }
 
     ExportMeshes();
+    MergeMeshes();
 
     ExportScene();
 
@@ -739,6 +740,27 @@ void glTF2Exporter::ExportMeshes()
             Ref<Node> rootJoint = FindSkeletonRootJoint(skinRef);
             meshNode->skeletons.push_back(rootJoint);
             meshNode->skin = skinRef;
+        }
+    }
+}
+
+void glTF2Exporter::MergeMeshes()
+{
+    for (unsigned int n = 0; n < mAsset->nodes.Size(); ++n) {
+        Ref<Node> node = mAsset->nodes.Get(n);
+
+        unsigned int nMeshes = node->meshes.size();
+
+        if (nMeshes) {
+            Ref<Mesh> firstMesh = node->meshes.at(0);
+
+            for (unsigned int m = 1; m < nMeshes; ++m) {
+                Ref<Mesh> mesh = node->meshes.at(m);
+                Mesh::Primitive primitive = mesh->primitives.at(0);
+                firstMesh->primitives.push_back(primitive);
+            }
+
+            node->meshes.erase(node->meshes.begin() + 1, node->meshes.end());
         }
     }
 }

--- a/code/glTF2Exporter.cpp
+++ b/code/glTF2Exporter.cpp
@@ -755,31 +755,18 @@ void glTF2Exporter::MergeMeshes()
         //skip if it's 1 or less meshes per node
         if (nMeshes > 1) {
             Ref<Mesh> firstMesh = node->meshes.at(0);
-            Mesh::Primitive firstPrimitive = firstMesh->primitives.at(0);
 
             //loop backwards to allow easy removal of a mesh from a node once it's merged
             for (unsigned int m = nMeshes - 1; m >= 1; --m) {
                 Ref<Mesh> mesh = node->meshes.at(m);
-                bool primitivesPushed = false;
 
-                for (unsigned int p = 0; p < mesh->primitives.size(); ++p) {
-                    Mesh::Primitive primitive = mesh->primitives.at(p);
+                firstMesh->primitives.insert(firstMesh->primitives.end(), mesh->primitives.begin(), mesh->primitives.end());
 
-                    if (firstPrimitive.mode == primitive.mode) {
-                        firstMesh->primitives.push_back(primitive);
-                        primitivesPushed = true;
-                    }
-                }
-
-                if (primitivesPushed) {
-                    //remove the merged meshes from the node
-                    node->meshes.erase(node->meshes.begin() + m);
-                }
+                node->meshes.erase(node->meshes.begin() + m);
             }
 
             //since we were looping backwards, reverse the order of merged primitives to their original order
             std::reverse(firstMesh->primitives.begin() + 1, firstMesh->primitives.end());
-
         }
     }
 }

--- a/code/glTF2Exporter.cpp
+++ b/code/glTF2Exporter.cpp
@@ -476,15 +476,16 @@ void glTF2Exporter::ExportMaterials()
  */
 bool FindMeshNode(Ref<Node>& nodeIn, Ref<Node>& meshNode, std::string meshID)
 {
-
-    if (nodeIn->mesh && meshID.compare(nodeIn->mesh->id) == 0) {
-        meshNode = nodeIn;
-        return true;
+    for (unsigned int i = 0; i < nodeIn->meshes.size(); ++i) {
+        if (meshID.compare(nodeIn->meshes[i]->id) == 0) {
+          meshNode = nodeIn;
+          return true;
+        }
     }
 
     for (unsigned int i = 0; i < nodeIn->children.size(); ++i) {
         if(FindMeshNode(nodeIn->children[i], meshNode, meshID)) {
-            return true;
+          return true;
         }
     }
 
@@ -755,8 +756,8 @@ unsigned int glTF2Exporter::ExportNodeHierarchy(const aiNode* n)
         CopyValue(n->mTransformation, node->matrix.value);
     }
 
-    if (n->mNumMeshes > 0) {
-        node->mesh = mAsset->meshes.Get(n->mMeshes[0]);
+    for (unsigned int i = 0; i < n->mNumMeshes; ++i) {
+        node->meshes.push_back(mAsset->meshes.Get(n->mMeshes[i]));
     }
 
     for (unsigned int i = 0; i < n->mNumChildren; ++i) {
@@ -784,8 +785,8 @@ unsigned int glTF2Exporter::ExportNode(const aiNode* n, Ref<Node>& parent)
         CopyValue(n->mTransformation, node->matrix.value);
     }
 
-    if (n->mNumMeshes > 0) {
-        node->mesh = mAsset->meshes.Get(n->mMeshes[0]);
+    for (unsigned int i = 0; i < n->mNumMeshes; ++i) {
+        node->meshes.push_back(mAsset->meshes.Get(n->mMeshes[i]));
     }
 
     for (unsigned int i = 0; i < n->mNumChildren; ++i) {

--- a/code/glTF2Exporter.h
+++ b/code/glTF2Exporter.h
@@ -120,6 +120,7 @@ namespace Assimp
         void ExportMetadata();
         void ExportMaterials();
         void ExportMeshes();
+        void MergeMeshes();
         unsigned int ExportNodeHierarchy(const aiNode* n);
         unsigned int ExportNode(const aiNode* node, glTF2::Ref<glTF2::Node>& parent);
         void ExportScene();

--- a/code/glTF2Importer.cpp
+++ b/code/glTF2Importer.cpp
@@ -517,24 +517,22 @@ aiNode* ImportNode(aiScene* pScene, glTF2::Asset& r, std::vector<unsigned int>& 
         }
     }
 
-    if (node.mesh) {
+    if (!node.meshes.empty()) {
+        int count = 0;
+        for (size_t i = 0; i < node.meshes.size(); ++i) {
+            int idx = node.meshes[i].GetIndex();
+            count += meshOffsets[idx + 1] - meshOffsets[idx];
+        }
+        ainode->mNumMeshes = count;
 
-        int idx = node.mesh.GetIndex();
+        ainode->mMeshes = new unsigned int[count];
 
-        ai_assert(idx >= 0 && idx < meshOffsets.size());
-
-        unsigned int offBegin = meshOffsets[idx];
-        unsigned int offEnd = meshOffsets[idx + 1];
         int k = 0;
-        
-        ai_assert(offEnd >= offBegin);
-
-        ainode->mNumMeshes = offEnd - offBegin;
-        ainode->mMeshes = new unsigned int[ainode->mNumMeshes];
-
-        for (unsigned int j = offBegin; j < offEnd; ++j, ++k) {
-            ai_assert(k < ainode->mNumMeshes);
-            ainode->mMeshes[k] = j;
+        for (size_t i = 0; i < node.meshes.size(); ++i) {
+            int idx = node.meshes[i].GetIndex();
+            for (unsigned int j = meshOffsets[idx]; j < meshOffsets[idx + 1]; ++j, ++k) {
+                ainode->mMeshes[k] = j;
+            }
         }
     }
 


### PR DESCRIPTION
This PR reverts a commit (a0d9750) where I incorrectly assumed that a glTF2's one mesh per node only ever meant one aiMesh per aiNode (when in reality, assimp data structure stores multiple primitives on a mesh as multiple aiMeshes per aiNode). This PR also adds code that takes multiple meshes on a node and merges their primitives into the first (and only) mesh on a node (as per glTF2 spec).

This fixes exporting models that defined multiple primitives per mesh, such as the Brainstem model (in the glTF2 samples repo), and the [random model of the car](https://github.com/assimp/assimp/issues/1301#issuecomment-330001082) that @jcowles found on Sketchfab. It also fixes missing geometry issues I had with many glTF 1 models being exported to glTF2.

---

With this PR, what happens in a glTF2 -> glTF2 export flow is this:

- glTF2 node has at most one mesh (per spec). A mesh has at least one primitive. To convert to assimp's data structure, each primitive is stored as an individual aiMesh on a aiNode (aiNode therefore has multiple aiMeshes)
- When converting from assimp's structure back to glTF, each aiNode's aiMesh is stored in a glTF's node (so multiple meshes per node)
- I then append a node's multiple meshes' primitives into the first mesh's primitives. I then delete the meshes that were merged from the node. This matches the input data.
- The glTF2 is written where each node has at most one mesh, with at least on primitive per mesh.

I couldn't find a cleaner way to achieve this merging behaviour in existing parts of the code, such as `ExportNodeHierarchy` and `ExportMeshes`. There might be a better way to achieve this, but it's beyond my ability and understanding of assimp's data structure. 

This PR also overwrites @jcowles' fix in glTF2Importer.cpp (#1442 - which essentially was a fix for a0d9750), with similar code, but code that's tailored to a node's now multiple meshes. 😞 Hope that's okay, @jcowles!