### PR TITLE
Add pyassimp code generation script for materials

### DIFF
--- a/port/PyAssimp/gen/materialgen.py
+++ b/port/PyAssimp/gen/materialgen.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+# -*- Coding: UTF-8 -*-
+
+# ---------------------------------------------------------------------------
+# Open Asset Import Library (ASSIMP)
+# ---------------------------------------------------------------------------
+#
+# Copyright (c) 2006-2010, ASSIMP Development Team
+#
+# All rights reserved.
+#
+# Redistribution and use of this software in source and binary forms, 
+# with or without modification, are permitted provided that the following 
+# conditions are met:
+# 
+# * Redistributions of source code must retain the above
+#   copyright notice, this list of conditions and the
+#   following disclaimer.
+# 
+# * Redistributions in binary form must reproduce the above
+#   copyright notice, this list of conditions and the
+#   following disclaimer in the documentation and/or other
+#   materials provided with the distribution.
+# 
+# * Neither the name of the ASSIMP team, nor the names of its
+#   contributors may be used to endorse or promote products
+#   derived from this software without specific prior
+#   written permission of the ASSIMP Development Team.
+# 
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+# ---------------------------------------------------------------------------
+
+"""Update PyAssimp's texture type constants C/C++ headers.
+
+This script is meant to be executed in the source tree, directly from
+port/PyAssimp/gen
+"""
+
+import os
+import re
+
+REenumTextureType = re.compile(r''
+                r'enum\saiTextureType'    # enum aiTextureType
+                r'[^{]*?\{'               # {
+                r'(?P<code>.*?)'          #   code 
+                r'\};'                    # };
+                , re.IGNORECASE + re.DOTALL + re.MULTILINE)
+
+# Replace comments
+RErpcom = re.compile(r''
+                r'\s*(/\*+\s|\*+/|\B\*\s?|///?!?)'   # /**
+                r'(?P<line>.*?)'                     #  * line 
+                , re.IGNORECASE + re.DOTALL)
+
+# Remove trailing commas
+RErmtrailcom = re.compile(r',$', re.IGNORECASE + re.DOTALL)
+
+# Remove #ifdef __cplusplus   
+RErmifdef = re.compile(r''
+                r'#ifndef SWIG'                       # #ifndef SWIG
+                r'(?P<code>.*)'                       #   code 
+                r'#endif(\s*//\s*!?\s*SWIG)*'  # #endif
+                , re.IGNORECASE + re.DOTALL)
+
+path = '../../../include/assimp'
+
+files = os.listdir (path)
+enumText = ''
+for fileName in files:
+    if fileName.endswith('.h'):
+      text = open(os.path.join(path, fileName)).read()
+      for enum in REenumTextureType.findall(text):
+        enumText = enum
+
+text = ''
+for line in enumText.split('\n'):
+  line = line.lstrip().rstrip()
+  line = RErmtrailcom.sub('', line)
+  text += RErpcom.sub('# \g<line>', line) + '\n'
+text = RErmifdef.sub('', text)
+
+file = open('material.py', 'w')
+file.write(text)
+file.close()
+
+print("Generation done. You can now review the file 'material.py' and merge it.")

--- a/port/PyAssimp/pyassimp/material.py
+++ b/port/PyAssimp/pyassimp/material.py
@@ -1,89 +1,89 @@
-## <hr>Dummy value.
+# Dummy value.
 #
-# No texture, but the value to be used as 'texture semantic'
-# (#aiMaterialProperty::mSemantic) for all material properties
-# *not* related to textures.
+#  No texture, but the value to be used as 'texture semantic'
+#  (#aiMaterialProperty::mSemantic) for all material properties
+# # not* related to textures.
 #
 aiTextureType_NONE = 0x0
 
-## <hr>The texture is combined with the result of the diffuse
-# lighting equation.
+# The texture is combined with the result of the diffuse
+#  lighting equation.
 #
 aiTextureType_DIFFUSE = 0x1
 
-## <hr>The texture is combined with the result of the specular
-# lighting equation.
+# The texture is combined with the result of the specular
+#  lighting equation.
 #
 aiTextureType_SPECULAR = 0x2
 
