### PR TITLE
Correct 3MF displaycolor import

### DIFF
--- a/code/D3MFImporter.cpp
+++ b/code/D3MFImporter.cpp
@@ -297,8 +297,9 @@ private:
             return false;
         }
 
+        //format of the color string: #RRGGBBAA or #RRGGBB (3MF Core chapter 5.1.1)
         const size_t len( strlen( color ) );
-        if ( 9 != len ) {
+        if ( 9 != len && 7 != len) {
             return false;
         }
 
@@ -313,26 +314,28 @@ private:
         ++buf;
         comp[ 1 ] = *buf;
         ++buf;
-        diffuse.r = static_cast<ai_real>( strtol( comp, NULL, 16 ) );
+        diffuse.r = static_cast<ai_real>( strtol( comp, NULL, 16 ) ) / 255.0;
 
 
         comp[ 0 ] = *buf;
         ++buf;
         comp[ 1 ] = *buf;
         ++buf;
-        diffuse.g = static_cast< ai_real >( strtol( comp, NULL, 16 ) );
+        diffuse.g = static_cast< ai_real >( strtol( comp, NULL, 16 ) ) / 255.0;
 
         comp[ 0 ] = *buf;
         ++buf;
         comp[ 1 ] = *buf;
         ++buf;
-        diffuse.b = static_cast< ai_real >( strtol( comp, NULL, 16 ) );
+        diffuse.b = static_cast< ai_real >( strtol( comp, NULL, 16 ) ) / 255.0;
 
+        if(7 == len)
+            return true;
         comp[ 0 ] = *buf;
         ++buf;
         comp[ 1 ] = *buf;
         ++buf;
-        diffuse.a = static_cast< ai_real >( strtol( comp, NULL, 16 ) );
+        diffuse.a = static_cast< ai_real >( strtol( comp, NULL, 16 ) ) / 255.0;
 
         return true;
     }


### PR DESCRIPTION
Was testing out 3mf import and this occurred to me:

The displaycolor property was imported with the values directly converted from hex:
```
#00FF00 -> {0.0, 255.0, 0.0}
```
Whereas other importers use a normalized range:
```
#00FF00 -> {0.0, 1.0, 0.0}
```

Also added option of "#RRGGBB" string in addition to assumed "#RRGGBBAA" string (see chapter 5.1.1 of https://github.com/3MFConsortium/spec_core/blob/master/3MF%20Core%20Specification.md)