### PR TITLE
Keep small triangles in triangulation

### DIFF
--- a/code/PostStepRegistry.cpp
+++ b/code/PostStepRegistry.cpp
@@ -164,9 +164,6 @@ void GetPostProcessingStepInstanceList(std::vector< BaseProcess* >& out)
 #if (!defined ASSIMP_BUILD_NO_OPTIMIZEGRAPH_PROCESS)
     out.push_back( new OptimizeGraphProcess());
 #endif
-#if (!defined ASSIMP_BUILD_NO_FINDDEGENERATES_PROCESS)
-    out.push_back( new FindDegeneratesProcess());
-#endif
 #ifndef ASSIMP_BUILD_NO_GENUVCOORDS_PROCESS
     out.push_back( new ComputeUVMappingProcess());
 #endif
@@ -178,6 +175,12 @@ void GetPostProcessingStepInstanceList(std::vector< BaseProcess* >& out)
 #endif
 #if (!defined ASSIMP_BUILD_NO_TRIANGULATE_PROCESS)
     out.push_back( new TriangulateProcess());
+#endif
+#if (!defined ASSIMP_BUILD_NO_FINDDEGENERATES_PROCESS)
+    //find degenerates should run after triangulation (to sort out small
+    //generated triangles) but before sort by p types (in case there are lines
+    //and points generated and inserted into a mesh)
+    out.push_back( new FindDegeneratesProcess());
 #endif
 #if (!defined ASSIMP_BUILD_NO_SORTBYPTYPE_PROCESS)
     out.push_back( new SortByPTypeProcess());

--- a/code/TriangulateProcess.cpp
+++ b/code/TriangulateProcess.cpp
@@ -485,21 +485,22 @@ bool TriangulateProcess::TriangulateMesh( aiMesh* pMesh)
         for(aiFace* f = last_face; f != curOut; ) {
             unsigned int* i = f->mIndices;
 
-            //  drop dumb 0-area triangles
-            if (std::fabs(GetArea2D(temp_verts[i[0]],temp_verts[i[1]],temp_verts[i[2]])) < 1e-5f) {
-                ASSIMP_LOG_DEBUG("Dropping triangle with area 0");
-                --curOut;
+            //  drop dumb 0-area triangles - deactivated for now:
+            //FindDegenerates post processing step can do the same thing
+            //if (std::fabs(GetArea2D(temp_verts[i[0]],temp_verts[i[1]],temp_verts[i[2]])) < 1e-5f) {
+            //    ASSIMP_LOG_DEBUG("Dropping triangle with area 0");
+            //    --curOut;
 
-                delete[] f->mIndices;
-                f->mIndices = NULL;
+            //    delete[] f->mIndices;
+            //    f->mIndices = nullptr;
 
-                for(aiFace* ff = f; ff != curOut; ++ff) {
-                    ff->mNumIndices = (ff+1)->mNumIndices;
-                    ff->mIndices = (ff+1)->mIndices;
-                    (ff+1)->mIndices = NULL;
-                }
-                continue;
-            }
+            //    for(aiFace* ff = f; ff != curOut; ++ff) {
+            //        ff->mNumIndices = (ff+1)->mNumIndices;
+            //        ff->mIndices = (ff+1)->mIndices;
+            //        (ff+1)->mIndices = nullptr;
+            //    }
+            //    continue;
+            //}
 
             i[0] = idx[i[0]];
             i[1] = idx[i[1]];


### PR DESCRIPTION
This patch changes two things:
1. Possible small triangles generated during triangulation are not rejected (in that post processing step). FindDegenerates can be used for that.
2. Change order of post processing steps, so that FindDegenerates runs after triangulation

This came up as a problem with one of our models, which had rather detailed geometry based on polygons. I also noted that Triangulation and FindDegenerates use different thresholds to reject triangles - Triangulation uses 1e-5 and FindDegenerates 1e-6.