### PR TITLE
Make gltf2's roughnessAsShininess matches between importer and exporter.

### DIFF
--- a/code/glTF2Importer.cpp
+++ b/code/glTF2Importer.cpp
@@ -272,7 +272,8 @@ static aiMaterial* ImportMaterial(std::vector<int>& embeddedTexIdxs, Asset& r, M
     aimat->AddProperty(&mat.pbrMetallicRoughness.metallicFactor, 1, AI_MATKEY_GLTF_PBRMETALLICROUGHNESS_METALLIC_FACTOR);
     aimat->AddProperty(&mat.pbrMetallicRoughness.roughnessFactor, 1, AI_MATKEY_GLTF_PBRMETALLICROUGHNESS_ROUGHNESS_FACTOR);
 
-    float roughnessAsShininess = (1 - mat.pbrMetallicRoughness.roughnessFactor) * 1000;
+    float roughnessAsShininess = 1 - mat.pbrMetallicRoughness.roughnessFactor;
+    roughnessAsShininess *= roughnessAsShininess * 1000;
     aimat->AddProperty(&roughnessAsShininess, 1, AI_MATKEY_SHININESS);
 
     SetMaterialTextureProperty(embeddedTexIdxs, r, mat.normalTexture, aimat, aiTextureType_NORMALS);


### PR DESCRIPTION
In glTF2Exporter, roughnessFactor = 1 - normalizedShininess = 1 - someFunc(sqrt(shininess / 1000)). But in gltf2Importer, roughnessAsShininess = (1 - roughnessFactor) * 1000. No sqr there. So if save a shininess to a gltf2 and load it back, the value changed.

This fix add a square to importer to make sure the consistency.