### PR TITLE
Ascii FBX Export

### DIFF
--- a/code/Exporter.cpp
+++ b/code/Exporter.cpp
@@ -98,7 +98,7 @@ void ExportSceneAssbin(const char*, IOSystem*, const aiScene*, const ExportPrope
 void ExportSceneAssxml(const char*, IOSystem*, const aiScene*, const ExportProperties*);
 void ExportSceneX3D(const char*, IOSystem*, const aiScene*, const ExportProperties*);
 void ExportSceneFBX(const char*, IOSystem*, const aiScene*, const ExportProperties*);
-//void ExportSceneFBXA(const char*, IOSystem*, const aiScene*, const ExportProperties*);
+void ExportSceneFBXA(const char*, IOSystem*, const aiScene*, const ExportProperties*);
 void ExportScene3MF( const char*, IOSystem*, const aiScene*, const ExportProperties* );
 
 // ------------------------------------------------------------------------------------------------
@@ -173,7 +173,7 @@ Exporter::ExportFormatEntry gExporters[] =
 
 #ifndef ASSIMP_BUILD_NO_FBX_EXPORTER
     Exporter::ExportFormatEntry( "fbx", "Autodesk FBX (binary)", "fbx", &ExportSceneFBX, 0 ),
-    //Exporter::ExportFormatEntry( "fbxa", "Autodesk FBX (ascii)", "fbx", &ExportSceneFBXA, 0 ),
+    Exporter::ExportFormatEntry( "fbxa", "Autodesk FBX (ascii)", "fbx", &ExportSceneFBXA, 0 ),
 #endif
 
 #ifndef ASSIMP_BUILD_NO_3MF_EXPORTER

--- a/code/FBXExportNode.cpp
+++ b/code/FBXExportNode.cpp
@@ -168,7 +168,7 @@ void FBX::Node::Dump(Assimp::StreamWriterLE &s)
     DumpChildren(s);
 
     // finish, filling in end offset placeholder
-    End(s, !children.empty());
+    End(s, force_has_children || !children.empty());
 }
 
 void FBX::Node::Begin(Assimp::StreamWriterLE &s)

--- a/code/FBXExportNode.cpp
+++ b/code/FBXExportNode.cpp
@@ -45,10 +45,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "FBXCommon.h"
 
 #include <assimp/StreamWriter.h> // StreamWriterLE
+#include <assimp/Exceptional.h> // DeadlyExportError
 #include <assimp/ai_assert.h>
 
 #include <string>
+#include <ostream>
+#include <sstream> // ostringstream
 #include <memory> // shared_ptr
+#include <cstdio> // snprintf
 
 // AddP70<type> helpers... there's no usable pattern here,
 // so all are defined as separate functions.
@@ -145,33 +149,174 @@ void FBX::Node::AddP70time(
 }
 
 
+// public member functions for writing nodes to stream
+
+void FBX::Node::Dump(
+    std::shared_ptr<Assimp::IOStream> outfile,
+    bool binary, int indent
+) {
+    if (binary) {
+        Assimp::StreamWriterLE outstream(outfile);
+        DumpBinary(outstream);
+    } else {
+        std::ostringstream ss;
+        DumpAscii(ss, indent);
+        std::string s = ss.str();
+        outfile->Write(s.c_str(), s.size(), 1);
+    }
+}
+
+void FBX::Node::Dump(
+    Assimp::StreamWriterLE &outstream,
+    bool binary, int indent
+) {
+    if (binary) {
+        DumpBinary(outstream);
+    } else {
+        std::ostringstream ss;
+        DumpAscii(ss, indent);
+        outstream.PutString(ss.str());
+    }
+}
+
+
+// public member functions for low-level writing
+
+void FBX::Node::Begin(
+    Assimp::StreamWriterLE &s,
+    bool binary, int indent
+) {
+    if (binary) {
+        BeginBinary(s);
+    } else {
+        // assume we're at the correct place to start already
+        (void)indent;
+        std::ostringstream ss;
+        BeginAscii(ss, indent);
+        s.PutString(ss.str());
+    }
+}
+
+void FBX::Node::DumpProperties(
+    Assimp::StreamWriterLE& s,
+    bool binary, int indent
+) {
+    if (binary) {
+        DumpPropertiesBinary(s);
+    } else {
+        std::ostringstream ss;
+        DumpPropertiesAscii(ss, indent);
+        s.PutString(ss.str());
+    }
+}
+
+void FBX::Node::EndProperties(
+    Assimp::StreamWriterLE &s,
+    bool binary, int indent
+) {
+    EndProperties(s, binary, indent, properties.size());
+}
+
+void FBX::Node::EndProperties(
+    Assimp::StreamWriterLE &s,
+    bool binary, int indent,
+    size_t num_properties
+) {
+    if (binary) {
+        EndPropertiesBinary(s, num_properties);
+    } else {
+        // nothing to do
+        (void)indent;
+    }
+}
+
+void FBX::Node::BeginChildren(
+    Assimp::StreamWriterLE &s,
+    bool binary, int indent
+) {
+    if (binary) {
+        // nothing to do
+    } else {
+        std::ostringstream ss;
+        BeginChildrenAscii(ss, indent);
+        s.PutString(ss.str());
+    }
+}
+
+void FBX::Node::DumpChildren(
+    Assimp::StreamWriterLE& s,
+    bool binary, int indent
+) {
+    if (binary) {
+        DumpChildrenBinary(s);
+    } else {
+        std::ostringstream ss;
+        DumpChildrenAscii(ss, indent);
+        s.PutString(ss.str());
+    }
+}
+
+void FBX::Node::End(
+    Assimp::StreamWriterLE &s,
+    bool binary, int indent,
+    bool has_children
+) {
+    if (binary) {
+        EndBinary(s, has_children);
+    } else {
+        std::ostringstream ss;
+        EndAscii(ss, indent, has_children);
+        s.PutString(ss.str());
+    }
+}
+
+
 // public member functions for writing to binary fbx
 
