### PR TITLE
Optimisation of FBX node name uniqueness

### DIFF
--- a/code/FBXConverter.cpp
+++ b/code/FBXConverter.cpp
@@ -185,12 +185,12 @@ void Converter::ConvertNodes( uint64_t id, aiNode& parent, const aiMatrix4x4& pa
                 }
 
                 if ( !name_carrier ) {
-                    NodeNameCache::const_iterator it( std::find( mNodeNames.begin(), mNodeNames.end(), original_name ) );
+                    NodeNameCache::const_iterator it = mNodeNames.find(original_name);
                     if ( it != mNodeNames.end() ) {
                         original_name = original_name + std::string( "001" );
                     }
 
-                    mNodeNames.push_back( original_name );
+                    mNodeNames.insert( original_name );
                     nodes_chain.push_back( new aiNode( original_name ) );
                 } else {
                     original_name = nodes_chain.back()->mName.C_Str();
@@ -398,30 +398,18 @@ void Converter::ConvertCamera( const Camera& cam, const std::string &orig_name )
     out_camera->mClipPlaneFar = cam.FarPlane();
 }
 
-static bool HasName( NodeNameCache &cache, const std::string &name ) {
-    NodeNameCache::const_iterator it( std::find( cache.begin(), cache.end(), name ) );
-    return it != cache.end();
-
-}
-void Converter::GetUniqueName( const std::string &name, std::string &uniqueName ) {
-    if ( !HasName( mNodeNames, name ) ) {
-        uniqueName = name;
-        mNodeNames.push_back( uniqueName );
-        return;
-    }
-
-    int i( 0 );
-    std::string newName( name );
-    while ( HasName( mNodeNames, newName ) ) {
+void Converter::GetUniqueName( const std::string &name, std::string &uniqueName )
+{
+    int i = 0;
+    uniqueName = name;
+    while (mNodeNames.find(uniqueName) != mNodeNames.end())
+    {
         ++i;
-        newName.clear();
-        newName += name;
         std::stringstream ext;
-        ext << std::setfill( '0' ) << std::setw( 3 ) << i;
-        newName += ext.str();
+        ext << name << std::setfill('0') << std::setw(3) << i;
+        uniqueName = ext.str();
     }
-    uniqueName = newName;
-    mNodeNames.push_back( uniqueName );
+    mNodeNames.insert(uniqueName);
 }
 
 

--- a/code/FBXConverter.h
+++ b/code/FBXConverter.h
@@ -68,7 +68,7 @@ namespace FBX {
 
 class Document;
 
-using NodeNameCache = std::vector<std::string>;
+using NodeNameCache = std::set<std::string>;
 
 /** 
  *  Convert a FBX #Document to #aiScene


### PR DESCRIPTION
Hello,

When importing a FBX file with a huge scene tree, the node names are checked to be unique with a time complexity in O(n²). This is the most time consuming task for importing such FBX files, so I rewrote this with a time complexity in O(n*log(n)).

Loïc