### PR TITLE
_stat64 doesn't seem to exist. use __stat64!

### DIFF
--- a/code/DefaultIOSystem.cpp
+++ b/code/DefaultIOSystem.cpp
@@ -80,7 +80,7 @@ bool DefaultIOSystem::Exists( const char* pFile) const
     if (isUnicode) {
 
         MultiByteToWideChar(CP_UTF8, MB_PRECOMPOSED, pFile, -1, fileName16, PATHLIMIT);
-        struct _stat64 filestat;
+        struct __stat64 filestat;
         if (0 != _wstat64(fileName16, &filestat)) {
             return false;
         }


### PR DESCRIPTION
I was trying to build Assimp from sources, by adding it as a submodule of my project. Then for some reason it wasn't compiling.

Then I found out that apparently `_stat64` is wrong, and it should be `__stat64`.

It compiled just fine after that.

🤷‍♂️ 