### PR TITLE
Fix another thread-safety issue

### DIFF
--- a/code/OgreXmlSerializer.cpp
+++ b/code/OgreXmlSerializer.cpp
@@ -835,7 +835,7 @@ void OgreXmlSerializer::ReadAnimationTracks(Animation *dest)
 
 void OgreXmlSerializer::ReadAnimationKeyFrames(Animation *anim, VertexAnimationTrack *dest)
 {
-    static const aiVector3D zeroVec(0.f, 0.f, 0.f);
+    const aiVector3D zeroVec(0.f, 0.f, 0.f);
 
     NextNode();
     while(m_currentNodeName == nnKeyFrame)


### PR DESCRIPTION
@kimkulling Please don't create static variables (even if const) in function scope. This forces the compiler to allocate memory for them and insert code which will check and initialize if necessary. This will cause issues for anyone trying to debug with Helgrind or DRD. Also in case of a small type like `aiVector3D` it will actually hinder optimization since it now has to do memory fetches instead of just loading a constant `0.0f`.