### PR TITLE
BaseImporter: fix lookup for tokens during inmemory imports.

### DIFF
--- a/code/BaseImporter.cpp
+++ b/code/BaseImporter.cpp
@@ -178,9 +178,17 @@ void BaseImporter::GetExtensionList(std::set<std::string>& extensions)
         }
         *cur2 = '\0';
 
+        std::string token;
         for (unsigned int i = 0; i < numTokens;++i) {
-            ai_assert(NULL != tokens[i]);
-            const char* r = strstr(buffer,tokens[i]);
+            ai_assert( nullptr != tokens[i] );
+            size_t len( strlen( tokens[ i ] ) );
+            token.clear();
+            const char *ptr( tokens[ i ] );
+            for ( size_t tokIdx = 0; tokIdx < len; ++tokIdx ) {
+                token.push_back( tolower( *ptr ) );
+                ++ptr;
+            }
+            const char* r = strstr( buffer, token.c_str() );
             if( !r ) {
                 continue;
             }

--- a/code/Importer/IFC/IFCLoader.cpp
+++ b/code/Importer/IFC/IFCLoader.cpp
@@ -141,7 +141,8 @@ bool IFCImporter::CanRead( const std::string& pFile, IOSystem* pIOHandler, bool 
         // it is only unambiguous as long as we don't support any further
         // file formats with STEP as their encoding.
         const char* tokens[] = {"ISO-10303-21"};
-        return SearchFileHeaderForToken(pIOHandler,pFile,tokens,1);
+        const bool found( SearchFileHeaderForToken( pIOHandler, pFile, tokens, 1 ) );
+        return found;
     }
     return false;
 }

--- a/test/unit/utIFCImportExport.cpp
+++ b/test/unit/utIFCImportExport.cpp
@@ -80,5 +80,6 @@ TEST_F( utIFCImportExport, importComplextypeAsColor ) {
         "#5 = IFCCOMPLEXPROPERTY( 'Color', $, 'Color', ( #19, #20, #21 ) );\n";
     Assimp::Importer importer;
     const aiScene *scene = importer.ReadFileFromMemory( asset.c_str(), asset.size(), 0 );
+    EXPECT_EQ( nullptr, scene );
 
 }

--- a/test/unit/utIFCImportExport.cpp
+++ b/test/unit/utIFCImportExport.cpp
@@ -62,3 +62,23 @@ public:
 TEST_F( utIFCImportExport, importIFCFromFileTest ) {
     EXPECT_TRUE( importerTest() );
 }
+
+TEST_F( utIFCImportExport, importComplextypeAsColor ) {
+    std::string asset =
+        "ISO-10303-21;\n"
+        "HEADER;\n"
+        "FILE_DESCRIPTION( ( 'ViewDefinition [CoordinationView, SpaceBoundary2ndLevelAddOnView]', 'Option [Filter: ]' ), '2;1' );\n"
+        "FILE_NAME( 'S:\\[IFC]\\[COMPLETE-BUILDINGS]\\FZK-MODELS\\FZK-Haus\\ArchiCAD-14\\AC14-FZK-Haus.ifc', '2010-10-07T13:40:52', ( 'Architect' ), ( 'Building Designer Office' ), 'PreProc - EDM 5.0', 'ArchiCAD 14.00 Release 1. Windows Build Number of the Ifc 2x3 interface: 3427', 'The authorising person' );\n"
+        "FILE_SCHEMA( ( 'IFC2X3' ) );\n"
+        "ENDSEC;\n"
+        "\n"
+        "DATA;\n"
+        "#1 = IFCORGANIZATION( 'GS', 'Graphisoft', 'Graphisoft', $, $ );\n"
+        "#2 = IFCPROPERTYSINGLEVALUE( 'Red', $, IFCINTEGER( 255 ), $ );\n"
+        "#3 = IFCPROPERTYSINGLEVALUE( 'Green', $, IFCINTEGER( 255 ), $ );\n"
+        "#4 = IFCPROPERTYSINGLEVALUE( 'Blue', $, IFCINTEGER( 255 ), $ );\n"
+        "#5 = IFCCOMPLEXPROPERTY( 'Color', $, 'Color', ( #19, #20, #21 ) );\n";
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFileFromMemory( asset.c_str(), asset.size(), 0 );
+
+}


### PR DESCRIPTION
When looking for tokens to validate, which importer shall be used the tokens of the file will be converted to lower case. The same must be done for the tokens to look for. This pull request will fix this.