### PR TITLE
Fix typo on gltf2 camera parameters

### DIFF
--- a/code/glTF2Asset.inl
+++ b/code/glTF2Asset.inl
@@ -934,7 +934,7 @@ inline void Camera::Read(Value& obj, Asset& /*r*/)
 {
     type = MemberOrDefault(obj, "type", Camera::Perspective);
 
-    const char* subobjId = (type == Camera::Orthographic) ? "ortographic" : "perspective";
+    const char* subobjId = (type == Camera::Orthographic) ? "orthographic" : "perspective";
 
     Value* it = FindObject(obj, subobjId);
     if (!it) throw DeadlyImportError("GLTF: Camera missing its parameters");


### PR DESCRIPTION
Orthographic cameras are not yet supported by assimp, but this fixes the parsing in case we support them in the future. 