### PR TITLE
[glTF2] Not duplicating embedded textures

### DIFF
--- a/code/glTF2Exporter.cpp
+++ b/code/glTF2Exporter.cpp
@@ -316,11 +316,9 @@ void glTF2Exporter::GetMatTex(const aiMaterial* mat, Ref<Texture>& texture, aiTe
             std::string path = tex.C_Str();
 
             if (path.size() > 0) {
-                if (path[0] != '*') {
-                    std::map<std::string, unsigned int>::iterator it = mTexturesByPath.find(path);
-                    if (it != mTexturesByPath.end()) {
-                        texture = mAsset->textures.Get(it->second);
-                    }
+                std::map<std::string, unsigned int>::iterator it = mTexturesByPath.find(path);
+                if (it != mTexturesByPath.end()) {
+                    texture = mAsset->textures.Get(it->second);
                 }
 
                 if (!texture) {


### PR DESCRIPTION
Before the PR, when generating a glb2, the embedded textures were duplicated. Thus, it's making a huge output file for no reason when textures are shared between materials.