### PR TITLE
Some FBX multi-material mesh fixes

### DIFF
--- a/code/FBX/FBXConverter.cpp
+++ b/code/FBX/FBXConverter.cpp
@@ -1247,10 +1247,10 @@ namespace Assimp {
             ai_assert(count_faces);
             ai_assert(count_vertices);
 
-            // mapping from output indices to DOM indexing, needed to resolve weights
+            // mapping from output indices to DOM indexing, needed to resolve weights or blendshapes
             std::vector<unsigned int> reverseMapping;
             std::map<unsigned int, unsigned int> translateIndexMap;
-            if (process_weights) {
+            if (process_weights || mesh.GetBlendShapes().size() > 0) {
                 reverseMapping.resize(count_vertices);
             }
 
@@ -1407,7 +1407,10 @@ namespace Assimp {
                             unsigned int count = 0;
                             const unsigned int* outIndices = mesh.ToOutputVertexIndex(index, count);
                             for (unsigned int k = 0; k < count; k++) {
-                                unsigned int index = translateIndexMap[outIndices[k]];
+                                unsigned int outIndex = outIndices[k];
+                                if (translateIndexMap.find(outIndex) == translateIndexMap.end())
+                                    continue;
+                                unsigned int index = translateIndexMap[outIndex];
                                 animMesh->mVertices[index] += vertex;
                                 if (animMesh->mNormals != nullptr) {
                                     animMesh->mNormals[index] += normal;
@@ -1418,6 +1421,15 @@ namespace Assimp {
                         animMesh->mWeight = shapeGeometries.size() > 1 ? blendShapeChannel->DeformPercent() / 100.0f : 1.0f;
                         animMeshes.push_back(animMesh);
                     }
+                }
+            }
+
+            const size_t numAnimMeshes = animMeshes.size();
+            if (numAnimMeshes > 0) {
+                out_mesh->mNumAnimMeshes = static_cast<unsigned int>(numAnimMeshes);
+                out_mesh->mAnimMeshes = new aiAnimMesh*[numAnimMeshes];
+                for (size_t i = 0; i < numAnimMeshes; i++) {
+                    out_mesh->mAnimMeshes[i] = animMeshes.at(i);
                 }
             }
 


### PR DESCRIPTION
Thank you @kimkulling so much for making the blendshapes work with the multi-material meshes, your work is amazing and has helped us tremendously! I found a few minor issues, but I've been able to fix these myself.

- Fixed anim meshes generated from blendshapes not being copied to output for multi-material meshes
- Fixed first vertex of each blendshape on a multi-material mesh having all unmapped vertice offsets being added to it
- Fixed blendshapes not importing for multi-material FBX meshes with no bones