### PR TITLE
Fix #1623 : crash when loading multiple PLY files

### DIFF
--- a/code/PlyLoader.cpp
+++ b/code/PlyLoader.cpp
@@ -91,9 +91,9 @@ namespace
 // ------------------------------------------------------------------------------------------------
 // Constructor to be privately used by Importer
 PLYImporter::PLYImporter()
-  : mBuffer()
-  , pcDOM()
-  , mGeneratedMesh(NULL){
+  : mBuffer(nullptr)
+  , pcDOM(nullptr)
+  , mGeneratedMesh(nullptr){
   // empty
 }
 
@@ -196,7 +196,10 @@ void PLYImporter::InternReadFile(const std::string& pFile,
       if (!PLY::DOM::ParseInstance(streamedBuffer, &sPlyDom, this))
       {
         if (mGeneratedMesh != NULL)
+        {
           delete(mGeneratedMesh);
+          mGeneratedMesh = nullptr;
+        }
 
         streamedBuffer.close();
         throw DeadlyImportError("Invalid .ply file: Unable to build DOM (#1)");
@@ -211,7 +214,10 @@ void PLYImporter::InternReadFile(const std::string& pFile,
       if (!PLY::DOM::ParseInstanceBinary(streamedBuffer, &sPlyDom, this, bIsBE))
       {
         if (mGeneratedMesh != NULL)
+        {
           delete(mGeneratedMesh);
+          mGeneratedMesh = nullptr;
+        }
 
         streamedBuffer.close();
         throw DeadlyImportError("Invalid .ply file: Unable to build DOM (#2)");
@@ -220,7 +226,10 @@ void PLYImporter::InternReadFile(const std::string& pFile,
     else
     {
       if (mGeneratedMesh != NULL)
+      {
         delete(mGeneratedMesh);
+        mGeneratedMesh = nullptr;
+      }
 
       streamedBuffer.close();
       throw DeadlyImportError("Invalid .ply file: Unknown file format");
@@ -230,7 +239,10 @@ void PLYImporter::InternReadFile(const std::string& pFile,
   {
     AI_DEBUG_INVALIDATE_PTR(this->mBuffer);
     if (mGeneratedMesh != NULL)
+    {
       delete(mGeneratedMesh);
+      mGeneratedMesh = nullptr;
+    }
 
     streamedBuffer.close();
     throw DeadlyImportError("Invalid .ply file: Missing format specification");
@@ -252,7 +264,10 @@ void PLYImporter::InternReadFile(const std::string& pFile,
     if (mGeneratedMesh->mNumVertices < 3)
     {
       if (mGeneratedMesh != NULL)
+      {
         delete(mGeneratedMesh);
+        mGeneratedMesh = nullptr;
+      }
 
       streamedBuffer.close();
       throw DeadlyImportError("Invalid .ply file: Not enough "
@@ -289,6 +304,7 @@ void PLYImporter::InternReadFile(const std::string& pFile,
   pScene->mNumMeshes = 1;
   pScene->mMeshes = new aiMesh*[pScene->mNumMeshes];
   pScene->mMeshes[0] = mGeneratedMesh;
+  mGeneratedMesh = nullptr;
 
   // generate a simple node structure
   pScene->mRootNode = new aiNode();

--- a/test/unit/utPLYImportExport.cpp
+++ b/test/unit/utPLYImportExport.cpp
@@ -85,6 +85,18 @@ TEST_F(utPLYImportExport, exportTest_Success ) {
 
 #endif // ASSIMP_BUILD_NO_EXPORT
 
+//Test issue 1623, crash when loading two PLY files in a row
+TEST_F(utPLYImportExport, importerMultipleTest) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/PLY/cube.ply", 0);
+
+    EXPECT_NE(nullptr, scene);
+
+    scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/PLY/cube.ply", 0);
+
+    EXPECT_NE(nullptr, scene);
+}
+
 TEST_F( utPLYImportExport, vertexColorTest ) {
     Assimp::Importer importer;
     const aiScene *scene = importer.ReadFile( ASSIMP_TEST_MODELS_DIR "/PLY/float-color.ply", 0 );


### PR DESCRIPTION
Pointer mGeneratedMesh was not reset to nullptr when transfering ownership
to pScene->mMeshes.