### PR TITLE
Properly reads in glTF/2.0 sampler address modes.

### DIFF
--- a/code/glTF2Importer.cpp
+++ b/code/glTF2Importer.cpp
@@ -121,6 +121,21 @@ bool glTF2Importer::CanRead(const std::string& pFile, IOSystem* pIOHandler, bool
     return false;
 }
 
+static aiTextureMapMode ConvertWrappingMode(SamplerWrap gltfWrapMode)
+{
+    switch (gltfWrapMode) {
+        case SamplerWrap::Mirrored_Repeat:
+            return aiTextureMapMode_Mirror;
+
+        case SamplerWrap::Clamp_To_Edge:
+            return aiTextureMapMode_Clamp;
+
+        case SamplerWrap::UNSET:
+        case SamplerWrap::Repeat:
+        default:
+            return aiTextureMapMode_Wrap;
+    }
+}
 
 //static void CopyValue(const glTF2::vec3& v, aiColor3D& out)
 //{
@@ -198,8 +213,10 @@ inline void SetMaterialTextureProperty(std::vector<int>& embeddedTexIdxs, Asset&
             mat->AddProperty(&name, AI_MATKEY_GLTF_MAPPINGNAME(texType, texSlot));
             mat->AddProperty(&id, AI_MATKEY_GLTF_MAPPINGID(texType, texSlot));
 
-            mat->AddProperty(&sampler->wrapS, 1, AI_MATKEY_MAPPINGMODE_U(texType, texSlot));
-            mat->AddProperty(&sampler->wrapT, 1, AI_MATKEY_MAPPINGMODE_V(texType, texSlot));
+            aiTextureMapMode wrapS = ConvertWrappingMode(sampler->wrapS);
+            aiTextureMapMode wrapT = ConvertWrappingMode(sampler->wrapT);
+            mat->AddProperty(&wrapS, 1, AI_MATKEY_MAPPINGMODE_U(texType, texSlot));
+            mat->AddProperty(&wrapT, 1, AI_MATKEY_MAPPINGMODE_V(texType, texSlot));
 
             if (sampler->magFilter != SamplerMagFilter::UNSET) {
                 mat->AddProperty(&sampler->magFilter, 1, AI_MATKEY_GLTF_MAPPINGFILTER_MAG(texType, texSlot));

--- a/test/models/glTF2/BoxTextured-glTF/BoxTextured.gltf
+++ b/test/models/glTF2/BoxTextured-glTF/BoxTextured.gltf
@@ -146,8 +146,8 @@
         {
             "magFilter": 9729,
             "minFilter": 9986,
-            "wrapS": 10497,
-            "wrapT": 10497
+            "wrapS": 33648,
+            "wrapT": 33071
         }
     ],
     "bufferViews": [

--- a/test/unit/utglTF2ImportExport.cpp
+++ b/test/unit/utglTF2ImportExport.cpp
@@ -46,6 +46,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/Importer.hpp>
 #include <assimp/Exporter.hpp>
 #include <assimp/postprocess.h>
+#include <assimp/scene.h>
 
 using namespace Assimp;
 
@@ -54,7 +55,21 @@ public:
     virtual bool importerTest() {
         Assimp::Importer importer;
         const aiScene *scene = importer.ReadFile( ASSIMP_TEST_MODELS_DIR "/glTF2/BoxTextured-glTF/BoxTextured.gltf", aiProcess_ValidateDataStructure);
-        return nullptr != scene;
+        EXPECT_NE( scene, nullptr );
+        if ( !scene ) return false;
+
+        EXPECT_TRUE( scene->HasMaterials() );
+        if ( !scene->HasMaterials() ) return false;
+        const aiMaterial *material = scene->mMaterials[0];
+
+        aiString path;
+        aiTextureMapMode modes[2];
+        EXPECT_EQ( aiReturn_SUCCESS, material->GetTexture(aiTextureType_DIFFUSE, 0, &path, nullptr, nullptr, nullptr, nullptr, modes) );
+        EXPECT_STREQ( path.C_Str(), "CesiumLogoFlat.png" );
+        EXPECT_EQ( modes[0], aiTextureMapMode_Mirror );
+        EXPECT_EQ( modes[1], aiTextureMapMode_Clamp );
+
+        return true;
     }
 
     virtual bool binaryImporterTest() {


### PR DESCRIPTION
Assimp was returning glTF/2.0 values as address modes instead of aiTextureMapModes.
Also modified text glTF/2.0 model's sampler uv address modes to mirror/clamp respectively, and tests for them in the unit test.