### PR TITLE
[glTF2] Fix transform matrices multiplication order

### DIFF
--- a/code/glTF2Importer.cpp
+++ b/code/glTF2Importer.cpp
@@ -515,7 +515,13 @@ aiNode* ImportNode(aiScene* pScene, glTF2::Asset& r, std::vector<unsigned int>& 
             CopyValue(node.translation.value, trans);
             aiMatrix4x4 t;
             aiMatrix4x4::Translation(trans, t);
-            matrix = t * matrix;
+            matrix = matrix * t;
+        }
+
+        if (node.rotation.isPresent) {
+            aiQuaternion rot;
+            CopyValue(node.rotation.value, rot);
+            matrix = matrix * aiMatrix4x4(rot.GetMatrix());
         }
 
         if (node.scale.isPresent) {
@@ -523,14 +529,7 @@ aiNode* ImportNode(aiScene* pScene, glTF2::Asset& r, std::vector<unsigned int>& 
             CopyValue(node.scale.value, scal);
             aiMatrix4x4 s;
             aiMatrix4x4::Scaling(scal, s);
-            matrix = s * matrix;
-        }
-
-
-        if (node.rotation.isPresent) {
-            aiQuaternion rot;
-            CopyValue(node.rotation.value, rot);
-            matrix = aiMatrix4x4(rot.GetMatrix()) * matrix;
+            matrix = matrix * s;
         }
     }
 


### PR DESCRIPTION
Per spec. This fixes the output of the [Polly model](https://github.com/KhronosGroup/glTF-Blender-Exporter/tree/master/polly)

Closes #1568

This work is @awefers' (via a .patch) and I have attributed it to them as such.