### PR TITLE
Fix lgtm alerts

### DIFF
--- a/port/PyAssimp/pyassimp/core.py
+++ b/port/PyAssimp/pyassimp/core.py
@@ -65,10 +65,10 @@ def make_tuple(ai_obj, type = None):
 
 # Returns unicode object for Python 2, and str object for Python 3.
 def _convert_assimp_string(assimp_string):
-    try:
-        return unicode(assimp_string.data, errors='ignore')
-    except UnicodeError:
+    if sys.version_info >= (3, 0):
         return str(assimp_string.data, errors='ignore')
+    else:
+        return unicode(assimp_string.data, errors='ignore')
 
 # It is faster and more correct to have an init function for each assimp class
 def _init_face(aiFace):
@@ -303,7 +303,7 @@ def load(filename,
         #                                      unsigned int pLength,
         #                                      unsigned int pFlags,
         #                                      const char* pHint)
-        if file_type == None:
+        if file_type is None:
             raise AssimpError('File type must be specified when passing file objects!')
         data  = filename.read()
         model = _assimp_lib.load_mem(data,

--- a/port/PyAssimp/pyassimp/core.py
+++ b/port/PyAssimp/pyassimp/core.py
@@ -6,7 +6,7 @@ This is the main-module of PyAssimp.
 
 import sys
 if sys.version_info < (2,6):
-    raise 'pyassimp: need python 2.6 or newer'
+    raise RuntimeError('pyassimp: need python 2.6 or newer')
 
 # xrange was renamed range in Python 3 and the original range from Python 2 was removed.
 # To keep compatibility with both Python 2 and 3, xrange is set to range for version 3.0 and up.

--- a/port/PyAssimp/pyassimp/core.py
+++ b/port/PyAssimp/pyassimp/core.py
@@ -13,12 +13,9 @@ if sys.version_info < (2,6):
 if sys.version_info >= (3,0):
     xrange = range
 
-import ctypes
-import os
 
 try: import numpy
 except: numpy = None
-
 import logging
 import ctypes
 logger = logging.getLogger("pyassimp")

--- a/port/PyAssimp/pyassimp/core.py
+++ b/port/PyAssimp/pyassimp/core.py
@@ -15,7 +15,7 @@ if sys.version_info >= (3,0):
 
 
 try: import numpy
-except: numpy = None
+except ImportError: numpy = None
 import logging
 import ctypes
 logger = logging.getLogger("pyassimp")
@@ -67,7 +67,7 @@ def make_tuple(ai_obj, type = None):
 def _convert_assimp_string(assimp_string):
     try:
         return unicode(assimp_string.data, errors='ignore')
-    except:
+    except UnicodeError:
         return str(assimp_string.data, errors='ignore')
 
 # It is faster and more correct to have an init function for each assimp class

--- a/port/PyAssimp/pyassimp/core.py
+++ b/port/PyAssimp/pyassimp/core.py
@@ -20,6 +20,7 @@ try: import numpy
 except: numpy = None
 
 import logging
+import ctypes
 logger = logging.getLogger("pyassimp")
 # attach default null handler to logger so it doesn't complain
 # even if you don't attach another handler to logger
@@ -343,8 +344,7 @@ def export(scene,
 
     '''
 
-    from ctypes import pointer
-    exportStatus = _assimp_lib.export(pointer(scene), file_type.encode("ascii"), filename.encode(sys.getfilesystemencoding()), processing)
+    exportStatus = _assimp_lib.export(ctypes.pointer(scene), file_type.encode("ascii"), filename.encode(sys.getfilesystemencoding()), processing)
 
     if exportStatus != 0:
         raise AssimpError('Could not export scene!')

--- a/port/PyAssimp/pyassimp/core.py
+++ b/port/PyAssimp/pyassimp/core.py
@@ -366,16 +366,14 @@ def export_blob(scene,
     ---------
     Pointer to structs.ExportDataBlob
     '''
-    from ctypes import pointer
-    exportBlobPtr = _assimp_lib.export_blob(pointer(scene), file_type.encode("ascii"), processing)
+    exportBlobPtr = _assimp_lib.export_blob(ctypes.pointer(scene), file_type.encode("ascii"), processing)
 
     if exportBlobPtr == 0:
         raise AssimpError('Could not export scene to blob!')
     return exportBlobPtr
 
 def release(scene):
-    from ctypes import pointer
-    _assimp_lib.release(pointer(scene))
+    _assimp_lib.release(ctypes.pointer(scene))
 
 def _finalize_texture(tex, target):
     setattr(target, "achformathint", tex.achFormatHint)
@@ -439,24 +437,22 @@ def _finalize_mesh(mesh, target):
     setattr(target, 'faces', faces)
 
 def _init_metadata_entry(entry):
-    from ctypes import POINTER, c_bool, c_int32, c_uint64, c_float, c_double, cast
-
     entry.type = entry.mType
     if entry.type == structs.MetadataEntry.AI_BOOL:
-        entry.data = cast(entry.mData, POINTER(c_bool)).contents.value
+        entry.data = ctypes.cast(entry.mData, ctypes.POINTER(ctypes.c_bool)).contents.value
     elif entry.type == structs.MetadataEntry.AI_INT32:
-        entry.data = cast(entry.mData, POINTER(c_int32)).contents.value
+        entry.data = ctypes.cast(entry.mData, ctypes.POINTER(ctypes.c_int32)).contents.value
     elif entry.type == structs.MetadataEntry.AI_UINT64:
-        entry.data = cast(entry.mData, POINTER(c_uint64)).contents.value
+        entry.data = ctypes.cast(entry.mData, ctypes.POINTER(ctypes.c_uint64)).contents.value
     elif entry.type == structs.MetadataEntry.AI_FLOAT:
-        entry.data = cast(entry.mData, POINTER(c_float)).contents.value
+        entry.data = ctypes.cast(entry.mData, ctypes.POINTER(ctypes.c_float)).contents.value
     elif entry.type == structs.MetadataEntry.AI_DOUBLE:
-        entry.data = cast(entry.mData, POINTER(c_double)).contents.value
+        entry.data = ctypes.cast(entry.mData, ctypes.POINTER(ctypes.c_double)).contents.value
     elif entry.type == structs.MetadataEntry.AI_AISTRING:
-        assimp_string = cast(entry.mData, POINTER(structs.String)).contents
+        assimp_string = ctypes.cast(entry.mData, ctypes.POINTER(structs.String)).contents
         entry.data = _convert_assimp_string(assimp_string)
     elif entry.type == structs.MetadataEntry.AI_AIVECTOR3D:
-        assimp_vector = cast(entry.mData, POINTER(structs.Vector3D)).contents
+        assimp_vector = ctypes.cast(entry.mData, ctypes.POINTER(structs.Vector3D)).contents
         entry.data = make_tuple(assimp_vector)
 
     return entry
@@ -510,15 +506,18 @@ def _get_properties(properties, length):
         key = (key.split('.')[1], p.mSemantic)
 
         #the data
-        from ctypes import POINTER, cast, c_int, c_float, sizeof
         if p.mType == 1:
-            arr = cast(p.mData, POINTER(c_float * int(p.mDataLength/sizeof(c_float)) )).contents
+            arr = ctypes.cast(p.mData,
+                              ctypes.POINTER(ctypes.c_float * int(p.mDataLength/ctypes.sizeof(ctypes.c_float)))
+                              ).contents
             value = [x for x in arr]
         elif p.mType == 3: #string can't be an array
-            value = _convert_assimp_string(cast(p.mData, POINTER(structs.MaterialPropertyString)).contents)
+            value = _convert_assimp_string(ctypes.cast(p.mData, ctypes.POINTER(structs.MaterialPropertyString)).contents)
 
         elif p.mType == 4:
-            arr = cast(p.mData, POINTER(c_int * int(p.mDataLength/sizeof(c_int)) )).contents
+            arr = ctypes.cast(p.mData,
+                              ctypes.POINTER(ctypes.c_int * int(p.mDataLength/ctypes.sizeof(ctypes.c_int)))
+                              ).contents
             value = [x for x in arr]
         else:
             value = p.mData[:p.mDataLength]
@@ -538,7 +537,9 @@ def decompose_matrix(matrix):
     rotation = structs.Quaternion()
     position = structs.Vector3D()
 
-    from ctypes import byref, pointer
-    _assimp_lib.dll.aiDecomposeMatrix(pointer(matrix), byref(scaling), byref(rotation), byref(position))
+    _assimp_lib.dll.aiDecomposeMatrix(ctypes.pointer(matrix),
+                                      ctypes.byref(scaling),
+                                      ctypes.byref(rotation),
+                                      ctypes.byref(position))
     return scaling._init(), rotation._init(), position._init()
     

--- a/port/PyAssimp/pyassimp/formats.py
+++ b/port/PyAssimp/pyassimp/formats.py
@@ -21,7 +21,7 @@ FORMATS = ["CSM",
             "STL", 
             "IRR", 
             "Q3O",
-            "Q3D"
+            "Q3D",
             "MS3D", 
             "Q3S", 
             "ZGL", 

--- a/port/PyAssimp/pyassimp/helper.py
+++ b/port/PyAssimp/pyassimp/helper.py
@@ -6,7 +6,6 @@ Some fancy helper functions.
 
 import os
 import ctypes
-from ctypes import POINTER
 import operator
 
 from distutils.sysconfig import get_python_lib
@@ -193,9 +192,9 @@ def try_load_functions(library_path, dll):
 
     # library found!
     from .structs import Scene, ExportDataBlob
-    load.restype = POINTER(Scene)
-    load_mem.restype = POINTER(Scene)
-    export2blob.restype = POINTER(ExportDataBlob)
+    load.restype = ctype.POINTER(Scene)
+    load_mem.restype = ctype.POINTER(Scene)
+    export2blob.restype = ctype.POINTER(ExportDataBlob)
     return (library_path, load, load_mem, export, export2blob, release, dll)
 
 def search_library():

--- a/port/PyAssimp/pyassimp/helper.py
+++ b/port/PyAssimp/pyassimp/helper.py
@@ -14,7 +14,7 @@ import re
 import sys
 
 try: import numpy
-except: numpy = None
+except ImportError: numpy = None
 
 import logging;logger = logging.getLogger("pyassimp")
 
@@ -276,5 +276,5 @@ def hasattr_silent(object, name):
 
     try:
         return hasattr(object, name)
-    except:
+    except AttributeError:
         return False

--- a/port/PyAssimp/pyassimp/helper.py
+++ b/port/PyAssimp/pyassimp/helper.py
@@ -192,9 +192,9 @@ def try_load_functions(library_path, dll):
 
     # library found!
     from .structs import Scene, ExportDataBlob
-    load.restype = ctypes.POINTER(Scene)
-    load_mem.restype = ctypes.POINTER(Scene)
-    export2blob.restype = ctypes.POINTER(ExportDataBlob)
+    load.restype = ctype.POINTER(Scene)
+    load_mem.restype = ctype.POINTER(Scene)
+    export2blob.restype = ctype.POINTER(ExportDataBlob)
     return (library_path, load, load_mem, export, export2blob, release, dll)
 
 def search_library():

--- a/port/PyAssimp/pyassimp/helper.py
+++ b/port/PyAssimp/pyassimp/helper.py
@@ -192,9 +192,9 @@ def try_load_functions(library_path, dll):
 
     # library found!
     from .structs import Scene, ExportDataBlob
-    load.restype = ctype.POINTER(Scene)
-    load_mem.restype = ctype.POINTER(Scene)
-    export2blob.restype = ctype.POINTER(ExportDataBlob)
+    load.restype = ctypes.POINTER(Scene)
+    load_mem.restype = ctypes.POINTER(Scene)
+    export2blob.restype = ctypes.POINTER(ExportDataBlob)
     return (library_path, load, load_mem, export, export2blob, release, dll)
 
 def search_library():

--- a/port/PyAssimp/pyassimp/postprocess.py
+++ b/port/PyAssimp/pyassimp/postprocess.py
@@ -435,6 +435,7 @@ aiProcess_Debone  = 0x4000000
 aiProcess_GenEntityMeshes = 0x100000
 aiProcess_OptimizeAnimations = 0x200000
 aiProcess_FixTexturePaths = 0x200000
+aiProcess_EmbedTextures  = 0x10000000,
 
 ## @def aiProcess_ConvertToLeftHanded
  #  @brief Shortcut flag for Direct3D-based applications. 

--- a/port/PyAssimp/pyassimp/structs.py
+++ b/port/PyAssimp/pyassimp/structs.py
@@ -1,6 +1,6 @@
 #-*- coding: UTF-8 -*-
 
-from ctypes import POINTER, c_void_p, c_int, c_uint, c_char, c_float, Structure, c_char_p, c_double, c_ubyte, c_size_t, c_uint32
+from ctypes import POINTER, c_void_p, c_uint, c_char, c_float, Structure, c_char_p, c_double, c_ubyte, c_size_t, c_uint32
 
 
 class Vector2D(Structure):

--- a/port/PyAssimp/scripts/fixed_pipeline_3d_viewer.py
+++ b/port/PyAssimp/scripts/fixed_pipeline_3d_viewer.py
@@ -24,12 +24,13 @@ This sample is based on several sources, including:
  - ASSIMP's C++ SimpleOpenGL viewer
 """
 
-import os, sys
+import sys
 from OpenGL.GLUT import *
 from OpenGL.GLU import *
 from OpenGL.GL import *
 
-import logging;logger = logging.getLogger("pyassimp_opengl")
+import logging
+logger = logging.getLogger("pyassimp_opengl")
 logging.basicConfig(level=logging.INFO)
 
 import math

--- a/port/PyAssimp/scripts/sample.py
+++ b/port/PyAssimp/scripts/sample.py
@@ -50,8 +50,8 @@ def main(filename=None):
         print("    colors:" + str(len(mesh.colors)))
         tcs = mesh.texturecoords
         if tcs.any():
-            for index, tc in enumerate(tcs):
-                print("    texture-coords "+ str(index) + ":" + str(len(tcs[index])) + "first3:" + str(tcs[index][:3]))
+            for tc_index, tc in enumerate(tcs):
+                print("    texture-coords "+ str(tc_index) + ":" + str(len(tcs[tc_index])) + "first3:" + str(tcs[tc_index][:3]))
 
         else:
             print("    no texture coordinates")

--- a/port/PyAssimp/scripts/sample.py
+++ b/port/PyAssimp/scripts/sample.py
@@ -5,7 +5,7 @@
 This module demonstrates the functionality of PyAssimp.
 """
 
-import os, sys
+import sys
 import logging
 logging.basicConfig(level=logging.INFO)
 

--- a/scripts/BlenderImporter/genblenddna.py
+++ b/scripts/BlenderImporter/genblenddna.py
@@ -291,7 +291,9 @@ def main():
     #s += "#endif\n"
         
     output.write(templt.replace("<HERE>",s))
-        
+
+    # we got here, so no error
+    return 0
 
 if __name__ == "__main__":
     sys.exit(main())

--- a/scripts/StepImporter/CppGenerator.py
+++ b/scripts/StepImporter/CppGenerator.py
@@ -151,10 +151,7 @@ def handle_unset_args(field,entity,schema,argnum):
     return n+template_allow_optional.format()
 
 def get_single_conversion(field,schema,argnum=0,classname='?'):
-    typen = field.type
     name = field.name
-    if field.collection:
-        typen = 'LIST'
     return template_convert_single.format(name=name,argnum=argnum,classname=classname,full_type=field.fullspec)
 
 def count_args_up(entity,schema):

--- a/scripts/StepImporter/CppGenerator.py
+++ b/scripts/StepImporter/CppGenerator.py
@@ -218,7 +218,7 @@ def get_derived(e,schema):
     return res
 
 def get_hierarchy(e,schema):
-    return get_derived(e.schema)+[e.name]+get_base_classes(e,schema)
+    return get_derived(e, schema)+[e.name]+get_base_classes(e,schema)
 
 def sort_entity_list(schema):
     deps = []

--- a/scripts/StepImporter/CppGenerator.py
+++ b/scripts/StepImporter/CppGenerator.py
@@ -155,7 +155,7 @@ def get_single_conversion(field,schema,argnum=0,classname='?'):
     name = field.name
     if field.collection:
         typen = 'LIST'
-    return template_convert_single.format(type=typen,name=name,argnum=argnum,classname=classname,full_type=field.fullspec)
+    return template_convert_single.format(name=name,argnum=argnum,classname=classname,full_type=field.fullspec)
 
 def count_args_up(entity,schema):
     return len(entity.members) + (count_args_up(schema.entities[entity.parent],schema) if entity.parent else 0)

--- a/scripts/StepImporter/CppGenerator.py
+++ b/scripts/StepImporter/CppGenerator.py
@@ -300,5 +300,8 @@ def work(filename):
         with open(output_file_cpp,'wt') as outp:
             outp.write(inp.read().replace('{schema-static-table}',schema_table).replace('{converter-impl}',converters))
 
+    # Finished without error, so return 0
+    return 0
+
 if __name__ == "__main__":
     sys.exit(work(sys.argv[1] if len(sys.argv)>1 else 'schema.exp'))

--- a/scripts/StepImporter/ExpressReader.py
+++ b/scripts/StepImporter/ExpressReader.py
@@ -43,7 +43,8 @@
 """Parse an EXPRESS file and extract basic information on all
 entities and data types contained"""
 
-import sys, os, re
+import sys
+import re
 from collections import OrderedDict
 
 re_match_entity = re.compile(r"""


### PR DESCRIPTION
Fix a number of lgtm alerts:
* port/PyAssimp/pyassimp/core.py: use correct raise RuntimeError(string) rather than deprecated/removed raise string
* Fix apparent typo in scripts/StepImporter/CppGenerator.py. @kimkulling may want to review this one - it appears to have been a typo that went uncaught in get_hierarchy because I guess that method is never called in the tests. But I could be missing something here, I didn't write the original code. I just noticed that lgtm noted an error, and the error was that a method was called with 1 argument, e.hierarchy, whereas the related methods are all called with arguments e, hierarchy
* More to come