### PR TITLE
Fixed warning on clang 3.9 caused by static data member in class template

### DIFF
--- a/code/BlenderBMesh.cpp
+++ b/code/BlenderBMesh.cpp
@@ -52,7 +52,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace Assimp
 {
-    template< > const std::string LogFunctions< BlenderBMeshConverter >::log_prefix = "BLEND_BMESH: ";
+    template< > const char* LogFunctions< BlenderBMeshConverter >::Prefix()
+    {
+        static auto prefix = "BLEND_BMESH: ";
+        return prefix;
+    }
 }
 
 using namespace Assimp;

--- a/code/BlenderLoader.cpp
+++ b/code/BlenderLoader.cpp
@@ -74,7 +74,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 namespace Assimp {
-    template<> const std::string LogFunctions<BlenderImporter>::log_prefix = "BLEND: ";
+    template<> const char* LogFunctions<BlenderImporter>::Prefix()
+    {
+        static auto prefix = "BLEND: ";
+        return prefix;
+    }
 }
 
 using namespace Assimp;

--- a/code/BlenderTessellator.cpp
+++ b/code/BlenderTessellator.cpp
@@ -59,7 +59,11 @@ static const unsigned int BLEND_TESS_MAGIC = 0x83ed9ac3;
 
 namspace Assimp
 {
-    template< > const std::string LogFunctions< BlenderTessellatorGL >::log_prefix = "BLEND_TESS_GL: ";
+    template< > const char* LogFunctions< BlenderTessellatorGL >::Prefix()
+    {
+        static auto prefix = "BLEND_TESS_GL: ";
+        return prefix;
+    }
 }
 
 using namespace Assimp;
@@ -252,7 +256,11 @@ void BlenderTessellatorGL::TessellateError( GLenum errorCode, void* )
 
 namespace Assimp
 {
-    template< > const std::string LogFunctions< BlenderTessellatorP2T >::log_prefix = "BLEND_TESS_P2T: ";
+    template< > const char* LogFunctions< BlenderTessellatorP2T >::Prefix()
+    {
+        static auto prefix = "BLEND_TESS_P2T: ";
+        return prefix;
+    }
 }
 
 using namespace Assimp;

--- a/code/FBXImporter.cpp
+++ b/code/FBXImporter.cpp
@@ -59,7 +59,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/importerdesc.h>
 
 namespace Assimp {
-    template<> const std::string LogFunctions<FBXImporter>::log_prefix = "FBX: ";
+    template<> const char* LogFunctions<FBXImporter>::Prefix()
+    {
+        static auto prefix = "FBX: ";
+        return prefix;
+    }
 }
 
 using namespace Assimp;

--- a/code/IFCLoader.cpp
+++ b/code/IFCLoader.cpp
@@ -66,7 +66,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 namespace Assimp {
-    template<> const std::string LogFunctions<IFCImporter>::log_prefix = "IFC: ";
+    template<> const char* LogFunctions<IFCImporter>::Prefix()
+    {
+        static auto prefix = "IFC: ";
+        return prefix;
+    }
 }
 
 using namespace Assimp;

--- a/code/LogAux.h
+++ b/code/LogAux.h
@@ -60,34 +60,34 @@ public:
     // ------------------------------------------------------------------------------------------------
     static void ThrowException(const std::string& msg)
     {
-        throw DeadlyImportError(log_prefix+msg);
+        throw DeadlyImportError(Prefix()+msg);
     }
 
     // ------------------------------------------------------------------------------------------------
     static void LogWarn(const Formatter::format& message)   {
         if (!DefaultLogger::isNullLogger()) {
-            DefaultLogger::get()->warn(log_prefix+(std::string)message);
+            DefaultLogger::get()->warn(Prefix() +(std::string)message);
         }
     }
 
     // ------------------------------------------------------------------------------------------------
     static void LogError(const Formatter::format& message)  {
         if (!DefaultLogger::isNullLogger()) {
-            DefaultLogger::get()->error(log_prefix+(std::string)message);
+            DefaultLogger::get()->error(Prefix() +(std::string)message);
         }
     }
 
     // ------------------------------------------------------------------------------------------------
     static void LogInfo(const Formatter::format& message)   {
         if (!DefaultLogger::isNullLogger()) {
-            DefaultLogger::get()->info(log_prefix+(std::string)message);
+            DefaultLogger::get()->info(Prefix() +(std::string)message);
         }
     }
 
     // ------------------------------------------------------------------------------------------------
     static void LogDebug(const Formatter::format& message)  {
         if (!DefaultLogger::isNullLogger()) {
-            DefaultLogger::get()->debug(log_prefix+(std::string)message);
+            DefaultLogger::get()->debug(Prefix() +(std::string)message);
         }
     }
 
@@ -125,8 +125,7 @@ public:
 #endif
 
 private:
-
-    static const std::string log_prefix;
+    static const char* Prefix();
 
 };
 

--- a/code/XGLLoader.cpp
+++ b/code/XGLLoader.cpp
@@ -83,8 +83,11 @@ struct free_it
 };
 
 namespace Assimp { // this has to be in here because LogFunctions is in ::Assimp
-template<> const std::string LogFunctions<XGLImporter>::log_prefix = "XGL: ";
-
+    template<> const char* LogFunctions<XGLImporter>::Prefix()
+    {
+        static auto prefix = "XGL: ";
+        return prefix;
+    }
 }
 
 static const aiImporterDesc desc = {


### PR DESCRIPTION
Static data members in class templates are a terrible idea. clang 3.9 is the only compiler that managed to identify the obvious issue with this.
This approach is only slightly more code and should also cut down on the number of temporary std::string objects created when logging errors, warnings or general log information.
This ties into the work currently being done to add clang 3.9 to the test matrix.