### PR TITLE
PyAssimp: Encode filename using file system encoding instead of ASCII

### DIFF
--- a/port/PyAssimp/pyassimp/core.py
+++ b/port/PyAssimp/pyassimp/core.py
@@ -312,7 +312,7 @@ def load(filename,
                                      file_type)
     else:
         # a filename string has been passed
-        model = _assimp_lib.load(filename.encode("ascii"), processing)
+        model = _assimp_lib.load(filename.encode(sys.getfilesystemencoding()), processing)
 
     if not model:
         raise AssimpError('Could not import file!')
@@ -342,7 +342,7 @@ def export(scene,
     '''
 
     from ctypes import pointer
-    exportStatus = _assimp_lib.export(pointer(scene), file_type.encode("ascii"), filename.encode("ascii"), processing)
+    exportStatus = _assimp_lib.export(pointer(scene), file_type.encode("ascii"), filename.encode(sys.getfilesystemencoding()), processing)
 
     if exportStatus != 0:
         raise AssimpError('Could not export scene!')


### PR DESCRIPTION
As of now, `load`ing and `export`ing a file causes a `UnicodeDecodeError` if the filename is not in ASCII format. 

I'm not sure if we really need this restriction here. One possible solution would be to expect a string here, but this would not be intuitive while using python 3. The other solution, proposed here, is to use the encoding `sys.getfilesystemencoding()` returns.