### PR TITLE
issue_2393: Added AI_MATKEY_TRANSPARENCYFACTOR

### DIFF
--- a/code/FBXConverter.cpp
+++ b/code/FBXConverter.cpp
@@ -2041,6 +2041,12 @@ namespace Assimp {
                 CalculatedOpacity = 1.0f - ((Transparent.r + Transparent.g + Transparent.b) / 3.0f);
             }
 
+            // try to get the transparency factor
+            const float TransparencyFactor = PropertyGet<float>(props, "TransparencyFactor", ok);
+            if (ok) {
+                out_mat->AddProperty(&TransparencyFactor, 1, AI_MATKEY_TRANSPARENCYFACTOR);
+            }
+
             // use of TransparencyFactor is inconsistent.
             // Maya always stores it as 1.0,
             // so we can't use it to set AI_MATKEY_OPACITY.

--- a/include/assimp/material.h
+++ b/include/assimp/material.h
@@ -900,6 +900,7 @@ extern "C" {
 #define AI_MATKEY_ENABLE_WIREFRAME "$mat.wireframe",0,0
 #define AI_MATKEY_BLEND_FUNC "$mat.blend",0,0
 #define AI_MATKEY_OPACITY "$mat.opacity",0,0
+#define AI_MATKEY_TRANSPARENCYFACTOR "$mat.transparencyfactor",0,0
 #define AI_MATKEY_BUMPSCALING "$mat.bumpscaling",0,0
 #define AI_MATKEY_SHININESS "$mat.shininess",0,0
 #define AI_MATKEY_REFLECTIVITY "$mat.reflectivity",0,0


### PR DESCRIPTION
We are switching from FBXSDK to Assimp. FBXSDK already has a way of fetching the "TransparencyFactor" from a material, which we need to support some models that don't use standard materials (exported from CAD software). We needed the same in Assimp, and there might be other users who need it too. I think it's good to expose this property since it's something FBX SDK already does.

See the description here: https://github.com/assimp/assimp/issues/2393