### PR TITLE
Bugfix issue: #2327 Build broken on clang-7.0.1

### DIFF
--- a/code/glTF2AssetWriter.inl
+++ b/code/glTF2AssetWriter.inl
@@ -97,10 +97,10 @@ namespace glTF2 {
     inline void Write(Value& obj, Accessor& a, AssetWriter& w)
     {
         obj.AddMember("bufferView", a.bufferView->index, w.mAl);
-        obj.AddMember("byteOffset", a.byteOffset, w.mAl);
+        obj.AddMember("byteOffset", (unsigned int)a.byteOffset, w.mAl);
 
         obj.AddMember("componentType", int(a.componentType), w.mAl);
-        obj.AddMember("count", a.count, w.mAl);
+        obj.AddMember("count", (unsigned int)a.count, w.mAl);
         obj.AddMember("type", StringRef(AttribType::ToString(a.type)), w.mAl);
 
         Value vTmpMax, vTmpMin;


### PR DESCRIPTION
This pull request fixes issue #2327 (master was not building on clang-7.0.1)

It seems that calling addMember with second parameter of type size_t is ambiguous, changed to unsigned int