### PR TITLE
Add point cloud support for OBJ importer

### DIFF
--- a/code/ObjFileImporter.cpp
+++ b/code/ObjFileImporter.cpp
@@ -244,12 +244,14 @@ void ObjFileImporter::CreateDataFromImport(const ObjFile::Model* pModel, aiScene
         mesh->mNumVertices = n;
 
         mesh->mVertices = new aiVector3D[n];
-        memcpy_s(mesh->mVertices, n*sizeof(aiVector3D), pModel->m_Vertices.data(), pModel->m_Vertices.size()*sizeof(aiVector3D) );
+        memcpy(mesh->mVertices, pModel->m_Vertices.data(), n*sizeof(aiVector3D) );
 
-        // Allocate memory for attributes
         if ( !pModel->m_Normals.empty() ) {
             mesh->mNormals = new aiVector3D[n];
-            memcpy_s(mesh->mNormals, n*sizeof(aiVector3D), pModel->m_Normals.data(), pModel->m_Normals.size()*sizeof(aiVector3D));
+            if (pModel->m_Normals.size() < n) {
+                throw DeadlyImportError("OBJ: vertex normal index out of range");
+            }
+            memcpy(mesh->mNormals, pModel->m_Normals.data(), n*sizeof(aiVector3D));
         }
 
         if ( !pModel->m_VertexColors.empty() ){
@@ -259,7 +261,7 @@ void ObjFileImporter::CreateDataFromImport(const ObjFile::Model* pModel, aiScene
                     const aiVector3D& color = pModel->m_VertexColors[i];
                     mesh->mColors[0][i] = aiColor4D(color.x, color.y, color.z, 1.0);
                 }else {
-                    mesh->mColors[0][i] = aiColor4D( 1.0, 1.0, 1.0, 1.0 ); // Any other ideas what to use as default color?
+                    throw DeadlyImportError("OBJ: vertex color index out of range");
                 }
             }
         }       

--- a/code/ObjFileImporter.cpp
+++ b/code/ObjFileImporter.cpp
@@ -228,18 +228,12 @@ void ObjFileImporter::CreateDataFromImport(const ObjFile::Model* pModel, aiScene
         // Create all materials
         createMaterials(pModel, pScene);
     }else {
-        if (pModel->m_Vertices.empty())
-            return;
+		if (pModel->m_Vertices.empty()){
+			return;
+		}
 
-        aiMesh* mesh = new aiMesh();
+		std::unique_ptr<aiMesh> mesh( new aiMesh );
         mesh->mPrimitiveTypes = aiPrimitiveType_POINT;
-        pScene->mRootNode->mNumMeshes = 1;
-        pScene->mRootNode->mMeshes = new unsigned int[1];
-        pScene->mRootNode->mMeshes[0] = 0;
-        pScene->mMeshes = new aiMesh*[1];
-        pScene->mNumMeshes = 1;
-        pScene->mMeshes[0] = mesh;
-
         unsigned int n = pModel->m_Vertices.size();
         mesh->mNumVertices = n;
 
@@ -264,7 +258,14 @@ void ObjFileImporter::CreateDataFromImport(const ObjFile::Model* pModel, aiScene
                     throw DeadlyImportError("OBJ: vertex color index out of range");
                 }
             }
-        }       
+        }
+
+        pScene->mRootNode->mNumMeshes = 1;
+        pScene->mRootNode->mMeshes = new unsigned int[1];
+        pScene->mRootNode->mMeshes[0] = 0;
+        pScene->mMeshes = new aiMesh*[1];
+        pScene->mNumMeshes = 1;
+        pScene->mMeshes[0] = mesh.release();
     }
 }
 


### PR DESCRIPTION
Hello!
I added point cloud support for OBJ format import. Logic is simple: if imported file has only vertex attributes it is point cloud. Such files can be created by MeshLab for example.
New mesh added directly to root node, no child nodes will be created.

Relates to https://github.com/assimp/assimp/issues/254

[points.zip](https://github.com/assimp/assimp/files/2281356/points.zip)

