### PR TITLE
Feature/jassimp IO system

### DIFF
--- a/port/jassimp/jassimp-native/src/jassimp.cpp
+++ b/port/jassimp/jassimp-native/src/jassimp.cpp
@@ -471,7 +471,10 @@ public:
 	
 	    return cnt;
     };
-    size_t Write(const void* pvBuffer, size_t pSize, size_t pCount) {};
+    size_t Write(const void* pvBuffer, size_t pSize, size_t pCount) 
+    {
+        return 0;
+    };
     
     aiReturn Seek(size_t pOffset, aiOrigin pOrigin)
     {

--- a/port/jassimp/jassimp-native/src/jassimp.h
+++ b/port/jassimp/jassimp-native/src/jassimp.h
@@ -39,7 +39,7 @@ JNIEXPORT jstring JNICALL Java_jassimp_Jassimp_getErrorString
  * Signature: (Ljava/lang/String;J)Ljassimp/AiScene;
  */
 JNIEXPORT jobject JNICALL Java_jassimp_Jassimp_aiImportFile
-  (JNIEnv *, jclass, jstring, jlong);
+  (JNIEnv *, jclass, jstring, jlong, jobject);
 
 #ifdef __cplusplus
 }

--- a/port/jassimp/jassimp/src/jassimp/AiClassLoaderIOSystem.java
+++ b/port/jassimp/jassimp/src/jassimp/AiClassLoaderIOSystem.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2017 Florida Institute for Human and Machine Cognition (IHMC)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. 
+ */
+package jassimp;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+/**
+ * IOSystem based on the Java classloader.<p>
+ * 
+ * This IOSystem allows loading models directly from the 
+ * classpath. No extraction to the file system is 
+ * necessary.
+ * 
+ * @author Jesper Smith
+ *
+ */
+public class AiClassLoaderIOSystem implements AiIOSystem<AiInputStreamIOStream>
+{
+   private final Class<?> clazz;
+   private final ClassLoader classLoader;
+  
+   /**
+    * Construct a new AiClassLoaderIOSystem.<p>
+    * 
+    * This constructor uses a ClassLoader to resolve
+    * resources.
+    * 
+    * @param classLoader classLoader to resolve resources.
+    */
+   public AiClassLoaderIOSystem(ClassLoader classLoader) {
+      this.clazz = null;
+      this.classLoader = classLoader;
+   }
+
+   /**
+    * Construct a new AiClassLoaderIOSystem.<p>
+    * 
+    * This constructor uses a Class to resolve
+    * resources.
+    * 
+    * @param class<?> class to resolve resources.
+    */
+   public AiClassLoaderIOSystem(Class<?> clazz) {
+      this.clazz = clazz;
+      this.classLoader = null;
+   }
+   
+
+   @Override
+   public AiInputStreamIOStream open(String filename, String ioMode) {
+      try {
+         
+         InputStream is;
+         
+         if(clazz != null) {
+            is = clazz.getResourceAsStream(filename);
+         }
+         else if (classLoader != null) {
+            is = classLoader.getResourceAsStream(filename);
+         }
+         else {
+            System.err.println("[" + getClass().getSimpleName() + 
+                "] No class or classLoader provided to resolve " + filename);
+            return null;
+         }
+         
+         if(is != null) {
+            return new AiInputStreamIOStream(is);
+         }
+         else {
+            System.err.println("[" + getClass().getSimpleName() + 
+                               "] Cannot find " + filename);
+            return null;
+         }
+      }
+      catch (IOException e) {
+         e.printStackTrace();
+         return null;
+      }
+   }
+
+   @Override
+   public void close(AiInputStreamIOStream file) {
+   }
+
+   @Override
+   public boolean exists(String path)
+   {
+      URL url = null;
+      if(clazz != null) {
+         url = clazz.getResource(path);
+      }
+      else if (classLoader != null) {
+         url = classLoader.getResource(path);
+      }
+
+      
+      if(url == null)
+      {
+         return false;
+      }
+      else
+      {
+         return true;
+      }
+      
+   }
+
+   @Override
+   public char getOsSeparator()
+   {
+      return '/';
+   }
+
+}

