### PR TITLE
[glTF2] Implemented reading binary glTF2 (glb) files

### DIFF
--- a/code/glTF2Asset.h
+++ b/code/glTF2Asset.h
@@ -192,15 +192,31 @@ namespace glTF2
         #include "./../include/assimp/Compiler/pushpack1.h"
     #endif
 
+    //! For binary .glb files
+    //! 12-byte header (+ the JSON + a "body" data section)
+    struct GLB_Header
+    {
+        uint8_t magic[4];     //!< Magic number: "glTF"
+        uint32_t version;     //!< Version number (always 2 as of the last update)
+        uint32_t length;      //!< Total length of the Binary glTF, including header, scene, and body, in bytes
+    } PACK_STRUCT;
+
+    struct GLB_Chunk
+    {
+        uint32_t chunkLength;
+        uint32_t chunkType;
+    } PACK_STRUCT;
+
     #ifdef ASSIMP_API
         #include "./../include/assimp/Compiler/poppack1.h"
     #endif
 
 
-    //! Values for the GLB_Header::sceneFormat field
-    enum SceneFormat
+    //! Values for the GLB_Chunk::chunkType field
+    enum ChunkType
     {
-        SceneFormat_JSON = 0
+        ChunkType_JSON = 0x4E4F534A,
+        ChunkType_BIN  = 0x004E4942
     };
 
     //! Values for the mesh primitive modes
@@ -1086,7 +1102,10 @@ namespace glTF2
         }
 
         //! Main function
-        void Load(const std::string& file);
+        void Load(const std::string& file, bool isBinary = false);
+
+        //! Enables binary encoding on the asset
+        void SetAsBinary();
 
         //! Search for an available name, starting from the given strings
         std::string FindUniqueID(const std::string& str, const char* suffix);
@@ -1095,6 +1114,8 @@ namespace glTF2
             { return mBodyBuffer; }
 
     private:
+        void ReadBinaryHeader(IOStream& stream, std::vector<char>& sceneData);
+
         void ReadExtensionsUsed(Document& doc);
 
         IOStream* OpenFile(std::string path, const char* mode, bool absolute = false);

--- a/code/glTF2Importer.cpp
+++ b/code/glTF2Importer.cpp
@@ -74,7 +74,7 @@ static const aiImporterDesc desc = {
     "",
     "",
     "",
-    aiImporterFlags_SupportTextFlavour | aiImporterFlags_LimitedSupport | aiImporterFlags_Experimental,
+    aiImporterFlags_SupportTextFlavour | aiImporterFlags_SupportBinaryFlavour | aiImporterFlags_LimitedSupport | aiImporterFlags_Experimental,
     0,
     0,
     0,
@@ -103,13 +103,13 @@ bool glTF2Importer::CanRead(const std::string& pFile, IOSystem* pIOHandler, bool
 {
     const std::string &extension = GetExtension(pFile);
 
-    if (extension != "gltf") // We currently can't read glTF2 binary files (.glb), yet
+    if (extension != "gltf" && extension != "glb")
         return false;
 
     if (checkSig && pIOHandler) {
         glTF2::Asset asset(pIOHandler);
         try {
-            asset.Load(pFile);
+            asset.Load(pFile, extension == "glb");
             std::string version = asset.asset.version;
             return !version.empty() && version[0] == '2';
         } catch (...) {
@@ -639,7 +639,7 @@ void glTF2Importer::InternReadFile(const std::string& pFile, aiScene* pScene, IO
 
     // read the asset file
     glTF2::Asset asset(pIOHandler);
-    asset.Load(pFile);
+    asset.Load(pFile, GetExtension(pFile) == "glb");
 
     //
     // Copy the data out


### PR DESCRIPTION
This is more or less a copy of the glb code in the glTF1 reader adjusted to the new glTF2 binary format.
