### PR TITLE
Fix static init ordering issue in 3mf importer

### DIFF
--- a/code/D3MFImporter.cpp
+++ b/code/D3MFImporter.cpp
@@ -419,8 +419,6 @@ private:
 
 } //namespace D3MF
 
-static const std::string Extension = "3mf";
-
 static const aiImporterDesc desc = {
     "3mf Importer",
     "",
@@ -431,7 +429,7 @@ static const aiImporterDesc desc = {
     0,
     0,
     0,
-    Extension.c_str()
+    "3mf"
 };
 
 D3MFImporter::D3MFImporter()
@@ -445,7 +443,7 @@ D3MFImporter::~D3MFImporter() {
 
 bool D3MFImporter::CanRead(const std::string &filename, IOSystem *pIOHandler, bool checkSig) const {
     const std::string extension( GetExtension( filename ) );
-    if(extension == Extension ) {
+    if(extension == "3mf" ) {
         return true;
     } else if ( !extension.length() || checkSig ) {
         if ( nullptr == pIOHandler ) {

--- a/code/D3MFImporter.cpp
+++ b/code/D3MFImporter.cpp
@@ -443,7 +443,7 @@ D3MFImporter::~D3MFImporter() {
 
 bool D3MFImporter::CanRead(const std::string &filename, IOSystem *pIOHandler, bool checkSig) const {
     const std::string extension( GetExtension( filename ) );
-    if(extension == "3mf" ) {
+    if(extension == desc.mFileExtensions ) {
         return true;
     } else if ( !extension.length() || checkSig ) {
         if ( nullptr == pIOHandler ) {


### PR DESCRIPTION
Same issue as #1253 but for D3MFImporter.  The 3mf importer has its `aiImporterDesc` completely unnecessarily initialized from the value of an `std::string`, even though `std::string` cannot be initialized at constant initialization time.  This fixes a crash for us.