### PR TITLE
Correction on Collada parser missing textures when the image is in CDATA

### DIFF
--- a/code/ColladaParser.cpp
+++ b/code/ColladaParser.cpp
@@ -3106,7 +3106,7 @@ const char* ColladaParser::TestTextContent()
     // read contents of the element
     if( !mReader->read() )
         return NULL;
-    if( mReader->getNodeType() != irr::io::EXN_TEXT)
+    if( mReader->getNodeType() != irr::io::EXN_TEXT && mReader->getNodeType() != irr::io::EXN_CDATA)
         return NULL;
 
     // skip leading whitespace


### PR DESCRIPTION
DAE file image exemple:
```
<image id="image-1404706686">
<init_from><![CDATA[textures\burgundy.png]]></init_from>
</image>
```