### PR TITLE
Fix skins not always being loaded in GlTF2

### DIFF
--- a/code/glTF2Asset.inl
+++ b/code/glTF2Asset.inl
@@ -1357,6 +1357,13 @@ inline void Asset::Load(const std::string& pFile, bool isBinary)
         }
     }
 
+    // Force reading of skins since they're not always directly referenced
+    if (Value* skinsArray = FindArray(doc, "skins")) {
+        for (unsigned int i = 0; i < skinsArray->Size(); ++i) {
+            skins.Retrieve(i);
+        }
+    }
+
     if (Value* animsArray = FindArray(doc, "animations")) {
         for (unsigned int i = 0; i < animsArray->Size(); ++i) {
             animations.Retrieve(i);

--- a/code/glTF2Asset.inl
+++ b/code/glTF2Asset.inl
@@ -1359,11 +1359,9 @@ inline void Asset::Load(const std::string& pFile, bool isBinary)
 
     // Force reading of skins since they're not always directly referenced
     if (Value* skinsArray = FindArray(doc, "skins")) {
-        if ( nullptr != skinsArray ) {
-                for (unsigned int i = 0; i < skinsArray->Size(); ++i) {
-                    skins.Retrieve(i);
-                }
-	}
+        for (unsigned int i = 0; i < skinsArray->Size(); ++i) {
+            skins.Retrieve(i);
+        }
     }
 
     if (Value* animsArray = FindArray(doc, "animations")) {

--- a/code/glTF2Asset.inl
+++ b/code/glTF2Asset.inl
@@ -1359,9 +1359,11 @@ inline void Asset::Load(const std::string& pFile, bool isBinary)
 
     // Force reading of skins since they're not always directly referenced
     if (Value* skinsArray = FindArray(doc, "skins")) {
-        for (unsigned int i = 0; i < skinsArray->Size(); ++i) {
-            skins.Retrieve(i);
-        }
+        if ( nullptr != skinsArray ) {
+                for (unsigned int i = 0; i < skinsArray->Size(); ++i) {
+                    skins.Retrieve(i);
+                }
+	}
     }
 
     if (Value* animsArray = FindArray(doc, "animations")) {


### PR DESCRIPTION
Skins aren't always referenced by other nodes but may still be needed. Fixes #2227