### PR TITLE
Fixed armature being marked as 'limbnode'

### DIFF
--- a/code/FBX/FBXConverter.cpp
+++ b/code/FBX/FBXConverter.cpp
@@ -1450,7 +1450,9 @@ namespace Assimp {
             const Skin& sk = *geo.DeformerSkin();
 
             std::vector<aiBone*> bones;
-            bones.reserve(sk.Clusters().size());
+            size_t clusterSize = sk.Clusters().size();
+            printf("Cluster size: %zu\n", clusterSize);
+            bones.reserve(clusterSize);
 
             const bool no_mat_check = materialIndex == NO_MATERIAL_SEPARATION;
             ai_assert(no_mat_check || outputVertStartIndices);
@@ -1462,13 +1464,13 @@ namespace Assimp {
 
                     const WeightIndexArray& indices = cluster->GetIndices();
 
-                    if (indices.empty() && mRemoveEmptyBones ) {
+                    // Disabled hack to prevent empty bones from existing
+                    /*if (indices.empty() && mRemoveEmptyBones ) {
+                        
                         continue;
-                    }
+                    }*/
 
                     const MatIndexArray& mats = geo.GetMaterialIndices();
-
-                    bool ok = false;
 
                     const size_t no_index_sentinel = std::numeric_limits<size_t>::max();
 
@@ -1509,8 +1511,7 @@ namespace Assimp {
                                     out_indices.push_back(std::distance(outputVertStartIndices->begin(), it));
                                 }
 
-                                ++count_out_indices.back();
-                                ok = true;
+                                ++count_out_indices.back();                               
                             }
                         }
                     }
@@ -1518,10 +1519,10 @@ namespace Assimp {
                     // if we found at least one, generate the output bones
                     // XXX this could be heavily simplified by collecting the bone
                     // data in a single step.
-                    if (ok && mRemoveEmptyBones) {
+                   // if (ok) {
                         ConvertCluster(bones, model, *cluster, out_indices, index_out_indices,
                             count_out_indices, node_global_transform);
-                    }
+                    //}
                 }
             }
             catch (std::exception&) {
@@ -3580,6 +3581,10 @@ void FBXConverter::SetShadingPropertiesRaw(aiMaterial* out_mat, const PropertyTa
             // note: the trailing () ensures initialization with NULL - not
             // many C++ users seem to know this, so pointing it out to avoid
             // confusion why this code works.
+            printf("C++ meshes count: %ld\n", meshes.size());
+            //printf("number of meshes read from fbx: %d\n", meshes.si);
+
+            assert(out->mNumMeshes == 0);
 
             if (meshes.size()) {
                 out->mMeshes = new aiMesh*[meshes.size()]();

--- a/code/FBX/FBXDocument.cpp
+++ b/code/FBX/FBXDocument.cpp
@@ -90,14 +90,6 @@ const Object* LazyObject::Get(bool dieOnError)
         return object.get();
     }
 
-    // if this is the root object, we return a dummy since there
-    // is no root object int he fbx file - it is just referenced
-    // with id 0.
-    if(id == 0L) {
-        object.reset(new Object(id, element, "Model::RootNode"));
-        return object.get();
-    }
-
     const Token& key = element.KeyToken();
     const TokenList& tokens = element.Tokens();
 

--- a/code/FBX/FBXMeshGeometry.cpp
+++ b/code/FBX/FBXMeshGeometry.cpp
@@ -115,7 +115,6 @@ MeshGeometry::MeshGeometry(uint64_t id, const Element& element, const std::strin
 
     if(tempVerts.empty()) {
         FBXImporter::LogWarn("encountered mesh with no vertices");
-        return;
     }
 
     std::vector<int> tempFaces;
@@ -123,7 +122,6 @@ MeshGeometry::MeshGeometry(uint64_t id, const Element& element, const std::strin
 
     if(tempFaces.empty()) {
         FBXImporter::LogWarn("encountered mesh with no faces");
-        return;
     }
 
     m_vertices.reserve(tempFaces.size());


### PR DESCRIPTION
This also fixes issue with root bone overwritten - which should not happen as it is a hack.

Before the behaviour would create an additional bone which would end up breaking animations completely on import.

Additionally this fixes required bones being removed.

Co-authored-by: K. S. Ernest (iFire) Lee <ernest.lee@chibifire.com>