### PR TITLE
[gltf1] Don’t ignore rgba(1,1,1,1) color properties

### DIFF
--- a/code/glTFImporter.cpp
+++ b/code/glTFImporter.cpp
@@ -174,9 +174,7 @@ inline void SetMaterialColorProperty(std::vector<int>& embeddedTexIdxs, Asset& r
     else {
         aiColor4D col;
         CopyValue(prop.color, col);
-        if (col.r != 1.f || col.g != 1.f || col.b != 1.f || col.a != 1.f) {
-            mat->AddProperty(&col, 1, pKey, type, idx);
-        }
+        mat->AddProperty(&col, 1, pKey, type, idx);
     }
 }
 
@@ -672,7 +670,7 @@ void glTFImporter::InternReadFile(const std::string& pFile, aiScene* pScene, IOS
     //pScene->mFlags |= AI_SCENE_FLAGS_NON_VERBOSE_FORMAT;
 	MakeVerboseFormatProcess process;
     process.Execute(pScene);
-    
+
 
     if (pScene->mNumMeshes == 0) {
         pScene->mFlags |= AI_SCENE_FLAGS_INCOMPLETE;


### PR DESCRIPTION
Do not ignore rgba(1,1,1,1) material properties when importing glTF1. While a white diffuse color may be the default value for a default assimp material, `1,1,1,1` is a very explicit color value for ambient/specular/emissive color properties.

Closes #1434