### PR TITLE
fix issue #2551

### DIFF
--- a/code/Collada/ColladaExporter.cpp
+++ b/code/Collada/ColladaExporter.cpp
@@ -318,7 +318,7 @@ void ColladaExporter::WriteTextures() {
 
             std::string name = mFile + "_texture_" + (i < 1000 ? "0" : "") + (i < 100 ? "0" : "") + (i < 10 ? "0" : "") + str + "." + ((const char*) texture->achFormatHint);
 
-            std::unique_ptr<IOStream> outfile(mIOSystem->Open(mPath + name, "wb"));
+            std::unique_ptr<IOStream> outfile(mIOSystem->Open(mPath + mIOSystem->getOsSeparator() + name, "wb"));
             if(outfile == NULL) {
                 throw DeadlyExportError("could not open output texture file: " + mPath + name);
             }


### PR DESCRIPTION
This PR fixes issues #2551 , where a separator is missing in the textures export path.