### PR TITLE
Bug/exception on empty mesh after degenerate removal

### DIFF
--- a/code/FindDegenerates.cpp
+++ b/code/FindDegenerates.cpp
@@ -54,6 +54,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using namespace Assimp;
 
+//remove mesh at position 'index' from the scene
+static void removeMesh(aiScene* pScene, unsigned const index);
+//correct node indices to meshes and remove references to deleted mesh
+static void updateSceneGraph(aiNode* pNode, unsigned const index);
+
 // ------------------------------------------------------------------------------------------------
 // Constructor to be privately used by Importer
 FindDegeneratesProcess::FindDegeneratesProcess()
@@ -87,9 +92,48 @@ void FindDegeneratesProcess::SetupProperties(const Importer* pImp) {
 void FindDegeneratesProcess::Execute( aiScene* pScene) {
     ASSIMP_LOG_DEBUG("FindDegeneratesProcess begin");
     for (unsigned int i = 0; i < pScene->mNumMeshes;++i){
-        ExecuteOnMesh( pScene->mMeshes[ i ] );
+        if (ExecuteOnMesh(pScene->mMeshes[i])) {
+            removeMesh(pScene, i);
+            --i; //the current i is removed, do not skip the next one
+        }
     }
     ASSIMP_LOG_DEBUG("FindDegeneratesProcess finished");
+}
+
+static void removeMesh(aiScene* pScene, unsigned const index) {
+    //we start at index and copy the pointers one position forward
+    //save the mesh pointer to delete it later
+    auto delete_me = pScene->mMeshes[index];
+    for (unsigned i = index; i < pScene->mNumMeshes - 1; ++i) {
+        pScene->mMeshes[i] = pScene->mMeshes[i+1];
+    }
+    pScene->mMeshes[pScene->mNumMeshes - 1] = nullptr;
+    --(pScene->mNumMeshes);
+    delete delete_me;
+
+    //removing a mesh also requires updating all references to it in the scene graph
+    updateSceneGraph(pScene->mRootNode, index);
+}
+
+static void updateSceneGraph(aiNode* pNode, unsigned const index) {
+    for (unsigned i = 0; i < pNode->mNumMeshes; ++i) {
+        if (pNode->mMeshes[i] > index) {
+            --(pNode->mMeshes[i]);
+            continue;
+        }
+        if (pNode->mMeshes[i] == index) {
+            for (unsigned j = i; j < pNode->mNumMeshes -1; ++j) {
+                pNode->mMeshes[j] = pNode->mMeshes[j+1];
+            }
+            --(pNode->mNumMeshes);
+            --i;
+            continue;
+        }
+    }
+    //recurse to all children
+    for (unsigned i = 0; i < pNode->mNumChildren; ++i) {
+        updateSceneGraph(pNode->mChildren[i], index);
+    }
 }
 
 static ai_real heron( ai_real a, ai_real b, ai_real c ) {
@@ -125,7 +169,7 @@ static ai_real calculateAreaOfTriangle( const aiFace& face, aiMesh* mesh ) {
 
 // ------------------------------------------------------------------------------------------------
 // Executes the post processing step on the given imported mesh
-void FindDegeneratesProcess::ExecuteOnMesh( aiMesh* mesh) {
+bool FindDegeneratesProcess::ExecuteOnMesh( aiMesh* mesh) {
     mesh->mPrimitiveTypes = 0;
 
     std::vector<bool> remove_me;
@@ -227,19 +271,22 @@ evil_jump_outside:
                 if (&face_src != &face_dest) {
                     // clear source
                     face_src.mNumIndices = 0;
-                    face_src.mIndices = NULL;
+                    face_src.mIndices = nullptr;
                 }
             }
             else {
                 // Otherwise delete it if we don't need this face
                 delete[] face_src.mIndices;
-                face_src.mIndices = NULL;
+                face_src.mIndices = nullptr;
                 face_src.mNumIndices = 0;
             }
         }
         // Just leave the rest of the array unreferenced, we don't care for now
         mesh->mNumFaces = n;
         if (!mesh->mNumFaces) {
+            //The whole mesh consists of degenerated faces
+            //signal upward, that this mesh should be deleted.
+            return true;
             // WTF!?
             // OK ... for completeness and because I'm not yet tired,
             // let's write code that will hopefully never be called
@@ -253,4 +300,5 @@ evil_jump_outside:
     if (deg && !DefaultLogger::isNullLogger()) {
         ASSIMP_LOG_WARN_F( "Found ", deg, " degenerated primitives");
     }
+    return false;
 }

--- a/code/FindDegenerates.cpp
+++ b/code/FindDegenerates.cpp
@@ -286,14 +286,8 @@ evil_jump_outside:
         if (!mesh->mNumFaces) {
             //The whole mesh consists of degenerated faces
             //signal upward, that this mesh should be deleted.
+            ASSIMP_LOG_DEBUG("FindDegeneratesProcess removed a mesh full of degenerated primitives");
             return true;
-            // WTF!?
-            // OK ... for completeness and because I'm not yet tired,
-            // let's write code that will hopefully never be called
-            // (famous last words)
-
-            // OK ... bad idea.
-            throw DeadlyImportError("Mesh is empty after removal of degenerated primitives ... WTF!?");
         }
     }
 

--- a/code/FindDegenerates.h
+++ b/code/FindDegenerates.h
@@ -74,7 +74,8 @@ public:
 
     // -------------------------------------------------------------------
     // Execute step on a given mesh
-    void ExecuteOnMesh( aiMesh* mesh);
+    ///@returns true if the current mesh should be deleted, false otherwise
+    bool ExecuteOnMesh( aiMesh* mesh);
 
     // -------------------------------------------------------------------
     /// @brief Enable the instant removal of degenerated primitives


### PR DESCRIPTION
I triggered "code that will hopefully never be called" when importing a 3DS model from one of our customers (It is an exported file from some other software I have no control over). When importing I use `aiProcess_FindDegenerates` in the postprocessing and set it to remove degenerates with `tImporter.SetPropertyBool(AI_CONFIG_PP_FD_REMOVE, true);`

The line that failed is FindDegenerates.cpp:249, it throws an exception if a mesh is empty after removing degenerate primitives. As far as I see, this should not be a case to abort the import, the mesh should simply be removed (maybe it can even be left as it is as empty mesh).

The mesh that triggered the exception was a quad that represented a point (all vertices have the same coordinates, 2 faces (triangles) that form a quad). I can't give you the original file, but I could try to construct a minimal OBJ that shows the same behaviour.

This patch changes the code to remove the mesh in this case. It also updates the scene graph to correct all mesh references. It works for me, but I have only minimal knowledge if assimp internals, so I recommend a second look if the delete is correct. Also I am using the C++11 auto keyword, but that should be easy to correct if it is a problem.

This keeps one edge case open: nodes without mesh references after mesh removal. They are kept as it is for now (they may still contain transformations and child references).

If you want me to correct/modify the patch, just give me a note.