### PR TITLE
glTF2 Material Improvements

### DIFF
--- a/code/glTF2Asset.h
+++ b/code/glTF2Asset.h
@@ -172,9 +172,7 @@ namespace glTF2
 	#define AI_MATKEY_GLTF_ALPHAMODE "$mat.gltf.alphaMode", 0, 0
 	#define AI_MATKEY_GLTF_ALPHACUTOFF "$mat.gltf.alphaCutoff", 0, 0
 	#define AI_MATKEY_GLTF_PBRSPECULARGLOSSINESS "$mat.gltf.pbrSpecularGlossiness", 0, 0
-	#define AI_MATKEY_GLTF_PBRSPECULARGLOSSINESS_SPECULAR_FACTOR "$clr.specular", 0, 1
 	#define AI_MATKEY_GLTF_PBRSPECULARGLOSSINESS_GLOSSINESS_FACTOR "$mat.gltf.pbrMetallicRoughness.glossinessFactor", 0, 0
-	#define AI_MATKEY_GLTF_PBRSPECULARGLOSSINESS_SPECULARGLOSSINESS_TEXTURE aiTextureType_UNKNOWN, 1
 
 	#define _AI_MATKEY_GLTF_TEXTURE_TEXCOORD_BASE "$tex.file.texCoord"
 	#define _AI_MATKEY_GLTF_MAPPINGNAME_BASE "$tex.mappingname"

--- a/code/glTF2Asset.h
+++ b/code/glTF2Asset.h
@@ -164,16 +164,16 @@ namespace glTF2
     //! Magic number for GLB files
 	#define AI_GLB_MAGIC_NUMBER "glTF"
 
+    #define AI_MATKEY_GLTF_PBRMETALLICROUGHNESS_BASE_COLOR_FACTOR "$mat.gltf.pbrMetallicRoughness.baseColorFactor", 0, 0
 	#define AI_MATKEY_GLTF_PBRMETALLICROUGHNESS_METALLIC_FACTOR "$mat.gltf.pbrMetallicRoughness.metallicFactor", 0, 0
 	#define AI_MATKEY_GLTF_PBRMETALLICROUGHNESS_ROUGHNESS_FACTOR "$mat.gltf.pbrMetallicRoughness.roughnessFactor", 0, 0
+    #define AI_MATKEY_GLTF_PBRMETALLICROUGHNESS_BASE_COLOR_TEXTURE aiTextureType_DIFFUSE, 1
 	#define AI_MATKEY_GLTF_PBRMETALLICROUGHNESS_METALLICROUGHNESS_TEXTURE aiTextureType_UNKNOWN, 0
 	#define AI_MATKEY_GLTF_ALPHAMODE "$mat.gltf.alphaMode", 0, 0
 	#define AI_MATKEY_GLTF_ALPHACUTOFF "$mat.gltf.alphaCutoff", 0, 0
 	#define AI_MATKEY_GLTF_PBRSPECULARGLOSSINESS "$mat.gltf.pbrSpecularGlossiness", 0, 0
-	#define AI_MATKEY_GLTF_PBRSPECULARGLOSSINESS_DIFFUSE_FACTOR "$clr.diffuse", 0, 1
 	#define AI_MATKEY_GLTF_PBRSPECULARGLOSSINESS_SPECULAR_FACTOR "$clr.specular", 0, 1
 	#define AI_MATKEY_GLTF_PBRSPECULARGLOSSINESS_GLOSSINESS_FACTOR "$mat.gltf.pbrMetallicRoughness.glossinessFactor", 0, 0
-	#define AI_MATKEY_GLTF_PBRSPECULARGLOSSINESS_DIFFUSE_TEXTURE aiTextureType_DIFFUSE, 1
 	#define AI_MATKEY_GLTF_PBRSPECULARGLOSSINESS_SPECULARGLOSSINESS_TEXTURE aiTextureType_UNKNOWN, 1
 
 	#define _AI_MATKEY_GLTF_TEXTURE_TEXCOORD_BASE "$tex.file.texCoord"

--- a/code/glTF2Exporter.cpp
+++ b/code/glTF2Exporter.cpp
@@ -470,11 +470,11 @@ void glTF2Exporter::ExportMaterials()
 
             PbrSpecularGlossiness pbrSG;
 
-            GetMatColor(mat, pbrSG.specularFactor, AI_MATKEY_GLTF_PBRSPECULARGLOSSINESS_SPECULAR_FACTOR);
             mat->Get(AI_MATKEY_GLTF_PBRSPECULARGLOSSINESS_GLOSSINESS_FACTOR, pbrSG.glossinessFactor);
