### PR TITLE
Eliminated warnings when building the project with clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,9 +204,11 @@ ELSEIF(MSVC)
   # enable multi-core compilation with MSVC
   add_compile_options(/MP)
 ELSEIF ( "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" )
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fvisibility=hidden -fPIC -Wall -Wno-long-long -pedantic -std=c++11" )
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fvisibility=hidden -fPIC -Wall -Wno-long-long -std=c++11" )
+  SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
 ELSEIF( CMAKE_COMPILER_IS_MINGW )
-  SET( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -Wall -Wno-long-long -pedantic -std=c++11" )
+  SET( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fvisibility=hidden -Wall -Wno-long-long -std=c++11" )
+  SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
   ADD_DEFINITIONS( -U__STRICT_ANSI__ )
 ENDIF()
 

--- a/code/MMDPmxParser.cpp
+++ b/code/MMDPmxParser.cpp
@@ -216,8 +216,8 @@ namespace pmx
 
 	void PmxMaterial::Read(std::istream *stream, PmxSetting *setting)
 	{
-		this->material_name = std::move(ReadString(stream, setting->encoding));
-		this->material_english_name = std::move(ReadString(stream, setting->encoding));
+		this->material_name = ReadString(stream, setting->encoding);
+		this->material_english_name = ReadString(stream, setting->encoding);
 		stream->read((char*) this->diffuse, sizeof(float) * 4);
 		stream->read((char*) this->specular, sizeof(float) * 3);
 		stream->read((char*) &this->specularlity, sizeof(float));
@@ -236,7 +236,7 @@ namespace pmx
 		else {
 			this->toon_texture_index = ReadIndex(stream, setting->texture_index_size);
 		}
-		this->memo = std::move(ReadString(stream, setting->encoding));
+		this->memo = ReadString(stream, setting->encoding);
 		stream->read((char*) &this->index_count, sizeof(int));
 	}
 
@@ -253,8 +253,8 @@ namespace pmx
 
 	void PmxBone::Read(std::istream *stream, PmxSetting *setting)
 	{
-		this->bone_name = std::move(ReadString(stream, setting->encoding));
-		this->bone_english_name = std::move(ReadString(stream, setting->encoding));
+		this->bone_name = ReadString(stream, setting->encoding);
+		this->bone_english_name = ReadString(stream, setting->encoding);
 		stream->read((char*) this->position, sizeof(float) * 3);
 		this->parent_index = ReadIndex(stream, setting->bone_index_size);
 		stream->read((char*) &this->level, sizeof(int));
@@ -528,10 +528,10 @@ namespace pmx
 		this->setting.Read(stream);
 
 		// モデル情報
-		this->model_name = std::move(ReadString(stream, setting.encoding));
-		this->model_english_name = std::move(ReadString(stream, setting.encoding));
-		this->model_comment = std::move(ReadString(stream, setting.encoding));
-		this->model_english_comment = std::move(ReadString(stream, setting.encoding));
+		this->model_name = ReadString(stream, setting.encoding);
+		this->model_english_name = ReadString(stream, setting.encoding);
+		this->model_comment = ReadString(stream, setting.encoding);
+		this->model_english_comment = ReadString(stream, setting.encoding);
 
 		// 頂点
 		stream->read((char*) &vertex_count, sizeof(int));

--- a/code/glTFAsset.h
+++ b/code/glTFAsset.h
@@ -232,7 +232,9 @@ namespace glTF
             case ComponentType_UNSIGNED_BYTE:
                 return 1;
             default:
-                throw DeadlyImportError("GLTF: Unsupported Component Type "+t);
+                std::string err = "GLTF: Unsupported Component Type ";
+                err += t;
+                throw DeadlyImportError(err);
         }
     }
 

--- a/contrib/unzip/unzip.c
+++ b/contrib/unzip/unzip.c
@@ -608,10 +608,16 @@ local int unzlocal_GetCurrentFileInfoInternal (file,
 
     /* we check the magic */
     if (err==UNZ_OK)
+    {
         if (unzlocal_getLong(&s->z_filefunc, s->filestream,&uMagic) != UNZ_OK)
+        {
             err=UNZ_ERRNO;
+        }
         else if (uMagic!=0x02014b50)
+        {
             err=UNZ_BADZIPFILE;
+        }
+    }
 
     if (unzlocal_getShort(&s->z_filefunc, s->filestream,&file_info.version) != UNZ_OK)
         err=UNZ_ERRNO;
@@ -688,18 +694,21 @@ local int unzlocal_GetCurrentFileInfoInternal (file,
             uSizeRead = extraFieldBufferSize;
 
         if (lSeek!=0)
+        {
             if (ZSEEK(s->z_filefunc, s->filestream,lSeek,ZLIB_FILEFUNC_SEEK_CUR)==0)
                 lSeek=0;
             else
                 err=UNZ_ERRNO;
+        }
         if ((file_info.size_file_extra>0) && (extraFieldBufferSize>0))
             if (ZREAD(s->z_filefunc, s->filestream,extraField,uSizeRead)!=uSizeRead)
                 err=UNZ_ERRNO;
         lSeek += file_info.size_file_extra - uSizeRead;
     }
     else
+    {
         lSeek+=file_info.size_file_extra;
-
+    }
 
     if ((err==UNZ_OK) && (szComment!=NULL))
     {
@@ -710,20 +719,26 @@ local int unzlocal_GetCurrentFileInfoInternal (file,
             uSizeRead = file_info.size_file_comment;
         }
         else
+        {
             uSizeRead = commentBufferSize;
+        }
 
         if (lSeek!=0)
+        {
             if (ZSEEK(s->z_filefunc, s->filestream,lSeek,ZLIB_FILEFUNC_SEEK_CUR)==0)
                 lSeek=0;
             else
                 err=UNZ_ERRNO;
+        }
         if ((file_info.size_file_comment>0) && (commentBufferSize>0))
             if (ZREAD(s->z_filefunc, s->filestream,szComment,uSizeRead)!=uSizeRead)
                 err=UNZ_ERRNO;
         lSeek+=file_info.size_file_comment - uSizeRead;
     }
     else
+    {
         lSeek+=file_info.size_file_comment;
+    }
 
     if ((err==UNZ_OK) && (pfile_info!=NULL))
         *pfile_info=file_info;
@@ -977,10 +992,12 @@ local int unzlocal_CheckCurrentFileCoherencyHeader (s,piSizeVar,
 
 
     if (err==UNZ_OK)
+    {
         if (unzlocal_getLong(&s->z_filefunc, s->filestream,&uMagic) != UNZ_OK)
             err=UNZ_ERRNO;
         else if (uMagic!=0x04034b50)
             err=UNZ_BADZIPFILE;
+    }
 
     if (unzlocal_getShort(&s->z_filefunc, s->filestream,&uData) != UNZ_OK)
         err=UNZ_ERRNO;
@@ -1239,7 +1256,7 @@ extern int ZEXPORT unzReadCurrentFile  (file, buf, len)
         return UNZ_PARAMERROR;
 
 
-    if ((pfile_in_zip_read_info->read_buffer == NULL))
+    if (pfile_in_zip_read_info->read_buffer == NULL)
         return UNZ_END_OF_LIST_OF_FILE;
     if (len==0)
         return 0;


### PR DESCRIPTION
This is the last remaining thing to be done to address issue #1330 
Only 1 warning remains. This warnings is in the zlib contribution.
`/contrib/zlib/inflate.c:1507:61: warning: 
      shifting a negative signed value is undefined [-Wshift-negative-value]
    if (strm == Z_NULL || strm->state == Z_NULL) return -1L << 16;`
This is a serious issue. We should consider getting an updated copy of this contribution, if we can't fix it ourselves and it has this issue fixed.