### PR TITLE
Fix segfault #2614

### DIFF
--- a/code/FBX/FBXMeshGeometry.cpp
+++ b/code/FBX/FBXMeshGeometry.cpp
@@ -610,7 +610,10 @@ void MeshGeometry::ReadVertexDataMaterials(std::vector<int>& materials_out, cons
     const std::string& ReferenceInformationType)
 {
     const size_t face_count = m_faces.size();
-    ai_assert(face_count);
+    if(face_count <= 0)
+    {
+        return;
+    }
 
     // materials are handled separately. First of all, they are assigned per-face
     // and not per polyvert. Secondly, ReferenceInformationType=IndexToDirect

--- a/code/FBX/FBXMeshGeometry.cpp
+++ b/code/FBX/FBXMeshGeometry.cpp
@@ -610,7 +610,7 @@ void MeshGeometry::ReadVertexDataMaterials(std::vector<int>& materials_out, cons
     const std::string& ReferenceInformationType)
 {
     const size_t face_count = m_faces.size();
-    if(face_count <= 0)
+    if(face_count == 0)
     {
         return;
     }


### PR DESCRIPTION
Fixes segfault with models with missing faces.

This can be a common thing if a modeller makes a mistake so unfortunately we must not crash the entire importer because this means you can't import some models.

This ensures compatibility even with bad modelling practices because humans aren't perfect.