### PR TITLE
fix build for independent build dir (mingw)

### DIFF
--- a/tools/assimp_cmd/CMakeLists.txt
+++ b/tools/assimp_cmd/CMakeLists.txt
@@ -42,6 +42,7 @@ cmake_minimum_required( VERSION 2.6 )
 INCLUDE_DIRECTORIES(
   ${Assimp_SOURCE_DIR}/include
   ${Assimp_SOURCE_DIR}/code
+  ${Assimp_BINARY_DIR}/tools/assimp_cmd
 )
 
 LINK_DIRECTORIES( ${Assimp_BINARY_DIR} ${Assimp_BINARY_DIR}/lib )


### PR DESCRIPTION
When I generate makefile to a independent build dir by cmake like this
```
cd assimp
mkdir build
cd build
cmake -G "MSYS Makefiles" ..
make
```
It can't build . The error message is
```
E:/assimp/tools/assimp_cmd/assimp_cmd.rc:4:10: fatal error: ../../revision.h: No such file or directory
 #include "../../revision.h"
          ^~~~~~~~~~~~~~~~~~
```
It seems that windres.exe use the source file path rather than current path, so we should add binary directory to include directories.