-void FBX::Node::Dump(std::shared_ptr<Assimp::IOStream> outfile)
-{
-    Assimp::StreamWriterLE outstream(outfile);
-    Dump(outstream);
-}
-
-void FBX::Node::Dump(Assimp::StreamWriterLE &s)
+void FBX::Node::DumpBinary(Assimp::StreamWriterLE &s)
 {
     // write header section (with placeholders for some things)
-    Begin(s);
+    BeginBinary(s);
 
     // write properties
-    DumpProperties(s);
+    DumpPropertiesBinary(s);
 
     // go back and fill in property related placeholders
-    EndProperties(s, properties.size());
+    EndPropertiesBinary(s, properties.size());
 
     // write children
-    DumpChildren(s);
+    DumpChildrenBinary(s);
 
     // finish, filling in end offset placeholder
-    End(s, force_has_children || !children.empty());
+    EndBinary(s, force_has_children || !children.empty());
 }
 
-void FBX::Node::Begin(Assimp::StreamWriterLE &s)
+
+// public member functions for writing to ascii fbx
+
+void FBX::Node::DumpAscii(std::ostream &s, int indent)
+{
+    // write name
+    BeginAscii(s, indent);
+
+    // write properties
+    DumpPropertiesAscii(s, indent);
+
+    if (force_has_children || !children.empty()) {
+        // begin children (with a '{')
+        BeginChildrenAscii(s, indent + 1);
+        // write children
+        DumpChildrenAscii(s, indent + 1);
+    }
+
+    // finish (also closing the children bracket '}')
+    EndAscii(s, indent, force_has_children || !children.empty());
+}
+
+
+// private member functions for low-level writing to fbx
+
+void FBX::Node::BeginBinary(Assimp::StreamWriterLE &s)
 {
     // remember start pos so we can come back and write the end pos
     this->start_pos = s.Tell();
@@ -189,26 +334,14 @@ void FBX::Node::Begin(Assimp::StreamWriterLE &s)
     this->property_start = s.Tell();
 }
 
-void FBX::Node::DumpProperties(Assimp::StreamWriterLE& s)
+void FBX::Node::DumpPropertiesBinary(Assimp::StreamWriterLE& s)
 {
     for (auto &p : properties) {
-        p.Dump(s);
+        p.DumpBinary(s);
     }
 }
 
