### PR TITLE
closes https://github.com/assimp/assimp/issues/1728: check if mesh is…

### DIFF
--- a/code/XFileImporter.cpp
+++ b/code/XFileImporter.cpp
@@ -246,6 +246,10 @@ void XFileImporter::CreateMeshes( aiScene* pScene, aiNode* pNode, const std::vec
     for( unsigned int a = 0; a < pMeshes.size(); a++)
     {
         XFile::Mesh* sourceMesh = pMeshes[a];
+        if ( nullptr == sourceMesh ) {
+            continue;
+        }
+
         // first convert its materials so that we can find them with their index afterwards
         ConvertMaterials( pScene, sourceMesh->mMaterials);
 


### PR DESCRIPTION
… a null instance before dereferencing it.