### PR TITLE
Exception spam fix for FBXMaterial

### DIFF
--- a/code/FBXMaterial.cpp
+++ b/code/FBXMaterial.cpp
@@ -316,7 +316,7 @@ Video::Video(uint64_t id, const Element& element, const Document& doc, const std
         relativeFileName = ParseTokenAsString(GetRequiredToken(*RelativeFilename,0));
     }
 
-    if(Content) {
+    if(Content && !Content->Tokens().empty()) {
         //this field is omitted when the embedded texture is already loaded, let's ignore if it's not found
         try {
             const Token& token = GetRequiredToken(*Content, 0);


### PR DESCRIPTION
It throws an exception too many times just 3 lines below
`const Token& token = GetRequiredToken(*Content, 0);`
though we can easily avoid it to check if there is any token to process.