### PR TITLE
Fix thread-safety issue in 3DS and ASE loaders

### DIFF
--- a/code/3DSConverter.cpp
+++ b/code/3DSConverter.cpp
@@ -127,9 +127,8 @@ void Discreet3DSImporter::ReplaceDefaultMaterial()
     if (cnt && idx == mScene->mMaterials.size())
     {
         // We need to create our own default material
-        D3DS::Material sMat;
+        D3DS::Material sMat("%%%DEFAULT");
         sMat.mDiffuse = aiColor3D(0.3f,0.3f,0.3f);
-        sMat.mName = "%%%DEFAULT";
         mScene->mMaterials.push_back(sMat);
 
         DefaultLogger::get()->info("3DS: Generating default material");

--- a/code/3DSHelper.h
+++ b/code/3DSHelper.h
@@ -388,6 +388,20 @@ struct Material
     }
 
 
+    //! Constructor with explicit name
+    explicit Material(const std::string &name)
+    : mDiffuse            ( ai_real( 0.6 ), ai_real( 0.6 ), ai_real( 0.6 ) ) // FIX ... we won't want object to be black
+    , mSpecularExponent   ( ai_real( 0.0 ) )
+    , mShininessStrength  ( ai_real( 1.0 ) )
+    , mShading(Discreet3DS::Gouraud)
+    , mTransparency       ( ai_real( 1.0 ) )
+    , mBumpHeight         ( ai_real( 1.0 ) )
+    , mTwoSided           (false)
+    {
+        mName = name;
+    }
+
+
     Material(const Material &other)            = default;
     Material(Material &&other)                 = default;
 

--- a/code/3DSHelper.h
+++ b/code/3DSHelper.h
@@ -387,6 +387,16 @@ struct Material
         mName = szTemp;
     }
 
+
+    Material(const Material &other)            = default;
+    Material(Material &&other)                 = default;
+
+    Material &operator=(const Material &other) = default;
+    Material &operator=(Material &&other)      = default;
+
+    ~Material() {}
+
+
     //! Name of the material
     std::string mName;
     //! Diffuse color of the material

