### PR TITLE
Add a way to select which exporters you want to compile in

### DIFF
--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -216,7 +216,7 @@ ENDIF ( ASSIMP_BUILD_NONFREE_C4D_IMPORTER )
 # ASSIMP_BUILD_XXX_IMPORTER to FALSE for each importer
 # if this variable is set to FALSE, the user can manually enable importers by setting
 # ASSIMP_BUILD_XXX_IMPORTER to TRUE for each importer
-OPTION(ASSIMP_BUILD_ALL_IMPORTERS_BY_DEFAULT "default value of all ASSIMP_BUILD_XXX_IMPORTER value" TRUE)
+OPTION(ASSIMP_BUILD_ALL_IMPORTERS_BY_DEFAULT "default value of all ASSIMP_BUILD_XXX_IMPORTER values" TRUE)
 
 # macro to add the CMake Option ADD_ASSIMP_IMPORTER_<name> which enables compile of loader
 # this way selective loaders can be compiled (reduces filesize + compile time)
@@ -232,19 +232,51 @@ MACRO(ADD_ASSIMP_IMPORTER name)
   IF (ASSIMP_IMPORTER_ENABLED)
     LIST(APPEND ASSIMP_LOADER_SRCS ${ARGN})
     SET(ASSIMP_IMPORTERS_ENABLED "${ASSIMP_IMPORTERS_ENABLED} ${name}")
-    SET(${name}_SRCS ${ARGN})
     SOURCE_GROUP(${name} FILES ${ARGN})
   ELSE()
     SET(${name}_SRC "")
     SET(ASSIMP_IMPORTERS_DISABLED "${ASSIMP_IMPORTERS_DISABLED} ${name}")
     add_definitions(-DASSIMP_BUILD_NO_${name}_IMPORTER)
+  ENDIF()
+ENDMACRO()
+
+# if this variable is set to TRUE, the user can manually disable exporters by setting
+# ASSIMP_BUILD_XXX_EXPORTER to FALSE for each exporter
+# if this variable is set to FALSE, the user can manually enable exporters by setting
+# ASSIMP_BUILD_XXX_EXPORTER to TRUE for each exporter
+OPTION(ASSIMP_BUILD_ALL_EXPORTERS_BY_DEFAULT "default value of all ASSIMP_BUILD_XXX_EXPORTER values" TRUE)
+
+# macro to add the CMake Option ADD_ASSIMP_IMPORTER_<name> which enables compile of loader
+# this way selective loaders can be compiled (reduces filesize + compile time)
+MACRO(ADD_ASSIMP_EXPORTER name)
+  IF (ASSIMP_NO_EXPORT)
+	set(ASSIMP_EXPORTER_ENABLED FALSE)
+  ELSEIF (ASSIMP_BUILD_ALL_EXPORTERS_BY_DEFAULT)
+    set(ASSIMP_EXPORTER_ENABLED TRUE)
+    IF (DEFINED ASSIMP_BUILD_${name}_EXPORTER AND NOT ASSIMP_BUILD_${name}_EXPORTER)
+      set(ASSIMP_EXPORTER_ENABLED FALSE)
+    ENDIF ()
+  ELSE ()
+    set(ASSIMP_EXPORTER_ENABLED ${ASSIMP_BUILD_${name}_EXPORTER})
+  ENDIF ()
+  
+  IF (ASSIMP_EXPORTER_ENABLED)
+    SET(ASSIMP_EXPORTERS_ENABLED "${ASSIMP_EXPORTERS_ENABLED} ${name}")
+	LIST(APPEND ASSIMP_EXPORTER_SRCS ${ARGN})
+    SOURCE_GROUP(${name}_EXPORTER FILES ${ARGN})
+  ELSE()
+    SET(ASSIMP_EXPORTERS_DISABLED "${ASSIMP_EXPORTERS_DISABLED} ${name}")
     add_definitions(-DASSIMP_BUILD_NO_${name}_EXPORTER)
   ENDIF()
 ENDMACRO()
 
 SET(ASSIMP_LOADER_SRCS "")
 SET(ASSIMP_IMPORTERS_ENABLED "") # list of enabled importers
