### PR TITLE
Fix Windows build with external zlib

### DIFF
--- a/code/res/assimp.rc
+++ b/code/res/assimp.rc
@@ -1,7 +1,7 @@
 // Microsoft Visual C++ generated resource script.
 //
 #include "resource.h"
-#include "..\..\revision.h"
+#include "revision.h"
 
 #define APSTUDIO_READONLY_SYMBOLS
 /////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
assimp.rc contains an include with a double-parent header search.
In a default build configuration, this is resolved via the
configuration header path generated for in-tree zlib.

When external zlib is used, this header search path is not provided
to the RC compiler, therefore fails to find revision.h.

This is solved by simply including "revision.h" since the root of
the binary directory is already used as a search path.