### PR TITLE
GetEmbeddedTexture should be a const function

### DIFF
--- a/include/assimp/scene.h
+++ b/include/assimp/scene.h
@@ -387,7 +387,7 @@ struct aiScene
     }
 
     //! Returns an embedded texture
-    const aiTexture* GetEmbeddedTexture(const char* filename) {
+    const aiTexture* GetEmbeddedTexture(const char* filename) const {
         const char* shortFilename = GetShortFilename(filename);
         for (unsigned int i = 0; i < mNumTextures; i++) {
             const char* shortTextureFilename = GetShortFilename(mTextures[i]->mFilename.C_Str());


### PR DESCRIPTION
As it stands, an assimp scene created from reading a file (returned as a const aiscene*) cannot call GetEmbeddedTexture() as it is not a const member of the object.