### PR TITLE
Support Maya 2018 Collada Export

### DIFF
--- a/code/ColladaParser.cpp
+++ b/code/ColladaParser.cpp
@@ -222,6 +222,7 @@ void ColladaParser::ReadStructure()
     }
 
 	PostProcessRootAnimations();
+    PostProcessControllers();
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -358,6 +359,21 @@ void ColladaParser::ReadAnimationClipLibrary()
 			break;
 		}
 	}
+}
+
+void ColladaParser::PostProcessControllers()
+{
+  for (ControllerLibrary::iterator it = mControllerLibrary.begin(); it != mControllerLibrary.end(); ++it)
+  {
+    std::string meshId = it->second.mMeshId;
+    ControllerLibrary::iterator findItr = mControllerLibrary.find(meshId);
+    while(findItr != mControllerLibrary.end()) {
+      meshId = findItr->second.mMeshId;
+      findItr = mControllerLibrary.find(meshId);
+    }
+    
+    it->second.mMeshId = meshId;
+  }
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/code/ColladaParser.h
+++ b/code/ColladaParser.h
@@ -87,6 +87,9 @@ namespace Assimp
 		/** Reads the animation clip library */
 		void ReadAnimationClipLibrary();
 
+        /** Unwrap controllers dependency hierarchy */
+        void PostProcessControllers();
+    
 		/** Re-build animations from animation clip library, if present, otherwise combine single-channel animations */
 		void PostProcessRootAnimations();
 


### PR DESCRIPTION
When blendshapes and bones are applied to a mesh Maya 2018 exports Collada with nested controllers which are not supported in Assimp. I've placed postprocessor which breaks the controllers hierarchy

[torus.zip](https://github.com/assimp/assimp/files/1817949/torus.zip)

