### PR TITLE
Ensure obj is not null before using hasattr

### DIFF
--- a/port/PyAssimp/pyassimp/core.py
+++ b/port/PyAssimp/pyassimp/core.py
@@ -82,7 +82,8 @@ def call_init(obj, caller = None):
         _init(obj,parent=caller)
 
 def _is_init_type(obj):
-    if helper.hasattr_silent(obj,'contents'): #pointer
+
+    if obj and helper.hasattr_silent(obj,'contents'): #pointer
         return _is_init_type(obj[0])
     # null-pointer case that arises when we reach a mesh attribute
     # like mBitangents which use mNumVertices rather than mNumBitangents


### PR DESCRIPTION
Verify that there is something there before inspecting it.

Fixes the error below:
```
  File "C:\Users\micro\build2\boxwin_external_libs\pyassimp\core.py", line 320, in load
    scene = _init(model.contents)
  File "C:\Users\micro\build2\boxwin_external_libs\pyassimp\core.py", line 206, in _init
    raise e
  File "C:\Users\micro\build2\boxwin_external_libs\pyassimp\core.py", line 187, in _init
    call_init(e, target)
  File "C:\Users\micro\build2\boxwin_external_libs\pyassimp\core.py", line 80, in call_init
    _init(obj.contents, obj, caller)
  File "C:\Users\micro\build2\boxwin_external_libs\pyassimp\core.py", line 214, in _init
    if _is_init_type(obj):
  File "C:\Users\micro\build2\boxwin_external_libs\pyassimp\core.py", line 86, in _is_init_type
    if helper.hasattr_silent(obj,'contents'): #pointer
  File "C:\Users\micro\build2\boxwin_external_libs\pyassimp\helper.py", line 277, in hasattr_silent
    return hasattr(object, name)
ValueError: NULL pointer access
```