### PR TITLE
Fix STL unittest in Debug mode

### DIFF
--- a/code/STLLoader.cpp
+++ b/code/STLLoader.cpp
@@ -365,10 +365,10 @@ void STLImporter::LoadASCIIFile( aiNode *root ) {
         pMesh->mNumFaces = static_cast<unsigned int>(positionBuffer.size() / 3);
         pMesh->mNumVertices = static_cast<unsigned int>(positionBuffer.size());
         pMesh->mVertices = new aiVector3D[pMesh->mNumVertices];
-        memcpy(pMesh->mVertices, &positionBuffer[0].x, pMesh->mNumVertices * sizeof(aiVector3D));
+        memcpy(pMesh->mVertices, positionBuffer.data(), pMesh->mNumVertices * sizeof(aiVector3D));
         positionBuffer.clear();
         pMesh->mNormals = new aiVector3D[pMesh->mNumVertices];
-        memcpy(pMesh->mNormals, &normalBuffer[0].x, pMesh->mNumVertices * sizeof(aiVector3D));
+        memcpy(pMesh->mNormals, normalBuffer.data(), pMesh->mNumVertices * sizeof(aiVector3D));
         normalBuffer.clear();
 
         // now copy faces


### PR DESCRIPTION
Hi,
in [STLLoader.cc Line 353](https://github.com/assimp/assimp/blob/master/code/STLLoader.cpp#L353),
the loader checks, if there is data or not.
Everything is fine, when there is data, but when there is no data, the code block continues and executes the memcpy later in line 368. This is not a real problem, since 0 Bytes are copied, but
we also access memory which is out of the containers bound in the same line via `&positionBuffer[0].x`.

Some Debuggers, i.e. VS in Debug mode, check, whether the program accesses out-of-bound memory or not and throw an exception, if so.
This results in a failed unittest (utSTLImporterExporter.test_with_empty_solid) using a debug build.

This PR uses `std::vector::data()` instead of `&positionBuffer[0].x`, trying to have a solution with minimal changes.