### PR TITLE
Fix fbx import regression

### DIFF
--- a/code/FBXMeshGeometry.cpp
+++ b/code/FBXMeshGeometry.cpp
@@ -437,6 +437,9 @@ void ResolveVertexDataArray(std::vector<T>& data_out, const Scope& source,
     // deal with this more elegantly and with less redundancy, but right
     // now it seems unavoidable.
     if (MappingInformationType == "ByVertice" && isDirect) {
+        if (!HasElement(source, indexDataElementName)) {
+            return;
+        }
         std::vector<T> tempData;
 		ParseVectorDataArray(tempData, GetRequiredElement(source, dataElementName));
 

--- a/test/unit/utFBXImporterExporter.cpp
+++ b/test/unit/utFBXImporterExporter.cpp
@@ -70,6 +70,10 @@ TEST_F( utFBXImporterExporter, importBareBoxWithoutColorsAndTextureCoords ) {
     Assimp::Importer importer;
     const aiScene *scene = importer.ReadFile( ASSIMP_TEST_MODELS_DIR "/FBX/box.fbx", aiProcess_ValidateDataStructure );
     EXPECT_NE( nullptr, scene );
+    EXPECT_EQ(scene->mNumMeshes, 1);
+    aiMesh* mesh = scene->mMeshes[0];
+    EXPECT_EQ(mesh->mNumFaces, 12);
+    EXPECT_EQ(mesh->mNumVertices, 36);
 }
 
 TEST_F( utFBXImporterExporter, importPhongMaterial ) {


### PR DESCRIPTION
Hi Kim,
I noticed that the fbx unit test box.fbx wasn't checking the number of meshes or vertices.
When I added this check, it appeared that this was broken and assimp reported 0 mesh.

Using git bisect, it seems that the regression appeared with PR #1735.

I'm not sure if I understand this code completely, but it seems that the check for `HasElement` has been removed when `isDirect` is true, which doesn't seem intended.