-## <hr>The texture is combined with the result of the ambient
-# lighting equation.
+# The texture is combined with the result of the ambient
+#  lighting equation.
 #
 aiTextureType_AMBIENT = 0x3
 
-## <hr>The texture is added to the result of the lighting
-# calculation. It isn't influenced by incoming light.
+# The texture is added to the result of the lighting
+#  calculation. It isn't influenced by incoming light.
 #
 aiTextureType_EMISSIVE = 0x4
 
-## <hr>The texture is a height map.
+# The texture is a height map.
 #
-# By convention, higher gray-scale values stand for
-# higher elevations from the base height.
+#  By convention, higher gray-scale values stand for
+#  higher elevations from the base height.
 #
 aiTextureType_HEIGHT = 0x5
 
-## <hr>The texture is a (tangent space) normal-map.
+# The texture is a (tangent space) normal-map.
 #
-# Again, there are several conventions for tangent-space
-# normal maps. Assimp does (intentionally) not
-# distinguish here.
+#  Again, there are several conventions for tangent-space
+#  normal maps. Assimp does (intentionally) not
+#  distinguish here.
 #
 aiTextureType_NORMALS = 0x6
 
-## <hr>The texture defines the glossiness of the material.
+# The texture defines the glossiness of the material.
 #
-# The glossiness is in fact the exponent of the specular
-# (phong) lighting equation. Usually there is a conversion
-# function defined to map the linear color values in the
-# texture to a suitable exponent. Have fun.
+#  The glossiness is in fact the exponent of the specular
+#  (phong) lighting equation. Usually there is a conversion
+#  function defined to map the linear color values in the
+#  texture to a suitable exponent. Have fun.
 #
 aiTextureType_SHININESS = 0x7
 
-## <hr>The texture defines per-pixel opacity.
+# The texture defines per-pixel opacity.
 #
-# Usually 'white' means opaque and 'black' means
-# 'transparency'. Or quite the opposite. Have fun.
+#  Usually 'white' means opaque and 'black' means
+#  'transparency'. Or quite the opposite. Have fun.
 #
 aiTextureType_OPACITY = 0x8
 
-## <hr>Displacement texture
+# Displacement texture
 #
-# The exact purpose and format is application-dependent.
-# Higher color values stand for higher vertex displacements.
+#  The exact purpose and format is application-dependent.
+#  Higher color values stand for higher vertex displacements.
 #
 aiTextureType_DISPLACEMENT = 0x9
 
-## <hr>Lightmap texture (aka Ambient Occlusion)
+# Lightmap texture (aka Ambient Occlusion)
 #
-# Both 'Lightmaps' and dedicated 'ambient occlusion maps' are
-# covered by this material property. The texture contains a
-# scaling value for the final color value of a pixel. Its
-# intensity is not affected by incoming light.
+#  Both 'Lightmaps' and dedicated 'ambient occlusion maps' are
+#  covered by this material property. The texture contains a
+#  scaling value for the final color value of a pixel. Its
+#  intensity is not affected by incoming light.
 #
 aiTextureType_LIGHTMAP = 0xA
 
-## <hr>Reflection texture
+# Reflection texture
 #
-#Contains the color of a perfect mirror reflection.
-#Rarely used, almost never for real-time applications.
+# Contains the color of a perfect mirror reflection.
+# Rarely used, almost never for real-time applications.
 #
 aiTextureType_REFLECTION = 0xB
 
-## <hr>Unknown texture
+# Unknown texture
 #
-# A texture reference that does not match any of the definitions
-# above is considered to be 'unknown'. It is still imported
-# but is excluded from any further postprocessing.
+#  A texture reference that does not match any of the definitions
+#  above is considered to be 'unknown'. It is still imported
+#  but is excluded from any further postprocessing.
 #
 aiTextureType_UNKNOWN = 0xC


### PR DESCRIPTION
In the style of gen/structsgen.py, we construct a similar method for
keeping the constants in materials.py up to date.