-SET(ASSIMP_IMPORTERS_DISABLED "") # disabled list (used to print)
+SET(ASSIMP_IMPORTERS_DISABLED "") # disabled importers list (used to print)
+
+SET(ASSIMP_EXPORTER_SRCS "")
+SET(ASSIMP_EXPORTERS_ENABLED "") # list of enabled exporters
+SET(ASSIMP_EXPORTERS_DISABLED "") # disabled exporters list (used to print)
 
 ADD_ASSIMP_IMPORTER( AMF
   AMFImporter.hpp
@@ -261,6 +293,9 @@ ADD_ASSIMP_IMPORTER( 3DS
   3DSHelper.h
   3DSLoader.cpp
   3DSLoader.h
+)
+
+ADD_ASSIMP_EXPORTER( 3DS
   3DSExporter.h
   3DSExporter.cpp
 )
@@ -278,10 +313,13 @@ ADD_ASSIMP_IMPORTER( ASE
 )
 
 ADD_ASSIMP_IMPORTER( ASSBIN
-  AssbinExporter.h
-  AssbinExporter.cpp
   AssbinLoader.h
   AssbinLoader.cpp
+)
+
+ADD_ASSIMP_EXPORTER( ASSBIN
+  AssbinExporter.h
+  AssbinExporter.cpp
 )
 
 ADD_ASSIMP_IMPORTER( ASSXML
@@ -305,6 +343,9 @@ ADD_ASSIMP_IMPORTER( COLLADA
   ColladaLoader.h
   ColladaParser.cpp
   ColladaParser.h
+)
+
+ADD_ASSIMP_EXPORTER( COLLADA
   ColladaExporter.h
   ColladaExporter.cpp
 )
@@ -421,6 +462,9 @@ ADD_ASSIMP_IMPORTER( OBJ
   ObjFileParser.cpp
   ObjFileParser.h
   ObjTools.h
+)
+
+ADD_ASSIMP_EXPORTER( OBJ
   ObjExporter.h
   ObjExporter.cpp
 )
@@ -439,11 +483,14 @@ ADD_ASSIMP_IMPORTER( OGRE
 )
 
 ADD_ASSIMP_IMPORTER( OPENGEX
-  OpenGEXExporter.cpp
-  OpenGEXExporter.h
   OpenGEXImporter.cpp
   OpenGEXImporter.h
   OpenGEXStructs.h
+)
+
+ADD_ASSIMP_EXPORTER( OPENGEX
+  OpenGEXExporter.cpp
+  OpenGEXExporter.h
 )
 
 ADD_ASSIMP_IMPORTER( PLY
@@ -451,6 +498,9 @@ ADD_ASSIMP_IMPORTER( PLY
   PlyLoader.h
   PlyParser.cpp
   PlyParser.h
+)
+
+ADD_ASSIMP_EXPORTER( PLY
   PlyExporter.cpp
   PlyExporter.h
 )
@@ -541,13 +591,16 @@ ADD_ASSIMP_IMPORTER( FBX
   FBXDeformer.cpp
   FBXBinaryTokenizer.cpp
   FBXDocumentUtil.cpp
+  FBXCommon.h
+)
+
+ADD_ASSIMP_EXPORTER( FBX
   FBXExporter.h
   FBXExporter.cpp
   FBXExportNode.h
   FBXExportNode.cpp
   FBXExportProperty.h
   FBXExportProperty.cpp
-  FBXCommon.h
 )
 
 SET( PostProcessing_SRCS
@@ -647,6 +700,9 @@ ADD_ASSIMP_IMPORTER( SMD
 ADD_ASSIMP_IMPORTER( STL
   STLLoader.cpp
   STLLoader.h
+)
+
+ADD_ASSIMP_EXPORTER( STL
   STLExporter.h
   STLExporter.cpp
 )
@@ -667,13 +723,14 @@ ADD_ASSIMP_IMPORTER( X
   XFileImporter.h
   XFileParser.cpp
   XFileParser.h
+)
+
+ADD_ASSIMP_EXPORTER( X
   XFileExporter.h
   XFileExporter.cpp
 )
 
 ADD_ASSIMP_IMPORTER( X3D
-  X3DExporter.cpp
-  X3DExporter.hpp
   X3DImporter.cpp
   X3DImporter.hpp
   X3DImporter_Geometry2D.cpp
@@ -693,6 +750,11 @@ ADD_ASSIMP_IMPORTER( X3D
   X3DVocabulary.cpp
 )
 
+ADD_ASSIMP_EXPORTER( X3D
+  X3DExporter.cpp
+  X3DExporter.hpp
+)
+
 ADD_ASSIMP_IMPORTER( GLTF
   glTFAsset.h
   glTFAsset.inl
@@ -700,26 +762,29 @@ ADD_ASSIMP_IMPORTER( GLTF
   glTFAssetWriter.inl
   glTFImporter.cpp
   glTFImporter.h
-  glTFExporter.h
-  glTFExporter.cpp
   glTF2Asset.h
   glTF2Asset.inl
   glTF2AssetWriter.h
   glTF2AssetWriter.inl
   glTF2Importer.cpp
   glTF2Importer.h
+)
+
+ADD_ASSIMP_EXPORTER( GLTF
+  glTFExporter.h
+  glTFExporter.cpp
   glTF2Exporter.h
   glTF2Exporter.cpp
 )
 
 ADD_ASSIMP_IMPORTER( 3MF
-    D3MFImporter.h
-    D3MFImporter.cpp
     D3MFExporter.h
     D3MFExporter.cpp
-    D3MFOpcPackage.h
-    D3MFOpcPackage.cpp
-    3MFXmlTags.h
+)
+
+ADD_ASSIMP_EXPORTER( 3MF
+    D3MFExporter.h
+    D3MFExporter.cpp
 )
 
 ADD_ASSIMP_IMPORTER( MMD
@@ -740,16 +805,21 @@ ADD_ASSIMP_IMPORTER( STEP
     Importer/StepFile/StepFileGen2.cpp
     Importer/StepFile/StepFileGen3.cpp
     Importer/StepFile/StepReaderGen.h
+)
+
+ADD_ASSIMP_EXPORTER( STEP
     StepExporter.h
     StepExporter.cpp
 )
 
-SET( Exporter_SRCS
-  Exporter.cpp
-  AssimpCExport.cpp
-  ${HEADER_PATH}/BlobIOSystem.h
-)
-SOURCE_GROUP( Exporter FILES ${Exporter_SRCS})
+if ((NOT ASSIMP_NO_EXPORT) OR (NOT ASSIMP_EXPORTERS_ENABLED STREQUAL ""))
+	SET( Exporter_SRCS
+	  Exporter.cpp
+	  AssimpCExport.cpp
+	  ${HEADER_PATH}/BlobIOSystem.h
+	)
+	SOURCE_GROUP( Exporter FILES ${Exporter_SRCS})
+endif()
 
 SET( Extra_SRCS
   MD4FileData.h
@@ -883,8 +953,11 @@ else (UNZIP_FOUND)
   INCLUDE_DIRECTORIES( "../contrib/unzip/" )
 endif (UNZIP_FOUND)
 
-MESSAGE(STATUS "Enabled formats:${ASSIMP_IMPORTERS_ENABLED}")
-MESSAGE(STATUS "Disabled formats:${ASSIMP_IMPORTERS_DISABLED}")
+MESSAGE(STATUS "Enabled importer formats:${ASSIMP_IMPORTERS_ENABLED}")
+MESSAGE(STATUS "Disabled importer formats:${ASSIMP_IMPORTERS_DISABLED}")
+
+MESSAGE(STATUS "Enabled exporter formats:${ASSIMP_EXPORTERS_ENABLED}")
+MESSAGE(STATUS "Disabled exporter formats:${ASSIMP_EXPORTERS_DISABLED}")
 
 SET( assimp_src
   # Assimp Files
@@ -899,6 +972,7 @@ SET( assimp_src
 
   # Model Support
   ${ASSIMP_LOADER_SRCS}
+  ${ASSIMP_EXPORTER_SRCS}
 
   # Third-party libraries
   ${IrrXML_SRCS}
@@ -912,7 +986,6 @@ SET( assimp_src
 
   ${PUBLIC_HEADERS}
   ${COMPILER_HEADERS}
-
 )
 ADD_DEFINITIONS( -DOPENDDLPARSER_BUILD )
 

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -778,8 +778,11 @@ ADD_ASSIMP_EXPORTER( GLTF
 )
 
 ADD_ASSIMP_IMPORTER( 3MF
-    D3MFExporter.h
-    D3MFExporter.cpp
+	D3MFImporter.h
+    D3MFImporter.cpp
+	D3MFOpcPackage.h
+    D3MFOpcPackage.cpp
+    3MFXmlTags.h
 )
 
 ADD_ASSIMP_EXPORTER( 3MF


### PR DESCRIPTION
Mimics the `ASSIMP_BUILD_ALL_IMPORTERS_BY_DEFAULT` / `ASSIMP_BUILD_XXX_IMPORTER` code but for exporters:

`ASSIMP_BUILD_ALL_EXPORTERS_BY_DEFAULT` / `ASSIMP_BUILD_XXX_EXPORTER`

This works exactly the same way with one exception - `ASSIMP_NO_EXPORT` still overrides everything and turns off all exporting.

Fixes #2377