### PR TITLE
Raise exception when obj file contains invalid face indice

### DIFF
--- a/code/ObjFileParser.cpp
+++ b/code/ObjFileParser.cpp
@@ -475,7 +475,11 @@ void ObjFileParser::getFace( aiPrimitiveType type ) {
                 } else {
                     reportErrorTokenInFace();
                 }
+            } else {
+                //On error, std::atoi will return 0 which is not a valid value
+                throw DeadlyImportError("OBJ: Invalid face indice");
             }
+
         }
         m_DataIt += iStep;
     }


### PR DESCRIPTION
On OBJ importer, face indices are parsed with std::atoi function.
This function could return 0 on ill-formed input. Since 0 is not a valid value, I think we should raise an exception if this happen.

This should prevent some crashes happening when fuzzing OBJ importer.