### PR TITLE
Fix glTF2 export with no texture coordinates

### DIFF
--- a/code/glTF2Exporter.cpp
+++ b/code/glTF2Exporter.cpp
@@ -732,6 +732,9 @@ void glTF2Exporter::ExportMeshes()
 
 		/************** Texture coordinates **************/
         for (int i = 0; i < AI_MAX_NUMBER_OF_TEXTURECOORDS; ++i) {
+			if (!aim->HasTextureCoords(i))
+				continue;
+			
             // Flip UV y coords
             if (aim -> mNumUVComponents[i] > 1) {
                 for (unsigned int j = 0; j < aim->mNumVertices; ++j) {
@@ -967,7 +970,7 @@ void glTF2Exporter::ExportMetadata()
 
 inline Ref<Accessor> GetSamplerInputRef(Asset& asset, std::string& animId, Ref<Buffer>& buffer, std::vector<float>& times)
 {
-    return ExportData(asset, animId, buffer, times.size(), &times[0], AttribType::SCALAR, AttribType::SCALAR, ComponentType_FLOAT);
+    return ExportData(asset, animId, buffer, (unsigned int)times.size(), &times[0], AttribType::SCALAR, AttribType::SCALAR, ComponentType_FLOAT);
 }
 
 inline void ExtractTranslationSampler(Asset& asset, std::string& animId, Ref<Buffer>& buffer, const aiNodeAnim* nodeChannel, float ticksPerSecond, Animation::Sampler& sampler)


### PR DESCRIPTION
Hello,

The glTF2 export crashed when there were no texture coordinates, so I added a test before reading texture coordinates.
I also fixed a warning (explicit cast from size_t to unsigned int).

Loïc