### PR TITLE
Amended the "Key" for the database ReadField

### DIFF
--- a/code/BlenderScene.cpp
+++ b/code/BlenderScene.cpp
@@ -203,7 +203,7 @@ template <> void Structure :: Convert<Lamp> (
     int temp = 0;
     ReadField<ErrorPolicy_Fail>(temp,"type",db);
     dest.type = static_cast<Assimp::Blender::Lamp::Type>(temp);
-    ReadField<ErrorPolicy_Igno>(dest.flags,"flags",db);
+    ReadField<ErrorPolicy_Igno>(dest.flags,"flag",db);
     ReadField<ErrorPolicy_Igno>(dest.colormodel,"colormodel",db);
     ReadField<ErrorPolicy_Igno>(dest.totex,"totex",db);
     ReadField<ErrorPolicy_Warn>(dest.r,"r",db);


### PR DESCRIPTION
Amended the key "flags" -> "flag". The field key("flags") was not matching the key("flag") in the BlendDNA. It was annoying during debug mode since the exception prompt for the mismatching key towards the DNA database.