### PR TITLE
FBX importer - general sweep of fixes - work in progress

### DIFF
--- a/code/FBX/FBXConverter.cpp
+++ b/code/FBX/FBXConverter.cpp
@@ -145,7 +145,7 @@ namespace Assimp {
             out->mRootNode->mName.Set(unique_name);
 
             // root has ID 0
-            ConvertNodes(0L, *out->mRootNode);
+            ConvertNodes(0L, out->mRootNode, out->mRootNode);
         }
 
         static std::string getAncestorBaseName(const aiNode* node)
@@ -179,8 +179,11 @@ namespace Assimp {
             GetUniqueName(original_name, unique_name);
             return unique_name;
         }
-
-        void FBXConverter::ConvertNodes(uint64_t id, aiNode& parent, const aiMatrix4x4& parent_transform) {
+        /// todo: pre-build node hierarchy
+        /// todo: get bone from stack
+        /// todo: make map of aiBone* to aiNode*
+        /// then update convert clusters to the new format
+        void FBXConverter::ConvertNodes(uint64_t id, aiNode *parent, aiNode *root_node) {
             const std::vector<const Connection*>& conns = doc.GetConnectionsByDestinationSequenced(id, "Model");
 
             std::vector<aiNode*> nodes;
@@ -209,10 +212,9 @@ namespace Assimp {
                         nodes_chain.clear();
                         post_nodes_chain.clear();
 
-                        aiMatrix4x4 new_abs_transform = parent_transform;
+                        aiMatrix4x4 new_abs_transform = parent->mTransformation;
 
-                        std::string unique_name = MakeUniqueNodeName(model, parent);
-
+                        std::string unique_name = FixNodeName(model->Name());
                         // even though there is only a single input node, the design of
                         // assimp (or rather: the complicated transformation chain that
                         // is employed by fbx) means that we may need multiple aiNode's
@@ -229,11 +231,11 @@ namespace Assimp {
                         SetupNodeMetadata(*model, *nodes_chain.back());
 
                         // link all nodes in a row
-                        aiNode* last_parent = &parent;
+                        aiNode* last_parent = parent;
                         for (aiNode* prenode : nodes_chain) {
                             ai_assert(prenode);
 
-                            if (last_parent != &parent) {
+                            if (last_parent != parent) {
                                 last_parent->mNumChildren = 1;
                                 last_parent->mChildren = new aiNode*[1];
                                 last_parent->mChildren[0] = prenode;
@@ -246,7 +248,7 @@ namespace Assimp {
                         }
 
                         // attach geometry
-                        ConvertModel(*model, *nodes_chain.back(), new_abs_transform);
+                        ConvertModel(*model, nodes_chain.back(), root_node);
 
                         // check if there will be any child nodes
                         const std::vector<const Connection*>& child_conns
@@ -258,7 +260,7 @@ namespace Assimp {
                             for (aiNode* postnode : post_nodes_chain) {
                                 ai_assert(postnode);
 
-                                if (last_parent != &parent) {
+                                if (last_parent != parent) {
                                     last_parent->mNumChildren = 1;
                                     last_parent->mChildren = new aiNode*[1];
                                     last_parent->mChildren[0] = postnode;
@@ -281,7 +283,7 @@ namespace Assimp {
                         }
 
                         // attach sub-nodes (if any)
-                        ConvertNodes(model->ID(), *last_parent, new_abs_transform);
+                        ConvertNodes(model->ID(), last_parent, root_node);
 
                         if (doc.Settings().readLights) {
                             ConvertLights(*model, unique_name);
@@ -297,10 +299,10 @@ namespace Assimp {
                 }
 
                 if (nodes.size()) {
-                    parent.mChildren = new aiNode*[nodes.size()]();
-                    parent.mNumChildren = static_cast<unsigned int>(nodes.size());
+                    parent->mChildren = new aiNode*[nodes.size()]();
+                    parent->mNumChildren = static_cast<unsigned int>(nodes.size());
 
-                    std::swap_ranges(nodes.begin(), nodes.end(), parent.mChildren);
+                    std::swap_ranges(nodes.begin(), nodes.end(), parent->mChildren);
                 }
             }
             catch (std::exception&) {
@@ -905,7 +907,7 @@ namespace Assimp {
             }
         }
 
-        void FBXConverter::ConvertModel(const Model& model, aiNode& nd, const aiMatrix4x4& node_global_transform)
+        void FBXConverter::ConvertModel(const Model& model, aiNode *parent, aiNode *root_node)
         {
             const std::vector<const Geometry*>& geos = model.GetGeometry();
 
@@ -917,11 +919,11 @@ namespace Assimp {
                 const MeshGeometry* const mesh = dynamic_cast<const MeshGeometry*>(geo);
                 const LineGeometry* const line = dynamic_cast<const LineGeometry*>(geo);
                 if (mesh) {
-                    const std::vector<unsigned int>& indices = ConvertMesh(*mesh, model, node_global_transform, nd);
+                    const std::vector<unsigned int>& indices = ConvertMesh(*mesh, model, parent, root_node);
                     std::copy(indices.begin(), indices.end(), std::back_inserter(meshes));
                 }
                 else if (line) {
-                    const std::vector<unsigned int>& indices = ConvertLine(*line, model, node_global_transform, nd);
+                    const std::vector<unsigned int>& indices = ConvertLine(*line, model, parent, root_node);
                     std::copy(indices.begin(), indices.end(), std::back_inserter(meshes));
                 }
                 else {
@@ -930,15 +932,15 @@ namespace Assimp {
             }
 
             if (meshes.size()) {
-                nd.mMeshes = new unsigned int[meshes.size()]();
-                nd.mNumMeshes = static_cast<unsigned int>(meshes.size());
+                parent->mMeshes = new unsigned int[meshes.size()]();
+                parent->mNumMeshes = static_cast<unsigned int>(meshes.size());
 
-                std::swap_ranges(meshes.begin(), meshes.end(), nd.mMeshes);
+                std::swap_ranges(meshes.begin(), meshes.end(), parent->mMeshes);
             }
         }
 
         std::vector<unsigned int> FBXConverter::ConvertMesh(const MeshGeometry& mesh, const Model& model,
-            const aiMatrix4x4& node_global_transform, aiNode& nd)
+                                                            aiNode *parent, aiNode *root_node)
         {
             std::vector<unsigned int> temp;
 
@@ -962,18 +964,18 @@ namespace Assimp {
                 const MatIndexArray::value_type base = mindices[0];
                 for (MatIndexArray::value_type index : mindices) {
                     if (index != base) {
-                        return ConvertMeshMultiMaterial(mesh, model, node_global_transform, nd);
+                        return ConvertMeshMultiMaterial(mesh, model, parent, root_node);
                     }
                 }
             }
 
             // faster code-path, just copy the data
-            temp.push_back(ConvertMeshSingleMaterial(mesh, model, node_global_transform, nd));
+            temp.push_back(ConvertMeshSingleMaterial(mesh, model, parent, root_node));
             return temp;
         }
 
         std::vector<unsigned int> FBXConverter::ConvertLine(const LineGeometry& line, const Model& model,
-            const aiMatrix4x4& node_global_transform, aiNode& nd)
+                                                            aiNode *parent, aiNode *root_node)
         {
             std::vector<unsigned int> temp;
 
@@ -984,7 +986,7 @@ namespace Assimp {
                 return temp;
             }
 
-            aiMesh* const out_mesh = SetupEmptyMesh(line, nd);
+            aiMesh* const out_mesh = SetupEmptyMesh(line, root_node);
             out_mesh->mPrimitiveTypes |= aiPrimitiveType_LINE;
 
             // copy vertices
@@ -1019,7 +1021,7 @@ namespace Assimp {
             return temp;
         }
 
-        aiMesh* FBXConverter::SetupEmptyMesh(const Geometry& mesh, aiNode& nd)
+        aiMesh* FBXConverter::SetupEmptyMesh(const Geometry& mesh, aiNode *parent)
         {
             aiMesh* const out_mesh = new aiMesh();
             meshes.push_back(out_mesh);
@@ -1036,17 +1038,17 @@ namespace Assimp {
             }
             else
             {
-                out_mesh->mName = nd.mName;
+                out_mesh->mName = parent->mName;
             }
 
             return out_mesh;
         }
 
         unsigned int FBXConverter::ConvertMeshSingleMaterial(const MeshGeometry& mesh, const Model& model,
-            const aiMatrix4x4& node_global_transform, aiNode& nd)
+                                                             aiNode *parent, aiNode *root_node)
         {
             const MatIndexArray& mindices = mesh.GetMaterialIndices();
-            aiMesh* const out_mesh = SetupEmptyMesh(mesh, nd);
+            aiMesh* const out_mesh = SetupEmptyMesh(mesh, parent);
 
             const std::vector<aiVector3D>& vertices = mesh.GetVertices();
             const std::vector<unsigned int>& faces = mesh.GetFaceIndexCounts();
@@ -1164,7 +1166,7 @@ namespace Assimp {
             }
 
             if (doc.Settings().readWeights && mesh.DeformerSkin() != NULL) {
-                ConvertWeights(out_mesh, model, mesh, node_global_transform, NO_MATERIAL_SEPARATION);
+                ConvertWeights(out_mesh, model, mesh, parent, root_node, NO_MATERIAL_SEPARATION);
             }
 
             std::vector<aiAnimMesh*> animMeshes;
@@ -1210,7 +1212,7 @@ namespace Assimp {
         }
 
         std::vector<unsigned int> FBXConverter::ConvertMeshMultiMaterial(const MeshGeometry& mesh, const Model& model,
-            const aiMatrix4x4& node_global_transform, aiNode& nd)
+                                                                         aiNode *parent, aiNode *root_node)
         {
             const MatIndexArray& mindices = mesh.GetMaterialIndices();
             ai_assert(mindices.size());
@@ -1221,7 +1223,7 @@ namespace Assimp {
             for (MatIndexArray::value_type index : mindices) {
                 if (had.find(index) == had.end()) {
 
-                    indices.push_back(ConvertMeshMultiMaterial(mesh, model, index, node_global_transform, nd));
+                    indices.push_back(ConvertMeshMultiMaterial(mesh, model, index, parent, root_node));
                     had.insert(index);
                 }
             }
@@ -1230,11 +1232,11 @@ namespace Assimp {
         }
 
         unsigned int FBXConverter::ConvertMeshMultiMaterial(const MeshGeometry& mesh, const Model& model,
-            MatIndexArray::value_type index,
-            const aiMatrix4x4& node_global_transform,
-            aiNode& nd)
+                                                            MatIndexArray::value_type index,
+                                                            aiNode *parent,
+                                                            aiNode *root_node)
         {
-            aiMesh* const out_mesh = SetupEmptyMesh(mesh, nd);
+            aiMesh* const out_mesh = SetupEmptyMesh(mesh, parent);
 
             const MatIndexArray& mindices = mesh.GetMaterialIndices();
             const std::vector<aiVector3D>& vertices = mesh.GetVertices();
@@ -1399,7 +1401,7 @@ namespace Assimp {
             ConvertMaterialForMesh(out_mesh, model, mesh, index);
 
             if (process_weights) {
-                ConvertWeights(out_mesh, model, mesh, node_global_transform, index, &reverseMapping);
+                ConvertWeights(out_mesh, model, mesh, parent, root_node, index, &reverseMapping);
             }
 
             std::vector<aiAnimMesh*> animMeshes;
@@ -1450,9 +1452,10 @@ namespace Assimp {
         }
 
         void FBXConverter::ConvertWeights(aiMesh* out, const Model& model, const MeshGeometry& geo,
-            const aiMatrix4x4& node_global_transform,
-            unsigned int materialIndex,
-            std::vector<unsigned int>* outputVertStartIndices)
+                                          aiNode* parent,
+                                          aiNode* root_node,
+                                          unsigned int materialIndex,
+                                          std::vector<unsigned int>* outputVertStartIndices)
         {
             ai_assert(geo.DeformerSkin());
 
@@ -1469,7 +1472,7 @@ namespace Assimp {
             ai_assert(no_mat_check || outputVertStartIndices);
 
             try {
-
+                // iterate over the sub deformers
                 for (const Cluster* cluster : sk.Clusters()) {
                     ai_assert(cluster);
 
@@ -1525,7 +1528,7 @@ namespace Assimp {
                     // XXX this could be heavily simplified by collecting the bone
                     // data in a single step.
                     ConvertCluster(bones, model, *cluster, out_indices, index_out_indices,
-                            count_out_indices, node_global_transform);
+                                   count_out_indices, parent, root_node);
                 }
             }
             catch (std::exception&) {
@@ -1543,22 +1546,41 @@ namespace Assimp {
             std::swap_ranges(bones.begin(), bones.end(), out->mBones);
         }
 
-        void FBXConverter::ConvertCluster(std::vector<aiBone*>& bones, const Model& /*model*/, const Cluster& cl,
-            std::vector<size_t>& out_indices,
-            std::vector<size_t>& index_out_indices,
-            std::vector<size_t>& count_out_indices,
-            const aiMatrix4x4& node_global_transform)
+        const aiNode* FBXConverter::GetNodeByName( const aiString& name, aiNode *current_node )
+        {
+            aiNode * iter = current_node;
+            printf("Child count: %d", iter->mNumChildren);
+            return iter;
+        }
+
+        void FBXConverter::ConvertCluster(std::vector<aiBone *> &bones, const Model &, const Cluster &cl,
+                                          std::vector<size_t> &out_indices,
+                                          std::vector<size_t> &index_out_indices,
+                                          std::vector<size_t> &count_out_indices, aiNode *parent,
+                                          aiNode *root_node)
         {
 
             aiBone* const bone = new aiBone();
             bones.push_back(bone);
+            aiString bone_name = aiString( FixNodeName(cl.TargetNode()->Name()));
+            printf("root node: %s parent node: %s\n", root_node->mName.C_Str(), parent->mName.C_Str());
+            printf("target bone name: %s\n", bone_name.C_Str());
+            bone->mName = bone_name;
 
-            bone->mName = FixNodeName(cl.TargetNode()->Name());
+            // todo: bone stack information
+            const aiNode * bone_node = FBXConverter::GetNodeByName(bone_name, root_node);
 
+            if(bone_node)
+            {
+                printf("Found bone: %s\n", bone_name.C_Str());
+            }
+
+            aiMatrix4x4t<float> transform = cl.Transform();
             bone->mOffsetMatrix = cl.TransformLink();
-            bone->mOffsetMatrix.Inverse();
+            bone->mOffsetMatrix = transform.Inverse();
 
-            bone->mOffsetMatrix = bone->mOffsetMatrix * node_global_transform;
+            // this is more correct but this assumes skeletons are always on root - bad assumption but lets test
+            bone->mOffsetMatrix = bone->mOffsetMatrix * root_node->mTransformation;
 
             bone->mNumWeights = static_cast<unsigned int>(out_indices.size());
             aiVertexWeight* cursor = bone->mWeights = new aiVertexWeight[out_indices.size()];
@@ -2735,7 +2757,6 @@ void FBXConverter::SetShadingPropertiesRaw(aiMaterial* out_mat, const PropertyTa
             NodeMap::const_iterator chain[TransformationComp_MAXIMUM];
 
             bool has_any = false;
-            bool has_complex = false;
 
             for (size_t i = 0; i < TransformationComp_MAXIMUM; ++i) {
                 const TransformationComp comp = static_cast<TransformationComp>(i);
@@ -2759,11 +2780,6 @@ void FBXConverter::SetShadingPropertiesRaw(aiMaterial* out_mat, const PropertyTa
                     }
 
                     has_any = true;
-
-                    if (comp != TransformationComp_Rotation && comp != TransformationComp_Scaling && comp != TransformationComp_Translation)
-                    {
-                        has_complex = true;
-                    }
                 }
             }
 
@@ -2772,159 +2788,23 @@ void FBXConverter::SetShadingPropertiesRaw(aiMaterial* out_mat, const PropertyTa
                 return;
             }
 
-            // this needs to play nicely with GenerateTransformationNodeChain() which will
-            // be invoked _later_ (animations come first). If this node has only rotation,
-            // scaling and translation _and_ there are no animated other components either,
-            // we can use a single node and also a single node animation channel.
-            if (!has_complex && !NeedsComplexTransformationChain(target)) {
+            aiNodeAnim* const nd = GenerateSimpleNodeAnim(fixed_name, target, chain,
+                node_property_map.end(),
+                layer_map,
+                start, stop,
+                max_time,
+                min_time,
+                true // input is TRS order, assimp is SRT
+            );
 
-                aiNodeAnim* const nd = GenerateSimpleNodeAnim(fixed_name, target, chain,
-                    node_property_map.end(),
-                    layer_map,
-                    start, stop,
-                    max_time,
-                    min_time,
-                    true // input is TRS order, assimp is SRT
-                );
-
-                ai_assert(nd);
-                if (nd->mNumPositionKeys == 0 && nd->mNumRotationKeys == 0 && nd->mNumScalingKeys == 0) {
-                    delete nd;
-                }
-                else {
-                    node_anims.push_back(nd);
-                }
-                return;
+            ai_assert(nd);
+            if (nd->mNumPositionKeys == 0 && nd->mNumRotationKeys == 0 && nd->mNumScalingKeys == 0) {
+                delete nd;
             }
-
-            // otherwise, things get gruesome and we need separate animation channels
-            // for each part of the transformation chain. Remember which channels
-            // we generated and pass this information to the node conversion
-            // code to avoid nodes that have identity transform, but non-identity
-            // animations, being dropped.
-            unsigned int flags = 0, bit = 0x1;
-            for (size_t i = 0; i < TransformationComp_MAXIMUM; ++i, bit <<= 1) {
-                const TransformationComp comp = static_cast<TransformationComp>(i);
-
-                if (chain[i] != node_property_map.end()) {
-                    flags |= bit;
-
-                    ai_assert(comp != TransformationComp_RotationPivotInverse);
-                    ai_assert(comp != TransformationComp_ScalingPivotInverse);
-
-                    const std::string& chain_name = NameTransformationChainNode(fixed_name, comp);
-
-                    aiNodeAnim* na = nullptr;
-                    switch (comp)
-                    {
-                    case TransformationComp_Rotation:
-                    case TransformationComp_PreRotation:
-                    case TransformationComp_PostRotation:
-                    case TransformationComp_GeometricRotation:
-                        na = GenerateRotationNodeAnim(chain_name,
-                            target,
-                            (*chain[i]).second,
-                            layer_map,
-                            start, stop,
-                            max_time,
-                            min_time);
-
-                        break;
-
-                    case TransformationComp_RotationOffset:
-                    case TransformationComp_RotationPivot:
-                    case TransformationComp_ScalingOffset:
-                    case TransformationComp_ScalingPivot:
-                    case TransformationComp_Translation:
-                    case TransformationComp_GeometricTranslation:
-                        na = GenerateTranslationNodeAnim(chain_name,
-                            target,
-                            (*chain[i]).second,
-                            layer_map,
-                            start, stop,
-                            max_time,
-                            min_time);
-
-                        // pivoting requires us to generate an implicit inverse channel to undo the pivot translation
-                        if (comp == TransformationComp_RotationPivot) {
-                            const std::string& invName = NameTransformationChainNode(fixed_name,
-                                TransformationComp_RotationPivotInverse);
-
-                            aiNodeAnim* const inv = GenerateTranslationNodeAnim(invName,
-                                target,
-                                (*chain[i]).second,
-                                layer_map,
-                                start, stop,
-                                max_time,
-                                min_time,
-                                true);
-
-                            ai_assert(inv);
-                            if (inv->mNumPositionKeys == 0 && inv->mNumRotationKeys == 0 && inv->mNumScalingKeys == 0) {
-                                delete inv;
-                            }
-                            else {
-                                node_anims.push_back(inv);
-                            }
-
-                            ai_assert(TransformationComp_RotationPivotInverse > i);
-                            flags |= bit << (TransformationComp_RotationPivotInverse - i);
-                        }
-                        else if (comp == TransformationComp_ScalingPivot) {
-                            const std::string& invName = NameTransformationChainNode(fixed_name,
-                                TransformationComp_ScalingPivotInverse);
-
-                            aiNodeAnim* const inv = GenerateTranslationNodeAnim(invName,
-                                target,
-                                (*chain[i]).second,
-                                layer_map,
-                                start, stop,
-                                max_time,
-                                min_time,
-                                true);
-
-                            ai_assert(inv);
-                            if (inv->mNumPositionKeys == 0 && inv->mNumRotationKeys == 0 && inv->mNumScalingKeys == 0) {
-                                delete inv;
-                            }
-                            else {
-                                node_anims.push_back(inv);
-                            }
-
-                            ai_assert(TransformationComp_RotationPivotInverse > i);
-                            flags |= bit << (TransformationComp_RotationPivotInverse - i);
-                        }
-
-                        break;
-
-                    case TransformationComp_Scaling:
-                    case TransformationComp_GeometricScaling:
-                        na = GenerateScalingNodeAnim(chain_name,
-                            target,
-                            (*chain[i]).second,
-                            layer_map,
-                            start, stop,
-                            max_time,
-                            min_time);
-
-                        break;
-
-                    default:
-                        ai_assert(false);
-                    }
-
-                    ai_assert(na);
-                    if (na->mNumPositionKeys == 0 && na->mNumRotationKeys == 0 && na->mNumScalingKeys == 0) {
-                        delete na;
-                    }
-                    else {
-                        node_anims.push_back(na);
-                    }
-                    continue;
-                }
+            else {
+                node_anims.push_back(nd);
             }
-
-            node_anim_chain_bits[fixed_name] = flags;
+            
         }
 
 

--- a/code/FBX/FBXConverter.cpp
+++ b/code/FBX/FBXConverter.cpp
@@ -68,6 +68,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <sstream>
 #include <iomanip>
 #include <cstdint>
+#include <iostream>
+#include <string>
+#include <float.h>
+
+#define FBX_ONE_SECOND 46186158000L
 
 
 namespace Assimp {
@@ -75,10 +80,10 @@ namespace Assimp {
 
         using namespace Util;
 
-#define MAGIC_NODE_TAG "_$AssimpFbx$"
+        #define MAGIC_NODE_TAG "_$AssimpFbx$"
 
-#define CONVERT_FBX_TIME(time) static_cast<double>(time) / 46186158000L
-
+        #define CONVERT_FBX_TIME_TO_SECONDS(time) static_cast<double>(time) / 46186158000L
+        #define CONVERT_FBX_TIME_TO_FRAMES(time, frames_per_second) CONVERT_FBX_TIME_TO_SECONDS(time) * frames_per_second
         FBXConverter::FBXConverter(aiScene* out, const Document& doc, bool removeEmptyBones )
         : defaultMaterialIndex()
         , lights()
@@ -758,6 +763,7 @@ namespace Assimp {
                 aiMatrix4x4::Scaling(Scaling, chain[TransformationComp_Scaling]);
             }
 
+            // use me rotation code
             const aiVector3D& Rotation = PropertyGet<aiVector3D>(props, "Lcl Rotation", ok);
             if (ok && Rotation.SquareLength() > zero_epsilon) {
                 chainBits = chainBits | (1 << TransformationComp_Rotation);
@@ -2530,18 +2536,15 @@ void FBXConverter::SetShadingPropertiesRaw(aiMaterial* out_mat, const PropertyTa
             // generate node animations
             std::vector<aiNodeAnim*> node_anims;
 
-            double min_time = 1e10;
-            double max_time = -1e10;
-
             int64_t start_time = st.LocalStart();
             int64_t stop_time = st.LocalStop();
             bool has_local_startstop = start_time != 0 || stop_time != 0;
-            if (!has_local_startstop) {
-                // no time range given, so accept every keyframe and use the actual min/max time
-                // the numbers are INT64_MIN/MAX, the 20000 is for safety because GenerateNodeAnimations uses an epsilon of 10000
-                start_time = -9223372036854775807ll + 20000;
-                stop_time = 9223372036854775807ll - 20000;
-            }
+
+            ASSIMP_LOG_DEBUG_F("Has local start stop? %s\n", has_local_startstop ? "yes" : "no" );
+
+            // Goal we need the number of frames passed
+            double start_time_frame_number = has_local_startstop ? (CONVERT_FBX_TIME_TO_SECONDS(start_time) * anim_fps) : 0;
+            double stop_time_frame_number = has_local_startstop ? (CONVERT_FBX_TIME_TO_SECONDS(stop_time) * anim_fps): DBL_MAX;
 
             try {
                 for (const NodeMap::value_type& kv : node_map) {
@@ -2549,9 +2552,8 @@ void FBXConverter::SetShadingPropertiesRaw(aiMaterial* out_mat, const PropertyTa
                         kv.first,
                         kv.second,
                         layer_map,
-                        start_time, stop_time,
-                        max_time,
-                        min_time);
+                        start_time_frame_number,
+                        stop_time_frame_number);
                 }
             }
             catch (std::exception&) {
@@ -2584,7 +2586,8 @@ void FBXConverter::SetShadingPropertiesRaw(aiMaterial* out_mat, const PropertyTa
                             meshMorphAnim->mKeys[j].mNumValuesAndWeights = numValuesAndWeights;
                             meshMorphAnim->mKeys[j].mValues = new unsigned int[numValuesAndWeights];
                             meshMorphAnim->mKeys[j].mWeights = new double[numValuesAndWeights];
-                            meshMorphAnim->mKeys[j].mTime = CONVERT_FBX_TIME(animIt.first) * anim_fps;
+
+                            meshMorphAnim->mKeys[j].mTime = CONVERT_FBX_TIME_TO_FRAMES(animIt.first, anim_fps);
                             for (unsigned int k = 0; k < numValuesAndWeights; k++) {
                                 meshMorphAnim->mKeys[j].mValues[k] = keyData->values.at(k);
                                 meshMorphAnim->mKeys[j].mWeights[k] = keyData->weights.at(k);
@@ -2603,32 +2606,7 @@ void FBXConverter::SetShadingPropertiesRaw(aiMaterial* out_mat, const PropertyTa
                 return;
             }
 
-            double start_time_fps = has_local_startstop ? (CONVERT_FBX_TIME(start_time) * anim_fps) : min_time;
-            double stop_time_fps = has_local_startstop ? (CONVERT_FBX_TIME(stop_time) * anim_fps) : max_time;
-
-            // adjust relative timing for animation
-            for (unsigned int c = 0; c < anim->mNumChannels; c++) {
-                aiNodeAnim* channel = anim->mChannels[c];
-                for (uint32_t i = 0; i < channel->mNumPositionKeys; i++) {
-                    channel->mPositionKeys[i].mTime -= start_time_fps;
-                }
-                for (uint32_t i = 0; i < channel->mNumRotationKeys; i++) {
-                    channel->mRotationKeys[i].mTime -= start_time_fps;
-                }
-                for (uint32_t i = 0; i < channel->mNumScalingKeys; i++) {
-                    channel->mScalingKeys[i].mTime -= start_time_fps;
-                }
-            }
-            for (unsigned int c = 0; c < anim->mNumMorphMeshChannels; c++) {
-                aiMeshMorphAnim* channel = anim->mMorphMeshChannels[c];
-                for (uint32_t i = 0; i < channel->mNumKeys; i++) {
-                    channel->mKeys[i].mTime -= start_time_fps;
-                }
-            }
-
-            // for some mysterious reason, mDuration is simply the maximum key -- the
-            // validator always assumes animations to start at zero.
-            anim->mDuration = stop_time_fps - start_time_fps;
+            anim->mDuration = stop_time_frame_number;
             anim->mTicksPerSecond = anim_fps;
         }
 
@@ -2662,24 +2640,27 @@ void FBXConverter::SetShadingPropertiesRaw(aiMaterial* out_mat, const PropertyTa
                                         else {
                                             animData = animIt->second;
                                         }
+                                        
                                         for (std::pair<std::string, const AnimationCurve*> curvesIt : node->Curves()) {
                                             if (curvesIt.first == "d|DeformPercent") {
                                                 const AnimationCurve* animationCurve = curvesIt.second;
-                                                const KeyTimeList& keys = animationCurve->GetKeys();
-                                                const KeyValueList& values = animationCurve->GetValues();
+                                                
                                                 unsigned int k = 0;
-                                                for (auto key : keys) {
+                                                for (auto key_value_pair : animationCurve->GetKeyframeData()) {
+                                                    
                                                     morphKeyData* keyData;
-                                                    auto keyIt = animData->find(key);
+
+                                                    // does our anim key already exist? if not create it!
+                                                    auto keyIt = animData->find(key_value_pair.first);
                                                     if (keyIt == animData->end()) {
                                                         keyData = new morphKeyData();
-                                                        animData->insert(std::make_pair(key, keyData));
+                                                        animData->insert(std::make_pair(key_value_pair.first, keyData));
                                                     }
                                                     else {
                                                         keyData = keyIt->second;
                                                     }
                                                     keyData->values.push_back(channelIndex);
-                                                    keyData->weights.push_back(values.at(k) / 100.0f);
+                                                    keyData->weights.push_back(key_value_pair.second / 100.0f);
                                                     k++;
                                                 }
                                             }
@@ -2701,644 +2682,319 @@ void FBXConverter::SetShadingPropertiesRaw(aiMaterial* out_mat, const PropertyTa
             bool strictMode) {
             const Object* target(NULL);
             for (const AnimationCurveNode* node : curves) {
+                if( node->Curves().size() == 0 || node->Target() == nullptr) continue; // prevents dumb data becoming part of the equation
                 if (!target) {
                     target = node->Target();
                 }
                 if (node->Target() != target) {
                     FBXImporter::LogWarn("Node target is nullptr type.");
-                }
+                }                
+
                 if (strictMode) {
-                    ai_assert(node->Target() == target);
+                    if(target == nullptr) continue;
                 }
             }
         }
 #endif // ASSIMP_BUILD_DEBUG
+
+
+
+    // can be expanded for other use cases
+    FBXConverter::FBX_PROPERTY_TYPE GetFBXPropertyType( const std::string& property_name )
+    {
+        try
+        {
+            if(property_name.compare("d|X") == 0)
+            {
+                return FBXConverter::X_AXIS;                           
+            }
+            else if(property_name.compare("d|Y") == 0)
+            {
+                return FBXConverter::Y_AXIS;
+            }
+            else if(property_name.compare("d|Z") == 0)
+            {
+                return FBXConverter::Z_AXIS;          
+            }
+            else if(property_name.compare("Lcl Translation") == 0)
+            {
+                return FBXConverter::Translation;
+            }
+            else if(property_name.compare("Lcl Rotation") == 0)
+            {
+               return FBXConverter::Rotation;
+            }
+            else if(property_name.compare("Lcl Scaling") == 0)
+            {
+                return FBXConverter::Scale;
+            }
+            
+        }
+        catch(const std::exception& e)
+        {
+            std::cerr << e.what() << '\n';
+        }
+        
+        return FBXConverter::UNKNOWN;
+    }
+
+        
 
         // ------------------------------------------------------------------------------------------------
         void FBXConverter::GenerateNodeAnimations(std::vector<aiNodeAnim*>& node_anims,
             const std::string& fixed_name,
             const std::vector<const AnimationCurveNode*>& curves,
             const LayerMap& layer_map,
-            int64_t start, int64_t stop,
-            double& max_time,
-            double& min_time)
+            double& start_time,
+            double& end_time)
         {
 
             NodeMap node_property_map;
             ai_assert(curves.size());
 
 #ifdef ASSIMP_BUILD_DEBUG
-            validateAnimCurveNodes(curves, doc.Settings().strictMode);
+            validateAnimCurveNodes(curves, true);
 #endif
-            const AnimationCurveNode* curve_node = NULL;
-            for (const AnimationCurveNode* node : curves) {
-                ai_assert(node);
 
-                if (node->TargetProperty().empty()) {
-                    FBXImporter::LogWarn("target property for animation curve not set: " + node->Name());
-                    continue;
-                }
+            // make new animation to hold this animations keyframes
+            aiNodeAnim * nodeAnim = new aiNodeAnim();
+            nodeAnim->mNumPositionKeys = 0;
+            nodeAnim->mNumRotationKeys = 0;
+            nodeAnim->mNumScalingKeys = 0;
 
-                curve_node = node;
-                if (node->Curves().empty()) {
-                    FBXImporter::LogWarn("no animation curves assigned to AnimationCurveNode: " + node->Name());
-                    continue;
-                }
+            // simple position, scale and rotation keys
+            // each will have a target, and if they have any duplicate target they will write to the value of the key.
+            std::map<const int64_t, aiVectorKey*> position_keys;
+            std::map<const int64_t, aiVectorKey*> rotation_keys;
+            std::map<const int64_t, aiVectorKey*> scale_keys;
 
-                node_property_map[node->TargetProperty()].push_back(node);
-            }
+            for( const AnimationCurveNode* curve : curves)
+            {
+                ASSIMP_LOG_DEBUG_F("[Header] Curve from fbx: ID %d Name: %s\n", curve->ID(), curve->Name().c_str());
+                
+                const Object *target = curve->Target();
+                std::string property_type = curve->TargetProperty();
 
-            ai_assert(curve_node);
-            ai_assert(curve_node->TargetAsModel());
-
-            const Model& target = *curve_node->TargetAsModel();
-
-            // check for all possible transformation components
-            NodeMap::const_iterator chain[TransformationComp_MAXIMUM];
-
-            bool has_any = false;
-
-            for (size_t i = 0; i < TransformationComp_MAXIMUM; ++i) {
-                const TransformationComp comp = static_cast<TransformationComp>(i);
-
-                // inverse pivots don't exist in the input, we just generate them
-                if (comp == TransformationComp_RotationPivotInverse || comp == TransformationComp_ScalingPivotInverse) {
-                    chain[i] = node_property_map.end();
-                    continue;
-                }
-
-                chain[i] = node_property_map.find(NameTransformationCompProperty(comp));
-                if (chain[i] != node_property_map.end()) {
-
-                    // check if this curves contains redundant information by looking
-                    // up the corresponding node's transformation chain.
-                    if (doc.Settings().optimizeEmptyAnimationCurves &&
-                        IsRedundantAnimationData(target, comp, (*chain[i]).second)) {
-
-                        FBXImporter::LogDebug("dropping redundant animation channel for node " + target.Name());
-                        continue;
-                    }
-
-                    has_any = true;
-                }
-            }
-
-            if (!has_any) {
-                FBXImporter::LogWarn("ignoring node animation, did not find any transformation key frames");
-                return;
-            }
-
-            aiNodeAnim* const nd = GenerateSimpleNodeAnim(fixed_name, target, chain,
-                node_property_map.end(),
-                layer_map,
-                start, stop,
-                max_time,
-                min_time,
-                true // input is TRS order, assimp is SRT
-            );
-
-            ai_assert(nd);
-            if (nd->mNumPositionKeys == 0 && nd->mNumRotationKeys == 0 && nd->mNumScalingKeys == 0) {
-                delete nd;
-            }
-            else {
-                node_anims.push_back(nd);
-            }
-            
-        }
-
-
-        bool FBXConverter::IsRedundantAnimationData(const Model& target,
-            TransformationComp comp,
-            const std::vector<const AnimationCurveNode*>& curves) {
-            ai_assert(curves.size());
-
-            // look for animation nodes with
-            //  * sub channels for all relevant components set
-            //  * one key/value pair per component
-            //  * combined values match up the corresponding value in the bind pose node transformation
-            // only such nodes are 'redundant' for this function.
-
-            if (curves.size() > 1) {
-                return false;
-            }
-
-            const AnimationCurveNode& nd = *curves.front();
-            const AnimationCurveMap& sub_curves = nd.Curves();
-
-            const AnimationCurveMap::const_iterator dx = sub_curves.find("d|X");
-            const AnimationCurveMap::const_iterator dy = sub_curves.find("d|Y");
-            const AnimationCurveMap::const_iterator dz = sub_curves.find("d|Z");
-
-            if (dx == sub_curves.end() || dy == sub_curves.end() || dz == sub_curves.end()) {
-                return false;
-            }
-
-            const KeyValueList& vx = (*dx).second->GetValues();
-            const KeyValueList& vy = (*dy).second->GetValues();
-            const KeyValueList& vz = (*dz).second->GetValues();
-
-            if (vx.size() != 1 || vy.size() != 1 || vz.size() != 1) {
-                return false;
-            }
-
-            const aiVector3D dyn_val = aiVector3D(vx[0], vy[0], vz[0]);
-            const aiVector3D& static_val = PropertyGet<aiVector3D>(target.Props(),
-                NameTransformationCompProperty(comp),
-                TransformationCompDefaultValue(comp)
-                );
-
-            const float epsilon = Math::getEpsilon<float>();
-            return (dyn_val - static_val).SquareLength() < epsilon;
-        }
-
-
-        aiNodeAnim* FBXConverter::GenerateRotationNodeAnim(const std::string& name,
-            const Model& target,
-            const std::vector<const AnimationCurveNode*>& curves,
-            const LayerMap& layer_map,
-            int64_t start, int64_t stop,
-            double& max_time,
-            double& min_time)
-        {
-            std::unique_ptr<aiNodeAnim> na(new aiNodeAnim());
-            na->mNodeName.Set(name);
-
-            ConvertRotationKeys(na.get(), curves, layer_map, start, stop, max_time, min_time, target.RotationOrder());
-
-            // dummy scaling key
-            na->mScalingKeys = new aiVectorKey[1];
-            na->mNumScalingKeys = 1;
-
-            na->mScalingKeys[0].mTime = 0.;
-            na->mScalingKeys[0].mValue = aiVector3D(1.0f, 1.0f, 1.0f);
-
-            // dummy position key
-            na->mPositionKeys = new aiVectorKey[1];
-            na->mNumPositionKeys = 1;
-
-            na->mPositionKeys[0].mTime = 0.;
-            na->mPositionKeys[0].mValue = aiVector3D();
-
-            return na.release();
-        }
-
-        aiNodeAnim* FBXConverter::GenerateScalingNodeAnim(const std::string& name,
-            const Model& /*target*/,
-            const std::vector<const AnimationCurveNode*>& curves,
-            const LayerMap& layer_map,
-            int64_t start, int64_t stop,
-            double& max_time,
-            double& min_time)
-        {
-            std::unique_ptr<aiNodeAnim> na(new aiNodeAnim());
-            na->mNodeName.Set(name);
-
-            ConvertScaleKeys(na.get(), curves, layer_map, start, stop, max_time, min_time);
-
-            // dummy rotation key
-            na->mRotationKeys = new aiQuatKey[1];
-            na->mNumRotationKeys = 1;
-
-            na->mRotationKeys[0].mTime = 0.;
-            na->mRotationKeys[0].mValue = aiQuaternion();
-
-            // dummy position key
-            na->mPositionKeys = new aiVectorKey[1];
-            na->mNumPositionKeys = 1;
-
-            na->mPositionKeys[0].mTime = 0.;
-            na->mPositionKeys[0].mValue = aiVector3D();
-
-            return na.release();
-        }
-
-        aiNodeAnim* FBXConverter::GenerateTranslationNodeAnim(const std::string& name,
-            const Model& /*target*/,
-            const std::vector<const AnimationCurveNode*>& curves,
-            const LayerMap& layer_map,
-            int64_t start, int64_t stop,
-            double& max_time,
-            double& min_time,
-            bool inverse) {
-            std::unique_ptr<aiNodeAnim> na(new aiNodeAnim());
-            na->mNodeName.Set(name);
-
-            ConvertTranslationKeys(na.get(), curves, layer_map, start, stop, max_time, min_time);
-
-            if (inverse) {
-                for (unsigned int i = 0; i < na->mNumPositionKeys; ++i) {
-                    na->mPositionKeys[i].mValue *= -1.0f;
-                }
-            }
-
-            // dummy scaling key
-            na->mScalingKeys = new aiVectorKey[1];
-            na->mNumScalingKeys = 1;
-
-            na->mScalingKeys[0].mTime = 0.;
-            na->mScalingKeys[0].mValue = aiVector3D(1.0f, 1.0f, 1.0f);
-
-            // dummy rotation key
-            na->mRotationKeys = new aiQuatKey[1];
-            na->mNumRotationKeys = 1;
-
-            na->mRotationKeys[0].mTime = 0.;
-            na->mRotationKeys[0].mValue = aiQuaternion();
-
-            return na.release();
-        }
-
-        aiNodeAnim* FBXConverter::GenerateSimpleNodeAnim(const std::string& name,
-            const Model& target,
-            NodeMap::const_iterator chain[TransformationComp_MAXIMUM],
-            NodeMap::const_iterator iter_end,
-            const LayerMap& layer_map,
-            int64_t start, int64_t stop,
-            double& max_time,
-            double& min_time,
-            bool reverse_order)
-
-        {
-            std::unique_ptr<aiNodeAnim> na(new aiNodeAnim());
-            na->mNodeName.Set(name);
-
-            const PropertyTable& props = target.Props();
-
-            // need to convert from TRS order to SRT?
-            if (reverse_order) {
-
-                aiVector3D def_scale = PropertyGet(props, "Lcl Scaling", aiVector3D(1.f, 1.f, 1.f));
-                aiVector3D def_translate = PropertyGet(props, "Lcl Translation", aiVector3D(0.f, 0.f, 0.f));
-                aiVector3D def_rot = PropertyGet(props, "Lcl Rotation", aiVector3D(0.f, 0.f, 0.f));
-
-                KeyFrameListList scaling;
-                KeyFrameListList translation;
-                KeyFrameListList rotation;
-
-                if (chain[TransformationComp_Scaling] != iter_end) {
-                    scaling = GetKeyframeList((*chain[TransformationComp_Scaling]).second, start, stop);
-                }
-
-                if (chain[TransformationComp_Translation] != iter_end) {
-                    translation = GetKeyframeList((*chain[TransformationComp_Translation]).second, start, stop);
-                }
-
-                if (chain[TransformationComp_Rotation] != iter_end) {
-                    rotation = GetKeyframeList((*chain[TransformationComp_Rotation]).second, start, stop);
-                }
-
-                KeyFrameListList joined;
-                joined.insert(joined.end(), scaling.begin(), scaling.end());
-                joined.insert(joined.end(), translation.begin(), translation.end());
-                joined.insert(joined.end(), rotation.begin(), rotation.end());
-
-                const KeyTimeList& times = GetKeyTimeList(joined);
-
-                aiQuatKey* out_quat = new aiQuatKey[times.size()];
-                aiVectorKey* out_scale = new aiVectorKey[times.size()];
-                aiVectorKey* out_translation = new aiVectorKey[times.size()];
-
-                if (times.size())
+                ASSIMP_LOG_DEBUG_F("-- Target property: %s\n", curve->TargetProperty().c_str());
+                
+                // I believe that an invalid target could 
+                // still be of use in certain cases so we 
+                // must keep this data for now.
+                if(target == nullptr)
                 {
-                    ConvertTransformOrder_TRStoSRT(out_quat, out_scale, out_translation,
-                        scaling,
-                        translation,
-                        rotation,
-                        times,
-                        max_time,
-                        min_time,
-                        target.RotationOrder(),
-                        def_scale,
-                        def_translate,
-                        def_rot);
+                    ASSIMP_LOG_DEBUG_F("-- [WARNING-Serious] Invalid node target: %d\n", curve->ID());
+                    continue; // skip this to make sure we handle this case.
+                }
+                else
+                {
+                    ASSIMP_LOG_DEBUG_F("-- Valid node target: %d\n", curve->ID());
                 }
 
-                // XXX remove duplicates / redundant keys which this operation did
-                // likely produce if not all three channels were equally dense.
 
-                na->mNumScalingKeys = static_cast<unsigned int>(times.size());
-                na->mNumRotationKeys = na->mNumScalingKeys;
-                na->mNumPositionKeys = na->mNumScalingKeys;
+                // std::map<std::string, const AnimationCurve*>
+                // please note this is an std::map
+                AnimationCurveMap map = curve->Curves();
+                AnimationCurveMap::iterator itr;
 
-                na->mScalingKeys = out_scale;
-                na->mRotationKeys = out_quat;
-                na->mPositionKeys = out_translation;
-            }
-            else {
 
-                // if a particular transformation is not given, grab it from
-                // the corresponding node to meet the semantics of aiNodeAnim,
-                // which requires all of rotation, scaling and translation
-                // to be set.
-                if (chain[TransformationComp_Scaling] != iter_end) {
-                    ConvertScaleKeys(na.get(), (*chain[TransformationComp_Scaling]).second,
-                        layer_map,
-                        start, stop,
-                        max_time,
-                        min_time);
-                }
-                else {
-                    na->mScalingKeys = new aiVectorKey[1];
-                    na->mNumScalingKeys = 1;
+                for( itr = map.begin(); itr != map.end(); ++itr)
+                {
+                    std::string subPropertyName = itr->first;
+                    const AnimationCurve* subCurve = itr->second;
+                    ASSIMP_LOG_DEBUG_F("-- SubCurve %s vs sub curve name %s\n", subPropertyName.c_str(), subCurve->Name().c_str());
+                    
+                    // todo make into dict
+                    const std::map<int64_t, float>& keyframes = subCurve->GetKeyframeData();
+                    ASSIMP_LOG_DEBUG_F("keyframe count: %ld\n", keyframes.size());
+                    // subCurve->GetKeys()
+                    // filter node
 
-                    na->mScalingKeys[0].mTime = 0.;
-                    na->mScalingKeys[0].mValue = PropertyGet(props, "Lcl Scaling",
-                        aiVector3D(1.f, 1.f, 1.f));
-                }
-
-                if (chain[TransformationComp_Rotation] != iter_end) {
-                    ConvertRotationKeys(na.get(), (*chain[TransformationComp_Rotation]).second,
-                        layer_map,
-                        start, stop,
-                        max_time,
-                        min_time,
-                        target.RotationOrder());
-                }
-                else {
-                    na->mRotationKeys = new aiQuatKey[1];
-                    na->mNumRotationKeys = 1;
-
-                    na->mRotationKeys[0].mTime = 0.;
-                    na->mRotationKeys[0].mValue = EulerToQuaternion(
-                        PropertyGet(props, "Lcl Rotation", aiVector3D(0.f, 0.f, 0.f)),
-                        target.RotationOrder());
-                }
-
-                if (chain[TransformationComp_Translation] != iter_end) {
-                    ConvertTranslationKeys(na.get(), (*chain[TransformationComp_Translation]).second,
-                        layer_map,
-                        start, stop,
-                        max_time,
-                        min_time);
-                }
-                else {
-                    na->mPositionKeys = new aiVectorKey[1];
-                    na->mNumPositionKeys = 1;
-
-                    na->mPositionKeys[0].mTime = 0.;
-                    na->mPositionKeys[0].mValue = PropertyGet(props, "Lcl Translation",
-                        aiVector3D(0.f, 0.f, 0.f));
-                }
-
-            }
-            return na.release();
-        }
-
-        FBXConverter::KeyFrameListList FBXConverter::GetKeyframeList(const std::vector<const AnimationCurveNode*>& nodes, int64_t start, int64_t stop)
-        {
-            KeyFrameListList inputs;
-            inputs.reserve(nodes.size() * 3);
-
-            //give some breathing room for rounding errors
-            int64_t adj_start = start - 10000;
-            int64_t adj_stop = stop + 10000;
-
-            for (const AnimationCurveNode* node : nodes) {
-                ai_assert(node);
-
-                const AnimationCurveMap& curves = node->Curves();
-                for (const AnimationCurveMap::value_type& kv : curves) {
-
-                    unsigned int mapto;
-                    if (kv.first == "d|X") {
-                        mapto = 0;
-                    }
-                    else if (kv.first == "d|Y") {
-                        mapto = 1;
-                    }
-                    else if (kv.first == "d|Z") {
-                        mapto = 2;
-                    }
-                    else {
-                        FBXImporter::LogWarn("ignoring scale animation curve, did not recognize target component");
-                        continue;
-                    }
-
-                    const AnimationCurve* const curve = kv.second;
-                    ai_assert(curve->GetKeys().size() == curve->GetValues().size() && curve->GetKeys().size());
-
-                    //get values within the start/stop time window
-                    std::shared_ptr<KeyTimeList> Keys(new KeyTimeList());
-                    std::shared_ptr<KeyValueList> Values(new KeyValueList());
-                    const size_t count = curve->GetKeys().size();
-                    Keys->reserve(count);
-                    Values->reserve(count);
-                    for (size_t n = 0; n < count; n++)
+                    // note target match is wrong.
+                    switch (GetFBXPropertyType(property_type))
                     {
-                        int64_t k = curve->GetKeys().at(n);
-                        if (k >= adj_start && k <= adj_stop)
-                        {
-                            Keys->push_back(k);
-                            Values->push_back(curve->GetValues().at(n));
-                        }
+                        case Translation:                        
+                            for( std::pair<const int64_t, float> keyframe_data : keyframes )
+                            {
+                                aiVectorKey *key;
+                                if( position_keys.count( keyframe_data.first ) )
+                                {
+                                    key = position_keys[keyframe_data.first];
+                                    ASSIMP_LOG_DEBUG_F("Found pre-existing pos key for sub curve %ld\n", keyframe_data.first);
+                                }
+                                else
+                                {
+                                    key = new aiVectorKey();
+                                    position_keys.insert( std::pair<const int64_t, aiVectorKey*>(keyframe_data.first, key) );
+                                    ASSIMP_LOG_DEBUG_F("Created pos key for sub curve %ld\n", keyframe_data.first);
+                                }                         
+                               
+                                key->mTime = CONVERT_FBX_TIME_TO_FRAMES(keyframe_data.first, anim_fps);
+
+                                switch ( GetFBXPropertyType( subPropertyName ) )
+                                {
+                                    case X_AXIS:
+                                        key->mValue.x = keyframe_data.second;
+                                    break;
+                                    case Y_AXIS:
+                                        key->mValue.y = keyframe_data.second;
+                                    break;                                    
+                                    case Z_AXIS:
+                                        key->mValue.z = keyframe_data.second;
+                                    break;
+                                }
+                            }
+                        break;
+                        case Rotation:
+                        for( std::pair<const int64_t, float> keyframe_data : keyframes )
+                            {
+                                aiVectorKey *key;
+                                if( rotation_keys.count( keyframe_data.first ) )
+                                {
+                                    key = rotation_keys[keyframe_data.first];
+                                    ASSIMP_LOG_DEBUG_F("Found pre-existing rot key for sub curve %ld\n", keyframe_data.first);
+                                }
+                                else
+                                {
+
+                                    key = new aiVectorKey();
+                                    rotation_keys.insert( std::pair<const int64_t, aiVectorKey*>(keyframe_data.first, key) );
+                                    ASSIMP_LOG_DEBUG_F("Created rot key for sub curve %ld\n", keyframe_data.first);
+                                }
+
+                                // set key frame time
+                                key->mTime = CONVERT_FBX_TIME_TO_FRAMES(keyframe_data.first, anim_fps);
+
+                                switch ( GetFBXPropertyType( subPropertyName ) )
+                                {
+                                    case X_AXIS:
+                                        key->mValue.x = keyframe_data.second;
+                                    break;
+                                    case Y_AXIS:
+                                        key->mValue.y = keyframe_data.second;
+                                    break;                                    
+                                    case Z_AXIS:
+                                        key->mValue.z = keyframe_data.second;
+                                    break;
+                                }
+                            }
+                        break;
+                        case Scale:
+                            for( std::pair<const int64_t, float> keyframe_data : keyframes )
+                            {
+                                aiVectorKey *key;
+                                if( scale_keys.count( keyframe_data.first ) )
+                                {
+                                    key = scale_keys[keyframe_data.first];
+                                    ASSIMP_LOG_DEBUG_F("Found pre-existing scale key for sub curve %ld\n", keyframe_data.first);
+                                }
+                                else
+                                {
+                                    key = new aiVectorKey();
+                                    scale_keys.insert( std::pair<const int64_t, aiVectorKey*>(keyframe_data.first, key) );
+                                    ASSIMP_LOG_DEBUG_F("Created scale key for sub curve %ld\n", keyframe_data.first);
+                                }                                
+
+
+                                key->mTime = CONVERT_FBX_TIME_TO_FRAMES(keyframe_data.first, anim_fps);
+
+                                switch ( GetFBXPropertyType( subPropertyName ) )
+                                {
+                                    case X_AXIS:
+                                        key->mValue.x = keyframe_data.second;
+                                    break;
+                                    case Y_AXIS:
+                                        key->mValue.y = keyframe_data.second;
+                                    break;                                    
+                                    case Z_AXIS:
+                                        key->mValue.z = keyframe_data.second;
+                                    break;
+                                }
+                            }
+                        break;
+                        default:
+                        break;
                     }
-
-                    inputs.push_back(std::make_tuple(Keys, Values, mapto));
-                }
-            }
-            return inputs; // pray for NRVO :-)
-        }
-
-
-        KeyTimeList FBXConverter::GetKeyTimeList(const KeyFrameListList& inputs) {
-            ai_assert(!inputs.empty());
-
-            // reserve some space upfront - it is likely that the key-frame lists
-            // have matching time values, so max(of all key-frame lists) should
-            // be a good estimate.
-            KeyTimeList keys;
-
-            size_t estimate = 0;
-            for (const KeyFrameList& kfl : inputs) {
-                estimate = std::max(estimate, std::get<0>(kfl)->size());
-            }
-
-            keys.reserve(estimate);
-
-            std::vector<unsigned int> next_pos;
-            next_pos.resize(inputs.size(), 0);
-
-            const size_t count = inputs.size();
-            while (true) {
-
-                int64_t min_tick = std::numeric_limits<int64_t>::max();
-                for (size_t i = 0; i < count; ++i) {
-                    const KeyFrameList& kfl = inputs[i];
-
-                    if (std::get<0>(kfl)->size() > next_pos[i] && std::get<0>(kfl)->at(next_pos[i]) < min_tick) {
-                        min_tick = std::get<0>(kfl)->at(next_pos[i]);
-                    }
                 }
 
-                if (min_tick == std::numeric_limits<int64_t>::max()) {
-                    break;
+                std::cout << std::endl;               
+
+                // todo: container which can contain arbitrary keyframe data?
+                // goal: convert FBX data to assimp aiAnimation.
+                // goal: only include what is needed for the animation
+            }
+
+            std::map<const int64_t, aiQuatKey*> real_rotation_keys;
+            // goal convert rotation keys into quaternion keys from euler (which is in FBX)
+            for( std::pair<const int64_t, aiVectorKey*> rot_key : rotation_keys)
+            {
+                auto quat_key = new aiQuatKey();
+                quat_key->mValue = EulerToQuaternion(rot_key.second->mValue, Model::RotOrder::RotOrder_EulerXYZ);
+                quat_key->mTime = rot_key.second->mTime;
+                real_rotation_keys.insert( std::pair<const int64_t, aiQuatKey*> (rot_key.first, quat_key ));  
+                delete rot_key.second; // clear allocation          
+            }
+
+            // this list is no longer required free it.
+            rotation_keys.clear();
+
+            ai_assert(nodeAnim); // if new fails then we need to report this asap and crash?
+            nodeAnim->mNodeName = fixed_name;
+            nodeAnim->mNumPositionKeys = position_keys.size();
+            nodeAnim->mNumRotationKeys = real_rotation_keys.size();
+            nodeAnim->mNumScalingKeys = scale_keys.size();
+
+            /*
+            /* Finalization stage
+             */
+
+            nodeAnim->mPositionKeys = new aiVectorKey[nodeAnim->mNumPositionKeys];
+            int ordered_insert = 0;
+            for (std::pair<const int64_t, aiVectorKey*> pos_key : position_keys)
+            {   
+                // why does this happen? 
+                // we need to remove keys the artist purposefully didn't include in the track :)
+                // 120 frame number
+                // 119.001 duration
+                if(pos_key.second->mTime <= end_time )
+                {                
+                    nodeAnim->mPositionKeys[ordered_insert] = *pos_key.second;
+                    ++ordered_insert;
                 }
-                keys.push_back(min_tick);
+                delete pos_key.second;
+            }
 
-                for (size_t i = 0; i < count; ++i) {
-                    const KeyFrameList& kfl = inputs[i];
-
-
-                    while (std::get<0>(kfl)->size() > next_pos[i] && std::get<0>(kfl)->at(next_pos[i]) == min_tick) {
-                        ++next_pos[i];
-                    }
+            nodeAnim->mScalingKeys = new aiVectorKey[nodeAnim->mNumScalingKeys];
+            ordered_insert = 0;
+            for (std::pair<const int64_t, aiVectorKey*> scale_key : scale_keys)
+            {
+                if( scale_key.second->mTime <= end_time )
+                { 
+                    nodeAnim->mScalingKeys[ordered_insert] = *scale_key.second;
+                    ++ordered_insert;
                 }
+                delete scale_key.second;
             }
 
-            return keys;
-        }
-
-        void FBXConverter::InterpolateKeys(aiVectorKey* valOut, const KeyTimeList& keys, const KeyFrameListList& inputs,
-            const aiVector3D& def_value,
-            double& max_time,
-            double& min_time) {
-            ai_assert(!keys.empty());
-            ai_assert(nullptr != valOut);
-
-            std::vector<unsigned int> next_pos;
-            const size_t count(inputs.size());
-
-            next_pos.resize(inputs.size(), 0);
-
-            for (KeyTimeList::value_type time : keys) {
-                ai_real result[3] = { def_value.x, def_value.y, def_value.z };
-
-                for (size_t i = 0; i < count; ++i) {
-                    const KeyFrameList& kfl = inputs[i];
-
-                    const size_t ksize = std::get<0>(kfl)->size();
-                    if (ksize == 0) {
-                        continue;
-                    }
-                    if (ksize > next_pos[i] && std::get<0>(kfl)->at(next_pos[i]) == time) {
-                        ++next_pos[i];
-                    }
-
-                    const size_t id0 = next_pos[i] > 0 ? next_pos[i] - 1 : 0;
-                    const size_t id1 = next_pos[i] == ksize ? ksize - 1 : next_pos[i];
-
-                    // use lerp for interpolation
-                    const KeyValueList::value_type valueA = std::get<1>(kfl)->at(id0);
-                    const KeyValueList::value_type valueB = std::get<1>(kfl)->at(id1);
-
-                    const KeyTimeList::value_type timeA = std::get<0>(kfl)->at(id0);
-                    const KeyTimeList::value_type timeB = std::get<0>(kfl)->at(id1);
-
-                    const ai_real factor = timeB == timeA ? ai_real(0.) : static_cast<ai_real>((time - timeA)) / (timeB - timeA);
-                    const ai_real interpValue = static_cast<ai_real>(valueA + (valueB - valueA) * factor);
-
-                    result[std::get<2>(kfl)] = interpValue;
+            nodeAnim->mRotationKeys = new aiQuatKey[nodeAnim->mNumRotationKeys];
+            ordered_insert = 0;
+            for (std::pair<const int64_t, aiQuatKey*> rot_key : real_rotation_keys)
+            {
+                if(rot_key.second->mTime <= end_time)
+                { 
+                    nodeAnim->mRotationKeys[ordered_insert] = *rot_key.second;
+                    ++ordered_insert;
                 }
-
-                // magic value to convert fbx times to seconds
-                valOut->mTime = CONVERT_FBX_TIME(time) * anim_fps;
-
-                min_time = std::min(min_time, valOut->mTime);
-                max_time = std::max(max_time, valOut->mTime);
-
-                valOut->mValue.x = result[0];
-                valOut->mValue.y = result[1];
-                valOut->mValue.z = result[2];
-
-                ++valOut;
-            }
-        }
-
-        void FBXConverter::InterpolateKeys(aiQuatKey* valOut, const KeyTimeList& keys, const KeyFrameListList& inputs,
-            const aiVector3D& def_value,
-            double& maxTime,
-            double& minTime,
-            Model::RotOrder order)
-        {
-            ai_assert(!keys.empty());
-            ai_assert(nullptr != valOut);
-
-            std::unique_ptr<aiVectorKey[]> temp(new aiVectorKey[keys.size()]);
-            InterpolateKeys(temp.get(), keys, inputs, def_value, maxTime, minTime);
-
-            aiMatrix4x4 m;
-
-            aiQuaternion lastq;
-
-            for (size_t i = 0, c = keys.size(); i < c; ++i) {
-
-                valOut[i].mTime = temp[i].mTime;
-
-                GetRotationMatrix(order, temp[i].mValue, m);
-                aiQuaternion quat = aiQuaternion(aiMatrix3x3(m));
-
-                // take shortest path by checking the inner product
-                // http://www.3dkingdoms.com/weekly/weekly.php?a=36
-                if (quat.x * lastq.x + quat.y * lastq.y + quat.z * lastq.z + quat.w * lastq.w < 0)
-                {
-                    quat.x = -quat.x;
-                    quat.y = -quat.y;
-                    quat.z = -quat.z;
-                    quat.w = -quat.w;
-                }
-                lastq = quat;
-
-                valOut[i].mValue = quat;
-            }
-        }
-
-        void FBXConverter::ConvertTransformOrder_TRStoSRT(aiQuatKey* out_quat, aiVectorKey* out_scale,
-            aiVectorKey* out_translation,
-            const KeyFrameListList& scaling,
-            const KeyFrameListList& translation,
-            const KeyFrameListList& rotation,
-            const KeyTimeList& times,
-            double& maxTime,
-            double& minTime,
-            Model::RotOrder order,
-            const aiVector3D& def_scale,
-            const aiVector3D& def_translate,
-            const aiVector3D& def_rotation)
-        {
-            if (rotation.size()) {
-                InterpolateKeys(out_quat, times, rotation, def_rotation, maxTime, minTime, order);
-            }
-            else {
-                for (size_t i = 0; i < times.size(); ++i) {
-                    out_quat[i].mTime = CONVERT_FBX_TIME(times[i]) * anim_fps;
-                    out_quat[i].mValue = EulerToQuaternion(def_rotation, order);
-                }
+                delete rot_key.second;
             }
 
-            if (scaling.size()) {
-                InterpolateKeys(out_scale, times, scaling, def_scale, maxTime, minTime);
+            if(real_rotation_keys.size() > 0 || position_keys.size() > 0 || scale_keys.size() > 0)
+            {
+                node_anims.push_back( nodeAnim );
             }
-            else {
-                for (size_t i = 0; i < times.size(); ++i) {
-                    out_scale[i].mTime = CONVERT_FBX_TIME(times[i]) * anim_fps;
-                    out_scale[i].mValue = def_scale;
-                }
-            }
-
-            if (translation.size()) {
-                InterpolateKeys(out_translation, times, translation, def_translate, maxTime, minTime);
-            }
-            else {
-                for (size_t i = 0; i < times.size(); ++i) {
-                    out_translation[i].mTime = CONVERT_FBX_TIME(times[i]) * anim_fps;
-                    out_translation[i].mValue = def_translate;
-                }
-            }
-
-            const size_t count = times.size();
-            for (size_t i = 0; i < count; ++i) {
-                aiQuaternion& r = out_quat[i].mValue;
-                aiVector3D& s = out_scale[i].mValue;
-                aiVector3D& t = out_translation[i].mValue;
-
-                aiMatrix4x4 mat, temp;
-                aiMatrix4x4::Translation(t, mat);
-                mat *= aiMatrix4x4(r.GetMatrix());
-                mat *= aiMatrix4x4::Scaling(s, temp);
-
-                mat.Decompose(s, r, t);
-            }
+            else
+            {
+                delete nodeAnim;
+            }            
         }
 
         aiQuaternion FBXConverter::EulerToQuaternion(const aiVector3D& rot, Model::RotOrder order)
@@ -3347,65 +3003,6 @@ void FBXConverter::SetShadingPropertiesRaw(aiMaterial* out_mat, const PropertyTa
             GetRotationMatrix(order, rot, m);
 
             return aiQuaternion(aiMatrix3x3(m));
-        }
-
-        void FBXConverter::ConvertScaleKeys(aiNodeAnim* na, const std::vector<const AnimationCurveNode*>& nodes, const LayerMap& /*layers*/,
-            int64_t start, int64_t stop,
-            double& maxTime,
-            double& minTime)
-        {
-            ai_assert(nodes.size());
-
-            // XXX for now, assume scale should be blended geometrically (i.e. two
-            // layers should be multiplied with each other). There is a FBX
-            // property in the layer to specify the behaviour, though.
-
-            const KeyFrameListList& inputs = GetKeyframeList(nodes, start, stop);
-            const KeyTimeList& keys = GetKeyTimeList(inputs);
-
-            na->mNumScalingKeys = static_cast<unsigned int>(keys.size());
-            na->mScalingKeys = new aiVectorKey[keys.size()];
-            if (keys.size() > 0) {
-                InterpolateKeys(na->mScalingKeys, keys, inputs, aiVector3D(1.0f, 1.0f, 1.0f), maxTime, minTime);
-            }
-        }
-
-        void FBXConverter::ConvertTranslationKeys(aiNodeAnim* na, const std::vector<const AnimationCurveNode*>& nodes,
-            const LayerMap& /*layers*/,
-            int64_t start, int64_t stop,
-            double& maxTime,
-            double& minTime)
-        {
-            ai_assert(nodes.size());
-
-            // XXX see notes in ConvertScaleKeys()
-            const KeyFrameListList& inputs = GetKeyframeList(nodes, start, stop);
-            const KeyTimeList& keys = GetKeyTimeList(inputs);
-
-            na->mNumPositionKeys = static_cast<unsigned int>(keys.size());
-            na->mPositionKeys = new aiVectorKey[keys.size()];
-            if (keys.size() > 0)
-                InterpolateKeys(na->mPositionKeys, keys, inputs, aiVector3D(0.0f, 0.0f, 0.0f), maxTime, minTime);
-        }
-
-        void FBXConverter::ConvertRotationKeys(aiNodeAnim* na, const std::vector<const AnimationCurveNode*>& nodes,
-            const LayerMap& /*layers*/,
-            int64_t start, int64_t stop,
-            double& maxTime,
-            double& minTime,
-            Model::RotOrder order)
-        {
-            ai_assert(nodes.size());
-
-            // XXX see notes in ConvertScaleKeys()
-            const std::vector< KeyFrameList >& inputs = GetKeyframeList(nodes, start, stop);
-            const KeyTimeList& keys = GetKeyTimeList(inputs);
-
-            na->mNumRotationKeys = static_cast<unsigned int>(keys.size());
-            na->mRotationKeys = new aiQuatKey[keys.size()];
-            if (!keys.empty()) {
-                InterpolateKeys(na->mRotationKeys, keys, inputs, aiVector3D(0.0f, 0.0f, 0.0f), maxTime, minTime, order);
-            }
         }
 
         void FBXConverter::ConvertGlobalSettings() {

--- a/code/FBX/FBXConverter.h
+++ b/code/FBX/FBXConverter.h
@@ -123,7 +123,7 @@ private:
 
     // ------------------------------------------------------------------------------------------------
     // collect and assign child nodes
-    void ConvertNodes(uint64_t id, aiNode& parent, const aiMatrix4x4& parent_transform = aiMatrix4x4());
+    void ConvertNodes(uint64_t id, aiNode *parent, aiNode *root_node);
 
     // ------------------------------------------------------------------------------------------------
     void ConvertLights(const Model& model, const std::string &orig_name );
@@ -179,32 +179,32 @@ private:
     void SetupNodeMetadata(const Model& model, aiNode& nd);
 
     // ------------------------------------------------------------------------------------------------
-    void ConvertModel(const Model& model, aiNode& nd, const aiMatrix4x4& node_global_transform);
+    void ConvertModel(const Model& model, aiNode *parent, aiNode *root_node);
     
     // ------------------------------------------------------------------------------------------------
     // MeshGeometry -> aiMesh, return mesh index + 1 or 0 if the conversion failed
     std::vector<unsigned int> ConvertMesh(const MeshGeometry& mesh, const Model& model,
-        const aiMatrix4x4& node_global_transform, aiNode& nd);
+                                          aiNode *parent, aiNode *root_node);
 
     // ------------------------------------------------------------------------------------------------
     std::vector<unsigned int> ConvertLine(const LineGeometry& line, const Model& model,
-        const aiMatrix4x4& node_global_transform, aiNode& nd);
+                                          aiNode *parent, aiNode *root_node);
 
     // ------------------------------------------------------------------------------------------------
-    aiMesh* SetupEmptyMesh(const Geometry& mesh, aiNode& nd);
+    aiMesh* SetupEmptyMesh(const Geometry& mesh, aiNode *parent);
 
     // ------------------------------------------------------------------------------------------------
     unsigned int ConvertMeshSingleMaterial(const MeshGeometry& mesh, const Model& model,
-        const aiMatrix4x4& node_global_transform, aiNode& nd);
+                                           aiNode *parent, aiNode *root_node);
 
     // ------------------------------------------------------------------------------------------------
     std::vector<unsigned int> ConvertMeshMultiMaterial(const MeshGeometry& mesh, const Model& model,
-        const aiMatrix4x4& node_global_transform, aiNode& nd);
+                                                       aiNode *parent, aiNode *root_node);
 
     // ------------------------------------------------------------------------------------------------
     unsigned int ConvertMeshMultiMaterial(const MeshGeometry& mesh, const Model& model,
-        MatIndexArray::value_type index,
-        const aiMatrix4x4& node_global_transform, aiNode& nd);
+                                          MatIndexArray::value_type index,
+                                          aiNode *parent, aiNode *root_node);
 
     // ------------------------------------------------------------------------------------------------
     static const unsigned int NO_MATERIAL_SEPARATION = /* std::numeric_limits<unsigned int>::max() */
@@ -218,16 +218,16 @@ private:
     *    each output vertex the DOM index it maps to.
     */
     void ConvertWeights(aiMesh* out, const Model& model, const MeshGeometry& geo,
-        const aiMatrix4x4& node_global_transform = aiMatrix4x4(),
-        unsigned int materialIndex = NO_MATERIAL_SEPARATION,
-        std::vector<unsigned int>* outputVertStartIndices = NULL);
-
+                        aiNode *parent = NULL,
+                        aiNode *root_node = NULL,
+                        unsigned int materialIndex = NO_MATERIAL_SEPARATION,
+                        std::vector<unsigned int>* outputVertStartIndices = NULL);
+    // lookup
+    static const aiNode* GetNodeByName( const aiString& name, aiNode *current_node );
     // ------------------------------------------------------------------------------------------------
-    void ConvertCluster(std::vector<aiBone*>& bones, const Model& /*model*/, const Cluster& cl,
-        std::vector<size_t>& out_indices,
-        std::vector<size_t>& index_out_indices,
-        std::vector<size_t>& count_out_indices,
-        const aiMatrix4x4& node_global_transform);
+    void ConvertCluster(std::vector<aiBone *> &bones, const Model &, const Cluster &cl, std::vector<size_t> &out_indices,
+                   std::vector<size_t> &index_out_indices, std::vector<size_t> &count_out_indices, aiNode *parent,
+                   aiNode *root_node);
 
     // ------------------------------------------------------------------------------------------------
     void ConvertMaterialForMesh(aiMesh* out, const Model& model, const MeshGeometry& geo,

--- a/code/FBX/FBXConverter.h
+++ b/code/FBX/FBXConverter.h
@@ -90,6 +90,9 @@ public:
     /**
     *  The different parts that make up the final local transformation of a fbx-node
     */
+
+   
+
     enum TransformationComp {
         TransformationComp_GeometricScalingInverse = 0,
         TransformationComp_GeometricRotationInverse,
@@ -111,6 +114,18 @@ public:
 
         TransformationComp_MAXIMUM
     };
+
+    enum FBX_PROPERTY_TYPE {
+        X_AXIS=0,
+        Y_AXIS,
+        Z_AXIS,
+        Translation,
+        Rotation,
+        Scale,
+        UNKNOWN,
+        Maximum        
+    };
+
 
 public:
     FBXConverter(aiScene* out, const Document& doc, bool removeEmptyBones);
@@ -307,42 +322,8 @@ private:
         const std::string& fixed_name,
         const std::vector<const AnimationCurveNode*>& curves,
         const LayerMap& layer_map,
-        int64_t start, int64_t stop,
         double& max_time,
         double& min_time);
-
-    // ------------------------------------------------------------------------------------------------
-    bool IsRedundantAnimationData(const Model& target,
-        TransformationComp comp,
-        const std::vector<const AnimationCurveNode*>& curves);
-
-    // ------------------------------------------------------------------------------------------------
-    aiNodeAnim* GenerateRotationNodeAnim(const std::string& name,
-        const Model& target,
-        const std::vector<const AnimationCurveNode*>& curves,
-        const LayerMap& layer_map,
-        int64_t start, int64_t stop,
-        double& max_time,
-        double& min_time);
-
-    // ------------------------------------------------------------------------------------------------
-    aiNodeAnim* GenerateScalingNodeAnim(const std::string& name,
-        const Model& /*target*/,
-        const std::vector<const AnimationCurveNode*>& curves,
-        const LayerMap& layer_map,
-        int64_t start, int64_t stop,
-        double& max_time,
-        double& min_time);
-
-    // ------------------------------------------------------------------------------------------------
-    aiNodeAnim* GenerateTranslationNodeAnim(const std::string& name,
-        const Model& /*target*/,
-        const std::vector<const AnimationCurveNode*>& curves,
-        const LayerMap& layer_map,
-        int64_t start, int64_t stop,
-        double& max_time,
-        double& min_time,
-        bool inverse = false);
 
     // ------------------------------------------------------------------------------------------------
     // generate node anim, extracting only Rotation, Scaling and Translation from the given chain
@@ -353,70 +334,12 @@ private:
         const LayerMap& layer_map,
         int64_t start, int64_t stop,
         double& max_time,
-        double& min_time,
-        bool reverse_order = false);
-
-    // key (time), value, mapto (component index)
-    typedef std::tuple<std::shared_ptr<KeyTimeList>, std::shared_ptr<KeyValueList>, unsigned int > KeyFrameList;
-    typedef std::vector<KeyFrameList> KeyFrameListList;
-
-    // ------------------------------------------------------------------------------------------------
-    KeyFrameListList GetKeyframeList(const std::vector<const AnimationCurveNode*>& nodes, int64_t start, int64_t stop);
-
-    // ------------------------------------------------------------------------------------------------
-    KeyTimeList GetKeyTimeList(const KeyFrameListList& inputs);
-
-    // ------------------------------------------------------------------------------------------------
-    void InterpolateKeys(aiVectorKey* valOut, const KeyTimeList& keys, const KeyFrameListList& inputs,
-        const aiVector3D& def_value,
-        double& max_time,
         double& min_time);
-
-    // ------------------------------------------------------------------------------------------------
-    void InterpolateKeys(aiQuatKey* valOut, const KeyTimeList& keys, const KeyFrameListList& inputs,
-        const aiVector3D& def_value,
-        double& maxTime,
-        double& minTime,
-        Model::RotOrder order);
-
-    // ------------------------------------------------------------------------------------------------
-    void ConvertTransformOrder_TRStoSRT(aiQuatKey* out_quat, aiVectorKey* out_scale,
-        aiVectorKey* out_translation,
-        const KeyFrameListList& scaling,
-        const KeyFrameListList& translation,
-        const KeyFrameListList& rotation,
-        const KeyTimeList& times,
-        double& maxTime,
-        double& minTime,
-        Model::RotOrder order,
-        const aiVector3D& def_scale,
-        const aiVector3D& def_translate,
-        const aiVector3D& def_rotation);
 
     // ------------------------------------------------------------------------------------------------
     // euler xyz -> quat
     aiQuaternion EulerToQuaternion(const aiVector3D& rot, Model::RotOrder order);
 
-    // ------------------------------------------------------------------------------------------------
-    void ConvertScaleKeys(aiNodeAnim* na, const std::vector<const AnimationCurveNode*>& nodes, const LayerMap& /*layers*/,
-        int64_t start, int64_t stop,
-        double& maxTime,
-        double& minTime);
-
-    // ------------------------------------------------------------------------------------------------
-    void ConvertTranslationKeys(aiNodeAnim* na, const std::vector<const AnimationCurveNode*>& nodes,
-        const LayerMap& /*layers*/,
-        int64_t start, int64_t stop,
-        double& maxTime,
-        double& minTime);
-
-    // ------------------------------------------------------------------------------------------------
-    void ConvertRotationKeys(aiNodeAnim* na, const std::vector<const AnimationCurveNode*>& nodes,
-        const LayerMap& /*layers*/,
-        int64_t start, int64_t stop,
-        double& maxTime,
-        double& minTime,
-        Model::RotOrder order);
 
     void ConvertGlobalSettings();
 

--- a/code/FBX/FBXConverter.h
+++ b/code/FBX/FBXConverter.h
@@ -194,12 +194,14 @@ private:
     void SetupNodeMetadata(const Model& model, aiNode& nd);
 
     // ------------------------------------------------------------------------------------------------
-    void ConvertModel(const Model& model, aiNode *parent, aiNode *root_node);
+    void ConvertModel(const Model &model, aiNode *parent, aiNode *root_node,
+                      const aiMatrix4x4 &absolute_transform);
     
     // ------------------------------------------------------------------------------------------------
     // MeshGeometry -> aiMesh, return mesh index + 1 or 0 if the conversion failed
-    std::vector<unsigned int> ConvertMesh(const MeshGeometry& mesh, const Model& model,
-                                          aiNode *parent, aiNode *root_node);
+    std::vector<unsigned int>
+    ConvertMesh(const MeshGeometry &mesh, const Model &model, aiNode *parent, aiNode *root_node,
+                const aiMatrix4x4 &absolute_transform);
 
     // ------------------------------------------------------------------------------------------------
     std::vector<unsigned int> ConvertLine(const LineGeometry& line, const Model& model,
@@ -209,17 +211,18 @@ private:
     aiMesh* SetupEmptyMesh(const Geometry& mesh, aiNode *parent);
 
     // ------------------------------------------------------------------------------------------------
-    unsigned int ConvertMeshSingleMaterial(const MeshGeometry& mesh, const Model& model,
-                                           aiNode *parent, aiNode *root_node);
+    unsigned int ConvertMeshSingleMaterial(const MeshGeometry &mesh, const Model &model,
+                                           const aiMatrix4x4 &absolute_transform, aiNode *parent,
+                                           aiNode *root_node);
 
     // ------------------------------------------------------------------------------------------------
-    std::vector<unsigned int> ConvertMeshMultiMaterial(const MeshGeometry& mesh, const Model& model,
-                                                       aiNode *parent, aiNode *root_node);
+    std::vector<unsigned int>
+    ConvertMeshMultiMaterial(const MeshGeometry &mesh, const Model &model, aiNode *parent, aiNode *root_node,
+                             const aiMatrix4x4 &absolute_transform);
 
     // ------------------------------------------------------------------------------------------------
-    unsigned int ConvertMeshMultiMaterial(const MeshGeometry& mesh, const Model& model,
-                                          MatIndexArray::value_type index,
-                                          aiNode *parent, aiNode *root_node);
+    unsigned int ConvertMeshMultiMaterial(const MeshGeometry &mesh, const Model &model, MatIndexArray::value_type index,
+                                          aiNode *parent, aiNode *root_node, const aiMatrix4x4 &absolute_transform);
 
     // ------------------------------------------------------------------------------------------------
     static const unsigned int NO_MATERIAL_SEPARATION = /* std::numeric_limits<unsigned int>::max() */
@@ -232,17 +235,17 @@ private:
     *  - outputVertStartIndices is only used when a material index is specified, it gives for
     *    each output vertex the DOM index it maps to.
     */
-    void ConvertWeights(aiMesh* out, const Model& model, const MeshGeometry& geo,
-                        aiNode *parent = NULL,
-                        aiNode *root_node = NULL,
+    void ConvertWeights(aiMesh *out, const Model &model, const MeshGeometry &geo, const aiMatrix4x4 &absolute_transform,
+                        aiNode *parent = NULL, aiNode *root_node = NULL,
                         unsigned int materialIndex = NO_MATERIAL_SEPARATION,
-                        std::vector<unsigned int>* outputVertStartIndices = NULL);
+                        std::vector<unsigned int> *outputVertStartIndices = NULL);
     // lookup
     static const aiNode* GetNodeByName( const aiString& name, aiNode *current_node );
     // ------------------------------------------------------------------------------------------------
-    void ConvertCluster(std::vector<aiBone *> &bones, const Model &, const Cluster &cl, std::vector<size_t> &out_indices,
-                   std::vector<size_t> &index_out_indices, std::vector<size_t> &count_out_indices, aiNode *parent,
-                   aiNode *root_node);
+    void ConvertCluster(std::vector<aiBone *> &local_mesh_bones, const Cluster *cl,
+                        std::vector<size_t> &out_indices, std::vector<size_t> &index_out_indices,
+                        std::vector<size_t> &count_out_indices, const aiMatrix4x4 &absolute_transform,
+                        aiNode *parent, aiNode *root_node);
 
     // ------------------------------------------------------------------------------------------------
     void ConvertMaterialForMesh(aiMesh* out, const Model& model, const MeshGeometry& geo,
@@ -375,10 +378,30 @@ private:
     using NodeNameCache = std::unordered_map<std::string, unsigned int>;
     NodeNameCache mNodeNames;
 
+    // Deformer name is not the same as a bone name - it does contain the bone name though :)
+    // Deformer names in FBX are always unique in an FBX file.
+    std::map<const std::string, aiBone *> bone_map;
+
     double anim_fps;
 
     aiScene* const out;
     const FBX::Document& doc;
+
+    static void BuildBoneList(aiNode *current_node, const aiNode *root_node, const aiScene *scene,
+                             std::vector<aiBone*>& bones);
+
+    void BuildBoneStack(aiNode *current_node, const aiNode *root_node, const aiScene *scene,
+                   const std::vector<aiBone *> &bones,
+                   std::map<aiBone *, aiNode *> &bone_stack,
+                   std::vector<aiNode*> &node_stack );
+
+    static void BuildNodeList(aiNode *current_node, std::vector<aiNode *> &nodes);
+
+    static aiNode *GetNodeFromStack(const aiString &node_name, std::vector<aiNode *> &nodes);
+
+    static aiNode *GetArmatureRoot(aiNode *bone_node, std::vector<aiBone*> &bone_list);
+
+    static bool IsBoneNode(const aiString &bone_name, std::vector<aiBone *> &bones);
 };
 
 }

--- a/code/FBX/FBXDocument.h
+++ b/code/FBX/FBXDocument.h
@@ -684,26 +684,19 @@ private:
     LayeredTextureMap layeredTextures;
 };
 
-typedef std::vector<int64_t> KeyTimeList;
-typedef std::vector<float> KeyValueList;
-
+typedef std::map<int64_t, float> KeyFrameValueMap;
 /** Represents a FBX animation curve (i.e. a 1-dimensional set of keyframes and values therefor) */
 class AnimationCurve : public Object {
 public:
     AnimationCurve(uint64_t id, const Element& element, const std::string& name, const Document& doc);
     virtual ~AnimationCurve();
 
-    /** get list of keyframe positions (time).
-     *  Invariant: |GetKeys()| > 0 */
-    const KeyTimeList& GetKeys() const {
-        return keys;
+    /* Return dictionary of the keyframe data */
+    const std::map<int64_t, float>& GetKeyframeData() const
+    {
+        return time_values;
     }
 
-    /** get list of keyframe values.
-      * Invariant: |GetKeys()| == |GetValues()| && |GetKeys()| > 0*/
-    const KeyValueList& GetValues() const {
-        return values;
-    }
 
     const std::vector<float>& GetAttributes() const {
         return attributes;
@@ -714,8 +707,7 @@ public:
     }
 
 private:
-    KeyTimeList keys;
-    KeyValueList values;
+    std::map<int64_t, float> time_values;
     std::vector<float> attributes;
     std::vector<unsigned int> flags;
 };

--- a/code/FBX/FBXImporter.cpp
+++ b/code/FBX/FBXImporter.cpp
@@ -48,26 +48,26 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "FBXImporter.h"
 
-#include "FBXTokenizer.h"
-#include "FBXParser.h"
-#include "FBXUtil.h"
-#include "FBXDocument.h"
 #include "FBXConverter.h"
+#include "FBXDocument.h"
+#include "FBXParser.h"
+#include "FBXTokenizer.h"
+#include "FBXUtil.h"
 
-#include <assimp/StreamReader.h>
 #include <assimp/MemoryIOWrapper.h>
-#include <assimp/Importer.hpp>
+#include <assimp/StreamReader.h>
 #include <assimp/importerdesc.h>
+#include <assimp/Importer.hpp>
 
 namespace Assimp {
 
-template<>
-const char* LogFunctions<FBXImporter>::Prefix() {
-    static auto prefix = "FBX: ";
-    return prefix;
+template <>
+const char *LogFunctions<FBXImporter>::Prefix() {
+	static auto prefix = "FBX: ";
+	return prefix;
 }
 
-}
+} // namespace Assimp
 
 using namespace Assimp;
 using namespace Assimp::Formatter;
@@ -76,131 +76,123 @@ using namespace Assimp::FBX;
 namespace {
 
 static const aiImporterDesc desc = {
-    "Autodesk FBX Importer",
-    "",
-    "",
-    "",
-    aiImporterFlags_SupportTextFlavour,
-    0,
-    0,
-    0,
-    0,
-    "fbx"
+	"Autodesk FBX Importer",
+	"",
+	"",
+	"",
+	aiImporterFlags_SupportTextFlavour,
+	0,
+	0,
+	0,
+	0,
+	"fbx"
 };
 }
 
 // ------------------------------------------------------------------------------------------------
 // Constructor to be privately used by #Importer
-FBXImporter::FBXImporter()
-{
+FBXImporter::FBXImporter() {
 }
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-FBXImporter::~FBXImporter()
-{
+FBXImporter::~FBXImporter() {
 }
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.
-bool FBXImporter::CanRead( const std::string& pFile, IOSystem* pIOHandler, bool checkSig) const
-{
-    const std::string& extension = GetExtension(pFile);
-    if (extension == std::string( desc.mFileExtensions ) ) {
-        return true;
-    }
+bool FBXImporter::CanRead(const std::string &pFile, IOSystem *pIOHandler, bool checkSig) const {
+	const std::string &extension = GetExtension(pFile);
+	if (extension == std::string(desc.mFileExtensions)) {
+		return true;
+	}
 
-    else if ((!extension.length() || checkSig) && pIOHandler)   {
-        // at least ASCII-FBX files usually have a 'FBX' somewhere in their head
-        const char* tokens[] = {"fbx"};
-        return SearchFileHeaderForToken(pIOHandler,pFile,tokens,1);
-    }
-    return false;
+	else if ((!extension.length() || checkSig) && pIOHandler) {
+		// at least ASCII-FBX files usually have a 'FBX' somewhere in their head
+		const char *tokens[] = { "fbx" };
+		return SearchFileHeaderForToken(pIOHandler, pFile, tokens, 1);
+	}
+	return false;
 }
 
 // ------------------------------------------------------------------------------------------------
 // List all extensions handled by this loader
-const aiImporterDesc* FBXImporter::GetInfo () const
-{
-    return &desc;
+const aiImporterDesc *FBXImporter::GetInfo() const {
+	return &desc;
 }
 
 // ------------------------------------------------------------------------------------------------
 // Setup configuration properties for the loader
-void FBXImporter::SetupProperties(const Importer* pImp)
-{
-    settings.readAllLayers = pImp->GetPropertyBool(AI_CONFIG_IMPORT_FBX_READ_ALL_GEOMETRY_LAYERS, true);
-    settings.readAllMaterials = pImp->GetPropertyBool(AI_CONFIG_IMPORT_FBX_READ_ALL_MATERIALS, false);
-    settings.readMaterials = pImp->GetPropertyBool(AI_CONFIG_IMPORT_FBX_READ_MATERIALS, true);
-    settings.readTextures = pImp->GetPropertyBool(AI_CONFIG_IMPORT_FBX_READ_TEXTURES, true);
-    settings.readCameras = pImp->GetPropertyBool(AI_CONFIG_IMPORT_FBX_READ_CAMERAS, true);
-    settings.readLights = pImp->GetPropertyBool(AI_CONFIG_IMPORT_FBX_READ_LIGHTS, true);
-    settings.readAnimations = pImp->GetPropertyBool(AI_CONFIG_IMPORT_FBX_READ_ANIMATIONS, true);
-    settings.strictMode = pImp->GetPropertyBool(AI_CONFIG_IMPORT_FBX_STRICT_MODE, false);
-    settings.preservePivots = pImp->GetPropertyBool(AI_CONFIG_IMPORT_FBX_PRESERVE_PIVOTS, true);
-    settings.optimizeEmptyAnimationCurves = pImp->GetPropertyBool(AI_CONFIG_IMPORT_FBX_OPTIMIZE_EMPTY_ANIMATION_CURVES, true);
-    settings.useLegacyEmbeddedTextureNaming = pImp->GetPropertyBool(AI_CONFIG_IMPORT_FBX_EMBEDDED_TEXTURES_LEGACY_NAMING, false);
-    settings.removeEmptyBones = pImp->GetPropertyBool(AI_CONFIG_IMPORT_REMOVE_EMPTY_BONES, true);
-    settings.convertToMeters = pImp->GetPropertyBool(AI_CONFIG_FBX_CONVERT_TO_M, false);
+void FBXImporter::SetupProperties(const Importer *pImp) {
+	settings.readAllLayers = pImp->GetPropertyBool(AI_CONFIG_IMPORT_FBX_READ_ALL_GEOMETRY_LAYERS, true);
+	settings.readAllMaterials = pImp->GetPropertyBool(AI_CONFIG_IMPORT_FBX_READ_ALL_MATERIALS, false);
+	settings.readMaterials = pImp->GetPropertyBool(AI_CONFIG_IMPORT_FBX_READ_MATERIALS, true);
+	settings.readTextures = pImp->GetPropertyBool(AI_CONFIG_IMPORT_FBX_READ_TEXTURES, true);
+	settings.readCameras = pImp->GetPropertyBool(AI_CONFIG_IMPORT_FBX_READ_CAMERAS, true);
+	settings.readLights = pImp->GetPropertyBool(AI_CONFIG_IMPORT_FBX_READ_LIGHTS, true);
+	settings.readAnimations = pImp->GetPropertyBool(AI_CONFIG_IMPORT_FBX_READ_ANIMATIONS, true);
+	settings.strictMode = pImp->GetPropertyBool(AI_CONFIG_IMPORT_FBX_STRICT_MODE, false);
+	settings.preservePivots = pImp->GetPropertyBool(AI_CONFIG_IMPORT_FBX_PRESERVE_PIVOTS, true);
+	settings.optimizeEmptyAnimationCurves = pImp->GetPropertyBool(AI_CONFIG_IMPORT_FBX_OPTIMIZE_EMPTY_ANIMATION_CURVES, true);
+	settings.useLegacyEmbeddedTextureNaming = pImp->GetPropertyBool(AI_CONFIG_IMPORT_FBX_EMBEDDED_TEXTURES_LEGACY_NAMING, false);
+	settings.removeEmptyBones = pImp->GetPropertyBool(AI_CONFIG_IMPORT_REMOVE_EMPTY_BONES, true);
+	settings.convertToMeters = pImp->GetPropertyBool(AI_CONFIG_FBX_CONVERT_TO_M, false);
 }
 
 // ------------------------------------------------------------------------------------------------
 // Imports the given file into the given scene structure.
-void FBXImporter::InternReadFile( const std::string& pFile, aiScene* pScene, IOSystem* pIOHandler)
-{
-    std::unique_ptr<IOStream> stream(pIOHandler->Open(pFile,"rb"));
-    if (!stream) {
-        ThrowException("Could not open file for reading");
-    }
+void FBXImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSystem *pIOHandler) {
+	std::unique_ptr<IOStream> stream(pIOHandler->Open(pFile, "rb"));
+	if (!stream) {
+		ThrowException("Could not open file for reading");
+	}
 
-    // read entire file into memory - no streaming for this, fbx
-    // files can grow large, but the assimp output data structure
-    // then becomes very large, too. Assimp doesn't support
-    // streaming for its output data structures so the net win with
-    // streaming input data would be very low.
-    std::vector<char> contents;
-    contents.resize(stream->FileSize()+1);
-    stream->Read( &*contents.begin(), 1, contents.size()-1 );
-    contents[ contents.size() - 1 ] = 0;
-    const char* const begin = &*contents.begin();
+	// read entire file into memory - no streaming for this, fbx
+	// files can grow large, but the assimp output data structure
+	// then becomes very large, too. Assimp doesn't support
+	// streaming for its output data structures so the net win with
+	// streaming input data would be very low.
+	std::vector<char> contents;
+	contents.resize(stream->FileSize() + 1);
+	stream->Read(&*contents.begin(), 1, contents.size() - 1);
+	contents[contents.size() - 1] = 0;
+	const char *const begin = &*contents.begin();
 
-    // broadphase tokenizing pass in which we identify the core
-    // syntax elements of FBX (brackets, commas, key:value mappings)
-    TokenList tokens;
-    try {
+	// broadphase tokenizing pass in which we identify the core
+	// syntax elements of FBX (brackets, commas, key:value mappings)
+	TokenList tokens;
+	try {
 
-        bool is_binary = false;
-        if (!strncmp(begin,"Kaydara FBX Binary",18)) {
-            is_binary = true;
-            TokenizeBinary(tokens,begin,contents.size());
-        }
-        else {
-            Tokenize(tokens,begin);
-        }
+		bool is_binary = false;
+		if (!strncmp(begin, "Kaydara FBX Binary", 18)) {
+			is_binary = true;
+			TokenizeBinary(tokens, begin, contents.size());
+		} else {
+			Tokenize(tokens, begin);
+		}
 
-        // use this information to construct a very rudimentary
-        // parse-tree representing the FBX scope structure
-        Parser parser(tokens, is_binary);
+		// use this information to construct a very rudimentary
+		// parse-tree representing the FBX scope structure
+		Parser parser(tokens, is_binary);
 
-        // take the raw parse-tree and convert it to a FBX DOM
-        Document doc(parser,settings);
+		// take the raw parse-tree and convert it to a FBX DOM
+		Document doc(parser, settings);
 
-        // convert the FBX DOM to aiScene
-        ConvertToAssimpScene(pScene, doc, settings.removeEmptyBones);
+		// convert the FBX DOM to aiScene
+		ConvertToAssimpScene(pScene, doc, settings.removeEmptyBones);
 
-        // size relative to cm
-        float size_relative_to_cm = doc.GlobalSettings().UnitScaleFactor();
+		// size relative to cm
+		float size_relative_to_cm = doc.GlobalSettings().UnitScaleFactor();
 
-        // Set FBX file scale is relative to CM must be converted to M for
-        // assimp universal format (M)
-        SetFileScale( size_relative_to_cm * 0.01f);
+		// Set FBX file scale is relative to CM must be converted to M for
+		// assimp universal format (M)
+		SetFileScale(size_relative_to_cm * 0.01f);
 
-        std::for_each(tokens.begin(),tokens.end(),Util::delete_fun<Token>());
-    }
-    catch(std::exception&) {
-        std::for_each(tokens.begin(),tokens.end(),Util::delete_fun<Token>());
-        throw;
-    }
+		std::for_each(tokens.begin(), tokens.end(), Util::delete_fun<Token>());
+	} catch (std::exception &) {
+		std::for_each(tokens.begin(), tokens.end(), Util::delete_fun<Token>());
+		throw;
+	}
 }
 
 #endif // !ASSIMP_BUILD_NO_FBX_IMPORTER

--- a/include/assimp/mesh.h
+++ b/include/assimp/mesh.h
@@ -251,6 +251,9 @@ struct aiVertexWeight {
 #endif // __cplusplus
 };
 
+// forward declaration for aiNode pointers (not for anything else)
+struct ASSIMP_API aiNode;
+
 
 // ---------------------------------------------------------------------------
 /** @brief A single bone of a mesh.
@@ -268,6 +271,12 @@ struct aiBone {
     //! The maximum value for this member is #AI_MAX_BONE_WEIGHTS.
     unsigned int mNumWeights;
 
+    // The bone armature node - used for skeleton conversion
+    C_STRUCT aiNode* mArmature;
+
+    // The bone node in the scene - used for skeleton conversion
+    C_STRUCT aiNode* mNode;
+
     //! The influence weights of this bone, by vertex index.
     C_STRUCT aiVertexWeight* mWeights;
 
@@ -283,6 +292,11 @@ struct aiBone {
      * or inverse bind pose matrix.
      */
     C_STRUCT aiMatrix4x4 mOffsetMatrix;
+
+    /** Matrix used for the global rest transform
+     * This tells you directly the rest without extending as required in most game engine implementations
+     * */
+    C_STRUCT aiMatrix4x4 mRestMatrix;
 
 #ifdef __cplusplus
 
@@ -773,7 +787,10 @@ struct aiMesh
         // DO NOT REMOVE THIS ADDITIONAL CHECK
         if (mNumBones && mBones)    {
             for( unsigned int a = 0; a < mNumBones; a++) {
-                delete mBones[a];
+                if(mBones[a])
+                {
+                    delete mBones[a];
+                }
             }
             delete [] mBones;
         }


### PR DESCRIPTION
**Intended features:**
- Maintainable animation code in FBX (significantly lower technical debt)
- Pivot transforms as maya/3ds intended (blender doesn't care about these but to get maya/3ds fbx's imported properly we need this.)
- Unit tests which can prove this works
- Simpler transform building
- FBX Culling data retrievable at importer side to tell us if culling should be enabled/disabled

**This introduces frame truncation in animations:**
- This will not remove keyframes
- This properly declares animation stop and start times for FBX properly.

**Reasoning behind this:**
- artists add extra keyframes sometimes before/after animations which are normally disabled which they can optionally re-enable

**TODO:**
- Remove the rest of the dead code for pivots
- Re-implement pivot data on this branch
- Merge bone stack handling into this branch and armature handling
- Write unit tests for FBX importer to prove it works and update additional tests.


Co-authored-by: K. S. Ernest (iFire) Lee <ernest.lee@chibifire.com>