-void FBX::Node::DumpChildren(Assimp::StreamWriterLE& s)
-{
-    for (FBX::Node& child : children) {
-        child.Dump(s);
-    }
-}
-
-void FBX::Node::EndProperties(Assimp::StreamWriterLE &s)
-{
-    EndProperties(s, properties.size());
-}
-
-void FBX::Node::EndProperties(
+void FBX::Node::EndPropertiesBinary(
     Assimp::StreamWriterLE &s,
     size_t num_properties
 ) {
@@ -222,7 +355,14 @@ void FBX::Node::EndProperties(
     s.Seek(pos);
 }
 
-void FBX::Node::End(
+void FBX::Node::DumpChildrenBinary(Assimp::StreamWriterLE& s)
+{
+    for (FBX::Node& child : children) {
+        child.DumpBinary(s);
+    }
+}
+
+void FBX::Node::EndBinary(
     Assimp::StreamWriterLE &s,
     bool has_children
 ) {
@@ -237,48 +377,192 @@ void FBX::Node::End(
 }
 
 
-// static member functions
+void FBX::Node::BeginAscii(std::ostream& s, int indent)
+{
+    s << '\n';
+    for (int i = 0; i < indent; ++i) { s << '\t'; }
+    s << name << ": ";
+}
 
-// convenience function to create and write a property node,
-// holding a single property which is an array of values.
-// does not copy the data, so is efficient for large arrays.
+void FBX::Node::DumpPropertiesAscii(std::ostream &s, int indent)
+{
+    for (size_t i = 0; i < properties.size(); ++i) {
+        if (i > 0) { s << ", "; }
+        properties[i].DumpAscii(s, indent);
+    }
+}
+
+void FBX::Node::BeginChildrenAscii(std::ostream& s, int indent)
+{
+    // only call this if there are actually children
+    s << " {";
+    (void)indent;
+}
+
+void FBX::Node::DumpChildrenAscii(std::ostream& s, int indent)
+{
+    // children will need a lot of padding and corralling
+    if (children.size() || force_has_children) {
+        for (size_t i = 0; i < children.size(); ++i) {
+            // no compression in ascii files, so skip this node if it exists
+            if (children[i].name == "EncryptionType") { continue; }
+            // the child can dump itself
+            children[i].DumpAscii(s, indent);
+        }
+    }
+}
+
+void FBX::Node::EndAscii(std::ostream& s, int indent, bool has_children)
+{
+    if (!has_children) { return; } // nothing to do
+    s << '\n';
+    for (int i = 0; i < indent; ++i) { s << '\t'; }
+    s << "}";
+}
+
+// private helpers for static member functions
+
+// ascii property node from vector of doubles
+void FBX::Node::WritePropertyNodeAscii(
+    const std::string& name,
+    const std::vector<double>& v,
+    Assimp::StreamWriterLE& s,
+    int indent
+){
+    char buffer[32];
+    FBX::Node node(name);
+    node.Begin(s, false, indent);
+    std::string vsize = std::to_string(v.size());
+    // *<size> {
+    s.PutChar('*'); s.PutString(vsize); s.PutString(" {\n");
+    // indent + 1
+    for (int i = 0; i < indent + 1; ++i) { s.PutChar('\t'); }
+    // a: value,value,value,...
+    s.PutString("a: ");
+    int count = 0;
+    for (size_t i = 0; i < v.size(); ++i) {
+        if (i > 0) { s.PutChar(','); }
+        int len = snprintf(buffer, sizeof(buffer), "%f", v[i]);
+        count += len;
+        if (count > 2048) { s.PutChar('\n'); count = 0; }
+        if (len < 0 || len > 31) {
+            // this should never happen
+            throw DeadlyExportError("failed to convert double to string");
+        }
+        for (int j = 0; j < len; ++j) { s.PutChar(buffer[j]); }
+    }
+    // }
+    s.PutChar('\n');
+    for (int i = 0; i < indent; ++i) { s.PutChar('\t'); }
+    s.PutChar('}'); s.PutChar(' ');
+    node.End(s, false, indent, false);
+}
+
+// ascii property node from vector of int32_t
+void FBX::Node::WritePropertyNodeAscii(
+    const std::string& name,
+    const std::vector<int32_t>& v,
+    Assimp::StreamWriterLE& s,
+    int indent
+){
+    char buffer[32];
+    FBX::Node node(name);
+    node.Begin(s, false, indent);
+    std::string vsize = std::to_string(v.size());
+    // *<size> {
+    s.PutChar('*'); s.PutString(vsize); s.PutString(" {\n");
+    // indent + 1
+    for (int i = 0; i < indent + 1; ++i) { s.PutChar('\t'); }
+    // a: value,value,value,...
+    s.PutString("a: ");
+    int count = 0;
+    for (size_t i = 0; i < v.size(); ++i) {
+        if (i > 0) { s.PutChar(','); }
+        int len = snprintf(buffer, sizeof(buffer), "%d", v[i]);
+        count += len;
+        if (count > 2048) { s.PutChar('\n'); count = 0; }
+        if (len < 0 || len > 31) {
+            // this should never happen
+            throw DeadlyExportError("failed to convert double to string");
+        }
+        for (int j = 0; j < len; ++j) { s.PutChar(buffer[j]); }
+    }
+    // }
+    s.PutChar('\n');
+    for (int i = 0; i < indent; ++i) { s.PutChar('\t'); }
+    s.PutChar('}'); s.PutChar(' ');
+    node.End(s, false, indent, false);
+}
+
+// binary property node from vector of doubles
 // TODO: optional zip compression!
-void FBX::Node::WritePropertyNode(
+void FBX::Node::WritePropertyNodeBinary(
     const std::string& name,
     const std::vector<double>& v,
     Assimp::StreamWriterLE& s
 ){
-    Node node(name);
-    node.Begin(s);
+    FBX::Node node(name);
+    node.BeginBinary(s);
     s.PutU1('d');
     s.PutU4(uint32_t(v.size())); // number of elements
     s.PutU4(0); // no encoding (1 would be zip-compressed)
     s.PutU4(uint32_t(v.size()) * 8); // data size
     for (auto it = v.begin(); it != v.end(); ++it) { s.PutF8(*it); }
-    node.EndProperties(s, 1);
-    node.End(s, false);
+    node.EndPropertiesBinary(s, 1);
+    node.EndBinary(s, false);
 }
 
-// convenience function to create and write a property node,
-// holding a single property which is an array of values.
-// does not copy the data, so is efficient for large arrays.
+// binary property node from vector of int32_t
 // TODO: optional zip compression!
-void FBX::Node::WritePropertyNode(
+void FBX::Node::WritePropertyNodeBinary(
     const std::string& name,
     const std::vector<int32_t>& v,
     Assimp::StreamWriterLE& s
 ){
-    Node node(name);
-    node.Begin(s);
+    FBX::Node node(name);
+    node.BeginBinary(s);
     s.PutU1('i');
     s.PutU4(uint32_t(v.size())); // number of elements
     s.PutU4(0); // no encoding (1 would be zip-compressed)
     s.PutU4(uint32_t(v.size()) * 4); // data size
     for (auto it = v.begin(); it != v.end(); ++it) { s.PutI4(*it); }
-    node.EndProperties(s, 1);
-    node.End(s, false);
+    node.EndPropertiesBinary(s, 1);
+    node.EndBinary(s, false);
 }
 
+// public static member functions
+
+// convenience function to create and write a property node,
+// holding a single property which is an array of values.
+// does not copy the data, so is efficient for large arrays.
+void FBX::Node::WritePropertyNode(
+    const std::string& name,
+    const std::vector<double>& v,
+    Assimp::StreamWriterLE& s,
+    bool binary, int indent
+){
+    if (binary) {
+        FBX::Node::WritePropertyNodeBinary(name, v, s);
+    } else {
+        FBX::Node::WritePropertyNodeAscii(name, v, s, indent);
+    }
+}
+
+// convenience function to create and write a property node,
+// holding a single property which is an array of values.
+// does not copy the data, so is efficient for large arrays.
+void FBX::Node::WritePropertyNode(
+    const std::string& name,
+    const std::vector<int32_t>& v,
+    Assimp::StreamWriterLE& s,
+    bool binary, int indent
+){
+    if (binary) {
+        FBX::Node::WritePropertyNodeBinary(name, v, s);
+    } else {
+        FBX::Node::WritePropertyNodeAscii(name, v, s, indent);
+    }
+}
 
 #endif // ASSIMP_BUILD_NO_FBX_EXPORTER
 #endif // ASSIMP_BUILD_NO_EXPORT

--- a/code/FBXExportNode.cpp
+++ b/code/FBXExportNode.cpp
@@ -47,12 +47,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/StreamWriter.h> // StreamWriterLE
 #include <assimp/Exceptional.h> // DeadlyExportError
 #include <assimp/ai_assert.h>
+#include <assimp/StringUtils.h> // ai_snprintf
 
 #include <string>
 #include <ostream>
 #include <sstream> // ostringstream
 #include <memory> // shared_ptr
-#include <cstdio> // snprintf
 
 // AddP70<type> helpers... there's no usable pattern here,
 // so all are defined as separate functions.
@@ -442,7 +442,7 @@ void FBX::Node::WritePropertyNodeAscii(
     int count = 0;
     for (size_t i = 0; i < v.size(); ++i) {
         if (i > 0) { s.PutChar(','); }
-        int len = snprintf(buffer, sizeof(buffer), "%f", v[i]);
+        int len = ai_snprintf(buffer, sizeof(buffer), "%f", v[i]);
         count += len;
         if (count > 2048) { s.PutChar('\n'); count = 0; }
         if (len < 0 || len > 31) {
@@ -478,7 +478,7 @@ void FBX::Node::WritePropertyNodeAscii(
     int count = 0;
     for (size_t i = 0; i < v.size(); ++i) {
         if (i > 0) { s.PutChar(','); }
-        int len = snprintf(buffer, sizeof(buffer), "%d", v[i]);
+        int len = ai_snprintf(buffer, sizeof(buffer), "%d", v[i]);
         count += len;
         if (count > 2048) { s.PutChar('\n'); count = 0; }
         if (len < 0 || len > 31) {

--- a/code/FBXExportNode.h
+++ b/code/FBXExportNode.h
@@ -66,6 +66,9 @@ public: // public data members
     std::vector<FBX::Property> properties; // node properties
     std::vector<FBX::Node> children; // child nodes
 
+    // some nodes always pretend they have children...
+    bool force_has_children = false;
+
 public: // constructors
     Node() = default;
     Node(const std::string& n) : name(n) {}

--- a/code/FBXExportNode.h
+++ b/code/FBXExportNode.h
@@ -142,19 +142,48 @@ public: // support specifically for dealing with Properties70 nodes
 
 public: // member functions for writing data to a file or stream
 
-    // write the full node as binary data to the given file or stream
-    void Dump(std::shared_ptr<Assimp::IOStream> outfile);
-    void Dump(Assimp::StreamWriterLE &s);
+    // write the full node to the given file or stream
+    void Dump(
+        std::shared_ptr<Assimp::IOStream> outfile,
+        bool binary, int indent
+    );
+    void Dump(Assimp::StreamWriterLE &s, bool binary, int indent);
 
     // these other functions are for writing data piece by piece.
     // they must be used carefully.
     // for usage examples see FBXExporter.cpp.
-    void Begin(Assimp::StreamWriterLE &s);
-    void DumpProperties(Assimp::StreamWriterLE& s);
-    void EndProperties(Assimp::StreamWriterLE &s);
-    void EndProperties(Assimp::StreamWriterLE &s, size_t num_properties);
-    void DumpChildren(Assimp::StreamWriterLE& s);
-    void End(Assimp::StreamWriterLE &s, bool has_children);
+    void Begin(Assimp::StreamWriterLE &s, bool binary, int indent);
+    void DumpProperties(Assimp::StreamWriterLE& s, bool binary, int indent);
+    void EndProperties(Assimp::StreamWriterLE &s, bool binary, int indent);
+    void EndProperties(
+        Assimp::StreamWriterLE &s, bool binary, int indent,
+        size_t num_properties
+    );
+    void BeginChildren(Assimp::StreamWriterLE &s, bool binary, int indent);
+    void DumpChildren(Assimp::StreamWriterLE& s, bool binary, int indent);
+    void End(
+        Assimp::StreamWriterLE &s, bool binary, int indent,
+        bool has_children
+    );
+
+private: // internal functions used for writing
+
+    void DumpBinary(Assimp::StreamWriterLE &s);
+    void DumpAscii(Assimp::StreamWriterLE &s, int indent);
+    void DumpAscii(std::ostream &s, int indent);
+
+    void BeginBinary(Assimp::StreamWriterLE &s);
+    void DumpPropertiesBinary(Assimp::StreamWriterLE& s);
+    void EndPropertiesBinary(Assimp::StreamWriterLE &s);
+    void EndPropertiesBinary(Assimp::StreamWriterLE &s, size_t num_properties);
+    void DumpChildrenBinary(Assimp::StreamWriterLE& s);
+    void EndBinary(Assimp::StreamWriterLE &s, bool has_children);
+
+    void BeginAscii(std::ostream &s, int indent);
+    void DumpPropertiesAscii(std::ostream &s, int indent);
+    void BeginChildrenAscii(std::ostream &s, int indent);
+    void DumpChildrenAscii(std::ostream &s, int indent);
+    void EndAscii(std::ostream &s, int indent, bool has_children);
 
 private: // data used for binary dumps
     size_t start_pos; // starting position in stream
@@ -169,11 +198,12 @@ public: // static member functions
     static void WritePropertyNode(
         const std::string& name,
         const T value,
-        Assimp::StreamWriterLE& s
+        Assimp::StreamWriterLE& s,
+        bool binary, int indent
     ) {
         FBX::Property p(value);
         FBX::Node node(name, p);
-        node.Dump(s);
+        node.Dump(s, binary, indent);
     }
 
     // convenience function to create and write a property node,
@@ -182,7 +212,8 @@ public: // static member functions
     static void WritePropertyNode(
         const std::string& name,
         const std::vector<double>& v,
-        Assimp::StreamWriterLE& s
+        Assimp::StreamWriterLE& s,
+        bool binary, int indent
     );
 
     // convenience function to create and write a property node,
@@ -191,8 +222,34 @@ public: // static member functions
     static void WritePropertyNode(
         const std::string& name,
         const std::vector<int32_t>& v,
+        Assimp::StreamWriterLE& s,
+        bool binary, int indent
+    );
+
+private: // static helper functions
+    static void WritePropertyNodeAscii(
+        const std::string& name,
+        const std::vector<double>& v,
+        Assimp::StreamWriterLE& s,
+        int indent
+    );
+    static void WritePropertyNodeAscii(
+        const std::string& name,
+        const std::vector<int32_t>& v,
+        Assimp::StreamWriterLE& s,
+        int indent
+    );
+    static void WritePropertyNodeBinary(
+        const std::string& name,
+        const std::vector<double>& v,
         Assimp::StreamWriterLE& s
     );
+    static void WritePropertyNodeBinary(
+        const std::string& name,
+        const std::vector<int32_t>& v,
+        Assimp::StreamWriterLE& s
+    );
+
 };
 
 

--- a/code/FBXExportNode.h
+++ b/code/FBXExportNode.h
@@ -69,11 +69,12 @@ public: // public data members
 public: // constructors
     Node() = default;
     Node(const std::string& n) : name(n) {}
-    Node(const std::string& n, const FBX::Property &p)
+
+    // convenience template to construct with properties directly
+    template <typename... More>
+    Node(const std::string& n, const More... more)
         : name(n)
-        { properties.push_back(p); }
-    Node(const std::string& n, const std::vector<FBX::Property> &pv)
-        : name(n), properties(pv) {}
+        { AddProperties(more...); }
 
 public: // functions to add properties or children
     // add a single property to the node

--- a/code/FBXExportProperty.h
+++ b/code/FBXExportProperty.h
@@ -53,6 +53,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <string>
 #include <vector>
+#include <ostream>
 #include <type_traits> // is_void
 
 namespace FBX {
@@ -113,7 +114,10 @@ public:
     size_t size();
 
     // write this property node as binary data to the given stream
-    void Dump(Assimp::StreamWriterLE &s);
+    void DumpBinary(Assimp::StreamWriterLE &s);
+    void DumpAscii(Assimp::StreamWriterLE &s, int indent=0);
+    void DumpAscii(std::ostream &s, int indent=0);
+    // note: make sure the ostream is in classic "C" locale
 
 private:
     char type;

--- a/code/FBXExporter.cpp
+++ b/code/FBXExporter.cpp
@@ -1521,7 +1521,7 @@ void FBXExporter::WriteObjects ()
             tnode.AddChild("RelativeFilename", texture_path);
             tnode.AddChild("ModelUVTranslation", double(0.0), double(0.0));
             tnode.AddChild("ModelUVScaling", double(1.0), double(1.0));
-            tnode.AddChild("Texture_Alpha_Soutce", "None");
+            tnode.AddChild("Texture_Alpha_Source", "None");
             tnode.AddChild(
                 "Cropping", int32_t(0), int32_t(0), int32_t(0), int32_t(0)
             );

--- a/code/FBXExporter.cpp
+++ b/code/FBXExporter.cpp
@@ -1784,7 +1784,7 @@ void FBXExporter::WriteObjects ()
 
             // this should be the same as the bone's mOffsetMatrix.
             // if it's not the same, the skeleton isn't in the bind pose.
-            const float epsilon = 1e-5f; // some error is to be expected
+            const float epsilon = 1e-4f; // some error is to be expected
             bool bone_xform_okay = true;
             if (b && ! tr.Equal(b->mOffsetMatrix, epsilon)) {
                 not_in_bind_pose.insert(b);

--- a/code/FBXExporter.cpp
+++ b/code/FBXExporter.cpp
@@ -419,6 +419,7 @@ void FBXExporter::WriteReferences ()
     // always empty for now.
     // not really sure what this is for.
     FBX::Node n("References");
+    n.force_has_children = true;
     n.Dump(outfile);
 }
 
@@ -1914,11 +1915,8 @@ void FBXExporter::WriteObjects ()
 
         // this node absurdly always pretends it has children
         // (in this case it does, but just in case...)
-        asnode.Begin(outstream);
-        asnode.DumpProperties(outstream);
-        asnode.EndProperties(outstream);
-        asnode.DumpChildren(outstream);
-        asnode.End(outstream, true);
+        asnode.force_has_children = true;
+        asnode.Dump(outstream);
 
         // note: animation stacks are not connected to anything
     }
@@ -1932,11 +1930,8 @@ void FBXExporter::WriteObjects ()
         alnode.AddProperties(animlayer_uid, FBX::SEPARATOR + "AnimLayer", "");
 
         // this node absurdly always pretends it has children
-        alnode.Begin(outstream);
-        alnode.DumpProperties(outstream);
-        alnode.EndProperties(outstream);
-        alnode.DumpChildren(outstream);
-        alnode.End(outstream, true);
+        alnode.force_has_children = true;
+        alnode.Dump(outstream);
 
         // connect to the relevant animstack
         connections.emplace_back(

--- a/code/FBXExporter.cpp
+++ b/code/FBXExporter.cpp
@@ -2258,15 +2258,6 @@ void FBXExporter::WriteModelNodes(
     // first collapse any expanded transformation chains created by FBX import.
     std::string node_name(node->mName.C_Str());
     if (node_name.find(MAGIC_NODE_TAG) != std::string::npos) {
-        if (node->mNumChildren != 1) {
-            // this should never happen
-            std::stringstream err;
-            err << "FBX transformation node should have exactly 1 child,";
-            err << " but " << node->mNumChildren << " found";
-            err << " on node \"" << node_name << "\"!";
-            throw DeadlyExportError(err.str());
-        }
-        aiNode* next_node = node->mChildren[0];
         auto pos = node_name.find(MAGIC_NODE_TAG) + MAGIC_NODE_TAG.size() + 1;
         std::string type_name = node_name.substr(pos);
         auto elem = transform_types.find(type_name);
@@ -2300,10 +2291,16 @@ void FBXExporter::WriteModelNodes(
             err << elem->second.second;
             throw DeadlyExportError(err.str());
         }
-        // now just continue to the next node
-        WriteModelNodes(
-            outstream, next_node, parent_uid, limbnodes, transform_chain
-        );
+        // now continue on to any child nodes
+        for (unsigned i = 0; i < node->mNumChildren; ++i) {
+            WriteModelNodes(
+                outstream,
+                node->mChildren[i],
+                parent_uid,
+                limbnodes,
+                transform_chain
+            );
+        }
         return;
     }
 

--- a/code/FBXExporter.cpp
+++ b/code/FBXExporter.cpp
@@ -520,7 +520,7 @@ void FBXExporter::WriteDefinitions ()
 
     // GlobalSettings
     // this seems to always be here in Maya exports
-    n = FBX::Node("ObjectType", Property("GlobalSettings"));
+    n = FBX::Node("ObjectType", "GlobalSettings");
     count = 1;
     n.AddChild("Count", count);
     object_nodes.push_back(n);
@@ -531,9 +531,9 @@ void FBXExporter::WriteDefinitions ()
     // but no harm seems to come of leaving it out.
     count = mScene->mNumAnimations;
     if (count) {
-        n = FBX::Node("ObjectType", Property("AnimationStack"));
+        n = FBX::Node("ObjectType", "AnimationStack");
         n.AddChild("Count", count);
-        pt = FBX::Node("PropertyTemplate", Property("FbxAnimStack"));
+        pt = FBX::Node("PropertyTemplate", "FbxAnimStack");
         p = FBX::Node("Properties70");
         p.AddP70string("Description", "");
         p.AddP70time("LocalStart", 0);
@@ -553,9 +553,9 @@ void FBXExporter::WriteDefinitions ()
     // so there will be one per aiAnimation
     count = mScene->mNumAnimations;
     if (count) {
-        n = FBX::Node("ObjectType", Property("AnimationLayer"));
+        n = FBX::Node("ObjectType", "AnimationLayer");
         n.AddChild("Count", count);
-        pt = FBX::Node("PropertyTemplate", Property("FBXAnimLayer"));
+        pt = FBX::Node("PropertyTemplate", "FBXAnimLayer");
         p = FBX::Node("Properties70");
         p.AddP70("Weight", "Number", "", "A", double(100));
         p.AddP70bool("Mute", 0);
@@ -583,9 +583,9 @@ void FBXExporter::WriteDefinitions ()
     count = 1; // TODO: select properly
     if (count) {
         // FbxSkeleton
-        n = FBX::Node("ObjectType", Property("NodeAttribute"));
+        n = FBX::Node("ObjectType", "NodeAttribute");
         n.AddChild("Count", count);
-        pt = FBX::Node("PropertyTemplate", Property("FbxSkeleton"));
+        pt = FBX::Node("PropertyTemplate", "FbxSkeleton");
         p = FBX::Node("Properties70");
         p.AddP70color("Color", 0.8, 0.8, 0.8);
         p.AddP70double("Size", 33.333333333333);
@@ -601,9 +601,9 @@ void FBXExporter::WriteDefinitions ()
     // <~~ node heirarchy
     count = int32_t(count_nodes(mScene->mRootNode)) - 1; // (not counting root node)
     if (count) {
-        n = FBX::Node("ObjectType", Property("Model"));
+        n = FBX::Node("ObjectType", "Model");
         n.AddChild("Count", count);
-        pt = FBX::Node("PropertyTemplate", Property("FbxNode"));
+        pt = FBX::Node("PropertyTemplate", "FbxNode");
         p = FBX::Node("Properties70");
         p.AddP70enum("QuaternionInterpolate", 0);
         p.AddP70vector("RotationOffset", 0.0, 0.0, 0.0);
@@ -698,9 +698,9 @@ void FBXExporter::WriteDefinitions ()
     // <~~ aiMesh
     count = mScene->mNumMeshes;
     if (count) {
-        n = FBX::Node("ObjectType", Property("Geometry"));
+        n = FBX::Node("ObjectType", "Geometry");
         n.AddChild("Count", count);
-        pt = FBX::Node("PropertyTemplate", Property("FbxMesh"));
+        pt = FBX::Node("PropertyTemplate", "FbxMesh");
         p = FBX::Node("Properties70");
         p.AddP70color("Color", 0, 0, 0);
         p.AddP70vector("BBoxMin", 0, 0, 0);
@@ -724,7 +724,7 @@ void FBXExporter::WriteDefinitions ()
     count = mScene->mNumMaterials;
     if (count) {
         bool has_phong = has_phong_mat(mScene);
-        n = FBX::Node("ObjectType", Property("Material"));
+        n = FBX::Node("ObjectType", "Material");
         n.AddChild("Count", count);
         pt = FBX::Node("PropertyTemplate");
         if (has_phong) {
@@ -771,9 +771,9 @@ void FBXExporter::WriteDefinitions ()
     // one for each image file.
     count = int32_t(count_images(mScene));
     if (count) {
-        n = FBX::Node("ObjectType", Property("Video"));
+        n = FBX::Node("ObjectType", "Video");
         n.AddChild("Count", count);
-        pt = FBX::Node("PropertyTemplate", Property("FbxVideo"));
+        pt = FBX::Node("PropertyTemplate", "FbxVideo");
         p = FBX::Node("Properties70");
         p.AddP70bool("ImageSequence", 0);
         p.AddP70int("ImageSequenceOffset", 0);
@@ -800,9 +800,9 @@ void FBXExporter::WriteDefinitions ()
     // <~~ aiTexture
     count = int32_t(count_textures(mScene));
     if (count) {
-        n = FBX::Node("ObjectType", Property("Texture"));
+        n = FBX::Node("ObjectType", "Texture");
         n.AddChild("Count", count);
-        pt = FBX::Node("PropertyTemplate", Property("FbxFileTexture"));
+        pt = FBX::Node("PropertyTemplate", "FbxFileTexture");
         p = FBX::Node("Properties70");
         p.AddP70enum("TextureTypeUse", 0);
         p.AddP70numberA("Texture alpha", 1.0);
@@ -829,9 +829,9 @@ void FBXExporter::WriteDefinitions ()
     // AnimationCurveNode / FbxAnimCurveNode
     count = mScene->mNumAnimations * 3;
     if (count) {
-        n = FBX::Node("ObjectType", Property("AnimationCurveNode"));
+        n = FBX::Node("ObjectType", "AnimationCurveNode");
         n.AddChild("Count", count);
-        pt = FBX::Node("PropertyTemplate", Property("FbxAnimCurveNode"));
+        pt = FBX::Node("PropertyTemplate", "FbxAnimCurveNode");
         p = FBX::Node("Properties70");
         p.AddP70("d", "Compound", "", "");
         pt.AddChild(p);
@@ -843,7 +843,7 @@ void FBXExporter::WriteDefinitions ()
     // AnimationCurve / FbxAnimCurve
     count = mScene->mNumAnimations * 9;
     if (count) {
-        n = FBX::Node("ObjectType", Property("AnimationCurve"));
+        n = FBX::Node("ObjectType", "AnimationCurve");
         n.AddChild("Count", count);
         object_nodes.push_back(n);
         total_count += count;
@@ -856,7 +856,7 @@ void FBXExporter::WriteDefinitions ()
         if (mesh->HasBones()) { ++count; }
     }
     if (count) {
-        n = FBX::Node("ObjectType", Property("Pose"));
+        n = FBX::Node("ObjectType", "Pose");
         n.AddChild("Count", count);
         object_nodes.push_back(n);
         total_count += count;
@@ -865,7 +865,7 @@ void FBXExporter::WriteDefinitions ()
     // Deformer
     count = int32_t(count_deformers(mScene));
     if (count) {
-        n = FBX::Node("ObjectType", Property("Deformer"));
+        n = FBX::Node("ObjectType", "Deformer");
         n.AddChild("Count", count);
         object_nodes.push_back(n);
         total_count += count;
@@ -874,9 +874,9 @@ void FBXExporter::WriteDefinitions ()
     // (template)
     count = 0;
     if (count) {
-        n = FBX::Node("ObjectType", Property(""));
+        n = FBX::Node("ObjectType", "");
         n.AddChild("Count", count);
-        pt = FBX::Node("PropertyTemplate", Property(""));
+        pt = FBX::Node("PropertyTemplate", "");
         p = FBX::Node("Properties70");
         pt.AddChild(p);
         n.AddChild(pt);
@@ -1008,7 +1008,7 @@ void FBXExporter::WriteObjects ()
 
         // normals, if any
         if (m->HasNormals()) {
-            FBX::Node normals("LayerElementNormal", Property(int32_t(0)));
+            FBX::Node normals("LayerElementNormal", int32_t(0));
             normals.Begin(outstream);
             normals.DumpProperties(outstream);
             normals.EndProperties(outstream);
@@ -1055,7 +1055,7 @@ void FBXExporter::WriteObjects ()
                 err << " but may be incorrectly interpreted on load.";
                 DefaultLogger::get()->warn(err.str());
             }
-            FBX::Node uv("LayerElementUV", Property(int32_t(uvi)));
+            FBX::Node uv("LayerElementUV", int32_t(uvi));
             uv.Begin(outstream);
             uv.DumpProperties(outstream);
             uv.EndProperties(outstream);
@@ -1100,7 +1100,7 @@ void FBXExporter::WriteObjects ()
         // i'm not really sure why this material section exists,
         // as the material is linked via "Connections".
         // it seems to always have the same "0" value.
-        FBX::Node mat("LayerElementMaterial", Property(int32_t(0)));
+        FBX::Node mat("LayerElementMaterial", int32_t(0));
         mat.AddChild("Version", int32_t(101));
         mat.AddChild("Name", "");
         mat.AddChild("MappingInformationType", "AllSame");
@@ -1112,7 +1112,7 @@ void FBXExporter::WriteObjects ()
         // finally we have the layer specifications,
         // which select the normals / UV set / etc to use.
         // TODO: handle multiple uv sets correctly?
-        FBX::Node layer("Layer", Property(int32_t(0)));
+        FBX::Node layer("Layer", int32_t(0));
         layer.AddChild("Version", int32_t(100));
         FBX::Node le("LayerElement");
         le.AddChild("Type", "LayerElementNormal");
@@ -1408,14 +1408,12 @@ void FBXExporter::WriteObjects ()
             const int64_t texture_uid = generate_uid();
 
             // link the texture to the material
-            FBX::Node c("C");
-            c.AddProperties("OP", texture_uid, material_uid, prop_name);
-            connections.push_back(c);
+            connections.emplace_back(
+                "C", "OP", texture_uid, material_uid, prop_name
+            );
 
             // link the image data to the texture
-            c = FBX::Node("C");
-            c.AddProperties("OO", image_uid, texture_uid);
-            connections.push_back(c);
+            connections.emplace_back("C", "OO", image_uid, texture_uid);
 
             // now write the actual texture node
             FBX::Node tnode("Texture");
@@ -1598,9 +1596,7 @@ void FBXExporter::WriteObjects ()
         dnode.Dump(outstream);
 
         // connect it
-        FBX::Node c("C");
-        c.AddProperties("OO", deformer_uid, mesh_uids[mi]);
-        connections.push_back(c); // TODO: emplace_back
+        connections.emplace_back("C", "OO", deformer_uid, mesh_uids[mi]);
 
         // we will be indexing by vertex...
         // but there might be a different number of "vertices"
@@ -1744,14 +1740,14 @@ void FBXExporter::WriteObjects ()
             sdnode.Dump(outstream);
 
             // lastly, connect to the parent deformer
-            c = FBX::Node("C");
-            c.AddProperties("OO", subdeformer_uid, deformer_uid);
-            connections.push_back(c); // TODO: emplace_back
+            connections.emplace_back(
+                "C", "OO", subdeformer_uid, deformer_uid
+            );
 
             // we also need to connect the limb node to the subdeformer.
-            c = FBX::Node("C");
-            c.AddProperties("OO", node_uids[bone_node], subdeformer_uid);
-            connections.push_back(c); // TODO: emplace_back
+            connections.emplace_back(
+                "C", "OO", node_uids[bone_node], subdeformer_uid
+            );
         }
 
         // if we cannot create a valid FBX file, simply die.
@@ -1943,9 +1939,9 @@ void FBXExporter::WriteObjects ()
         alnode.End(outstream, true);
 
         // connect to the relevant animstack
-        FBX::Node c("C");
-        c.AddProperties("OO", animlayer_uid, animation_stack_uids[ai]);
-        connections.push_back(c); // TODO: emplace_back
+        connections.emplace_back(
+            "C", "OO", animlayer_uid, animation_stack_uids[ai]
+        );
     }
 
     // AnimCurveNode - three per aiNodeAnim
@@ -2240,9 +2236,7 @@ void FBXExporter::WriteModelNodes(
             node_uid = generate_uid();
             node_uids[node] = node_uid;
         }
-        FBX::Node c("C");
-        c.AddProperties("OO", node_uid, parent_uid);
-        connections.push_back(c);
+        connections.emplace_back("C", "OO", node_uid, parent_uid);
     }
 
     // what type of node is this?
@@ -2250,17 +2244,15 @@ void FBXExporter::WriteModelNodes(
         // handled later
     } else if (node->mNumMeshes == 1) {
         // connect to child mesh, which should have been written previously
-        FBX::Node c("C");
-        c.AddProperties("OO", mesh_uids[node->mMeshes[0]], node_uid);
-        connections.push_back(c);
+        connections.emplace_back(
+            "C", "OO", mesh_uids[node->mMeshes[0]], node_uid
+        );
         // also connect to the material for the child mesh
-        c = FBX::Node("C");
-        c.AddProperties(
-            "OO",
+        connections.emplace_back(
+            "C", "OO",
             material_uids[mScene->mMeshes[node->mMeshes[0]]->mMaterialIndex],
             node_uid
         );
-        connections.push_back(c);
         // write model node
         WriteModelNode(outstream, node, node_uid, "Mesh", transform_chain);
     } else if (limbnodes.count(node)) {
@@ -2274,9 +2266,7 @@ void FBXExporter::WriteModelNodes(
         na.AddChild("TypeFlags", Property("Skeleton"));
         na.Dump(outstream);
         // and connect them
-        FBX::Node c("C");
-        c.AddProperties("OO", node_attribute_uid, node_uid);
-        connections.push_back(c);
+        connections.emplace_back("C", "OO", node_attribute_uid, node_uid);
     } else {
         // generate a null node so we can add children to it
         WriteModelNode(outstream, node, node_uid, "Null", transform_chain);
@@ -2288,23 +2278,19 @@ void FBXExporter::WriteModelNodes(
             // make a new model node
             int64_t new_node_uid = generate_uid();
             // connect to parent node
-            FBX::Node c("C");
-            c.AddProperties("OO", new_node_uid, node_uid);
-            connections.push_back(c);
+            connections.emplace_back("C", "OO", new_node_uid, node_uid);
             // connect to child mesh, which should have been written previously
-            c = FBX::Node("C");
-            c.AddProperties("OO", mesh_uids[node->mMeshes[i]], new_node_uid);
-            connections.push_back(c);
+            connections.emplace_back(
+                "C", "OO", mesh_uids[node->mMeshes[i]], new_node_uid
+            );
             // also connect to the material for the child mesh
-            c = FBX::Node("C");
-            c.AddProperties(
-                "OO",
+            connections.emplace_back(
+                "C", "OO",
                 material_uids[
                     mScene->mMeshes[node->mMeshes[i]]->mMaterialIndex
                 ],
                 new_node_uid
             );
-            connections.push_back(c);
             // write model node
             FBX::Node m("Model");
             // take name from mesh name, if it exists
@@ -2346,13 +2332,9 @@ void FBXExporter::WriteAnimationCurveNode(
     n.AddChild(p);
     n.Dump(outstream);
     // connect to layer
-    FBX::Node cl("C");
-    cl.AddProperties("OO", uid, layer_uid);
-    this->connections.push_back(cl); // TODO: emplace_back
+    this->connections.emplace_back("C", "OO", uid, layer_uid);
     // connect to bone
-    FBX::Node cb("C");
-    cb.AddProperties("OP", uid, node_uid, property_name);
-    this->connections.push_back(cb); // TODO: emplace_back
+    this->connections.emplace_back("C", "OP", uid, node_uid, property_name);
 }
 
 
@@ -2380,9 +2362,9 @@ void FBXExporter::WriteAnimationCurve(
         std::vector<int32_t>{static_cast<int32_t>(times.size())}
     );
     n.Dump(outstream);
-    FBX::Node c("C");
-    c.AddProperties("OP", curve_uid, curvenode_uid, property_link);
-    this->connections.push_back(c); // TODO: emplace_back
+    this->connections.emplace_back(
+        "C", "OP", curve_uid, curvenode_uid, property_link
+    );
 }
 
 

--- a/code/FBXExporter.h
+++ b/code/FBXExporter.h
@@ -48,6 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef ASSIMP_BUILD_NO_FBX_EXPORTER
 
 #include "FBXExportNode.h" // FBX::Node
+#include "FBXCommon.h" // FBX::TransformInheritance
 
 #include <assimp/types.h>
 //#include <assimp/material.h>
@@ -104,6 +105,9 @@ namespace Assimp
         void WriteBinaryHeader();
         void WriteBinaryFooter();
 
+        // ascii files have a comment at the top
+        void WriteAsciiHeader();
+
         // WriteAllNodes does the actual export.
         // It just calls all the Write<Section> methods below in order.
         void WriteAllNodes();
@@ -126,6 +130,7 @@ namespace Assimp
         // WriteTakes(); // deprecated since at least 2015 (fbx 7.4)
 
         // helpers
+        void WriteAsciiSectionHeader(const std::string& title);
         void WriteModelNodes(
             Assimp::StreamWriterLE& s,
             const aiNode* node,
@@ -138,6 +143,15 @@ namespace Assimp
             int64_t parent_uid,
             const std::unordered_set<const aiNode*>& limbnodes,
             std::vector<std::pair<std::string,aiVector3D>>& transform_chain
+        );
+        void WriteModelNode( // nor this
+            StreamWriterLE& s,
+            bool binary,
+            const aiNode* node,
+            int64_t node_uid,
+            const std::string& type,
+            const std::vector<std::pair<std::string,aiVector3D>>& xfm_chain,
+            FBX::TransformInheritance ti_type=FBX::TransformInheritance_RSrs
         );
         void WriteAnimationCurveNode(
             StreamWriterLE& outstream,

--- a/include/assimp/StreamWriter.h
+++ b/include/assimp/StreamWriter.h
@@ -204,6 +204,12 @@ public:
     }
 
     // ---------------------------------------------------------------------
+    /** Write a single character to the stream */
+    void PutChar(char c)    {
+        Put(c);
+    }
+
+    // ---------------------------------------------------------------------
     /** Write an aiString to the stream */
     void PutString(const aiString& s)
     {


### PR DESCRIPTION
Seems to work for my test models. Should make it easier to debug FBX export in general.

It mostly shares the same code with the binary exporter, just with some small divergences as the file structures differ slightly.

Based off the branch with animation support.