### PR TITLE
FBX Export: add missing 0 value to file footer.

### DIFF
--- a/code/FBXExporter.cpp
+++ b/code/FBXExporter.cpp
@@ -247,6 +247,11 @@ void FBXExporter::WriteBinaryFooter()
         outfile->Write("\x00", 1, 1);
     }
 
+    // not sure what this is, but it seems to always be 0 in modern files
+    for (size_t i = 0; i < 4; ++i) {
+        outfile->Write("\x00", 1, 1);
+    }
+
     // now the file version again
     {
         StreamWriterLE outstream(outfile);


### PR DESCRIPTION
This correctly aligns the footer. The FBX SDK doesn't seem to care when importing (neither does Blender, or probably anything else), but this better matches the footer of officially-exported FBX files.