### PR TITLE
All textures use relative path except embedded textures, this is a fix for it

### DIFF
--- a/code/FBX/FBXConverter.cpp
+++ b/code/FBX/FBXConverter.cpp
@@ -1642,7 +1642,7 @@ namespace Assimp {
             out_tex->pcData = reinterpret_cast<aiTexel*>(const_cast<Video&>(video).RelinquishContent());
 
             // try to extract a hint from the file extension
-            const std::string& filename = video.FileName().empty() ? video.RelativeFilename() : video.FileName();
+            const std::string& filename = video.RelativeFilename().empty() ? video.FileName() : video.RelativeFilename();
             std::string ext = BaseImporter::GetExtension(filename);
 
             if (ext == "jpeg") {
@@ -1653,7 +1653,7 @@ namespace Assimp {
                 memcpy(out_tex->achFormatHint, ext.c_str(), ext.size());
             }
 
-            out_tex->mFilename.Set(video.FileName().c_str());
+            out_tex->mFilename.Set(filename.c_str());
 
             return static_cast<unsigned int>(textures.size() - 1);
         }

--- a/test/unit/utFBXImporterExporter.cpp
+++ b/test/unit/utFBXImporterExporter.cpp
@@ -241,6 +241,7 @@ TEST_F(utFBXImporterExporter, importEmbeddedAsciiTest) {
     aiString path;
     aiTextureMapMode modes[2];
     EXPECT_EQ(aiReturn_SUCCESS, mat->GetTexture(aiTextureType_DIFFUSE, 0, &path, nullptr, nullptr, nullptr, nullptr, modes));
+    ASSERT_STREQ(path.C_Str(), "..\\..\\..\\Desktop\\uv_test.png");
 
     ASSERT_EQ(1, scene->mNumTextures);
     ASSERT_TRUE(scene->mTextures[0]->pcData);


### PR DESCRIPTION
`FBXConverter::GetTexturePath` returns RelativeFilename() for all textures (this is stored in the material $tex.name), but `FBXConverter::ConvertVideo` returns FileName() as a texture name, so it's very hard to match both strings in run-time to figure out which embedded texture it is.
I propose to use relative path everywhere, that helps a lot.