### PR TITLE
Use CMAKE_INSTALL_PREFIX as ASSIMP_ROOT_DIR.

### DIFF
--- a/assimp-config.cmake.in
+++ b/assimp-config.cmake.in
@@ -10,10 +10,7 @@
 # ASSIMP_LIBRARY_DIRS - link directories
 # ASSIMP_LIBRARIES - libraries to link plugins with
 # ASSIMP_Boost_VERSION - the boost version assimp was compiled with
-get_filename_component(_PREFIX "${CMAKE_CURRENT_LIST_FILE}" PATH)
-get_filename_component(_PREFIX "${_PREFIX}" PATH)
-get_filename_component(_PREFIX "${_PREFIX}" PATH)
-get_filename_component(ASSIMP_ROOT_DIR "${_PREFIX}" PATH)
+get_filename_component(ASSIMP_ROOT_DIR "@CMAKE_INSTALL_PREFIX@" REALPATH)
 
 if( MSVC )
   # in order to prevent DLL hell, each of the DLLs have to be suffixed with the major version and msvc prefix


### PR DESCRIPTION
Since the ASSIMP_LIB_INSTALL_DIR where this CMake config file is  installed to may contain multiple nested directories, we should not use it to back-calculate the location of the ASSIMP_ROOT_DIR unless we can take the directory depth into account. Instead use the
CMAKE_INSTALL_PREFIX as the ASSIMP_ROOT_DIR at configure-time.

This approach is more flexible with respect to install directories but it means that assimp files are not relocatable after installation and I don't think it works if a DESTDIR option is provided when running `make install` after cmake configuration.

Proposed to resolve #1914.