### PR TITLE
Fix Assimp viewer build with MinGW

### DIFF
--- a/tools/assimp_view/Display.cpp
+++ b/tools/assimp_view/Display.cpp
@@ -2251,7 +2251,7 @@ int CDisplay::RenderTextureView()
         const float ny = (float)sRect.bottom;
         const float  x = (float)sDesc.Width;
         const float  y = (float)sDesc.Height;
-        float f = min((nx-30) / x,(ny-30) / y) * (m_fTextureZoom/1000.0f);
+        float f = std::min((nx-30) / x,(ny-30) / y) * (m_fTextureZoom/1000.0f);
 
         float fHalfX = (nx - (f * x)) / 2.0f;
         float fHalfY = (ny - (f * y)) / 2.0f;

--- a/tools/assimp_view/Material.cpp
+++ b/tools/assimp_view/Material.cpp
@@ -275,7 +275,7 @@ bool CMaterialManager::TryLongerPath(char* szTemp,aiString* p_szString)
                         for (unsigned int i = 0; i < iSizeFound;++i)
                             info.cFileName[i] = (CHAR)tolower(info.cFileName[i]);
 
-                        if (0 == memcmp(info.cFileName,szFile2, min(iSizeFound,iSize)))
+                        if (0 == memcmp(info.cFileName,szFile2, std::min(iSizeFound,iSize)))
                         {
                             // we have it. Build the full path ...
                             char* sz = strrchr(szTempB,'*');

--- a/tools/assimp_view/MessageProc.cpp
+++ b/tools/assimp_view/MessageProc.cpp
@@ -45,7 +45,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <windowsx.h>
 #include <commdlg.h>
+
+#ifdef __MINGW32__
+#include <mmsystem.h>
+#else
 #include <timeapi.h>
+#endif
 
 namespace AssimpView {
 
@@ -1050,9 +1055,9 @@ void DoExport(size_t formatId)
         ai_assert(strlen(szFileName) <= MAX_PATH);
 
         // invent a nice default file name
-        char* sz = max(strrchr(szFileName,'\\'),strrchr(szFileName,'/'));
+        char* sz = std::max(strrchr(szFileName,'\\'),strrchr(szFileName,'/'));
         if (sz) {
-            strncpy(sz,max(strrchr(g_szFileName,'\\'),strrchr(g_szFileName,'/')),MAX_PATH);
+            strncpy(sz,std::max(strrchr(g_szFileName,'\\'),strrchr(g_szFileName,'/')),MAX_PATH);
         }
     }
     else {

--- a/tools/assimp_view/assimp_view.cpp
+++ b/tools/assimp_view/assimp_view.cpp
@@ -43,9 +43,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include "assimp_view.h"
-#include <timeapi.h>
 #include <assimp/StringUtils.h>
 #include <map>
+
+#ifdef __MINGW32__
+#include <mmsystem.h>
+#else
+#include <timeapi.h>
+#endif
 
 using namespace std;
 

--- a/tools/assimp_view/assimp_view.h
+++ b/tools/assimp_view/assimp_view.h
@@ -46,6 +46,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define AI_SHADER_COMPILE_FLAGS D3DXSHADER_USE_LEGACY_D3DX9_31_DLL
 
+// Because Dx headers include windef.h with min/max redefinition
+#define NOMINMAX
+
 // include resource definitions
 #include "resource.h"
 
@@ -177,7 +180,7 @@ type clamp(intype in)
 {
     // for unsigned types only ...
     intype mask = (0x1u << (sizeof(type)*8))-1;
-    return (type)max((intype)0,min(in,mask));
+    return (type)std::max((intype)0,std::min(in,mask));
 }
 
 


### PR DESCRIPTION
- Use std::min/max instead of min/max macro in windef.h ( https://github.com/assimp/assimp/issues/952 )
- Use mmsytem.h instead of timeapi.h with MinGW

The changes have been tested with MinGW 5.3 and Visual Studio 2017.