### PR TITLE
[WIP] Fix FBX units not being converted from CM to application scale

### DIFF
--- a/code/FBX/FBXImporter.cpp
+++ b/code/FBX/FBXImporter.cpp
@@ -193,8 +193,8 @@ void FBXImporter::InternReadFile( const std::string& pFile, aiScene* pScene, IOS
         // convert the FBX DOM to aiScene
         ConvertToAssimpScene(pScene, doc, settings.removeEmptyBones, unit);
         
-        // Set file scale relative to meters
-        SetFileScale( doc.GlobalSettings().UnitScaleFactor() );
+        // units is relative to CM :) we need it in meters for assimp
+        SetFileScale( doc.GlobalSettings().UnitScaleFactor() * 0.01f);
 
         std::for_each(tokens.begin(),tokens.end(),Util::delete_fun<Token>());
     }

--- a/code/FBX/FBXMeshGeometry.cpp
+++ b/code/FBX/FBXMeshGeometry.cpp
@@ -610,8 +610,12 @@ void MeshGeometry::ReadVertexDataMaterials(std::vector<int>& materials_out, cons
     const std::string& ReferenceInformationType)
 {
     const size_t face_count = m_faces.size();
-    ai_assert(face_count);
 
+    if(face_count == 0)
+    {
+        return;
+    }
+    
     // materials are handled separately. First of all, they are assigned per-face
     // and not per polyvert. Secondly, ReferenceInformationType=IndexToDirect
     // has a slightly different meaning for materials.


### PR DESCRIPTION
This is an urgent hotfix for an issue with FBX reading.

This fixes scaling being off by 100 units, apologies testing methodology was wrong and has now been corrected. (FBXExporter doesn't file UnitScale therefore this was broken when I was testing)

I tested by importing model into Godot and seeing the visual scaling results.

I will submit a bug for the meta data missing on FBX Export (it's not handled at the moment / not implemented) 

