### PR TITLE
Updated GLView to draw with white lighting after drawCoordSystem().

### DIFF
--- a/tools/assimp_qt_viewer/glview.cpp
+++ b/tools/assimp_qt_viewer/glview.cpp
@@ -609,6 +609,7 @@ void CGLView::drawCoordSystem() {
     // Z, -Z
     qglColor(QColor(Qt::blue)), glVertex3f(0.0, 0.0, 0.0), glVertex3f(0.0, 0.0, 100000.0);
     qglColor(QColor(Qt::yellow)), glVertex3f(0.0, 0.0, 0.0), glVertex3f(0.0, 0.0, -100000.0);
+    qglColor(QColor(Qt::white));
     glEnd();
 }
 


### PR DESCRIPTION
This resolves a bug in assimp_qt_viewer where objects draw as yellow when the lighting is disabled.