### PR TITLE
Use unique_ptr in B3DImporter

### DIFF
--- a/code/B3DImporter.cpp
+++ b/code/B3DImporter.cpp
@@ -267,6 +267,21 @@ T *B3DImporter::to_array( const vector<T> &v ){
     return p;
 }
 
+
+// ------------------------------------------------------------------------------------------------
+template<class T>
+T **unique_to_array( vector<std::unique_ptr<T> > &v ){
+    if( v.empty() ) {
+        return 0;
+    }
+    T **p = new T*[ v.size() ];
+    for( size_t i = 0; i < v.size(); ++i ){
+        p[i] = v[i].release();
+    }
+    return p;
+}
+
+
 // ------------------------------------------------------------------------------------------------
 void B3DImporter::ReadTEXS(){
     while( ChunkSize() ){

--- a/code/B3DImporter.cpp
+++ b/code/B3DImporter.cpp
@@ -400,8 +400,7 @@ void B3DImporter::ReadTRIS( int v0 ){
         Fail( "Bad material id" );
     }
 
-    aiMesh *mesh=new aiMesh;
-    _meshes.push_back( mesh );
+    std::unique_ptr<aiMesh> mesh(new aiMesh);
 
     mesh->mMaterialIndex=matid;
     mesh->mNumFaces=0;
@@ -429,6 +428,8 @@ void B3DImporter::ReadTRIS( int v0 ){
         ++mesh->mNumFaces;
         ++face;
     }
+
+    _meshes.emplace_back( std::move(mesh) );
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -635,7 +636,7 @@ void B3DImporter::ReadBB3D( aiScene *scene ){
         aiNode *node=_nodes[i];
 
         for( size_t j=0;j<node->mNumMeshes;++j ){
-            aiMesh *mesh=_meshes[node->mMeshes[j]];
+            aiMesh *mesh = _meshes[node->mMeshes[j]].get();
 
             int n_tris=mesh->mNumFaces;
             int n_verts=mesh->mNumVertices=n_tris * 3;
@@ -708,7 +709,7 @@ void B3DImporter::ReadBB3D( aiScene *scene ){
 
     //meshes
     scene->mNumMeshes= static_cast<unsigned int>(_meshes.size());
-    scene->mMeshes=to_array( _meshes );
+    scene->mMeshes = unique_to_array( _meshes );
 
     //animations
     if( _animations.size()==1 && _nodeAnims.size() ){

--- a/code/B3DImporter.cpp
+++ b/code/B3DImporter.cpp
@@ -702,6 +702,7 @@ void B3DImporter::ReadBB3D( aiScene *scene ){
 
     //nodes
     scene->mRootNode=_nodes[0];
+    _nodes.clear();  // node ownership now belongs to scene
 
     //material
     if( !_materials.size() ){

--- a/code/B3DImporter.cpp
+++ b/code/B3DImporter.cpp
@@ -309,8 +309,7 @@ void B3DImporter::ReadBRUS(){
         /*int blend=**/ReadInt();
         int fx=ReadInt();
 
-        aiMaterial *mat=new aiMaterial;
-        _materials.push_back( mat );
+        std::unique_ptr<aiMaterial> mat(new aiMaterial);
 
         // Name
         aiString ainame( name );
@@ -347,6 +346,7 @@ void B3DImporter::ReadBRUS(){
                 mat->AddProperty( &texname,AI_MATKEY_TEXTURE_DIFFUSE(0) );
             }
         }
+        _materials.emplace_back( std::move(mat) );
     }
 }
 
@@ -702,10 +702,10 @@ void B3DImporter::ReadBB3D( aiScene *scene ){
 
     //material
     if( !_materials.size() ){
-        _materials.push_back( new aiMaterial );
+        _materials.emplace_back( std::unique_ptr<aiMaterial>(new aiMaterial) );
     }
     scene->mNumMaterials= static_cast<unsigned int>(_materials.size());
-    scene->mMaterials=to_array( _materials );
+    scene->mMaterials = unique_to_array( _materials );
 
     //meshes
     scene->mNumMeshes= static_cast<unsigned int>(_meshes.size());

--- a/code/B3DImporter.h
+++ b/code/B3DImporter.h
@@ -117,7 +117,7 @@ private:
     std::vector<unsigned> _stack;
 
     std::vector<std::string> _textures;
-    std::vector<aiMaterial*> _materials;
+    std::vector<std::unique_ptr<aiMaterial> > _materials;
 
     int _vflags,_tcsets,_tcsize;
     std::vector<Vertex> _vertices;

--- a/code/B3DImporter.h
+++ b/code/B3DImporter.h
@@ -124,7 +124,7 @@ private:
 
     std::vector<aiNode*> _nodes;
     std::vector<std::unique_ptr<aiMesh> > _meshes;
-    std::vector<aiNodeAnim*> _nodeAnims;
+    std::vector<std::unique_ptr<aiNodeAnim> > _nodeAnims;
     std::vector<std::unique_ptr<aiAnimation> > _animations;
 };
 

--- a/code/B3DImporter.h
+++ b/code/B3DImporter.h
@@ -123,7 +123,7 @@ private:
     std::vector<Vertex> _vertices;
 
     std::vector<aiNode*> _nodes;
-    std::vector<aiMesh*> _meshes;
+    std::vector<std::unique_ptr<aiMesh> > _meshes;
     std::vector<aiNodeAnim*> _nodeAnims;
     std::vector<std::unique_ptr<aiAnimation> > _animations;
 };

--- a/code/B3DImporter.h
+++ b/code/B3DImporter.h
@@ -49,6 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/material.h>
 #include "BaseImporter.h"
 
+#include <memory>
 #include <vector>
 
 struct aiNodeAnim;
@@ -124,7 +125,7 @@ private:
     std::vector<aiNode*> _nodes;
     std::vector<aiMesh*> _meshes;
     std::vector<aiNodeAnim*> _nodeAnims;
-    std::vector<aiAnimation*> _animations;
+    std::vector<std::unique_ptr<aiAnimation> > _animations;
 };
 
 }


### PR DESCRIPTION
Before it crashed if reusing one instance of Importer.

aiNodes should also be stored with unique_ptr but their ownership is complicated. It probably needs a more significant refactor.