### PR TITLE
Findassimp.cmake: add hint for lib search path for Linux

### DIFF
--- a/cmake-modules/Findassimp.cmake
+++ b/cmake-modules/Findassimp.cmake
@@ -54,8 +54,10 @@ else(WIN32)
 
 	find_path(
 	  assimp_INCLUDE_DIRS
-	  NAMES postprocess.h scene.h version.h config.h cimport.h
-	  PATHS /usr/local/include/
+	  NAMES assimp/postprocess.h assimp/scene.h assimp/version.h assimp/config.h assimp/cimport.h
+	  PATHS /usr/local/include
+	  PATHS /usr/include/
+
 	)
 
 	find_library(

--- a/cmake-modules/Findassimp.cmake
+++ b/cmake-modules/Findassimp.cmake
@@ -62,6 +62,8 @@ else(WIN32)
 	  assimp_LIBRARIES
 	  NAMES assimp
 	  PATHS /usr/local/lib/
+	  PATHS /usr/lib64/
+	  PATHS /usr/lib/
 	)
 
 	if (assimp_INCLUDE_DIRS AND assimp_LIBRARIES)


### PR DESCRIPTION
Add /usr/lib64 and /usr/lib directory hints to cmake module

libassimp.so library installs in /usr/lib for 32bit or
in /usr/lib64 for 64bit distros.

All linux distros apply custom patch to extend cmake HINTs to
systems /usr/lib and /usr/lib64
(see https://gitweb.gentoo.org/repo/gentoo.git/tree/media-libs/assimp/files/findassimp-3.3.1.patch)

Signed-off-by: Maksym Sditanov <msditanov@200volts.com>