### PR TITLE
Fix non-ascii encoding in comments in FBXMaterial.cpp.

### DIFF
--- a/code/FBXMaterial.cpp
+++ b/code/FBXMaterial.cpp
@@ -291,40 +291,40 @@ Video::Video(uint64_t id, const Element& element, const Document& doc, const std
 
     if(FileName) {
         fileName = ParseTokenAsString(GetRequiredToken(*FileName,0));
-	}
+    }
 
     if(RelativeFilename) {
         relativeFileName = ParseTokenAsString(GetRequiredToken(*RelativeFilename,0));
     }
 
     if(Content) {
-		//this field is ommited when the embedded texture is already loaded, let's ignore if it´s not found
-		try {
-			const Token& token = GetRequiredToken(*Content, 0);
-			const char* data = token.begin();
-			if (!token.IsBinary()) {
-				DOMWarning("video content is not binary data, ignoring", &element);
-			}
-			else if (static_cast<size_t>(token.end() - data) < 5) {
-				DOMError("binary data array is too short, need five (5) bytes for type signature and element count", &element);
-			}
-			else if (*data != 'R') {
-				DOMWarning("video content is not raw binary data, ignoring", &element);
-			}
-			else {
-				// read number of elements
-				uint32_t len = 0;
-				::memcpy(&len, data + 1, sizeof(len));
-				AI_SWAP4(len);
+        //this field is ommited when the embedded texture is already loaded, let's ignore if it's not found
+        try {
+            const Token& token = GetRequiredToken(*Content, 0);
+            const char* data = token.begin();
+            if (!token.IsBinary()) {
+                DOMWarning("video content is not binary data, ignoring", &element);
+            }
+            else if (static_cast<size_t>(token.end() - data) < 5) {
+                DOMError("binary data array is too short, need five (5) bytes for type signature and element count", &element);
+            }
+            else if (*data != 'R') {
+                DOMWarning("video content is not raw binary data, ignoring", &element);
+            }
+            else {
+                // read number of elements
+                uint32_t len = 0;
+                ::memcpy(&len, data + 1, sizeof(len));
+                AI_SWAP4(len);
 
-				contentLength = len;
+                contentLength = len;
 
-				content = new uint8_t[len];
-				::memcpy(content, data + 5, len);
-			}
-		} catch (runtime_error runtimeError) {
-			//we don´t need the content data for contents that has already been loaded
-		}
+                content = new uint8_t[len];
+                ::memcpy(content, data + 5, len);
+            }
+        } catch (runtime_error runtimeError) {
+            //we don't need the content data for contents that has already been loaded
+        }
     }
 
     props = GetPropertyTable(doc,"Video.FbxVideo",element,sc);


### PR DESCRIPTION
It looks like it was just saved with a wrong encoding,
as these 0xB4 characters were in place of "'".

Also converted tabs to spaces to match indent in the rest of the file.