--- a/port/jassimp/jassimp/src/jassimp/AiIOStream.java
+++ b/port/jassimp/jassimp/src/jassimp/AiIOStream.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 Florida Institute for Human and Machine Cognition (IHMC)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. 
+ */
+package jassimp;
+
+import java.nio.ByteBuffer;
+
+
+/**
+ * Interface to allow custom resource loaders for jassimp.<p>
+ *
+ * The design is based on passing the file wholly in memory, 
+ * because Java inputstreams do not have to support seek. <p>
+ * 
+ * Writing files from Java is unsupported.
+ * 
+ * 
+ * @author Jesper Smith
+ *
+ */
+public interface AiIOStream
+{
+
+   /**
+    * Read all data into buffer. <p>
+    * 
+    * The whole stream should be read into the buffer. 
+    * No support is provided for partial reads. 
+    * 
+    * @param buffer Target buffer for the model data
+    * 
+    * @return true if successful, false if an error occurred.
+    */
+   boolean read(ByteBuffer buffer);
+
+   /**
+    * The total size of this stream. <p>
+    *  
+    * @return total size of this stream
+    */
+   int getFileSize();
+
+}

--- a/port/jassimp/jassimp/src/jassimp/AiIOSystem.java
+++ b/port/jassimp/jassimp/src/jassimp/AiIOSystem.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 Florida Institute for Human and Machine Cognition (IHMC)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. 
+ */
+package jassimp;
+
+public interface AiIOSystem <T extends AiIOStream>
+{
+   /**
+    * 
+    * Open a new file with a given path.
+    * When the access to the file is finished, call close() to release all associated resources
+    * 
+    * @param path Path to the file
+    * @param ioMode file I/O mode. Required are: "wb", "w", "wt", "rb", "r", "rt".
+    * 
+    * @return AiIOStream or null if an error occurred
+    */
+   public T open(String path, String ioMode);
+   
+   
+   /**
+    * Tests for the existence of a file at the given path.
+    *  
+    * @param path path to the file
+    * @return true if there is a file with this path, else false.
+    */
+   public boolean exists(String path);
+
+   /**
+    * Returns the system specific directory separator.<p>
+    * 
+    * @return System specific directory separator
+    */
+   public char getOsSeparator();
+   
+   /**
+    * Closes the given file and releases all resources associated with it.
+    * 
+    * @param file The file instance previously created by Open().
+    */
+   public void close(T file);
+}

--- a/port/jassimp/jassimp/src/jassimp/AiInputStreamIOStream.java
+++ b/port/jassimp/jassimp/src/jassimp/AiInputStreamIOStream.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2017 Florida Institute for Human and Machine Cognition (IHMC)
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *     
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. 
+ */
+package jassimp;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.URL;
+import java.nio.ByteBuffer;
+
+
+/**
+ * Implementation of AiIOStream reading from a InputStream
+ * 
+ * @author Jesper Smith
+ *
+ */
+public class AiInputStreamIOStream implements AiIOStream
+{
+   private final ByteArrayOutputStream os = new ByteArrayOutputStream(); 
+   
+   
+   public AiInputStreamIOStream(URI uri) throws IOException {
+      this(uri.toURL());
+   }
+   
+   public AiInputStreamIOStream(URL url) throws IOException {
+      this(url.openStream());
+   }
+   
+   public AiInputStreamIOStream(InputStream is) throws IOException {
+      int read;
+      byte[] data = new byte[1024];
+      while((read = is.read(data, 0, data.length)) != -1) {
+         os.write(data, 0, read);
+      }
+      os.flush();
+      
+      is.close();
+   }
+   
+   @Override
+   public int getFileSize() {
+      return os.size();
+   }
+   
+   @Override
+   public boolean read(ByteBuffer buffer) {
+     ByteBufferOutputStream bos = new ByteBufferOutputStream(buffer);
+     try
+     {
+        os.writeTo(bos);
+     }
+     catch (IOException e)
+     {
+        e.printStackTrace();
+        return false;
+     }
+     return true;
+   }
+   
+   /**
+    * Internal helper class to copy the contents of an OutputStream
+    * into a ByteBuffer. This avoids a copy.
+    *
+    */
+   private static class ByteBufferOutputStream extends OutputStream {
+
+      private final ByteBuffer buffer;
+      
+      public ByteBufferOutputStream(ByteBuffer buffer) {
+         this.buffer = buffer;
+      }
+      
+      @Override
+      public void write(int b) throws IOException
+      {
+         buffer.put((byte) b);
+      }
+    
+      @Override
+      public void write(byte b[], int off, int len) throws IOException {
+         buffer.put(b, off, len);
+      }
+   }
+}
+

