### PR TITLE
Enginmanap issue 2693

### DIFF
--- a/code/Common/Version.cpp
+++ b/code/Common/Version.cpp
@@ -46,8 +46,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/scene.h>
 #include "ScenePrivate.h"
 
-static const unsigned int MajorVersion = 4;
-static const unsigned int MinorVersion = 1;
+static const unsigned int MajorVersion = 5;
+static const unsigned int MinorVersion = 0;
 
 // --------------------------------------------------------------------------------
 // Legal information string - don't remove this.

--- a/test/unit/utVersion.cpp
+++ b/test/unit/utVersion.cpp
@@ -4,8 +4,6 @@ Open Asset Import Library (assimp)
 
 Copyright (c) 2006-2019, assimp team
 
-
-
 All rights reserved.
 
 Redistribution and use of this software in source and binary forms,
@@ -55,11 +53,11 @@ TEST_F( utVersion, aiGetLegalStringTest ) {
 }
 
 TEST_F( utVersion, aiGetVersionMinorTest ) {
-    EXPECT_EQ( aiGetVersionMinor(), 1U );
+    EXPECT_EQ( aiGetVersionMinor(), 0U );
 }
     
 TEST_F( utVersion, aiGetVersionMajorTest ) {
-    EXPECT_EQ( aiGetVersionMajor(), 4U );
+    EXPECT_EQ( aiGetVersionMajor(), 5U );
 }
 
 TEST_F( utVersion, aiGetCompileFlagsTest ) {


### PR DESCRIPTION
closes https://github.com/assimp/assimp/issues/2693 .

Fix version mismatch.