### PR TITLE
Fix thread-safety false positives in Ogre importer

### DIFF
--- a/code/OgreXmlSerializer.cpp
+++ b/code/OgreXmlSerializer.cpp
@@ -538,20 +538,20 @@ void OgreXmlSerializer::ReadGeometryVertexBuffer(VertexDataXml *dest)
 
 void OgreXmlSerializer::ReadSubMesh(MeshXml *mesh)
 {
-    static const std::string anMaterial          = "material";
-    static const std::string anUseSharedVertices = "usesharedvertices";
-    static const std::string anCount             = "count";
-    static const std::string anV1                = "v1";
-    static const std::string anV2                = "v2";
-    static const std::string anV3                = "v3";
-    static const std::string anV4                = "v4";
+    static const char *anMaterial          = "material";
+    static const char *anUseSharedVertices = "usesharedvertices";
+    static const char *anCount             = "count";
+    static const char *anV1                = "v1";
+    static const char *anV2                = "v2";
+    static const char *anV3                = "v3";
+    static const char *anV4                = "v4";
 
     SubMeshXml* submesh = new SubMeshXml();
 
-    if (HasAttribute(anMaterial.c_str())) {
+    if (HasAttribute(anMaterial)) {
         submesh->materialRef = ReadAttribute<std::string>(anMaterial);
     }
-    if (HasAttribute(anUseSharedVertices.c_str())) {
+    if (HasAttribute(anUseSharedVertices)) {
         submesh->usesSharedVertexData = ReadAttribute<bool>(anUseSharedVertices);
     }
 
@@ -587,7 +587,7 @@ void OgreXmlSerializer::ReadSubMesh(MeshXml *mesh)
                 face.mIndices[2] = ReadAttribute<uint32_t>(anV3);
 
                 /// @todo Support quads if Ogre even supports them in XML (I'm not sure but I doubt it)
-                if (!quadWarned && HasAttribute(anV4.c_str())) {
+                if (!quadWarned && HasAttribute(anV4)) {
                     DefaultLogger::get()->warn("Submesh <face> has quads with <v4>, only triangles are supported at the moment!");
                     quadWarned = true;
                 }
@@ -635,9 +635,9 @@ void OgreXmlSerializer::ReadBoneAssignments(VertexDataXml *dest)
         throw DeadlyImportError("Cannot read bone assignments, vertex data is null.");
     }
 
-    static const std::string anVertexIndex = "vertexindex";
-    static const std::string anBoneIndex   = "boneindex";
-    static const std::string anWeight      = "weight";
+    static const char *anVertexIndex = "vertexindex";
+    static const char *anBoneIndex   = "boneindex";
+    static const char *anWeight      = "weight";
 
     std::set<uint32_t> influencedVertices;
 

--- a/code/OgreXmlSerializer.cpp
+++ b/code/OgreXmlSerializer.cpp
@@ -72,11 +72,11 @@ AI_WONT_RETURN void ThrowAttibuteError(const XmlReader* reader, const std::strin
 }
 
 template<>
-int32_t OgreXmlSerializer::ReadAttribute<int32_t>(const std::string &name) const
+int32_t OgreXmlSerializer::ReadAttribute<int32_t>(const char *name) const
 {
-    if (HasAttribute(name.c_str()))
+    if (HasAttribute(name))
     {
-        return static_cast<int32_t>(m_reader->getAttributeValueAsInt(name.c_str()));
+        return static_cast<int32_t>(m_reader->getAttributeValueAsInt(name));
     }
     else
     {
@@ -86,9 +86,9 @@ int32_t OgreXmlSerializer::ReadAttribute<int32_t>(const std::string &name) const
 }
 
 template<>
-uint32_t OgreXmlSerializer::ReadAttribute<uint32_t>(const std::string &name) const
+uint32_t OgreXmlSerializer::ReadAttribute<uint32_t>(const char *name) const
 {
-    if (HasAttribute(name.c_str()))
+    if (HasAttribute(name))
     {
         /** @note This is hackish. But we are never expecting unsigned values that go outside the
             int32_t range. Just monitor for negative numbers and kill the import. */
@@ -110,9 +110,9 @@ uint32_t OgreXmlSerializer::ReadAttribute<uint32_t>(const std::string &name) con
 }
 
 template<>
-uint16_t OgreXmlSerializer::ReadAttribute<uint16_t>(const std::string &name) const
+uint16_t OgreXmlSerializer::ReadAttribute<uint16_t>(const char *name) const
 {
-    if (HasAttribute(name.c_str()))
+    if (HasAttribute(name))
     {
         return static_cast<uint16_t>(ReadAttribute<uint32_t>(name));
     }
@@ -124,11 +124,11 @@ uint16_t OgreXmlSerializer::ReadAttribute<uint16_t>(const std::string &name) con
 }
 
 template<>
-float OgreXmlSerializer::ReadAttribute<float>(const std::string &name) const
+float OgreXmlSerializer::ReadAttribute<float>(const char *name) const
 {
-    if (HasAttribute(name.c_str()))
+    if (HasAttribute(name))
     {
-        return m_reader->getAttributeValueAsFloat(name.c_str());
+        return m_reader->getAttributeValueAsFloat(name);
     }
     else
     {
@@ -138,9 +138,9 @@ float OgreXmlSerializer::ReadAttribute<float>(const std::string &name) const
 }
 
 template<>
-std::string OgreXmlSerializer::ReadAttribute<std::string>(const std::string &name) const
+std::string OgreXmlSerializer::ReadAttribute<std::string>(const char *name) const
 {
-    const char* value = m_reader->getAttributeValue(name.c_str());
+    const char* value = m_reader->getAttributeValue(name);
     if (value)
     {
         return std::string(value);
@@ -153,7 +153,7 @@ std::string OgreXmlSerializer::ReadAttribute<std::string>(const std::string &nam
 }
 
 template<>
-bool OgreXmlSerializer::ReadAttribute<bool>(const std::string &name) const
+bool OgreXmlSerializer::ReadAttribute<bool>(const char *name) const
 {
     std::string value = Ogre::ToLower(ReadAttribute<std::string>(name));
     if (ASSIMP_stricmp(value, "true") == 0)

--- a/code/OgreXmlSerializer.cpp
+++ b/code/OgreXmlSerializer.cpp
@@ -231,75 +231,75 @@ std::string &OgreXmlSerializer::SkipCurrentNode()
 // Mesh XML constants
 
 // <mesh>
-const std::string nnMesh                = "mesh";
-const std::string nnSharedGeometry      = "sharedgeometry";
-const std::string nnSubMeshes           = "submeshes";
-const std::string nnSubMesh             = "submesh";
-const std::string nnSubMeshNames        = "submeshnames";
-const std::string nnSkeletonLink        = "skeletonlink";
-const std::string nnLOD                 = "levelofdetail";
-const std::string nnExtremes            = "extremes";
-const std::string nnPoses               = "poses";
-const std::string nnAnimations          = "animations";
+const char *nnMesh                = "mesh";
+const char *nnSharedGeometry      = "sharedgeometry";
+const char *nnSubMeshes           = "submeshes";
+const char *nnSubMesh             = "submesh";
+const char *nnSubMeshNames        = "submeshnames";
+const char *nnSkeletonLink        = "skeletonlink";
+const char *nnLOD                 = "levelofdetail";
+const char *nnExtremes            = "extremes";
+const char *nnPoses               = "poses";
+const char *nnAnimations          = "animations";
 
 // <submesh>
-const std::string nnFaces               = "faces";
-const std::string nnFace                = "face";
-const std::string nnGeometry            = "geometry";
-const std::string nnTextures            = "textures";
+const char *nnFaces               = "faces";
+const char *nnFace                = "face";
+const char *nnGeometry            = "geometry";
+const char *nnTextures            = "textures";
 
 // <mesh/submesh>
-const std::string nnBoneAssignments     = "boneassignments";
+const char *nnBoneAssignments     = "boneassignments";
 
 // <sharedgeometry/geometry>
-const std::string nnVertexBuffer        = "vertexbuffer";
+const char *nnVertexBuffer        = "vertexbuffer";
 
 // <vertexbuffer>
-const std::string nnVertex              = "vertex";
-const std::string nnPosition            = "position";
-const std::string nnNormal              = "normal";
-const std::string nnTangent             = "tangent";
-const std::string nnBinormal            = "binormal";
-const std::string nnTexCoord            = "texcoord";
-const std::string nnColorDiffuse        = "colour_diffuse";
-const std::string nnColorSpecular       = "colour_specular";
+const char *nnVertex              = "vertex";
+const char *nnPosition            = "position";
+const char *nnNormal              = "normal";
+const char *nnTangent             = "tangent";
+const char *nnBinormal            = "binormal";
+const char *nnTexCoord            = "texcoord";
+const char *nnColorDiffuse        = "colour_diffuse";
+const char *nnColorSpecular       = "colour_specular";
 
 // <boneassignments>
-const std::string nnVertexBoneAssignment = "vertexboneassignment";
+const char *nnVertexBoneAssignment = "vertexboneassignment";
 
 // Skeleton XML constants
 
 // <skeleton>
-const std::string nnSkeleton            = "skeleton";
-const std::string nnBones               = "bones";
-const std::string nnBoneHierarchy       = "bonehierarchy";
-const std::string nnAnimationLinks      = "animationlinks";
+const char *nnSkeleton            = "skeleton";
+const char *nnBones               = "bones";
+const char *nnBoneHierarchy       = "bonehierarchy";
+const char *nnAnimationLinks      = "animationlinks";
 
 // <bones>
-const std::string nnBone                = "bone";
-const std::string nnRotation            = "rotation";
-const std::string nnAxis                = "axis";
-const std::string nnScale               = "scale";
+const char *nnBone                = "bone";
+const char *nnRotation            = "rotation";
+const char *nnAxis                = "axis";
+const char *nnScale               = "scale";
 
 // <bonehierarchy>
-const std::string nnBoneParent          = "boneparent";
+const char *nnBoneParent          = "boneparent";
 
 // <animations>
-const std::string nnAnimation           = "animation";
-const std::string nnTracks              = "tracks";
+const char *nnAnimation           = "animation";
+const char *nnTracks              = "tracks";
 
 // <tracks>
-const std::string nnTrack               = "track";
-const std::string nnKeyFrames           = "keyframes";
-const std::string nnKeyFrame            = "keyframe";
-const std::string nnTranslate           = "translate";
-const std::string nnRotate              = "rotate";
+const char *nnTrack               = "track";
+const char *nnKeyFrames           = "keyframes";
+const char *nnKeyFrame            = "keyframe";
+const char *nnTranslate           = "translate";
+const char *nnRotate              = "rotate";
 
 // Common XML constants
 
-const std::string anX = "x";
-const std::string anY = "y";
-const std::string anZ = "z";
+const char *anX = "x";
+const char *anY = "y";
+const char *anZ = "z";
 
 // Mesh
 
@@ -968,11 +968,11 @@ void OgreXmlSerializer::ReadBones(Skeleton *skeleton)
                 }
                 else
                 {
-                    if (HasAttribute(anX.c_str()))
+                    if (HasAttribute(anX))
                         bone->scale.x = ReadAttribute<float>(anX);
-                    if (HasAttribute(anY.c_str()))
+                    if (HasAttribute(anY))
                         bone->scale.y = ReadAttribute<float>(anY);
-                    if (HasAttribute(anZ.c_str()))
+                    if (HasAttribute(anZ))
                         bone->scale.z = ReadAttribute<float>(anZ);
                 }
             }

--- a/code/OgreXmlSerializer.cpp
+++ b/code/OgreXmlSerializer.cpp
@@ -171,9 +171,9 @@ bool OgreXmlSerializer::ReadAttribute<bool>(const std::string &name) const
     }
 }
 
-bool OgreXmlSerializer::HasAttribute(const std::string &name) const
+bool OgreXmlSerializer::HasAttribute(const char *name) const
 {
-    return (m_reader->getAttributeValue(name.c_str()) != 0);
+    return (m_reader->getAttributeValue(name) != 0);
 }
 
 std::string &OgreXmlSerializer::NextNode()
@@ -548,10 +548,10 @@ void OgreXmlSerializer::ReadSubMesh(MeshXml *mesh)
 
     SubMeshXml* submesh = new SubMeshXml();
 
-    if (HasAttribute(anMaterial)) {
+    if (HasAttribute(anMaterial.c_str())) {
         submesh->materialRef = ReadAttribute<std::string>(anMaterial);
     }
-    if (HasAttribute(anUseSharedVertices)) {
+    if (HasAttribute(anUseSharedVertices.c_str())) {
         submesh->usesSharedVertexData = ReadAttribute<bool>(anUseSharedVertices);
     }
 
@@ -587,7 +587,7 @@ void OgreXmlSerializer::ReadSubMesh(MeshXml *mesh)
                 face.mIndices[2] = ReadAttribute<uint32_t>(anV3);
 
                 /// @todo Support quads if Ogre even supports them in XML (I'm not sure but I doubt it)
-                if (!quadWarned && HasAttribute(anV4)) {
+                if (!quadWarned && HasAttribute(anV4.c_str())) {
                     DefaultLogger::get()->warn("Submesh <face> has quads with <v4>, only triangles are supported at the moment!");
                     quadWarned = true;
                 }
@@ -968,11 +968,11 @@ void OgreXmlSerializer::ReadBones(Skeleton *skeleton)
                 }
                 else
                 {
-                    if (HasAttribute(anX))
+                    if (HasAttribute(anX.c_str()))
                         bone->scale.x = ReadAttribute<float>(anX);
-                    if (HasAttribute(anY))
+                    if (HasAttribute(anY.c_str()))
                         bone->scale.y = ReadAttribute<float>(anY);
-                    if (HasAttribute(anZ))
+                    if (HasAttribute(anZ.c_str()))
                         bone->scale.z = ReadAttribute<float>(anZ);
                 }
             }

--- a/code/OgreXmlSerializer.h
+++ b/code/OgreXmlSerializer.h
@@ -99,7 +99,7 @@ private:
 
     template<typename T>
     T ReadAttribute(const std::string &name) const;
-    bool HasAttribute(const std::string &name) const;
+    bool HasAttribute(const char *name) const;
 
     std::string &NextNode();
     std::string &SkipCurrentNode();

--- a/code/OgreXmlSerializer.h
+++ b/code/OgreXmlSerializer.h
@@ -98,7 +98,7 @@ private:
     void ReadAnimationKeyFrames(Animation *anim, VertexAnimationTrack *dest);
 
     template<typename T>
-    T ReadAttribute(const std::string &name) const;
+    T ReadAttribute(const char *name) const;
     bool HasAttribute(const char *name) const;
 
     std::string &NextNode();


### PR DESCRIPTION
Replace `std::string` with `const char *`. This fixes some race condition false positives from Helgrind. It was also kind of silly to create a `std::string` and immediately pass it as `const char *` to another function.