### PR TITLE
Fix progress reporting in ObjFileParser. Remove old unused code which…

### DIFF
--- a/code/ObjFileImporter.cpp
+++ b/code/ObjFileImporter.cpp
@@ -144,38 +144,6 @@ void ObjFileImporter::InternReadFile( const std::string &file, aiScene* pScene, 
         modelName = file;
     }
 
-    // This next stage takes ~ 1/3th of the total readFile task
-    // so should amount for 1/3th of the progress
-    // only update every 100KB or it'll be too slow
-    /*unsigned int progress = 0;
-    unsigned int progressCounter = 0;
-    const unsigned int updateProgressEveryBytes = 100 * 1024;
-    const unsigned int progressTotal = static_cast<unsigned int>(3*m_Buffer.size()/updateProgressEveryBytes);*/
-    // process all '\'
-    /*std::vector<char> ::iterator iter = m_Buffer.begin();
-    while (iter != m_Buffer.end())
-    {
-        if (*iter == '\\')
-        {
-            // remove '\'
-            iter = m_Buffer.erase(iter);
-            // remove next character
-            while (*iter == '\r' || *iter == '\n')
-                iter = m_Buffer.erase(iter);
-        }
-        else
-            ++iter;
-
-        if (++progressCounter >= updateProgressEveryBytes)
-        {
-            m_progress->UpdateFileRead(++progress, progressTotal);
-            progressCounter = 0;
-        }
-    }*/
-
-    // 1/3rd progress
-    m_progress->UpdateFileRead(1, 3);
-
     // parse the file into a temporary representation
     ObjFileParser parser( streamedBuffer, modelName, pIOHandler, m_progress, file);
 

--- a/code/ObjFileParser.cpp
+++ b/code/ObjFileParser.cpp
@@ -113,8 +113,7 @@ void ObjFileParser::parseFile( IOStreamBuffer<char> &streamBuffer ) {
     //const unsigned int updateProgressEveryBytes = 100 * 1024;
     unsigned int progressCounter = 0;
     const unsigned int bytesToProcess = static_cast<unsigned int>(streamBuffer.size());
-    const unsigned int progressTotal = 3 * bytesToProcess;
-    const unsigned int progressOffset = bytesToProcess;
+    const unsigned int progressTotal = bytesToProcess;
     unsigned int processed = 0;
     size_t lastFilePos( 0 );
 
@@ -126,10 +125,10 @@ void ObjFileParser::parseFile( IOStreamBuffer<char> &streamBuffer ) {
         // Handle progress reporting
         const size_t filePos( streamBuffer.getFilePos() );
         if ( lastFilePos < filePos ) {
-            processed += static_cast<unsigned int>(filePos);
+            processed = static_cast<unsigned int>(filePos);
             lastFilePos = filePos;
             progressCounter++;
-            m_progress->UpdateFileRead( progressOffset + processed * 2, progressTotal );
+            m_progress->UpdateFileRead( processed, progressTotal );
         }
 
         // parse line


### PR DESCRIPTION
… is claiming to still take up "1/3" of the total progress.