### PR TITLE
Update AssimpNet redirect

### DIFF
--- a/port/AssimpNET/Readme.md
+++ b/port/AssimpNET/Readme.md
@@ -1,1 +1,1 @@
-Please check the following github-repo for the source: https://github.com/kebby/assimp-net
+Please check the following git-repo for the source: https://bitbucket.org/Starnick/assimpnet


### PR DESCRIPTION
After the exchange on twitter, I noticed that this readme never actually had a link pointing to the bitbucket repository that I maintain (originally the googlecode one, and then a fork of the googlecode one that I didn't know about).

This is very confusing for people who report issues, and I would like them to make sure they can report on a tracker that I keep tabs on.