### PR TITLE
Fixes DXF loader false positive on FBX file

### DIFF
--- a/code/DXFLoader.cpp
+++ b/code/DXFLoader.cpp
@@ -127,7 +127,7 @@ bool DXFImporter::CanRead( const std::string& pFile, IOSystem* pIOHandler, bool 
 
     if ( extension.empty() || checkSig ) {
         static const char *pTokens[] = { "SECTION", "HEADER", "ENDSEC", "BLOCKS" };
-        return BaseImporter::SearchFileHeaderForToken(pIOHandler, pFile, pTokens, 4 );
+        return BaseImporter::SearchFileHeaderForToken(pIOHandler, pFile, pTokens, 4, 32 );
     }
 
     return false;


### PR DESCRIPTION
A binary FBX file can have an header section `FBXHeaderVersion` which starts around the 70th byte.
Therefore, the token check for DXF file was hitting true because the `SearchFileHeaderForToken` is case insensitive.
We limit the scope of the token search to the first 32 bytes.