### PR TITLE
Suggested fix for issue 2043

### DIFF
--- a/code/FBXMaterial.cpp
+++ b/code/FBXMaterial.cpp
@@ -206,6 +206,20 @@ Texture::Texture(uint64_t id, const Element& element, const Document& doc, const
 
     props = GetPropertyTable(doc,"Texture.FbxFileTexture",element,sc);
 
+    // 3DS Max and FBX SDK use "Scaling" and "Translation" instead of "ModelUVScaling" and "ModelUVTranslation". Use these properties if available.
+    bool ok;
+    const aiVector3D& scaling = PropertyGet<aiVector3D>(*props, "Scaling", ok);
+    if (ok) {
+        uvScaling.x = scaling.x;
+        uvScaling.y = scaling.y;
+    }
+
+    const aiVector3D& trans = PropertyGet<aiVector3D>(*props, "Translation", ok);
+    if (ok) {
+        uvTrans.x = trans.x;
+        uvTrans.y = trans.y;
+    }
+
     // resolve video links
     if(doc.Settings().readTextures) {
         const std::vector<const Connection*>& conns = doc.GetConnectionsByDestinationSequenced(ID());


### PR DESCRIPTION
If available, use "Scaling" and "Translation" instead of "ModelUVScaling" and "ModelUVTranslation". This seems to be what 3DS Max and FBX SDK use.

See comment here: https://github.com/assimp/assimp/issues/2043

> I have done some testing, and as far as I can see "ModelUVScaling" and "ModelUVTranslation" have no effect on 3DS Max. When exporting from 3DS Max these are always set to the default values (scale: 1,1; offset: 0,0).
So all models I export from 3DS Max get the wrong UV scale when using Assimp. However, when using FBX SDK I can fetch the correct UV scale using FbxTexture::GetUVScaling(). The value returned is the one stored in "Scaling".

So far I haven't seen any models where  "ModelUVScaling" and "ModelUVTranslation" are used.
Please let me know if you have any information and feedback on this.

Alternatively we can also expose all these properties as (_AI_MATKEY_...).