--- a/port/jassimp/jassimp/src/jassimp/Jassimp.java
+++ b/port/jassimp/jassimp/src/jassimp/Jassimp.java
@@ -79,6 +79,20 @@ public final class Jassimp {
         return importFile(filename, EnumSet.noneOf(AiPostProcessSteps.class));
     }
     
+    /**
+     * Imports a file via assimp without post processing.
+     * 
+     * @param filename the file to import
+     * @param ioSystem ioSystem to load files, or null for default
+     * @return the loaded scene
+     * @throws IOException if an error occurs
+     */
+    public static AiScene importFile(String filename, AiIOSystem<?> ioSystem) 
+          throws IOException {
+       
+       return importFile(filename, EnumSet.noneOf(AiPostProcessSteps.class), ioSystem);
+    }
+    
     
     /**
      * Imports a file via assimp.
@@ -89,12 +103,28 @@ public final class Jassimp {
      * @throws IOException if an error occurs
      */
     public static AiScene importFile(String filename, 
-            Set<AiPostProcessSteps> postProcessing) throws IOException {
+                                     Set<AiPostProcessSteps> postProcessing) 
+                                           throws IOException {
+        return importFile(filename, postProcessing, null);
+    }
+    
+    /**
+     * Imports a file via assimp.
+     * 
+     * @param filename the file to import
+     * @param postProcessing post processing flags
+     * @param ioSystem ioSystem to load files, or null for default
+     * @return the loaded scene, or null if an error occurred
+     * @throws IOException if an error occurs
+     */
+    public static AiScene importFile(String filename, 
+            Set<AiPostProcessSteps> postProcessing, AiIOSystem<?> ioSystem) 
+                  throws IOException {
         
        loadLibrary();
        
         return aiImportFile(filename, AiPostProcessSteps.toRawValue(
-                postProcessing));
+                postProcessing), ioSystem);
     }
     
     
@@ -310,7 +340,7 @@ public final class Jassimp {
      * @throws IOException if an error occurs
      */
     private static native AiScene aiImportFile(String filename, 
-            long postProcessing) throws IOException;
+            long postProcessing, AiIOSystem<?> ioSystem) throws IOException;
     
     
     /**


### PR DESCRIPTION
To distribute our software easily, we load Java resources from the class loader. This pull request adds the ability to define a custom IOSystem in jassimp.

When importing a model, the C++ IOSystem.open() function will call to the Java code and return a java native ByteBuffer (a continuous memory block accessible from the C++ code). The IOStream acts directly on this memory block. 

Using a memory buffer instead of calling back to the Java code for seeking in the file seems the most straightforward solution, especially considering that no seeking is supported in resources loaded from the class loader. 

A implementation of the Java IO system for loading files from the class loader (classpath) is provided.(AiClassLoaderIOSystem)

To provide support for getting the system path separator and checking if a file exists without opening the file I've switched the Jassimp code to use the C++ assimp interface.

