### PR TITLE
Fix automatic name assignment for ColladaLoader when using name based assignment

### DIFF
--- a/code/ColladaLoader.cpp
+++ b/code/ColladaLoader.cpp
@@ -1926,21 +1926,28 @@ const Collada::Node* ColladaLoader::FindNodeBySID( const Collada::Node* pNode, c
 std::string ColladaLoader::FindNameForNode( const Collada::Node* pNode)
 {
     // If explicitly requested, just use the collada name.
-    if (useColladaName) {
-        return pNode->mName;
-    }
-
-    // Now setup the name of the assimp node. The collada name might not be
-    // unique, so we use the collada ID.
-    if (!pNode->mID.empty())
-        return pNode->mID;
-    else if (!pNode->mSID.empty())
-    return pNode->mSID;
-  else
+    if (useColladaName)
     {
-        // No need to worry. Unnamed nodes are no problem at all, except
-        // if cameras or lights need to be assigned to them.
-    return format() << "$ColladaAutoName$_" << mNodeNameCounter++;
+        if (!pNode->mName.empty()) {
+            return pNode->mName;
+        } else {
+            return format() << "$ColladaAutoName$_" << mNodeNameCounter++;
+        }
+    }
+    else
+    {
+        // Now setup the name of the assimp node. The collada name might not be
+        // unique, so we use the collada ID.
+        if (!pNode->mID.empty())
+            return pNode->mID;
+        else if (!pNode->mSID.empty())
+            return pNode->mSID;
+        else
+        {
+            // No need to worry. Unnamed nodes are no problem at all, except
+            // if cameras or lights need to be assigned to them.
+            return format() << "$ColladaAutoName$_" << mNodeNameCounter++;
+        }
     }
 }
 


### PR DESCRIPTION
In ColladaLoader in version 3.2.0 (release est. 2015) the name assignment was based on name attribute (xml) with optional fallbacks to id and sid. Over time this was changed to fix a bug and support for names was removed, only to be later (re)added using an optional `useColladaName` setting. We discovered a problem that with when using the name based assignment it doesn't assign automatically generated names like what it did in the logic in v3.2.0 and on the id based approach on current master.

We discovered this causes problems with matching the aiCamera and aiLight. So we rectified this problem by auto-generating names also on the name based method.