### PR TITLE
IFC fixes

### DIFF
--- a/code/Importer/IFC/IFCLoader.cpp
+++ b/code/Importer/IFC/IFCLoader.cpp
@@ -435,7 +435,7 @@ bool ProcessMappedItem(const Schema_2x3::IfcMappedItem& mapped, aiNode* nd_src, 
 
     msrc = m*msrc;
 
-    std::vector<unsigned int> meshes;
+    std::set<unsigned int> meshes;
     const size_t old_openings = conv.collect_openings ? conv.collect_openings->size() : 0;
     if (conv.apply_openings) {
         IfcMatrix4 minv = msrc;
@@ -550,7 +550,7 @@ void ProcessProductRepresentation(const Schema_2x3::IfcProduct& el, aiNode* nd, 
 
     // extract Color from metadata, if present
     unsigned int matid = ProcessMaterials( el.GetID(), std::numeric_limits<uint32_t>::max(), conv, false);
-    std::vector<unsigned int> meshes;
+    std::set<unsigned int> meshes;
 
     // we want only one representation type, so bring them in a suitable order (i.e try those
     // that look as if we could read them quickly at first). This way of reading

--- a/code/Importer/IFC/IFCUtil.h
+++ b/code/Importer/IFC/IFCUtil.h
@@ -205,7 +205,7 @@ struct ConversionData
         bool operator == (const MeshCacheIndex& o) const { return item == o.item && matindex == o.matindex; }
         bool operator < (const MeshCacheIndex& o) const { return item < o.item || (item == o.item && matindex < o.matindex); }
     };
-    typedef std::map<MeshCacheIndex, std::vector<unsigned int> > MeshCache;
+    typedef std::map<MeshCacheIndex, std::set<unsigned int> > MeshCache;
     MeshCache cached_meshes;
 
     typedef std::map<const IFC::Schema_2x3::IfcSurfaceStyle*, unsigned int> MaterialCache;
@@ -281,8 +281,8 @@ unsigned int ProcessMaterials(uint64_t id, unsigned int prevMatId, ConversionDat
 
 // IFCGeometry.cpp
 IfcMatrix3 DerivePlaneCoordinateSpace(const TempMesh& curmesh, bool& ok, IfcVector3& norOut);
-bool ProcessRepresentationItem(const Schema_2x3::IfcRepresentationItem& item, unsigned int matid, std::vector<unsigned int>& mesh_indices, ConversionData& conv);
-void AssignAddedMeshes(std::vector<unsigned int>& mesh_indices,aiNode* nd,ConversionData& /*conv*/);
+bool ProcessRepresentationItem(const Schema_2x3::IfcRepresentationItem& item, unsigned int matid, std::set<unsigned int>& mesh_indices, ConversionData& conv);
+void AssignAddedMeshes(std::set<unsigned int>& mesh_indices,aiNode* nd,ConversionData& /*conv*/);
 
 void ProcessSweptAreaSolid(const Schema_2x3::IfcSweptAreaSolid& swept, TempMesh& meshout,
                            ConversionData& conv);

--- a/code/Importer/IFC/STEPFileReader.cpp
+++ b/code/Importer/IFC/STEPFileReader.cpp
@@ -492,10 +492,17 @@ STEP::LazyObject::LazyObject(DB& db, uint64_t id,uint64_t /*line*/, const char* 
                 --skip_depth;
             }
 
-            if (skip_depth >= 1 && *a=='#') {
-                const char* tmp;
-                const int64_t num = static_cast<int64_t>( strtoul10_64(a+1,&tmp) );
-                db.MarkRef(num,id);
+			if (skip_depth >= 1 && *a=='#') {
+				if (*(a + 1) != '#')
+				{
+					const char* tmp;
+					const int64_t num = static_cast<int64_t>(strtoul10_64(a + 1, &tmp));
+					db.MarkRef(num, id);
+				}
+				else
+				{
+					++a;
+				}
             }
             ++a;
         }


### PR DESCRIPTION
Different fixes for IFC import:
- fixed parser to handle '##' symbols in strings as they should not be interpreted as references
- improved underlying data structure in mesh cache to reduce memory footprint. Indeed, when trying to load big IFC files, the previous implementation would lead to out-of-memory exceptions. This was caused by vectors of indexes of meshes containing lots of duplicated elements (~700 millions elements per object in my case, repeated many times), which resulted in lots of memory wasted. The proposed implementation use sets instead, to avoid keeping duplicated elements. Moreover, it also speed up the import process a little, as we do not need to sort and remove duplicates in those vectors anymore.
