### PR TITLE
[PLY] fix for TextureFile with number in file name

### DIFF
--- a/code/PlyParser.cpp
+++ b/code/PlyParser.cpp
@@ -381,6 +381,11 @@ bool PLY::Element::ParseElement(IOStreamBuffer<char> &streamBuffer, std::vector<
   {
     char* endPos = &buffer[0] + (strlen(&buffer[0]) - 1);
     pOut->szName = std::string(&buffer[0], endPos);
+
+    // go to the next line
+    PLY::DOM::SkipSpacesAndLineEnd(buffer);
+
+    return true;
   }
 
   //parse the number of occurrences of this element
@@ -933,7 +938,7 @@ bool PLY::PropertyInstance::ParseValue(const char* &pCur,
 {
   ai_assert(NULL != pCur);
   ai_assert(NULL != out);
-  
+
   //calc element size
   bool ret = true;
   switch (eType)


### PR DESCRIPTION
In cases where the TextureFile name would start with an integer, `strtoul10` would parse that number and incorrectly set `numOccur` to that number. This caused PLY parsing to fail for vertex positions.

For example, a file name like `512.png` would set `numOccur` to `512`, causing issues when continuing to parse. `foo.png` would  keep `numOccur` at `0`. This PR fixes the issues by always keeping `numOccur` at `0` for TextureFile, by returning early.

Since TextureFile is a single line, and does not have any follow-up lines, it’s okay to return early.

Fixes #1324