### PR TITLE
Invalid texture coordinates cleaning fix

### DIFF
--- a/code/FindInvalidDataProcess.cpp
+++ b/code/FindInvalidDataProcess.cpp
@@ -360,10 +360,13 @@ int FindInvalidDataProcess::ProcessMesh (aiMesh* pMesh)
     // process texture coordinates
     for (unsigned int i = 0; i < AI_MAX_NUMBER_OF_TEXTURECOORDS && pMesh->mTextureCoords[i];++i)    {
         if (ProcessArray(pMesh->mTextureCoords[i],pMesh->mNumVertices,"uvcoords",dirtyMask))    {
+            pMesh->mNumUVComponents[i] = 0;
 
             // delete all subsequent texture coordinate sets.
-            for (unsigned int a = i+1; a < AI_MAX_NUMBER_OF_TEXTURECOORDS;++a)  {
-                delete[] pMesh->mTextureCoords[a]; pMesh->mTextureCoords[a] = NULL;
+            for (unsigned int a = i + 1; a < AI_MAX_NUMBER_OF_TEXTURECOORDS; ++a) {
+                delete[] pMesh->mTextureCoords[a];
+                pMesh->mTextureCoords[a] = NULL;
+                pMesh->mNumUVComponents[a] = 0;
             }
             ret = true;
         }

--- a/code/FindInvalidDataProcess.cpp
+++ b/code/FindInvalidDataProcess.cpp
@@ -339,27 +339,28 @@ void FindInvalidDataProcess::ProcessAnimationChannel (aiNodeAnim* anim)
 int FindInvalidDataProcess::ProcessMesh (aiMesh* pMesh)
 {
     bool ret = false;
-    std::vector<bool> dirtyMask(pMesh->mNumVertices,(pMesh->mNumFaces ? true : false));
+    std::vector<bool> dirtyMask(pMesh->mNumVertices, pMesh->mNumFaces);
 
     // Ignore elements that are not referenced by vertices.
     // (they are, for example, caused by the FindDegenerates step)
-    for (unsigned int m = 0; m < pMesh->mNumFaces;++m)  {
+    for (unsigned int m = 0; m < pMesh->mNumFaces; ++m) {
         const aiFace& f = pMesh->mFaces[m];
 
-        for (unsigned int i = 0; i < f.mNumIndices;++i) {
+        for (unsigned int i = 0; i < f.mNumIndices; ++i) {
             dirtyMask[f.mIndices[i]] = false;
         }
     }
 
     // Process vertex positions
-    if(pMesh->mVertices && ProcessArray(pMesh->mVertices,pMesh->mNumVertices,"positions",dirtyMask))    {
+    if (pMesh->mVertices && ProcessArray(pMesh->mVertices, pMesh->mNumVertices, "positions", dirtyMask)) {
         DefaultLogger::get()->error("Deleting mesh: Unable to continue without vertex positions");
+
         return 2;
     }
 
     // process texture coordinates
-    for (unsigned int i = 0; i < AI_MAX_NUMBER_OF_TEXTURECOORDS && pMesh->mTextureCoords[i];++i)    {
-        if (ProcessArray(pMesh->mTextureCoords[i],pMesh->mNumVertices,"uvcoords",dirtyMask))    {
+    for (unsigned int i = 0; i < AI_MAX_NUMBER_OF_TEXTURECOORDS && pMesh->mTextureCoords[i]; ++i) {
+        if (ProcessArray(pMesh->mTextureCoords[i], pMesh->mNumVertices, "uvcoords", dirtyMask)) {
             pMesh->mNumUVComponents[i] = 0;
 
             // delete all subsequent texture coordinate sets.
@@ -368,6 +369,7 @@ int FindInvalidDataProcess::ProcessMesh (aiMesh* pMesh)
                 pMesh->mTextureCoords[a] = NULL;
                 pMesh->mNumUVComponents[a] = 0;
             }
+
             ret = true;
         }
     }


### PR DESCRIPTION
When the `aiProcess_FindInvalidData` post processing step is enabled, line 703 in glTF2 exporter crashes:

https://github.com/assimp/assimp/blob/938c02a3587766d0ebbedebba4cb162445cb397c/code/glTF2Exporter.cpp#L701-L705

I tracked it down to texture coordinates being removed in post processing, but `mNumUVComponents` for the corresponding sets not being set to `0`, causing an access error when flipping texture coordinates.

Is this fix correct?