-            GetMatTex(mat, pbrSG.specularGlossinessTexture, AI_MATKEY_GLTF_PBRSPECULARGLOSSINESS_SPECULARGLOSSINESS_TEXTURE);
             GetMatColor(mat, pbrSG.diffuseFactor, AI_MATKEY_COLOR_DIFFUSE);
+            GetMatColor(mat, pbrSG.specularFactor, AI_MATKEY_COLOR_SPECULAR);
             GetMatTex(mat, pbrSG.diffuseTexture, aiTextureType_DIFFUSE);
+            GetMatTex(mat, pbrSG.specularGlossinessTexture, aiTextureType_SPECULAR);
 
             m->pbrSpecularGlossiness = Nullable<PbrSpecularGlossiness>(pbrSG);
         }

--- a/code/glTF2Exporter.cpp
+++ b/code/glTF2Exporter.cpp
@@ -475,7 +475,7 @@ void glTF2Exporter::ExportMaterials()
 
             if (mat->Get(AI_MATKEY_OPACITY, opacity) == AI_SUCCESS) {
                 if (opacity < 1) {
-                    m->alphaMode = "MASK";
+                    m->alphaMode = "BLEND";
                     m->pbrMetallicRoughness.baseColorFactor[3] *= opacity;
                 }
             }

--- a/code/glTF2Exporter.cpp
+++ b/code/glTF2Exporter.cpp
@@ -448,7 +448,7 @@ void glTF2Exporter::ExportMaterials()
                 float specularIntensity = specularColor[0] * 0.2125 + specularColor[1] * 0.7154 + specularColor[2] * 0.0721;
                 float roughnessFactor = 1 - std::sqrt(shininess / 1000);
 
-                roughnessFactor = std::powf(roughnessFactor, 2);
+                roughnessFactor = std::pow(roughnessFactor, 2);
                 roughnessFactor = std::min(std::max(roughnessFactor, 0.0f), 1.0f);
 
                 // low specular intensity values should produce a rough material even if shininess is high.

--- a/code/glTF2Exporter.h
+++ b/code/glTF2Exporter.h
@@ -115,8 +115,8 @@ namespace Assimp
         void GetMatTex(const aiMaterial* mat, glTF2::TextureInfo& prop, aiTextureType tt, unsigned int slot);
         void GetMatTex(const aiMaterial* mat, glTF2::NormalTextureInfo& prop, aiTextureType tt, unsigned int slot);
         void GetMatTex(const aiMaterial* mat, glTF2::OcclusionTextureInfo& prop, aiTextureType tt, unsigned int slot);
-        void GetMatColor(const aiMaterial* mat, glTF2::vec4& prop, const char* propName, int type, int idx);
-        void GetMatColor(const aiMaterial* mat, glTF2::vec3& prop, const char* propName, int type, int idx);
+        aiReturn GetMatColor(const aiMaterial* mat, glTF2::vec4& prop, const char* propName, int type, int idx);
+        aiReturn GetMatColor(const aiMaterial* mat, glTF2::vec3& prop, const char* propName, int type, int idx);
         void ExportMetadata();
         void ExportMaterials();
         void ExportMeshes();

--- a/code/glTF2Importer.cpp
+++ b/code/glTF2Importer.cpp
@@ -228,7 +228,11 @@ void glTF2Importer::ImportMaterials(glTF2::Asset& r)
         }
 
         SetMaterialColorProperty(r, mat.pbrMetallicRoughness.baseColorFactor, aimat, AI_MATKEY_COLOR_DIFFUSE);
+        SetMaterialColorProperty(r, mat.pbrMetallicRoughness.baseColorFactor, aimat, AI_MATKEY_GLTF_PBRMETALLICROUGHNESS_BASE_COLOR_FACTOR);
+
         SetMaterialTextureProperty(embeddedTexIdxs, r, mat.pbrMetallicRoughness.baseColorTexture, aimat, aiTextureType_DIFFUSE);
+        SetMaterialTextureProperty(embeddedTexIdxs, r, mat.pbrMetallicRoughness.baseColorTexture, aimat, AI_MATKEY_GLTF_PBRMETALLICROUGHNESS_BASE_COLOR_TEXTURE);
+
         SetMaterialTextureProperty(embeddedTexIdxs, r, mat.pbrMetallicRoughness.metallicRoughnessTexture, aimat, AI_MATKEY_GLTF_PBRMETALLICROUGHNESS_METALLICROUGHNESS_TEXTURE);
         aimat->AddProperty(&mat.pbrMetallicRoughness.metallicFactor, 1, AI_MATKEY_GLTF_PBRMETALLICROUGHNESS_METALLIC_FACTOR);
         aimat->AddProperty(&mat.pbrMetallicRoughness.roughnessFactor, 1, AI_MATKEY_GLTF_PBRMETALLICROUGHNESS_ROUGHNESS_FACTOR);
