### PR TITLE
FBXImporter: Fix GetUniqueName to return names properly

### DIFF
--- a/code/FBXConverter.cpp
+++ b/code/FBXConverter.cpp
@@ -411,7 +411,7 @@ void Converter::GetUniqueName( const std::string &name, std::string &uniqueName 
     }
 
     int i( 0 );
-    std::string newName (name);
+    std::string newName( name );
     while ( HasName( mNodeNames, newName ) ) {
         ++i;
         newName.clear();

--- a/code/FBXConverter.cpp
+++ b/code/FBXConverter.cpp
@@ -73,10 +73,6 @@ using namespace Util;
 
 #define CONVERT_FBX_TIME(time) static_cast<double>(time) / 46186158000L
 
-// XXX vc9's debugger won't step into anonymous namespaces
-//namespace {
-
-
 Converter::Converter( aiScene* out, const Document& doc )
 : defaultMaterialIndex()
 , out( out )
@@ -3100,8 +3096,6 @@ void Converter::TransferDataToScene()
         std::swap_ranges( textures.begin(), textures.end(), out->mTextures );
     }
 }
-
-//} // !anon
 
 // ------------------------------------------------------------------------------------------------
 void ConvertToAssimpScene(aiScene* out, const Document& doc)

--- a/code/FBXConverter.cpp
+++ b/code/FBXConverter.cpp
@@ -407,14 +407,15 @@ static bool HasName( NodeNameCache &cache, const std::string &name ) {
     return it != cache.end();
 
 }
-void Converter::GetUniqueName( const std::string &name, std::string uniqueName ) {
+void Converter::GetUniqueName( const std::string &name, std::string& uniqueName ) {
     if ( !HasName( mNodeNames, name ) ) {
         uniqueName = name;
+        mNodeNames.push_back( uniqueName );
         return;
     }
 
     int i( 0 );
-    std::string newName;
+    std::string newName (name);
     while ( HasName( mNodeNames, newName ) ) {
         ++i;
         newName.clear();

--- a/code/FBXConverter.cpp
+++ b/code/FBXConverter.cpp
@@ -407,7 +407,7 @@ static bool HasName( NodeNameCache &cache, const std::string &name ) {
     return it != cache.end();
 
 }
-void Converter::GetUniqueName( const std::string &name, std::string& uniqueName ) {
+void Converter::GetUniqueName( const std::string &name, std::string &uniqueName ) {
     if ( !HasName( mNodeNames, name ) ) {
         uniqueName = name;
         mNodeNames.push_back( uniqueName );

--- a/code/FBXConverter.h
+++ b/code/FBXConverter.h
@@ -131,7 +131,7 @@ private:
     void ConvertCamera( const Camera& cam, const std::string &orig_name );
 
     // ------------------------------------------------------------------------------------------------
-    void GetUniqueName( const std::string &name, std::string uniqueName );
+    void GetUniqueName( const std::string &name, std::string& uniqueName );
 
     // ------------------------------------------------------------------------------------------------
     // this returns unified names usable within assimp identifiers (i.e. no space characters -


### PR DESCRIPTION
`FBXImporter` has a function called `GetUniqueName` to try to generate new names for nodes if duplicates are found. Unfortunately instead, it just ends up naming nodes "" (empty) and makes a mess of the tree (transforms tend to get on the empty nodes, which makes things like skeletal animation completely broken). This fixes that and some other bugs with the function, allowing it to generate names properly again.

Example assimp tree before this patch ([empty] was an empty-string named node):
```
Tree: RootNode
├─  - [empty]
│   ├─ Armature
│   │   ├─ [empty]
│   │   │   ├─ RootBone
│   │   │   │   ├─ [empty]
│   │   │   │   │   ├─ Bone.PosPosPos
├─  - [empty]
│   ├─ Cube
├─  - [empty]
│   ├─ Lamp
├─  - [empty]
│   ├─ Camera
```

After
```
Tree: RootNode
├─ Armature
│   ├─ RootBone
│   │   ├─ Bone.PosPosPos
├─ Cube
├─ Lamp
├─ Camera
```
