### PR TITLE
Fix indentation error in python bindings

### DIFF
--- a/port/PyAssimp/pyassimp/helper.py
+++ b/port/PyAssimp/pyassimp/helper.py
@@ -274,8 +274,8 @@ def hasattr_silent(object, name):
     """
 
     try:
-	    if not object:
-		    return False
+        if not object:
+            return False
         return hasattr(object, name)
     except AttributeError:
         return False


### PR DESCRIPTION
The fact that this error made it into the repo indicates we should create some tests for the python bindings.