### PR TITLE
Clarify the matrix layout in the documentation

### DIFF
--- a/doc/dox.h
+++ b/doc/dox.h
@@ -566,19 +566,22 @@ A typical 4x4 matrix including a translational part looks like this:
 X1  Y1  Z1  T1
 X2  Y2  Z2  T2
 X3  Y3  Z3  T3
-0   0   0   1
+ 0   0   0   1
 @endcode
-with <tt>(X1, X2, X3)</tt> being the image of the X base vector, <tt>(Y1, Y2, Y3)</tt> being the image of the
-Y base vector, <tt>(Z1, Z2, Z3)</tt> being the image of the Z base vector and <tt>(T1, T2, T3)</tt> being the
-translation part. 
-All matrices in the library are row-major. That means that the matrix elements are stored row by row in memory,
-which is identical to the OpenGL matrix layout. So the above matrix is stored in memory as
-<tt>[X1, Y1, Z1, T1, X2, Y2, Z2, T2, X3, Y3, Z3, T3, 0, 0, 0, 1]</tt>. If you want to use these matrices
-in a framework, which expects the matrix layout to be column-major (stored along the columns), such as
-DirectX or Matlab, you will have to transpose the matrix first.
+with <tt>(X1, X2, X3)</tt> being the local X base vector, <tt>(Y1, Y2, Y3)</tt> being the local
+Y base vector, <tt>(Z1, Z2, Z3)</tt> being the local Z base vector and <tt>(T1, T2, T3)</tt> being the
+offset of the local origin (the translational part). 
+All matrices in the library use row-major storage order. That means that the matrix elements are
+stored row-by-row, i.e. they end up like this in memory: 
+<tt>[X1, Y1, Z1, T1, X2, Y2, Z2, T2, X3, Y3, Z3, T3, 0, 0, 0, 1]</tt>. 
 
-To be very precise: The transposition has nothing to do with a left-handed or right-handed coordinate system
-but 'converts' between row-major and column-major storage format. 
+Note that this is neither the OpenGL format nor the DirectX format, because both of them specify the
+matrix layout such that the translational part occupies three consecutive addresses in memory (so those
+matrices end with <tt>[..., T1, T2, T3, 1]</tt>), whereas the translation in an Assimp matrix is found at
+the offsets 3, 7 and 11 (spread across the matrix). You can transpose an Assimp matrix to end up with
+the format that OpenGL and DirectX mandate. To be very precise: The transposition has nothing
+to do with a left-handed or right-handed coordinate system but 'converts' between row-major and
+column-major storage format.
 
 <hr>
 

--- a/doc/dox.h
+++ b/doc/dox.h
@@ -561,17 +561,24 @@ The output UV coordinate system has its origin in the lower-left corner:
 @endcode
 Use the #aiProcess_FlipUVs flag to get UV coordinates with the upper-left corner als origin.
 
-All matrices in the library are row-major. That means that the matrices are stored row by row in memory,
-which is similar to the OpenGL matrix layout. A typical 4x4 matrix including a translational part looks like this:
+A typical 4x4 matrix including a translational part looks like this:
 @code
 X1  Y1  Z1  T1
 X2  Y2  Z2  T2
 X3  Y3  Z3  T3
 0   0   0   1
 @endcode
-with (X1, X2, X3) being the X base vector, (Y1, Y2, Y3) being the Y base vector, (Z1, Z2, Z3)
-being the Z base vector and (T1, T2, T3) being the translation part. If you want to use these matrices
-in DirectX functions, you have to transpose them.
+with <tt>(X1, X2, X3)</tt> being the image of the X base vector, <tt>(Y1, Y2, Y3)</tt> being the image of the
+Y base vector, <tt>(Z1, Z2, Z3)</tt> being the image of the Z base vector and <tt>(T1, T2, T3)</tt> being the
+translation part. 
+All matrices in the library are row-major. That means that the matrix elements are stored row by row in memory,
+which is identical to the OpenGL matrix layout. So the above matrix is stored in memory as
+<tt>[X1, Y1, Z1, T1, X2, Y2, Z2, T2, X3, Y3, Z3, T3, 0, 0, 0, 1]</tt>. If you want to use these matrices
+in a framework, which expects the matrix layout to be column-major (stored along the columns), such as
+DirectX or Matlab, you will have to transpose the matrix first.
+
+To be very precise: The transposition has nothing to do with a left-handed or right-handed coordinate system
+but 'converts' between row-major and column-major storage format. 
 
 <hr>
 


### PR DESCRIPTION
The statement in the documentation that Assimp uses the same memory layout for matrices
as OpenGL does is wrong. Actually, both OpenGL and DirectX specify a matrix layout where
the base vectors and the translational part is consecutive in memory.

OpenGL uses post-multiplication of column-vectors and stores the matrix in column-major storage format:

    | X1  Y1  Z1  T1 |  | a |
    | X2  Y2  Z2  T2 |  | b |
    | X3  Y3  Z3  T3 |  | c |
    |  0   0   0   1 |  | 1 |

DirectX on the other hand uses row-major storage format but also pre-multiplication of
row-vectors

    | a b c 1 | | X1  X2  X3  0 |
                | Y1  Y2  Y3  0 |
                | Z1  Z2  Z3  0 |
                | T1  T2  T3  1 |

So a matrix is stored the same way in both frameworks and both times the translational part is consecutive at offsets 12, 13 and 14, which is not the format that Assimp uses (in Assimp the
translation can be found at offsets 3, 7 and 11 in the matrix memory, for example).
