### PR TITLE
Fix: except `SyntaxError` for py3 viewer

### DIFF
--- a/port/PyAssimp/scripts/3d_viewer_py3.py
+++ b/port/PyAssimp/scripts/3d_viewer_py3.py
@@ -468,7 +468,7 @@ class PyAssimp3DViewer:
         try:
             self.set_shaders_v130()
             self.prepare_shaders()
-        except RuntimeError, message:
+        except RuntimeError as message:
             sys.stderr.write("%s\n" % message)
             sys.stdout.write("Could not compile shaders in version 1.30, trying version 1.20\n")
 


### PR DESCRIPTION
This was causing `SyntaxError` in python 3.7 (Windows 10)
And should now conform to the new syntax: https://www.python.org/dev/peps/pep-3110/