--- a/code/3DSHelper.h
+++ b/code/3DSHelper.h
@@ -370,22 +370,8 @@ struct Texture
 /** Helper structure representing a 3ds material */
 struct Material
 {
-    //! Default constructor. Builds a default name for the material
-    Material()
-    : mDiffuse            ( ai_real( 0.6 ), ai_real( 0.6 ), ai_real( 0.6 ) ) // FIX ... we won't want object to be black
-    , mSpecularExponent   ( ai_real( 0.0 ) )
-    , mShininessStrength  ( ai_real( 1.0 ) )
-    , mShading(Discreet3DS::Gouraud)
-    , mTransparency       ( ai_real( 1.0 ) )
-    , mBumpHeight         ( ai_real( 1.0 ) )
-    , mTwoSided           (false)
-    {
-        static int iCnt = 0;
-
-        char szTemp[128];
-        ai_snprintf(szTemp, 128, "UNNAMED_%i",iCnt++);
-        mName = szTemp;
-    }
+    //! Default constructor has been deleted
+    Material() = delete;
 
 
     //! Constructor with explicit name

--- a/code/3DSHelper.h
+++ b/code/3DSHelper.h
@@ -389,10 +389,62 @@ struct Material
 
 
     Material(const Material &other)            = default;
-    Material(Material &&other)                 = default;
-
     Material &operator=(const Material &other) = default;
-    Material &operator=(Material &&other)      = default;
+
+
+    //! Move constructor. This is explicitly written because MSVC doesn't support defaulting it
+    Material(Material &&other)
+    : mName(std::move(other.mName))
+    , mDiffuse(std::move(other.mDiffuse))
+    , mSpecularExponent(std::move(other.mSpecularExponent))
+    , mShininessStrength(std::move(other.mShininessStrength))
+    , mSpecular(std::move(other.mSpecular))
+    , mAmbient(std::move(other.mAmbient))
+    , mShading(std::move(other.mShading))
+    , mTransparency(std::move(other.mTransparency))
+    , sTexDiffuse(std::move(other.sTexDiffuse))
+    , sTexOpacity(std::move(other.sTexOpacity))
+    , sTexSpecular(std::move(other.sTexSpecular))
+    , sTexReflective(std::move(other.sTexReflective))
+    , sTexBump(std::move(other.sTexBump))
+    , sTexEmissive(std::move(other.sTexEmissive))
+    , sTexShininess(std::move(other.sTexShininess))
+    , mBumpHeight(std::move(other.mBumpHeight))
+    , mEmissive(std::move(other.mEmissive))
+    , sTexAmbient(std::move(other.sTexAmbient))
+    , mTwoSided(std::move(other.mTwoSided))
+    {
+    }
+
+
+    Material &operator=(Material &&other) {
+        if (this == &other) {
+            return *this;
+        }
+
+        mName = std::move(other.mName);
+        mDiffuse = std::move(other.mDiffuse);
+        mSpecularExponent = std::move(other.mSpecularExponent);
+        mShininessStrength = std::move(other.mShininessStrength),
+        mSpecular = std::move(other.mSpecular);
+        mAmbient = std::move(other.mAmbient);
+        mShading = std::move(other.mShading);
+        mTransparency = std::move(other.mTransparency);
+        sTexDiffuse = std::move(other.sTexDiffuse);
+        sTexOpacity = std::move(other.sTexOpacity);
+        sTexSpecular = std::move(other.sTexSpecular);
+        sTexReflective = std::move(other.sTexReflective);
+        sTexBump = std::move(other.sTexBump);
+        sTexEmissive = std::move(other.sTexEmissive);
+        sTexShininess = std::move(other.sTexShininess);
+        mBumpHeight = std::move(other.mBumpHeight);
+        mEmissive = std::move(other.mEmissive);
+        sTexAmbient = std::move(other.sTexAmbient);
+        mTwoSided = std::move(other.mTwoSided);
+
+        return *this;
+    }
+
 
     ~Material() {}
 

--- a/code/3DSHelper.h
+++ b/code/3DSHelper.h
@@ -376,7 +376,8 @@ struct Material
 
     //! Constructor with explicit name
     explicit Material(const std::string &name)
-    : mDiffuse            ( ai_real( 0.6 ), ai_real( 0.6 ), ai_real( 0.6 ) ) // FIX ... we won't want object to be black
+    : mName(name)
+    , mDiffuse            ( ai_real( 0.6 ), ai_real( 0.6 ), ai_real( 0.6 ) ) // FIX ... we won't want object to be black
     , mSpecularExponent   ( ai_real( 0.0 ) )
     , mShininessStrength  ( ai_real( 1.0 ) )
     , mShading(Discreet3DS::Gouraud)
@@ -384,7 +385,6 @@ struct Material
     , mBumpHeight         ( ai_real( 1.0 ) )
     , mTwoSided           (false)
     {
-        mName = name;
     }
 
 

--- a/code/3DSLoader.cpp
+++ b/code/3DSLoader.cpp
@@ -105,14 +105,14 @@ static const aiImporterDesc desc = {
 // ------------------------------------------------------------------------------------------------
 // Constructor to be privately used by Importer
 Discreet3DSImporter::Discreet3DSImporter()
-    : stream(),
-    mLastNodeIndex(),
-    mCurrentNode(),
-    mRootNode(),
-    mScene(),
-    mMasterScale(),
-    bHasBG(),
-    bIsPrj()
+: stream()
+, mLastNodeIndex()
+, mCurrentNode()
+, mRootNode()
+, mScene()
+, mMasterScale()
+, bHasBG()
+, bIsPrj()
 {}
 
 // ------------------------------------------------------------------------------------------------

--- a/code/3DSLoader.cpp
+++ b/code/3DSLoader.cpp
@@ -346,7 +346,7 @@ void Discreet3DSImporter::ParseObjectChunk()
     case Discreet3DS::CHUNK_MAT_MATERIAL:
 
         // Add a new material to the list
-        mScene->mMaterials.push_back(D3DS::Material());
+        mScene->mMaterials.push_back(D3DS::Material(std::string("UNNAMED_" + std::to_string(mScene->mMaterials.size()))));
         ParseMaterialChunk();
         break;
 

--- a/code/ASELoader.cpp
+++ b/code/ASELoader.cpp
@@ -276,14 +276,13 @@ void ASEImporter::GenerateDefaultMaterial()
     }
     if (bHas || mParser->m_vMaterials.empty())  {
         // add a simple material without submaterials to the parser's list
-        mParser->m_vMaterials.push_back ( ASE::Material() );
+        mParser->m_vMaterials.push_back ( ASE::Material(AI_DEFAULT_MATERIAL_NAME) );
         ASE::Material& mat = mParser->m_vMaterials.back();
 
         mat.mDiffuse  = aiColor3D(0.6f,0.6f,0.6f);
         mat.mSpecular = aiColor3D(1.0f,1.0f,1.0f);
         mat.mAmbient  = aiColor3D(0.05f,0.05f,0.05f);
         mat.mShading  = Discreet3DS::Gouraud;
-        mat.mName     = AI_DEFAULT_MATERIAL_NAME;
     }
 }
 

