### PR TITLE
Fix line continuations in OBJ files

### DIFF
--- a/code/Obj/ObjFileParser.cpp
+++ b/code/Obj/ObjFileParser.cpp
@@ -118,7 +118,7 @@ void ObjFileParser::parseFile( IOStreamBuffer<char> &streamBuffer ) {
     size_t lastFilePos( 0 );
 
     std::vector<char> buffer;
-    while ( streamBuffer.getNextDataLine( buffer, '\0' ) ) {
+    while ( streamBuffer.getNextDataLine( buffer, '\\' ) ) {
         m_DataIt = buffer.begin();
         m_DataItEnd = buffer.end();
 

--- a/test/unit/utObjImportExport.cpp
+++ b/test/unit/utObjImportExport.cpp
@@ -448,3 +448,37 @@ TEST_F(utObjImportExport, import_without_linend) {
     const aiScene *scene = myImporter.ReadFile(ASSIMP_TEST_MODELS_DIR "/OBJ/box_without_lineending.obj", 0);
     ASSERT_NE(nullptr, scene);
 }
+
+TEST_F(utObjImportExport, import_with_line_continuations) {
+    static const char *ObjModel =
+        "v -0.5 -0.5 0.5\n"
+        "v -0.5 \\\n"
+        "  -0.5 -0.5\n"
+        "v -0.5 \\\n"
+        "   0.5 \\\n"
+        "   -0.5\n"
+        "f 1 2 3\n";
+
+    Assimp::Importer myImporter;
+    const aiScene *scene = myImporter.ReadFileFromMemory(ObjModel, strlen(ObjModel), 0);
+    EXPECT_NE(nullptr, scene);
+
+    EXPECT_EQ(scene->mNumMeshes, 1U);
+    EXPECT_EQ(scene->mMeshes[0]->mNumVertices, 3U);
+    EXPECT_EQ(scene->mMeshes[0]->mNumFaces, 1U);
+
+    auto vertices = scene->mMeshes[0]->mVertices;
+    const float threshold = 0.0001f;
+
+    EXPECT_NEAR(vertices[0].x, -0.5f, threshold);
+    EXPECT_NEAR(vertices[0].y, -0.5f, threshold);
+    EXPECT_NEAR(vertices[0].z, 0.5f, threshold);
+
+    EXPECT_NEAR(vertices[1].x, -0.5f, threshold);
+    EXPECT_NEAR(vertices[1].y, -0.5f, threshold);
+    EXPECT_NEAR(vertices[1].z, -0.5f, threshold);
+
+    EXPECT_NEAR(vertices[2].x, -0.5f, threshold);
+    EXPECT_NEAR(vertices[2].y, 0.5f, threshold);
+    EXPECT_NEAR(vertices[2].z, -0.5f, threshold);
+}


### PR DESCRIPTION
Hi,
This fix to the OBJ parser reverts a faulty line from a January [commit](https://github.com/assimp/assimp/commit/35a044bda37b2bad50a41746622c746acd139631).

Some OBJ files have backslashes for line continuations, like in [this documentation](http://paulbourke.net/dataformats/obj/) or in OBJ files exported from Rhino for instance.

In such cases

`v 0.00000000001 0.00000000002 \`
`0.00000000003`

is equivalent to

`v 0.00000000001 0.00000000002 0.00000000003`

Assimp's OBJ parser dealt successfully with this case via the [getNextDataLine()](https://github.com/assimp/assimp/blob/475e51d157e7826bdcbc0d88e6a73b1764960e0a/include/assimp/IOStreamBuffer.h#L244) method which role is specifically to join lines separated by a continuation character (`\` in our case).

However, its usage was changed in the aforementioned commit. From [this issue](https://github.com/assimp/assimp/issues/2186) by the same author, it seems that they wanted to fix another bug related to material names and changed the continuation character but it actually broke OBJ parsing (the final data is wrong in most cases, and it crashes in other cases).

Tested on various obj files with continuations and now it works well, as before. The unit tests all pass.