### PR TITLE
Fixed issue#1219. CalcTangentsProcess::ProcessMesh.

### DIFF
--- a/code/CalcTangentsProcess.cpp
+++ b/code/CalcTangentsProcess.cpp
@@ -190,7 +190,7 @@ bool CalcTangentsProcess::ProcessMesh( aiMesh* pMesh, unsigned int meshIndex)
         float tx = meshTex[p2].x - meshTex[p0].x, ty = meshTex[p2].y - meshTex[p0].y;
         float dirCorrection = (tx * sy - ty * sx) < 0.0f ? -1.0f : 1.0f;
         // when t1, t2, t3 in same position in UV space, just use default UV direction.
-        if ( 0 == sx && 0 ==sy && 0 == tx && 0 == ty ) {
+        if (  sx * ty == sy * tx ) {
             sx = 0.0; sy = 1.0;
             tx = 1.0; ty = 0.0;
         }


### PR DESCRIPTION
From #1219.

> In the file CalcTangentsProcess.cpp (line 191), in the function CalcTangentsProcess::ProcessMesh, we test if the 3 points are aligned instead of being at the same place. Because if they are aligned, the tangent and bitangent can't be computed.
Code:
if ( 0 == sx && 0 ==sy && 0 == tx && 0 == ty )
should be replaced with:
if ( sx * ty == sy * tx 

> )

Implemented suggested solution.