### PR TITLE
[glTF2] Correctly export images with bufferView

### DIFF
--- a/code/glTF2Exporter.cpp
+++ b/code/glTF2Exporter.cpp
@@ -109,6 +109,10 @@ glTF2Exporter::glTF2Exporter(const char* filename, IOSystem* pIOSystem, const ai
 
     mAsset.reset( new Asset( pIOSystem ) );
 
+    if (isBinary) {
+        mAsset->SetAsBinary();
+    }
+
     ExportMetadata();
 
     ExportMaterials();


### PR DESCRIPTION
When exporting, we now export embedded images correctly.
