### PR TITLE
glTF 2.0 Lights import

### DIFF
--- a/code/glTF2/glTF2Asset.h
+++ b/code/glTF2/glTF2Asset.h
@@ -46,6 +46,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * glTF Extensions Support:
  *   KHR_materials_pbrSpecularGlossiness full
  *   KHR_materials_unlit full
+ *   KHR_lights_punctual full
  */
 #ifndef GLTF2ASSET_H_INC
 #define GLTF2ASSET_H_INC
@@ -668,6 +669,28 @@ namespace glTF2
         void Read(Value& obj, Asset& r);
     };
 
+    //! A light (from KHR_lights_punctual extension)
+    struct Light : public Object
+    {
+        enum Type
+        {
+            Directional,
+            Point,
+            Spot
+        };
+
+        Type type;
+
+        vec3 color;
+        float intensity;
+        Nullable<float> range;
+
+        float innerConeAngle;
+        float outerConeAngle;
+
+        Light() {}
+        void Read(Value& obj, Asset& r);
+    };
 
     //! Image data used to create a texture.
     struct Image : public Object
@@ -819,6 +842,7 @@ namespace glTF2
         Nullable<vec3> scale;
 
         Ref<Camera> camera;
+        Ref<Light>  light;
 
         std::vector< Ref<Node> > skeletons;       //!< The ID of skeleton nodes. Each of which is the root of a node hierarchy.
         Ref<Skin> skin;                           //!< The ID of the skin referenced by this node.
@@ -1050,6 +1074,7 @@ namespace glTF2
         {
             bool KHR_materials_pbrSpecularGlossiness;
             bool KHR_materials_unlit;
+            bool KHR_lights_punctual;
 
         } extensionsUsed;
 
@@ -1063,6 +1088,7 @@ namespace glTF2
         LazyDict<Buffer>      buffers;
         LazyDict<BufferView>  bufferViews;
         LazyDict<Camera>      cameras;
+        LazyDict<Light>       lights;
         LazyDict<Image>       images;
         LazyDict<Material>    materials;
         LazyDict<Mesh>        meshes;
@@ -1083,6 +1109,7 @@ namespace glTF2
             , buffers       (*this, "buffers")
             , bufferViews   (*this, "bufferViews")
             , cameras       (*this, "cameras")
+            , lights        (*this, "lights", "KHR_lights_punctual")
             , images        (*this, "images")
             , materials     (*this, "materials")
             , meshes        (*this, "meshes")

--- a/code/glTF2/glTF2AssetWriter.inl
+++ b/code/glTF2/glTF2AssetWriter.inl
@@ -202,6 +202,11 @@ namespace glTF2 {
 
     }
 
+    inline void Write(Value& /*obj*/, Light& /*c*/, AssetWriter& /*w*/)
+    {
+
+    }
+
     inline void Write(Value& obj, Image& img, AssetWriter& w)
     {
         if (img.bufferView) {


### PR DESCRIPTION
Importing of lights according to glTF 2.0 extension KHR_lights_punctual https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_lights_punctual

Since glTF lights are based on PBR they use different attenuation model than conventional lights supported by assimp. It is possible to use attenuation factors in assimp to describe inverse square law fallof. But the light structure does not provide means to save range property. Therefore I resorted to use of metadata. When range parameter is present, I put it into 'PBR_LightRange' metadata of light's node. Please, see comment in glTF2Importer file.