### PR TITLE
Enable clang static analysis using clang 3.9

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -45,8 +45,8 @@ fi
 if [ "$TRAVIS_OS_NAME" = "linux" ]; then
   if [ $ANALYZE = "ON" ] ; then
     if [ "$CC" = "clang" ]; then
-        scan-build cmake -G "Unix Makefiles" -DBUILD_SHARED_LIBS=OFF -DASSIMP_BUILD_TESTS=OFF
-        scan-build --status-bugs make -j2
+        scan-build-3.9 cmake -G "Unix Makefiles" -DBUILD_SHARED_LIBS=OFF -DASSIMP_BUILD_TESTS=OFF
+        scan-build-3.9 --status-bugs make -j2
     else
         cppcheck --version
         generate \

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,9 @@ env:
 
 matrix:
   include:
-    # disabled until clang 5.0 analyzer issues are fixed
-    # - os: linux
-    #   compiler: clang
-    #   env: ANALYZE=ON
+    - os: linux
+      compiler: clang
+      env: ANALYZE=ON
     - os: linux
       compiler: clang
       env: ASAN=ON


### PR DESCRIPTION
Since 5.0 has some false positives. This way we get at least some static analysis. The only question is whether travis images kept the old clang in addition to the new one.