### PR TITLE
closes https://github.com/assimp/assimp/issues/1533:

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -725,7 +725,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is 
 # run.
 
-EXCLUDE                = 
+EXCLUDE                = irrXML.h
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or 
 # directories that are symbolic links (a Unix file system feature) are excluded 


### PR DESCRIPTION
Put irrXML onto exclucde list for doxygen run.  The second image. will is referenced by the docu generated by doxygen comes from irrXML and we don't want to include this into our own doc.