### PR TITLE
Fix some static analyser warnings

### DIFF
--- a/code/FIReader.hpp
+++ b/code/FIReader.hpp
@@ -62,6 +62,7 @@ namespace Assimp {
 
 struct FIValue {
     virtual const std::string &toString() const = 0;
+    virtual ~FIValue() {}
 };
 
 struct FIStringValue: public FIValue {
@@ -121,6 +122,7 @@ struct FICDATAValue: public FIStringValue {
 
 struct FIDecoder {
     virtual std::shared_ptr<const FIValue> decode(const uint8_t *data, size_t len) = 0;
+    virtual ~FIDecoder() {}
 };
 
 struct FIQName {

--- a/code/MDCLoader.cpp
+++ b/code/MDCLoader.cpp
@@ -294,8 +294,8 @@ void MDCImporter::InternReadFile(
             pcMesh->mMaterialIndex = (unsigned int)aszShaders.size();
 
             // create a new shader
-            aszShaders.push_back(std::string( pcShader->ucName, std::min(
-                ::strlen(pcShader->ucName),sizeof(pcShader->ucName)) ));
+            aszShaders.push_back(std::string( pcShader->ucName, 
+                ::strnlen(pcShader->ucName, sizeof(pcShader->ucName)) ));
         }
         // need to create a default material
         else if (UINT_MAX == iDefaultMatIndex)

--- a/code/MDCLoader.cpp
+++ b/code/MDCLoader.cpp
@@ -283,9 +283,8 @@ void MDCImporter::InternReadFile(
         pcMesh->mNumVertices = pcMesh->mNumFaces * 3;
 
         // store the name of the surface for use as node name.
-        // FIX: make sure there is a 0 termination
-        const_cast<char&>(pcSurface->ucName[AI_MDC_MAXQPATH-1]) = '\0';
-        pcMesh->mTextureCoords[3] = (aiVector3D*)pcSurface->ucName;
+        pcMesh->mName.Set(std::string(pcSurface->ucName
+                                    , strnlen(pcSurface->ucName, AI_MDC_MAXQPATH - 1)));
 
         // go to the first shader in the file. ignore the others.
         if (pcSurface->ulNumShaders)
@@ -432,7 +431,7 @@ void MDCImporter::InternReadFile(
     else if (1 == pScene->mNumMeshes)
     {
         pScene->mRootNode = new aiNode();
-        pScene->mRootNode->mName.Set(std::string((const char*)pScene->mMeshes[0]->mTextureCoords[3]));
+        pScene->mRootNode->mName = pScene->mMeshes[0]->mName;
         pScene->mRootNode->mNumMeshes = 1;
         pScene->mRootNode->mMeshes = new unsigned int[1];
         pScene->mRootNode->mMeshes[0] = 0;
@@ -447,16 +446,12 @@ void MDCImporter::InternReadFile(
         {
             aiNode* pcNode = pScene->mRootNode->mChildren[i] = new aiNode();
             pcNode->mParent = pScene->mRootNode;
-            pcNode->mName.Set(std::string((const char*)pScene->mMeshes[i]->mTextureCoords[3]));
+            pcNode->mName = pScene->mMeshes[i]->mName;
             pcNode->mNumMeshes = 1;
             pcNode->mMeshes = new unsigned int[1];
             pcNode->mMeshes[0] = i;
         }
     }
-
-    // make sure we invalidate the pointer to the mesh name
-    for (unsigned int i = 0; i < pScene->mNumMeshes;++i)
-        pScene->mMeshes[i]->mTextureCoords[3] = NULL;
 
     // create materials
     pScene->mNumMaterials = (unsigned int)aszShaders.size();

--- a/code/MMDPmxParser.h
+++ b/code/MMDPmxParser.h
@@ -87,6 +87,7 @@ namespace pmx
 	{
 	public:
 		virtual void Read(std::istream *stream, PmxSetting *setting) = 0;
+		virtual ~PmxVertexSkinning() {}
 	};
 
 	class PmxVertexSkinningBDEF1 : public PmxVertexSkinning

--- a/code/ObjFileImporter.cpp
+++ b/code/ObjFileImporter.cpp
@@ -317,7 +317,7 @@ aiMesh *ObjFileImporter::createTopology( const ObjFile::Model* pModel, const Obj
         return NULL;
     }
 
-    aiMesh* pMesh = new aiMesh;
+    std::unique_ptr<aiMesh> pMesh(new aiMesh);
     if( !pObjMesh->m_name.empty() ) {
         pMesh->mName.Set( pObjMesh->m_name );
     }
@@ -382,9 +382,9 @@ aiMesh *ObjFileImporter::createTopology( const ObjFile::Model* pModel, const Obj
     }
 
     // Create mesh vertices
-    createVertexArray(pModel, pData, meshIndex, pMesh, uiIdxCount);
+    createVertexArray(pModel, pData, meshIndex, pMesh.get(), uiIdxCount);
 
-    return pMesh;
+    return pMesh.release();
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/code/ObjFileImporter.cpp
+++ b/code/ObjFileImporter.cpp
@@ -264,8 +264,12 @@ aiNode *ObjFileImporter::createNodes(const ObjFile::Model* pModel, const ObjFile
     {
         unsigned int meshId = pObject->m_Meshes[ i ];
         aiMesh *pMesh = createTopology( pModel, pObject, meshId );
-        if( pMesh && pMesh->mNumFaces > 0 ) {
-            MeshArray.push_back( pMesh );
+        if( pMesh ) {
+            if (pMesh->mNumFaces > 0) {
+                MeshArray.push_back( pMesh );
+            } else {
+                delete pMesh;
+            }
         }
     }
 

--- a/code/Q3BSPFileImporter.cpp
+++ b/code/Q3BSPFileImporter.cpp
@@ -447,6 +447,7 @@ void Q3BSPFileImporter::createTriangleTopology( const Q3BSP::Q3BSPModel *pModel,
         pMesh->mTextureCoords[ 0 ][ rVertIdx ].Set( pVertex->vTexCoord.x, pVertex->vTexCoord.y, 0.0f );
         pMesh->mTextureCoords[ 1 ][ rVertIdx ].Set( pVertex->vLightmap.x, pVertex->vLightmap.y, 0.0f );
 
+        ai_assert( m_pCurrentFace );
         m_pCurrentFace->mIndices[ idx ] = rVertIdx;
         rVertIdx++;
 


### PR DESCRIPTION
Fix some of the new clang 5.0 analyzer warnings and a few virtual destructor issues which will cause a warning on clang 6.0 (still in development).

Doesn't re-enable the analyzer on Travis because it looks like there are some false positives which can't be silenced.