### PR TITLE
Fix some warnings

### DIFF
--- a/code/FBXDocument.h
+++ b/code/FBXDocument.h
@@ -596,10 +596,10 @@ public:
 		return textures[index];
 
     }
-	const int textureCount() const {
+	int textureCount() const {
 		return static_cast<int>(textures.size());
 	}
-    const BlendMode GetBlendMode() const
+    BlendMode GetBlendMode() const
     {
         return blendMode;
     }
@@ -647,7 +647,7 @@ public:
         return content;
     }
 
-    const uint32_t ContentLength() const {
+    uint32_t ContentLength() const {
         return contentLength;
     }
 

--- a/code/GenericProperty.h
+++ b/code/GenericProperty.h
@@ -111,7 +111,7 @@ inline void SetGenericPropertyPtr(std::map< unsigned int, T* >& list,
 
 // ------------------------------------------------------------------------------------------------
 template <class T>
-inline const bool HasGenericProperty(const std::map< unsigned int, T >& list,
+inline bool HasGenericProperty(const std::map< unsigned int, T >& list,
     const char* szName)
 {
     ai_assert(NULL != szName);

--- a/contrib/Open3DGC/o3dgcAdjacencyInfo.h
+++ b/contrib/Open3DGC/o3dgcAdjacencyInfo.h
@@ -140,8 +140,8 @@ namespace o3dgc
                                 { 
                                     return End(element) - Begin(element);
                                 }
-        long * const            GetNumNeighborsBuffer() { return m_numNeighbors;}
-        long * const            GetNeighborsBuffer()    { return m_neighbors;}
+        long *                  GetNumNeighborsBuffer() { return m_numNeighbors;}
+        long *                  GetNeighborsBuffer()    { return m_neighbors;}
 
     private:
         long                    m_neighborsSize;    // actual allocated size for m_neighbors

--- a/contrib/Open3DGC/o3dgcBinaryStream.h
+++ b/contrib/Open3DGC/o3dgcBinaryStream.h
@@ -395,15 +395,15 @@ namespace o3dgc
                                 {
                                     return m_stream.GetSize();
                                 }
-    const unsigned char * const GetBuffer(unsigned long position) const
+    const unsigned char *       GetBuffer(unsigned long position) const
                                 {
                                     return m_stream.GetBuffer() + position;
                                 }
-    unsigned char * const       GetBuffer(unsigned long position)
+    unsigned char *             GetBuffer(unsigned long position)
                                 {
                                     return (m_stream.GetBuffer() + position);
                                 }                                
-    unsigned char * const       GetBuffer()
+    unsigned char *             GetBuffer()
                                 {
                                     return m_stream.GetBuffer();
                                 }                                

--- a/contrib/Open3DGC/o3dgcDynamicVector.h
+++ b/contrib/Open3DGC/o3dgcDynamicVector.h
@@ -48,10 +48,10 @@ namespace o3dgc
         unsigned long               GetNVector()       const { return m_num;}
         unsigned long               GetDimVector()     const { return m_dim;}
         unsigned long               GetStride()        const { return m_stride;}
-        const Real * const          GetMin()           const { return m_min;}
-        const Real * const          GetMax()           const { return m_max;}
-        const Real * const          GetVectors()       const { return m_vectors;}
-        Real * const                GetVectors()             { return m_vectors;}
+        const Real *                GetMin()           const { return m_min;}
+        const Real *                GetMax()           const { return m_max;}
+        const Real *                GetVectors()       const { return m_vectors;}
+        Real *                      GetVectors()             { return m_vectors;}
         Real                        GetMin(unsigned long j) const { return m_min[j];}
         Real                        GetMax(unsigned long j) const { return m_max[j];}
 

--- a/contrib/Open3DGC/o3dgcFIFO.h
+++ b/contrib/Open3DGC/o3dgcFIFO.h
@@ -81,8 +81,8 @@ namespace o3dgc
                                         m_end = 0;
                                     }
                                 }
-        const unsigned long     GetSize()          const { return m_size;};
-        const unsigned long     GetAllocatedSize() const { return m_allocated;};
+        unsigned long           GetSize()          const { return m_size;};
+        unsigned long           GetAllocatedSize() const { return m_allocated;};
         void                    Clear() { m_start = m_end = m_size = 0;};
 
     private:

--- a/contrib/Open3DGC/o3dgcIndexedFaceSet.h
+++ b/contrib/Open3DGC/o3dgcIndexedFaceSet.h
@@ -62,26 +62,26 @@ namespace o3dgc
                                          }
         unsigned long                    GetNumFloatAttributes()  const { return m_numFloatAttributes;}
         unsigned long                    GetNumIntAttributes()    const { return m_numIntAttributes  ;}
-        const Real * const               GetCoordMin   () const { return m_coordMin;}
-        const Real * const               GetCoordMax   () const { return m_coordMax;}
-        const Real * const               GetNormalMin  () const { return m_normalMin;}
-        const Real * const               GetNormalMax  () const { return m_normalMax;}
+        const Real *                     GetCoordMin   () const { return m_coordMin;}
+        const Real *                     GetCoordMax   () const { return m_coordMax;}
+        const Real *                     GetNormalMin  () const { return m_normalMin;}
+        const Real *                     GetNormalMax  () const { return m_normalMax;}
         Real                             GetCoordMin   (int j)  const { return m_coordMin[j]       ;}
         Real                             GetCoordMax   (int j)  const { return m_coordMax[j]       ;}
         Real                             GetNormalMin  (int j)  const { return m_normalMin[j]      ;}
         Real                             GetNormalMax  (int j)  const { return m_normalMax[j]      ;}
 
-        const O3DGCIFSFloatAttributeType GetFloatAttributeType(unsigned long a) const
+        O3DGCIFSFloatAttributeType       GetFloatAttributeType(unsigned long a) const
                                          { 
                                              assert(a < O3DGC_SC3DMC_MAX_NUM_FLOAT_ATTRIBUTES);
                                              return m_typeFloatAttribute[a];
                                          }
-        const O3DGCIFSIntAttributeType   GetIntAttributeType(unsigned long a) const
+        O3DGCIFSIntAttributeType         GetIntAttributeType(unsigned long a) const
                                          { 
                                              assert(a < O3DGC_SC3DMC_MAX_NUM_INT_ATTRIBUTES);
                                              return m_typeIntAttribute[a];
                                          }
-        const unsigned long              GetFloatAttributeDim(unsigned long a) const
+        unsigned long                    GetFloatAttributeDim(unsigned long a) const
                                          { 
                                              assert(a < O3DGC_SC3DMC_MAX_NUM_FLOAT_ATTRIBUTES);
                                              return m_dimFloatAttribute[a];
@@ -91,12 +91,12 @@ namespace o3dgc
                                              assert(a < O3DGC_SC3DMC_MAX_NUM_INT_ATTRIBUTES);
                                              return m_dimIntAttribute[a];
                                          }
-        const Real * const               GetFloatAttributeMin(unsigned long a) const
+        const Real *                     GetFloatAttributeMin(unsigned long a) const
                                          { 
                                              assert(a < O3DGC_SC3DMC_MAX_NUM_FLOAT_ATTRIBUTES);
                                              return &(m_minFloatAttribute[a * O3DGC_SC3DMC_MAX_DIM_ATTRIBUTES]);
                                          }
-        const Real * const               GetFloatAttributeMax(unsigned long a) const
+        const Real *                     GetFloatAttributeMax(unsigned long a) const
                                          { 
                                              assert(a < O3DGC_SC3DMC_MAX_NUM_FLOAT_ATTRIBUTES);
                                              return &(m_maxFloatAttribute[a * O3DGC_SC3DMC_MAX_DIM_ATTRIBUTES]);
@@ -118,17 +118,17 @@ namespace o3dgc
         bool                             GetSolid()            const { return m_solid           ;}
         bool                             GetConvex()           const { return m_convex          ;}
         bool                             GetIsTriangularMesh() const { return m_isTriangularMesh;}
-        const unsigned long * const      GetIndexBufferID()    const { return m_indexBufferID   ;}
-        const T * const                  GetCoordIndex()       const { return m_coordIndex;}
-        T * const                        GetCoordIndex()             { return m_coordIndex;}
-        Real * const                     GetCoord()            const { return m_coord     ;}
-        Real * const                     GetNormal()           const { return m_normal    ;}
-        Real * const                     GetFloatAttribute(unsigned long a)  const 
+        const unsigned long *            GetIndexBufferID()    const { return m_indexBufferID   ;}
+        const T *                        GetCoordIndex()       const { return m_coordIndex;}
+        T *                              GetCoordIndex()             { return m_coordIndex;}
+        Real *                           GetCoord()            const { return m_coord     ;}
+        Real *                           GetNormal()           const { return m_normal    ;}
+        Real *                           GetFloatAttribute(unsigned long a)  const
                                          {
                                              assert(a < O3DGC_SC3DMC_MAX_NUM_FLOAT_ATTRIBUTES);
                                              return m_floatAttribute[a];
                                          }
-        long * const                     GetIntAttribute(unsigned long a)   const 
+        long *                           GetIntAttribute(unsigned long a)   const
                                          {
                                              assert(a < O3DGC_SC3DMC_MAX_NUM_INT_ATTRIBUTES);
                                              return m_intAttribute[a]  ;

--- a/contrib/Open3DGC/o3dgcTriangleListEncoder.h
+++ b/contrib/Open3DGC/o3dgcTriangleListEncoder.h
@@ -50,10 +50,10 @@ namespace o3dgc
                                            BinaryStream & bstream);
         O3DGCStreamType       GetStreamType() const { return m_streamType; }
         void                        SetStreamType(O3DGCStreamType streamType) { m_streamType = streamType; }
-        const long * const          GetInvVMap() const { return m_invVMap;}
-        const long * const          GetInvTMap() const { return m_invTMap;}        
-        const long * const          GetVMap()    const { return m_vmap;}
-        const long * const          GetTMap()    const { return m_tmap;}
+        const long *                GetInvVMap() const { return m_invVMap;}
+        const long *                GetInvTMap() const { return m_invTMap;}
+        const long *                GetVMap()    const { return m_vmap;}
+        const long *                GetTMap()    const { return m_tmap;}
         const AdjacencyInfo &       GetVertexToTriangle() const { return m_vertexToTriangle;}
 
         private:

--- a/contrib/Open3DGC/o3dgcVector.h
+++ b/contrib/Open3DGC/o3dgcVector.h
@@ -88,8 +88,8 @@ namespace o3dgc
                                     assert(m_size < m_allocated);
                                     m_buffer[m_size++] = value;
                                 }
-        const T * const         GetBuffer() const { return m_buffer;};
-        T * const               GetBuffer()       { return m_buffer;};
+        const T *               GetBuffer() const { return m_buffer;};
+        T *                     GetBuffer()       { return m_buffer;};
         unsigned long                  GetSize()   const { return m_size;};
         void                    SetSize(unsigned long size)
                                 { 


### PR DESCRIPTION
Fix some warnings enabled by -Wextra parameter of GCC and Clang. Does not enable -Wextra as part of Travis build since it's not yet clean.