### PR TITLE
Fix possible infinite loop when exporting to gltf2

### DIFF
--- a/code/glTF2Asset.inl
+++ b/code/glTF2Asset.inl
@@ -1118,11 +1118,12 @@ inline std::string Asset::FindUniqueID(const std::string& str, const char* suffi
     if (it == mUsedIds.end())
         return id;
 
-    char buffer[256];
-    int offset = ai_snprintf(buffer, sizeof(buffer), "%s_", id.c_str());
+    std::vector<char> buffer;
+    buffer.resize(id.size() + 16);
+    int offset = ai_snprintf(buffer.data(), buffer.size(), "%s_", id.c_str());
     for (int i = 0; it != mUsedIds.end(); ++i) {
-        ai_snprintf(buffer + offset, sizeof(buffer) - offset, "%d", i);
-        id = buffer;
+        ai_snprintf(buffer.data() + offset, buffer.size() - offset, "%d", i);
+        id = buffer.data();
         it = mUsedIds.find(id);
     }
 


### PR DESCRIPTION
Some of the postprocessing options generate node names that are crazy long... in the case of one model I was looking at, more than 256 characters. This was causing `glTF2::Asset::FindUniqueID()` to enter an infinite loop.

I can't provide the model unfortunately, but it has a lot of small meshes in it, and the processing flags I used were:
`-cts -jiv -gsn -sbpt -fid -guv -og -om -icl -rrm`