### PR TITLE
[glTF2] Moved byteStride from accessor to bufferView

### DIFF
--- a/code/glTF2Asset.h
+++ b/code/glTF2Asset.h
@@ -436,7 +436,6 @@ namespace glTF2
     {
         Ref<BufferView> bufferView;  //!< The ID of the bufferView. (required)
         unsigned int byteOffset;     //!< The offset relative to the start of the bufferView in bytes. (required)
-        unsigned int byteStride;     //!< The stride, in bytes, between attributes referenced by this accessor. (default: 0)
         ComponentType componentType; //!< The datatype of components in the attribute. (required)
         unsigned int count;          //!< The number of attributes referenced by this accessor. (required)
         AttribType::Value type;      //!< Specifies if the attribute is a scalar, vector, or matrix. (required)
@@ -627,6 +626,7 @@ namespace glTF2
         Ref<Buffer> buffer; //! The ID of the buffer. (required)
         size_t byteOffset; //! The offset into the buffer in bytes. (required)
         size_t byteLength; //! The length of the bufferView in bytes. (default: 0)
+        unsigned int byteStride; //!< The stride, in bytes, between attributes referenced by this accessor. (default: 0)
 
         BufferViewTarget target; //! The target that the WebGL buffer should be bound to.
 

--- a/code/glTF2Asset.inl
+++ b/code/glTF2Asset.inl
@@ -512,6 +512,7 @@ inline void BufferView::Read(Value& obj, Asset& r)
 
     byteOffset = MemberOrDefault(obj, "byteOffset", 0u);
     byteLength = MemberOrDefault(obj, "byteLength", 0u);
+    byteStride = MemberOrDefault(obj, "byteStride", 0u);
 }
 
 //
@@ -526,7 +527,6 @@ inline void Accessor::Read(Value& obj, Asset& r)
     }
 
     byteOffset = MemberOrDefault(obj, "byteOffset", 0u);
-    byteStride = MemberOrDefault(obj, "byteStride", 0u);
     componentType = MemberOrDefault(obj, "componentType", ComponentType_BYTE);
     count = MemberOrDefault(obj, "count", 0u);
 
@@ -601,7 +601,7 @@ bool Accessor::ExtractData(T*& outData)
     const size_t elemSize = GetElementSize();
     const size_t totalSize = elemSize * count;
 
-    const size_t stride = byteStride ? byteStride : elemSize;
+    const size_t stride = bufferView && bufferView->byteStride ? bufferView->byteStride : elemSize;
 
     const size_t targetElemSize = sizeof(T);
     ai_assert(elemSize <= targetElemSize);
@@ -641,7 +641,7 @@ inline Accessor::Indexer::Indexer(Accessor& acc)
     : accessor(acc)
     , data(acc.GetPointer())
     , elemSize(acc.GetElementSize())
-    , stride(acc.byteStride ? acc.byteStride : elemSize)
+    , stride(acc.bufferView && acc.bufferView->byteStride ? acc.bufferView->byteStride : elemSize)
 {
 
 }

--- a/code/glTF2AssetWriter.inl
+++ b/code/glTF2AssetWriter.inl
@@ -98,10 +98,6 @@ namespace glTF2 {
         obj.AddMember("bufferView", a.bufferView->index, w.mAl);
         obj.AddMember("byteOffset", a.byteOffset, w.mAl);
 
-        if (a.byteStride != 0) {
-            obj.AddMember("byteStride", a.byteStride, w.mAl);
-        }
-
         obj.AddMember("componentType", int(a.componentType), w.mAl);
         obj.AddMember("count", a.count, w.mAl);
         obj.AddMember("type", StringRef(AttribType::ToString(a.type)), w.mAl);
@@ -168,6 +164,9 @@ namespace glTF2 {
         obj.AddMember("buffer", bv.buffer->index, w.mAl);
         obj.AddMember("byteOffset", static_cast<uint64_t>(bv.byteOffset), w.mAl);
         obj.AddMember("byteLength", static_cast<uint64_t>(bv.byteLength), w.mAl);
+        if (bv.byteStride != 0) {
+            obj.AddMember("byteStride", bv.byteStride, w.mAl);
+        }
         obj.AddMember("target", int(bv.target), w.mAl);
     }
 

--- a/code/glTF2Exporter.cpp
+++ b/code/glTF2Exporter.cpp
@@ -170,13 +170,13 @@ inline Ref<Accessor> ExportData(Asset& a, std::string& meshName, Ref<Buffer>& bu
     bv->buffer = buffer;
     bv->byteOffset = unsigned(offset);
     bv->byteLength = length; //! The target that the WebGL buffer should be bound to.
+    bv->byteStride = 0;
     bv->target = isIndices ? BufferViewTarget_ELEMENT_ARRAY_BUFFER : BufferViewTarget_ARRAY_BUFFER;
 
     // accessor
     Ref<Accessor> acc = a.accessors.Create(a.FindUniqueID(meshName, "accessor"));
     acc->bufferView = bv;
     acc->byteOffset = 0;
-    acc->byteStride = 0;
     acc->componentType = compType;
     acc->count = count;
     acc->type = typeOut;


### PR DESCRIPTION
Bugfix: Moved byteStride member from accessor object to bufferView object. In glTF1, byteStride was part of accessor, but in glTF2, it is part of bufferView. When creating the glTF2 loader/writer by copying the glTF1 loader/writer, someone forgot to move byteStride to the right place.
