### PR TITLE
Use delete[] instead of delete to clear mMeshes

### DIFF
--- a/code/SplitByBoneCountProcess.cpp
+++ b/code/SplitByBoneCountProcess.cpp
@@ -393,7 +393,7 @@ void SplitByBoneCountProcess::UpdateNode( aiNode* pNode) const
             newMeshList.insert( newMeshList.end(), replaceMeshes.begin(), replaceMeshes.end());
         }
 
-        delete pNode->mMeshes;
+        delete [] pNode->mMeshes;
         pNode->mNumMeshes = static_cast<unsigned int>(newMeshList.size());
         pNode->mMeshes = new unsigned int[pNode->mNumMeshes];
         std::copy( newMeshList.begin(), newMeshList.end(), pNode->mMeshes);


### PR DESCRIPTION
aiNode->mMeshes is allocated with new[] rather than new.  We need to delete via delete[]

mMeshes is allocated in the importers, for example
https://github.com/assimp/assimp/blob/master/code/glTF2Importer.cpp#L753
https://github.com/assimp/assimp/blob/master/code/ACLoader.cpp#L574
etc