### PR TITLE
Fix a GCC 9 warning:

### DIFF
--- a/include/assimp/types.h
+++ b/include/assimp/types.h
@@ -161,7 +161,14 @@ struct aiColor3D
     explicit aiColor3D (ai_real _r) : r(_r), g(_r), b(_r) {}
     aiColor3D (const aiColor3D& o) : r(o.r), g(o.g), b(o.b) {}
 
-    /** Component-wise comparison */
+	aiColor3D &operator=(const aiColor3D &o) {
+		r = o.r;
+		g = o.g;
+		b = o.b;
+		return *this;
+	}
+
+	/** Component-wise comparison */
     // TODO: add epsilon?
     bool operator == (const aiColor3D& other) const
         {return r == other.r && g == other.g && b == other.b;}


### PR DESCRIPTION
```
assimp/include/assimp/material.inl: In member function 'aiReturn aiMaterial::Get(const char*, unsigned int, unsigned int, aiColor3D&) const':
assimp/include/assimp/material.inl:176:33: error: implicitly-declared 'aiColor3D& aiColor3D::operator=(const aiColor3D&)' is deprecated [-Werror=deprecated-copy]
176 |     pOut = aiColor3D(c.r,c.g,c.b);
```