### PR TITLE
glTF/2.0: Pick scene 0 as scene to load if no "scene" property is specified

### DIFF
--- a/code/glTF2Asset.inl
+++ b/code/glTF2Asset.inl
@@ -1216,12 +1216,15 @@ inline void Asset::Load(const std::string& pFile, bool isBinary)
 
     // Read the "scene" property, which specifies which scene to load
     // and recursively load everything referenced by it
+    unsigned int sceneIndex = 0;
     if (Value* scene = FindUInt(doc, "scene")) {
-        unsigned int sceneIndex = scene->GetUint();
+        sceneIndex = scene->GetUint();
+    }
 
-        Ref<Scene> s = scenes.Retrieve(sceneIndex);
-
-        this->scene = s;
+    if (Value* scenesArray = FindArray(doc, "scenes")) {
+        if (sceneIndex < scenesArray->Size()) {
+            this->scene = scenes.Retrieve(sceneIndex);
+        }
     }
 
     // Clean up


### PR DESCRIPTION
re: https://github.com/assimp/assimp/issues/1932

This assumes scene 0 if none specified. I believe this behavior is consistent with online viewers.