### PR TITLE
macOS build fix

### DIFF
--- a/code/glTF2AssetWriter.inl
+++ b/code/glTF2AssetWriter.inl
@@ -584,7 +584,7 @@ namespace glTF2 {
         if (bodyBuffer->byteLength > 0) {
             rapidjson::Value glbBodyBuffer;
             glbBodyBuffer.SetObject();
-            glbBodyBuffer.AddMember("byteLength", bodyBuffer->byteLength, mAl);
+            glbBodyBuffer.AddMember("byteLength", static_cast<uint64_t>(bodyBuffer->byteLength), mAl);
             mDoc["buffers"].PushBack(glbBodyBuffer, mAl);
         }
 


### PR DESCRIPTION
Requires cast from size_t to uint64_t like in other places, otherwise the implicit call to the GenericValue constructor is ambiguous.

Fixes #1684