### PR TITLE
Remove check for 'assimp' in pyassimp search path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,7 @@ test/gtest/src/gtest-stamp/Debug/gtest-build
 *.lib
 test/gtest/src/gtest-stamp/Debug/
 tools/assimp_view/assimp_viewer.vcxproj.user
+*.pyc
 
 # Unix editor backups
 *~

--- a/port/PyAssimp/pyassimp/helper.py
+++ b/port/PyAssimp/pyassimp/helper.py
@@ -51,11 +51,8 @@ if os.name=='posix':
 elif os.name=='nt':
     ext_whitelist.append('.dll')
     path_dirs = os.environ['PATH'].split(';')
-    for dir_candidate in path_dirs:
-        if 'assimp' in dir_candidate.lower():
-            additional_dirs.append(dir_candidate)
+    additional_dirs.extend(path_dirs)
 
-#print(additional_dirs)
 def vec2tuple(x):
     """ Converts a VECTOR3D to a Tuple """
     return (x.x, x.y, x.z)


### PR DESCRIPTION
Also ignore compiled python files that may be generated.

Reference #1667 