@@ -249,11 +253,11 @@ void glTF2Importer::ImportMaterials(glTF2::Asset& r)
             PbrSpecularGlossiness &pbrSG = mat.pbrSpecularGlossiness.value;
 
             aimat->AddProperty(&mat.pbrSpecularGlossiness.isPresent, 1, AI_MATKEY_GLTF_PBRSPECULARGLOSSINESS);
-            SetMaterialColorProperty(r, pbrSG.diffuseFactor, aimat, AI_MATKEY_GLTF_PBRSPECULARGLOSSINESS_DIFFUSE_FACTOR);
             SetMaterialColorProperty(r, pbrSG.specularFactor, aimat, AI_MATKEY_GLTF_PBRSPECULARGLOSSINESS_SPECULAR_FACTOR);
+            SetMaterialColorProperty(r, pbrSG.diffuseFactor, aimat, AI_MATKEY_COLOR_DIFFUSE);
             aimat->AddProperty(&pbrSG.glossinessFactor, 1, AI_MATKEY_GLTF_PBRSPECULARGLOSSINESS_GLOSSINESS_FACTOR);
-            SetMaterialTextureProperty(embeddedTexIdxs, r, pbrSG.diffuseTexture, aimat, AI_MATKEY_GLTF_PBRSPECULARGLOSSINESS_DIFFUSE_TEXTURE);
             SetMaterialTextureProperty(embeddedTexIdxs, r, pbrSG.specularGlossinessTexture, aimat, AI_MATKEY_GLTF_PBRSPECULARGLOSSINESS_SPECULARGLOSSINESS_TEXTURE);
+            SetMaterialTextureProperty(embeddedTexIdxs, r, pbrSG.diffuseTexture, aimat, aiTextureType_DIFFUSE);
         }
     }
 }

--- a/code/glTF2Importer.cpp
+++ b/code/glTF2Importer.cpp
@@ -234,8 +234,12 @@ void glTF2Importer::ImportMaterials(glTF2::Asset& r)
         SetMaterialTextureProperty(embeddedTexIdxs, r, mat.pbrMetallicRoughness.baseColorTexture, aimat, AI_MATKEY_GLTF_PBRMETALLICROUGHNESS_BASE_COLOR_TEXTURE);
 
         SetMaterialTextureProperty(embeddedTexIdxs, r, mat.pbrMetallicRoughness.metallicRoughnessTexture, aimat, AI_MATKEY_GLTF_PBRMETALLICROUGHNESS_METALLICROUGHNESS_TEXTURE);
+
         aimat->AddProperty(&mat.pbrMetallicRoughness.metallicFactor, 1, AI_MATKEY_GLTF_PBRMETALLICROUGHNESS_METALLIC_FACTOR);
         aimat->AddProperty(&mat.pbrMetallicRoughness.roughnessFactor, 1, AI_MATKEY_GLTF_PBRMETALLICROUGHNESS_ROUGHNESS_FACTOR);
+
+        float roughnessAsShininess = (1 - mat.pbrMetallicRoughness.roughnessFactor) * 1000;
+        aimat->AddProperty(&roughnessAsShininess, 1, AI_MATKEY_SHININESS);
 
         SetMaterialTextureProperty(embeddedTexIdxs, r, mat.normalTexture, aimat, aiTextureType_NORMALS);
         SetMaterialTextureProperty(embeddedTexIdxs, r, mat.occlusionTexture, aimat, aiTextureType_LIGHTMAP);
@@ -255,6 +259,9 @@ void glTF2Importer::ImportMaterials(glTF2::Asset& r)
             aimat->AddProperty(&mat.pbrSpecularGlossiness.isPresent, 1, AI_MATKEY_GLTF_PBRSPECULARGLOSSINESS);
             SetMaterialColorProperty(r, pbrSG.diffuseFactor, aimat, AI_MATKEY_COLOR_DIFFUSE);
             SetMaterialColorProperty(r, pbrSG.specularFactor, aimat, AI_MATKEY_COLOR_SPECULAR);
+
+            float glossinessAsShininess = pbrSG.glossinessFactor * 1000.0f;
+            aimat->AddProperty(&glossinessAsShininess, 1, AI_MATKEY_SHININESS);
             aimat->AddProperty(&pbrSG.glossinessFactor, 1, AI_MATKEY_GLTF_PBRSPECULARGLOSSINESS_GLOSSINESS_FACTOR);
 
             SetMaterialTextureProperty(embeddedTexIdxs, r, pbrSG.diffuseTexture, aimat, aiTextureType_DIFFUSE);

