### PR TITLE
Solved pyassimp.errors.AssimpError in conda

### DIFF
--- a/port/PyAssimp/pyassimp/helper.py
+++ b/port/PyAssimp/pyassimp/helper.py
@@ -232,7 +232,6 @@ def search_library():
                     break
                 if is_out:
                   continue
-                ##### Modified Code --- to correctly select extension files #####
                 
                 library_path = os.path.join(curfolder, filename)
                 logger.debug('Try ' + library_path)

--- a/port/PyAssimp/pyassimp/helper.py
+++ b/port/PyAssimp/pyassimp/helper.py
@@ -27,7 +27,7 @@ additional_dirs, ext_whitelist = [],[]
 if os.name=='posix':
     additional_dirs.append('./')
     additional_dirs.append('/usr/lib/')
-    additional_dirs.append('/usr/lib/x86_64-linux-gnu')
+    additional_dirs.append('/usr/lib/x86_64-linux-gnu/')
     additional_dirs.append('/usr/local/lib/')
 
     if 'LD_LIBRARY_PATH' in os.environ:
@@ -223,10 +223,25 @@ def search_library():
                 # our minimum requirement for candidates is that
                 # they should contain 'assimp' somewhere in
                 # their name
-                if filename.lower().find('assimp')==-1 or\
-                    os.path.splitext(filename)[-1].lower() not in ext_whitelist:
+                
+                
+                #if filename.lower().find('assimp')==-1 or\                  
+                #    os.path.splitext(filename)[-1].lower() not in ext_whitelist:  ### this line had bugs, failed to select files with extensions .so.x  [.so.1  .so.2  .so.3.1]
+                #    continue                                                      ### worked on simple extensions only. like- .so .dll
+                
+                
+                ##### Modified Code --- to correctly select extension files #####
+                if filename.lower().find('assimp')==-1 : 
                     continue
-
+                is_out=1
+                for et in ext_whitelist:
+                  if et in filename.lower():
+                    is_out=0
+                    break
+                if is_out:
+                  continue
+                ##### Modified Code --- to correctly select extension files #####
+                
                 library_path = os.path.join(curfolder, filename)
                 logger.debug('Try ' + library_path)
                 try:

--- a/port/PyAssimp/pyassimp/helper.py
+++ b/port/PyAssimp/pyassimp/helper.py
@@ -222,15 +222,7 @@ def search_library():
             for filename in os.listdir(curfolder):
                 # our minimum requirement for candidates is that
                 # they should contain 'assimp' somewhere in
-                # their name
-                
-                
-                #if filename.lower().find('assimp')==-1 or\                  
-                #    os.path.splitext(filename)[-1].lower() not in ext_whitelist:  ### this line had bugs, failed to select files with extensions .so.x  [.so.1  .so.2  .so.3.1]
-                #    continue                                                      ### worked on simple extensions only. like- .so .dll
-                
-                
-                ##### Modified Code --- to correctly select extension files #####
+                # their name                                  
                 if filename.lower().find('assimp')==-1 : 
                     continue
                 is_out=1


### PR DESCRIPTION
This error occurred because of error in finding .extension files.
 
os.path.splitext(filename)[-1].lower() not in ext_whitelist:  ### this line had bugs, failed to select files with extensions .so.x  [.so.1  .so.2  .so.3.1] but worked on simple extensions only. like- .so .dll

Added a mechanism to remove this bug.