### PR TITLE
Fix for crash in StreamWriter::PutString when exporting ASCII FBX

### DIFF
--- a/code/FBXExportNode.cpp
+++ b/code/FBXExportNode.cpp
@@ -252,7 +252,8 @@ void FBX::Node::DumpChildren(
     } else {
         std::ostringstream ss;
         DumpChildrenAscii(ss, indent);
-        s.PutString(ss.str());
+        if (ss.tellp() > 0)
+            s.PutString(ss.str());
     }
 }
 
@@ -266,7 +267,8 @@ void FBX::Node::End(
     } else {
         std::ostringstream ss;
         EndAscii(ss, indent, has_children);
-        s.PutString(ss.str());
+        if (ss.tellp() > 0)
+            s.PutString(ss.str());
     }
 }
 


### PR DESCRIPTION
**The fix:**
Don't call PutString with an empty string. Both DumpChildrenAscii and EndAscii can return without modifyting the string, so we need to check the string before calling PutString.
This used to cause a crash.