--- a/code/ASELoader.cpp
+++ b/code/ASELoader.cpp
@@ -83,11 +83,11 @@ static const aiImporterDesc desc = {
 // ------------------------------------------------------------------------------------------------
 // Constructor to be privately used by Importer
 ASEImporter::ASEImporter()
-    : mParser(),
-    mBuffer(),
-    pcScene(),
-    configRecomputeNormals(),
-    noSkeletonMesh()
+: mParser()
+, mBuffer()
+, pcScene()
+, configRecomputeNormals()
+, noSkeletonMesh()
 {}
 
 // ------------------------------------------------------------------------------------------------

--- a/code/ASEParser.cpp
+++ b/code/ASEParser.cpp
@@ -528,7 +528,7 @@ void Parser::ParseLV1MaterialListBlock()
                 ParseLV4MeshLong(iMaterialCount);
 
                 // now allocate enough storage to hold all materials
-                m_vMaterials.resize(iOldMaterialCount+iMaterialCount);
+                m_vMaterials.resize(iOldMaterialCount+iMaterialCount, Material("INVALID"));
                 continue;
             }
             if (TokenMatch(filePtr,"MATERIAL",8))

--- a/code/ASEParser.cpp
+++ b/code/ASEParser.cpp
@@ -706,7 +706,7 @@ void Parser::ParseLV2MaterialBlock(ASE::Material& mat)
                 ParseLV4MeshLong(iNumSubMaterials);
 
                 // allocate enough storage
-                mat.avSubMaterials.resize(iNumSubMaterials);
+                mat.avSubMaterials.resize(iNumSubMaterials, Material("INVALID SUBMATERIAL"));
             }
             // submaterial chunks
             if (TokenMatch(filePtr,"SUBMATERIAL",11))

--- a/code/ASEParser.h
+++ b/code/ASEParser.h
@@ -80,10 +80,36 @@ struct Material : public D3DS::Material
 
 
     Material(const Material &other)            = default;
-    Material(Material &&other)                 = default;
-
     Material &operator=(const Material &other) = default;
-    Material &operator=(Material &&other)      = default;
+
+
+    //! Move constructor. This is explicitly written because MSVC doesn't support defaulting it
+    Material(Material &&other)
+    : D3DS::Material(std::move(other))
+    , avSubMaterials(std::move(other.avSubMaterials))
+    , pcInstance(std::move(other.pcInstance))
+    , bNeed(std::move(other.bNeed))
+    {
+        other.pcInstance = nullptr;
+    }
+
+
+    Material &operator=(Material &&other) {
+        if (this == &other) {
+            return *this;
+        }
+
+        D3DS::Material::operator=(std::move(other));
+
+        avSubMaterials = std::move(other.avSubMaterials);
+        pcInstance = std::move(other.pcInstance);
+        bNeed = std::move(other.bNeed);
+
+        other.pcInstance = nullptr;
+
+        return *this;
+    }
+
 
     ~Material() {}
 

--- a/code/ASEParser.h
+++ b/code/ASEParser.h
@@ -67,11 +67,8 @@ using namespace D3DS;
 /** Helper structure representing an ASE material */
 struct Material : public D3DS::Material
 {
-    //! Default constructor
-    Material()
-    : pcInstance(NULL)
-    , bNeed (false)
-    {}
+    //! Default constructor has been deleted
+    Material() = delete;
 
 
     //! Constructor with explicit name

--- a/code/ASEParser.h
+++ b/code/ASEParser.h
@@ -68,7 +68,9 @@ using namespace D3DS;
 struct Material : public D3DS::Material
 {
     //! Default constructor
-    Material() : pcInstance(NULL), bNeed (false)
+    Material()
+    : pcInstance(NULL)
+    , bNeed (false)
     {}
 
     //! Contains all sub materials of this material

--- a/code/ASEParser.h
+++ b/code/ASEParser.h
@@ -73,6 +73,16 @@ struct Material : public D3DS::Material
     , bNeed (false)
     {}
 
+
+    Material(const Material &other)            = default;
+    Material(Material &&other)                 = default;
+
+    Material &operator=(const Material &other) = default;
+    Material &operator=(Material &&other)      = default;
+
+    ~Material() {}
+
+
     //! Contains all sub materials of this material
     std::vector<Material> avSubMaterials;
 

--- a/code/ASEParser.h
+++ b/code/ASEParser.h
@@ -74,6 +74,14 @@ struct Material : public D3DS::Material
     {}
 
 
+    //! Constructor with explicit name
+    explicit Material(const std::string &name)
+    : D3DS::Material(name)
+    , pcInstance(NULL)
+    , bNeed (false)
+    {}
+
+
     Material(const Material &other)            = default;
     Material(Material &&other)                 = default;
 


### PR DESCRIPTION
3DS::Material creates a default name by incrementing a static non-atomic counter. This is neither thread-safe (even with separate Importer instances) nor reproducible in one thread. Refactor it by always passing in a name.
