### PR TITLE
C4703 workaround for msvc++

### DIFF
--- a/code/MDLLoader.cpp
+++ b/code/MDLLoader.cpp
@@ -415,7 +415,7 @@ void MDLImporter::InternReadFile_Quake1() {
         // FIXME: the cast is wrong and cause a warning on clang 5.0
         // disable this code for now, fix it later
         ai_assert(false && "Bad pointer cast");
-        pcFirstFrame = NULL;
+        pcFirstFrame = nullptr; // Workaround: msvc++ C4703 error
 #else
         BE_NCONST MDL::GroupFrame* pcFrames2 = (BE_NCONST MDL::GroupFrame*)pcFrames;
         pcFirstFrame = (BE_NCONST MDL::SimpleFrame*)(&pcFrames2->time + pcFrames->type);

--- a/code/MDLLoader.cpp
+++ b/code/MDLLoader.cpp
@@ -413,8 +413,9 @@ void MDLImporter::InternReadFile_Quake1() {
 
 #if 1
         // FIXME: the cast is wrong and cause a warning on clang 5.0
-        // disable thi code for now, fix it later
+        // disable this code for now, fix it later
         ai_assert(false && "Bad pointer cast");
+        pcFirstFrame = NULL;
 #else
         BE_NCONST MDL::GroupFrame* pcFrames2 = (BE_NCONST MDL::GroupFrame*)pcFrames;
         pcFirstFrame = (BE_NCONST MDL::SimpleFrame*)(&pcFrames2->time + pcFrames->type);


### PR DESCRIPTION
`error C4703: potentially uninitialized local pointer variable 'pcFirstFrame'` in debug mode