--- a/code/glTF2Importer.cpp
+++ b/code/glTF2Importer.cpp
@@ -253,11 +253,13 @@ void glTF2Importer::ImportMaterials(glTF2::Asset& r)
             PbrSpecularGlossiness &pbrSG = mat.pbrSpecularGlossiness.value;
 
             aimat->AddProperty(&mat.pbrSpecularGlossiness.isPresent, 1, AI_MATKEY_GLTF_PBRSPECULARGLOSSINESS);
-            SetMaterialColorProperty(r, pbrSG.specularFactor, aimat, AI_MATKEY_GLTF_PBRSPECULARGLOSSINESS_SPECULAR_FACTOR);
             SetMaterialColorProperty(r, pbrSG.diffuseFactor, aimat, AI_MATKEY_COLOR_DIFFUSE);
+            SetMaterialColorProperty(r, pbrSG.specularFactor, aimat, AI_MATKEY_COLOR_SPECULAR);
             aimat->AddProperty(&pbrSG.glossinessFactor, 1, AI_MATKEY_GLTF_PBRSPECULARGLOSSINESS_GLOSSINESS_FACTOR);
-            SetMaterialTextureProperty(embeddedTexIdxs, r, pbrSG.specularGlossinessTexture, aimat, AI_MATKEY_GLTF_PBRSPECULARGLOSSINESS_SPECULARGLOSSINESS_TEXTURE);
+
             SetMaterialTextureProperty(embeddedTexIdxs, r, pbrSG.diffuseTexture, aimat, aiTextureType_DIFFUSE);
+
+            SetMaterialTextureProperty(embeddedTexIdxs, r, pbrSG.specularGlossinessTexture, aimat, aiTextureType_SPECULAR);
         }
     }
 }


### PR DESCRIPTION
TL;DR:
- Diffuse and specular colours and textures are persisted better; and
- glossiness/roughness can be derived from shininess and specularity and vice-versa. 

All of this allows better interoperability between traditional lighting material models and PBR material models.

---

This PR improves importing and exporting some material properties in glTF2. Changes:

- Diffuse Color:
    - Importing:
        - pbrMetallicRoughness' (pbrMR) baseColorFactor is stored as `$clr.diffuse`, as well as a `$mat.gltf.pbrMetallicRoughness.baseColorFactor`.
        - If pbrSpecularGlossiness (pbrSG) is present with a diffuseFactor, it will store and overwrite `$clr.diffuse`
    - Exporting:
        - pbrMR will read from `$mat.gltf.pbrMetallicRoughness.baseColorFactor` first, then fallback to `$clr.diffuse`
        - pbrSG (if present) will read from `$clr.diffuse`
- Diffuse Texture:
   - same behaviour as diffuse colour, but with diffuse textures
- Specular Color:
    - Importing:
        - If pbrSG is present with a specularFactor, it will store `$clr.specular`
    - Exporting:
        - If pbrSG is present, any `$clr.specular` value will be exported to specularFactor
- SpecularGlossiness Texture:
   - similar behaviour as with specular colour
   - Slight issue is that the texture used for specularGlossiness stores specular values in RGB, and glossiness in A channel. This means glossiness in the texture is not accounted for (when not going from pbrSG to pbrSG). One solution would be to store extract the channel groups into two separate texture files, but that seems to be out-of-scope of assimp's responsibilities (maybe).
- Roughness/Glossiness:
    - Importing:
        - the inverse of pbrMR's roughness value (and after being multiplied by 1000†) will be stored in the aiMaterial's shininess slot.
            - This is only a rough approximation of shininess-specularity. But it means that shiny models won't export as flat anymore.
        - pbrSG's glossiness value, times 1000, is stored in the aiMaterial's shininess slot.
    - Exporting:
        - When exporting pbrMR, the roughness value is first retrieved from `AI_MATKEY_GLTF_PBRMETALLICROUGHNESS_ROUGHNESS_FACTOR`, and if that isn't present, the value is derived from the `AI_MATKEY_SHININESS` by dividing it by 1000, square-root-ing, and multiplying by any specular colour's luminance.
        - When exporting pbrSG, the glossiness value is first retrieved from `AI_MATKEY_GLTF_PBRSPECULARGLOSSINESS_GLOSSINESS_FACTOR`, and if that isn't present, the aiMaterial's shininess value (if any) is converted to glossiness by dividing it by 1000.
- alphaMode
    - Use `"BLEND"` over `"MASK"` as the value, for nicer looking results.

†1000 because most shininess exponential values seem to range from 0-1000 (OBJ/MTL spec, and three.js docs). There are other ranges: 0-128, 0-200, 0-500, 0-infinity. But 1000 seems to be most common. The code in this PR also takes the square root of the shininess value, so the difference between larger values (250-1000) aren't so extreme. The code also takes care to clamp the values to [0,1] when exporting to glTF. 