### PR TITLE
MemoryIOSystem delegates to existing IOSystem

### DIFF
--- a/code/Importer.cpp
+++ b/code/Importer.cpp
@@ -483,7 +483,7 @@ const aiScene* Importer::ReadFileFromMemory( const void* pBuffer,
     IOSystem* io = pimpl->mIOHandler;
     pimpl->mIOHandler = NULL;
 
-    SetIOHandler(new MemoryIOSystem((const uint8_t*)pBuffer,pLength));
+    SetIOHandler(new MemoryIOSystem((const uint8_t*)pBuffer,pLength,io));
 
     // read the file and recover the previous IOSystem
     static const size_t BufSize(Importer::MaxLenHint + 28);

--- a/include/assimp/MemoryIOWrapper.h
+++ b/include/assimp/MemoryIOWrapper.h
@@ -51,6 +51,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdint.h>
 
 namespace Assimp    {
+    
 #define AI_MEMORYIO_MAGIC_FILENAME "$$$___magic___$$$"
 #define AI_MEMORYIO_MAGIC_FILENAME_LENGTH 17
 
@@ -78,9 +79,11 @@ public:
     size_t Read(void* pvBuffer, size_t pSize, size_t pCount)    {
         ai_assert(nullptr != pvBuffer);
         ai_assert(0 != pSize);
-        const size_t cnt = std::min(pCount,(length-pos)/pSize), ofs = pSize*cnt;
+        
+        const size_t cnt = std::min( pCount, (length-pos) / pSize);
+        const size_t ofs = pSize * cnt;
 
-        memcpy(pvBuffer,buffer+pos,ofs);
+        ::memcpy(pvBuffer,buffer+pos,ofs);
         pos += ofs;
 
         return cnt;
@@ -148,20 +151,18 @@ public:
     : buffer(buff)
     , length(len)
     , existing_io(io)
-    , created_stream() {
+    , created_streams() {
         // empty
     }
 
     /** Destructor. */
     ~MemoryIOSystem() {
-        delete created_stream;
-        created_stream = nullptr;
     }
 
     // -------------------------------------------------------------------
     /** Tests for the existence of a file at the given path. */
     bool Exists(const char* pFile) const override {
-        if (!strncmp(pFile,AI_MEMORYIO_MAGIC_FILENAME,AI_MEMORYIO_MAGIC_FILENAME_LENGTH)) {
+        if (0 == strncmp( pFile, AI_MEMORYIO_MAGIC_FILENAME, AI_MEMORYIO_MAGIC_FILENAME_LENGTH ) ) {
             return true;
         }
         return existing_io ? existing_io->Exists(pFile) : false;
@@ -177,9 +178,9 @@ public:
     // -------------------------------------------------------------------
     /** Open a new file with a given path. */
     IOStream* Open(const char* pFile, const char* pMode = "rb") override {
-        if (!strncmp(pFile,AI_MEMORYIO_MAGIC_FILENAME,AI_MEMORYIO_MAGIC_FILENAME_LENGTH)) {
-            created_stream = new MemoryIOStream(buffer, length);
-            return created_stream;
+        if ( 0 == strncmp( pFile, AI_MEMORYIO_MAGIC_FILENAME, AI_MEMORYIO_MAGIC_FILENAME_LENGTH ) ) {
+            created_streams.emplace_back(new MemoryIOStream(buffer, length));
+            return created_streams.back();
         }
         return existing_io ? existing_io->Open(pFile, pMode) : NULL;
     }
@@ -187,9 +188,10 @@ public:
     // -------------------------------------------------------------------
     /** Closes the given file and releases all resources associated with it. */
     void Close( IOStream* pFile) override {
-        if (pFile == created_stream) {
-            delete created_stream;
-            created_stream = nullptr;
+        auto it = std::find(created_streams.begin(), created_streams.end(), pFile);
+        if (it != created_streams.end()) {
+            delete pFile;
+            created_streams.erase(it);
         } else if (existing_io) {
             existing_io->Close(pFile);
         }
@@ -234,7 +236,7 @@ private:
     const uint8_t* buffer;
     size_t length;
     IOSystem* existing_io;
-    IOStream *created_stream;
+    std::vector<IOStream*> created_streams;
 };
 
 } // end namespace Assimp


### PR DESCRIPTION
Goal is to support cases where the initial file has already been loaded (hence a desire to use `ReadFileFromMemory`) but there may be other files necessary to resolve.