### PR TITLE
Set directory and name properties for installing static lib PDB

### DIFF
--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -1138,6 +1138,16 @@ if (ASSIMP_ANDROID_JNIIOSYSTEM)
 ENDIF(ASSIMP_ANDROID_JNIIOSYSTEM)
 
 if(MSVC AND ASSIMP_INSTALL_PDB)
+  # When only the static library is built, these properties must
+  # be set to ensure the static lib .pdb is staged for installation.
+  IF(NOT BUILD_SHARED_LIBS)
+    SET_TARGET_PROPERTIES( assimp PROPERTIES
+      COMPILE_PDB_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+      COMPILE_PDB_NAME assimp${LIBRARY_SUFFIX}
+      COMPILE_PDB_NAME_DEBUG assimp${LIBRARY_SUFFIX}${CMAKE_DEBUG_POSTFIX}
+    )
+  ENDIF()
+
   IF(CMAKE_GENERATOR MATCHES "^Visual Studio")
     install(FILES ${Assimp_BINARY_DIR}/code/Debug/assimp${LIBRARY_SUFFIX}${CMAKE_DEBUG_POSTFIX}.pdb
       DESTINATION ${ASSIMP_LIB_INSTALL_DIR}


### PR DESCRIPTION
These properties allow assimp to be installed as a static library along with its PDB. The dynamic PDB will continue to take precedence unless the builder has disabled BUILD_SHARED_LIBS.