### PR TITLE
FBX import: fix import of normal data + unify node renaming strategy

### DIFF
--- a/code/FBXConverter.cpp
+++ b/code/FBXConverter.cpp
@@ -185,12 +185,8 @@ void FBXConverter::ConvertNodes( uint64_t id, aiNode& parent, const aiMatrix4x4&
                 }
 
                 if ( !name_carrier ) {
-                    NodeNameCache::const_iterator it = mNodeNames.find(original_name);
-                    if ( it != mNodeNames.end() ) {
-                        original_name = original_name + std::string( "001" );
-                    }
-
-                    mNodeNames.insert( original_name );
+                    std::string old_original_name = original_name;
+                    GetUniqueName(old_original_name, original_name);
                     nodes_chain.push_back( new aiNode( original_name ) );
                 } else {
                     original_name = nodes_chain.back()->mName.C_Str();

--- a/code/FBXMeshGeometry.cpp
+++ b/code/FBXMeshGeometry.cpp
@@ -437,9 +437,6 @@ void ResolveVertexDataArray(std::vector<T>& data_out, const Scope& source,
     // deal with this more elegantly and with less redundancy, but right
     // now it seems unavoidable.
     if (MappingInformationType == "ByVertice" && isDirect) {
-        if (!HasElement(source, indexDataElementName)) {
-            return;
-        }
         std::vector<T> tempData;
 		ParseVectorDataArray(tempData, GetRequiredElement(source, dataElementName));
 


### PR DESCRIPTION
Hi,

The normals are not imported for some FBX files because of a check which seems not necessary (checking of unecessary indexed data). The check was added in pull request "Fix fbx import regression" #2037 and it has been discussed that maybe it was a mistake because the unit tests are still functional even without this check.

Also I found that the nodes are renaming to be unique at FBX import. It is done at two different steps in the code but not in the same way, so I propose to unify this. In fact, the node renaming is maybe not a good idea because it can be very time consuming for FBX files with a huge scene tree with many duplicate node names, and it is supported by the FBX specifications to have duplicate names, but I guess if it has been implemented it is for a good reason so I didn't remove it.

Loïc