### PR TITLE
Fix #1970 STL Ascii, failed managing "empty solid" 

### DIFF
--- a/code/STLLoader.cpp
+++ b/code/STLLoader.cpp
@@ -352,7 +352,7 @@ void STLImporter::LoadASCIIFile( aiNode *root ) {
 
         if (positionBuffer.empty())    {
             pMesh->mNumFaces = 0;
-            throw DeadlyImportError("STL: ASCII file is empty or invalid; no data loaded");
+            ASSIMP_LOG_WARN("STL: mesh is empty or invalid; no data loaded");
         }
         if (positionBuffer.size() % 3 != 0)    {
             pMesh->mNumFaces = 0;

--- a/code/ValidateDataStructure.cpp
+++ b/code/ValidateDataStructure.cpp
@@ -369,7 +369,7 @@ void ValidateDSProcess::Validate( const aiMesh* pMesh)
 
     // positions must always be there ...
     if (!pMesh->mNumVertices || (!pMesh->mVertices && !mScene->mFlags)) {
-        ReportError("The mesh contains no vertices");
+        ReportError("The mesh %s contains no vertices", pMesh->mName.C_Str());
     }
 
     if (pMesh->mNumVertices > AI_MAX_VERTICES) {
@@ -386,7 +386,7 @@ void ValidateDSProcess::Validate( const aiMesh* pMesh)
 
     // faces, too
     if (!pMesh->mNumFaces || (!pMesh->mFaces && !mScene->mFlags))   {
-        ReportError("Mesh contains no faces");
+        ReportError("Mesh %s contains no faces", pMesh->mName.C_Str());
     }
 
     // now check whether the face indexing layout is correct:

--- a/test/models/STL/triangle_with_empty_solid.stl
+++ b/test/models/STL/triangle_with_empty_solid.stl
@@ -1,0 +1,11 @@
+solid testTriangle
+  facet normal 0.0 0.0 1.0 
+    outer loop 
+      vertex 1.0 1.0 0.0 
+      vertex -1.0 1.0 0.0 
+      vertex 0.0 -1.0 0.0 
+    endloop 
+  endfacet 
+endsolid
+solid emptySolid
+endsolid

--- a/test/unit/utSTLImportExport.cpp
+++ b/test/unit/utSTLImportExport.cpp
@@ -73,6 +73,16 @@ TEST_F( utSTLImporterExporter, test_with_two_solids ) {
     EXPECT_NE( nullptr, scene );
 }
 
+TEST_F(utSTLImporterExporter, test_with_empty_solid) {
+    Assimp::Importer importer;
+    //STL File with empty mesh. We should still be able to import other meshes in this file. ValidateDataStructure should fail.
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/STL/triangle_with_empty_solid.stl", 0);
+    EXPECT_NE(nullptr, scene);
+
+    const aiScene *scene2 = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/STL/triangle_with_empty_solid.stl", aiProcess_ValidateDataStructure);
+    EXPECT_EQ(nullptr, scene2);
+}
+
 #ifndef ASSIMP_BUILD_NO_EXPORT
 
 TEST_F(utSTLImporterExporter, exporterTest) {


### PR DESCRIPTION
Should fix issue #1970.

Also add more info to assimp_cmd when ValidateDataStructure fails.