### PR TITLE
Fixed File Size reported as 0 in tests that use temporary files

### DIFF
--- a/test/unit/utDefaultIOStream.cpp
+++ b/test/unit/utDefaultIOStream.cpp
@@ -69,6 +69,11 @@ TEST_F( utDefaultIOStream, FileSizeTest ) {
         auto vflush = std::fflush( fs );
         ASSERT_EQ(vflush, 0);
 
+		std::fclose(fs);
+		fs = std::fopen(fpath, "r");
+
+		ASSERT_NE(nullptr, fs);
+
         TestDefaultIOStream myStream( fs, fpath);
         size_t size = myStream.FileSize();
         EXPECT_EQ( size, dataSize);

--- a/test/unit/utIOStreamBuffer.cpp
+++ b/test/unit/utIOStreamBuffer.cpp
@@ -90,7 +90,11 @@ TEST_F( IOStreamBufferTest, open_close_Test ) {
     
     auto written = std::fwrite( data, sizeof(*data), dataCount, fs );
     EXPECT_NE( 0U, written );
-    std::fflush( fs );
+    auto flushResult = std::fflush( fs );
+	ASSERT_EQ(0, flushResult);
+	std::fclose( fs );
+	fs = std::fopen(fname, "r");
+	ASSERT_NE(nullptr, fs);
     {
         TestDefaultIOStream myStream( fs, fname );
 
@@ -112,7 +116,12 @@ TEST_F( IOStreamBufferTest, readlineTest ) {
 
     auto written = std::fwrite( data, sizeof(*data), dataCount, fs );
     EXPECT_NE( 0U, written );
-    std::fflush( fs );
+
+	auto flushResult = std::fflush(fs);
+	ASSERT_EQ(0, flushResult);
+	std::fclose(fs);
+	fs = std::fopen(fname, "r");
+	ASSERT_NE(nullptr, fs);
 
     const auto tCacheSize = 26u;
 


### PR DESCRIPTION
This issue only appears on MSVC 2013. This is caused by a temporary file being created and written to, but is slow to be flushed to until it is reopened for reading. This is a blocker for #1479. Once this is merged, that work should be ready to merge.