### PR TITLE
Fully addressed identifiable build warnings on gcc

### DIFF
--- a/contrib/unzip/crypt.h
+++ b/contrib/unzip/crypt.h
@@ -32,7 +32,7 @@
 /***********************************************************************
  * Return the next byte in the pseudo-random sequence
  */
-static int decrypt_byte(unsigned long* pkeys, const unsigned long* pcrc_32_tab)
+static int decrypt_byte(unsigned long* pkeys, const z_crc_t* pcrc_32_tab)
 {
     unsigned temp;  /* POTENTIAL BUG:  temp*(temp^1) may overflow in an
                      * unpredictable manner on 16-bit systems; not a problem
@@ -62,7 +62,7 @@ static int update_keys(unsigned long* pkeys,const z_crc_t* pcrc_32_tab,int c)
  * Initialize the encryption keys and the random header according to
  * the given password.
  */
-static void init_keys(const char* passwd,unsigned long* pkeys,const unsigned long* pcrc_32_tab)
+static void init_keys(const char* passwd,unsigned long* pkeys,const z_crc_t* pcrc_32_tab)
 {
     *(pkeys+0) = 305419896L;
     *(pkeys+1) = 591751049L;

--- a/contrib/unzip/crypt.h
+++ b/contrib/unzip/crypt.h
@@ -45,7 +45,7 @@ static int decrypt_byte(unsigned long* pkeys, const unsigned long* pcrc_32_tab)
 /***********************************************************************
  * Update the encryption keys with the next byte of plain text
  */
-static int update_keys(unsigned long* pkeys,const unsigned long* pcrc_32_tab,int c)
+static int update_keys(unsigned long* pkeys,const z_crc_t* pcrc_32_tab,int c)
 {
     (*(pkeys+0)) = CRC32((*(pkeys+0)), c);
     (*(pkeys+1)) += (*(pkeys+0)) & 0xff;

--- a/contrib/unzip/unzip.c
+++ b/contrib/unzip/unzip.c
@@ -147,7 +147,7 @@ typedef struct
     int encrypted;
 #    ifndef NOUNCRYPT
     unsigned long keys[3];     /* keys defining the pseudo-random sequence */
-    const unsigned long* pcrc_32_tab;
+    const z_crc_t* pcrc_32_tab;
 #    endif
 } unz_s;
 

--- a/test/unit/UnitTestFileGenerator.h
+++ b/test/unit/UnitTestFileGenerator.h
@@ -46,7 +46,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #if defined(__GNUC__) || defined(__clang__)
 #define TMP_PATH "/tmp/"
-inline FILE* MakeTmpFilePath(char* tmplate)
+inline FILE* MakeTmpFile(char* tmplate)
 {
     auto fd = mkstemp(tmplate);
     EXPECT_NE(-1, fd);
@@ -61,7 +61,7 @@ inline FILE* MakeTmpFilePath(char* tmplate)
 #elif defined(_MSC_VER)
 #include <io.h>
 #define TMP_PATH "./"
-inline FILE* MakeTmpFilePath(char* tmplate)
+inline FILE* MakeTmpFile(char* tmplate)
 {
     auto pathtemplate = _mktemp(tmplate);
     EXPECT_NE(pathtemplate, nullptr);

--- a/test/unit/utDefaultIOStream.cpp
+++ b/test/unit/utDefaultIOStream.cpp
@@ -60,7 +60,7 @@ TEST_F( utDefaultIOStream, FileSizeTest ) {
     const auto dataCount = dataSize / sizeof(*data);
 
     char fpath[] = { TMP_PATH"rndfp.XXXXXX" };
-    auto* fs = MakeTmpFilePath(fpath);
+    auto* fs = MakeTmpFile(fpath);
     ASSERT_NE(nullptr, fs);
     {
         auto written = std::fwrite(data, sizeof(*data), dataCount, fs );

--- a/test/unit/utIOStreamBuffer.cpp
+++ b/test/unit/utIOStreamBuffer.cpp
@@ -43,6 +43,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "UnitTestPCH.h"
 #include "IOStreamBuffer.h"
 #include "TestIOStream.h"
+#include "UnitTestFileGenerator.h"
 
 class IOStreamBufferTest : public ::testing::Test {
     // empty
@@ -68,40 +69,59 @@ TEST_F( IOStreamBufferTest, accessCacheSizeTest ) {
     EXPECT_EQ( 100U, myBuffer2.cacheSize() );
 }
 
+const char data[]{"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Qui\
+sque luctus sem diam, ut eleifend arcu auctor eu. Vestibulum id est vel nulla l\
+obortis malesuada ut sed turpis. Nulla a volutpat tortor. Nunc vestibulum portt\
+itor sapien ornare sagittis volutpat."};
+
+
 TEST_F( IOStreamBufferTest, open_close_Test ) {
     IOStreamBuffer<char> myBuffer;
 
     EXPECT_FALSE( myBuffer.open( nullptr ) );
     EXPECT_FALSE( myBuffer.close() );
+    
+    const auto dataSize = sizeof(data);
+    const auto dataCount = dataSize / sizeof(*data);
 
-    char buffer[ L_tmpnam ];
-    tmpnam( buffer );
-    std::FILE *fs( std::fopen( buffer, "w+" ) );
-    size_t written( std::fwrite( buffer, 1, sizeof( char ) * L_tmpnam, fs ) );
+    char fname[]={ "octest.XXXXXX" };
+    auto* fs = MakeTmpFile(fname);
+    ASSERT_NE(nullptr, fs);
+    
+    auto written = std::fwrite( data, sizeof(*data), dataCount, fs );
     EXPECT_NE( 0U, written );
     std::fflush( fs );
+    {
+        TestDefaultIOStream myStream( fs, fname );
 
-    TestDefaultIOStream myStream( fs, buffer );
-
-    EXPECT_TRUE( myBuffer.open( &myStream ) );
-    EXPECT_FALSE( myBuffer.open( &myStream ) );
-    EXPECT_TRUE( myBuffer.close() );
+        EXPECT_TRUE( myBuffer.open( &myStream ) );
+        EXPECT_FALSE( myBuffer.open( &myStream ) );
+        EXPECT_TRUE( myBuffer.close() );
+    }
+    remove(fname);
 }
 
 TEST_F( IOStreamBufferTest, readlineTest ) {
-    char buffer[ L_tmpnam ];
-    tmpnam( buffer );
-    std::FILE *fs( std::fopen( buffer, "w+" ) );
-    size_t written( std::fwrite( buffer, 1, sizeof( char ) * L_tmpnam, fs ) );
+    
+    const auto dataSize = sizeof(data);
+    const auto dataCount = dataSize / sizeof(*data);
+
+    char fname[]={ "readlinetest.XXXXXX" };
+    auto* fs = MakeTmpFile(fname);
+    ASSERT_NE(nullptr, fs);
+
+    auto written = std::fwrite( data, sizeof(*data), dataCount, fs );
     EXPECT_NE( 0U, written );
     std::fflush( fs );
 
-    IOStreamBuffer<char> myBuffer( 26 );
-    EXPECT_EQ( 26U, myBuffer.cacheSize() );
+    const auto tCacheSize = 26u;
 
-    TestDefaultIOStream myStream( fs, buffer );
-    size_t size( myStream.FileSize() );
-    size_t numBlocks( size / myBuffer.cacheSize() );
+    IOStreamBuffer<char> myBuffer( tCacheSize );
+    EXPECT_EQ(tCacheSize, myBuffer.cacheSize() );
+
+    TestDefaultIOStream myStream( fs, fname );
+    auto size = myStream.FileSize();
+    auto numBlocks = size / myBuffer.cacheSize();
     if ( size % myBuffer.cacheSize() > 0 ) {
         numBlocks++;
     }


### PR DESCRIPTION
These changes should address build warnings for the project when compiling with gcc. One warning required a change to the interface of some functions in the unzip contribution project. The remainder were internal to the implementation.