### PR TITLE
Changed 'souces' to 'sources'.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,7 +311,7 @@ IF ( NOT ASSIMP_BUILD_ZLIB )
 ENDIF( NOT ASSIMP_BUILD_ZLIB )
 
 IF( NOT ZLIB_FOUND )
-  MESSAGE(STATUS "compiling zlib from souces")
+  MESSAGE(STATUS "compiling zlib from sources")
   INCLUDE(CheckIncludeFile)
   INCLUDE(CheckTypeSize)
   INCLUDE(CheckFunctionExists)


### PR DESCRIPTION
There was a typo in the `CMakeLists.txt` where if zlib was not found, it would say "Compiling from souces" instead of "Compiling from sources". Added a 'r' to fix the typo.