### PR TITLE
Fix element access operator of aiColor4D

### DIFF
--- a/include/assimp/color4.inl
+++ b/include/assimp/color4.inl
@@ -85,6 +85,8 @@ AI_FORCE_INLINE TReal aiColor4t<TReal>::operator[](unsigned int i) const {
             return g;
         case 2:
             return b;
+        case 3:
+            return a;
         default:
             break;
     }
@@ -100,6 +102,8 @@ AI_FORCE_INLINE TReal& aiColor4t<TReal>::operator[](unsigned int i) {
             return g;
         case 2:
             return b;
+        case 3:
+            return a;
         default:
             break;
     }


### PR DESCRIPTION
The element access operator of `aiColor4D` doesn't point to the alpha component by index 3. Instead, it points to the red component, which is not the expected behavior I believe. This is because [the operator is missing a case for index 3](https://github.com/assimp/assimp/blob/55cdf1d37c4ecd973c2a2e134e213cf32a772635/include/assimp/color4.inl#L94-L107). This PR fixes it by adding the missing case.