### PR TITLE
Update CXMLReaderImpl.h

### DIFF
--- a/contrib/irrXML/CXMLReaderImpl.h
+++ b/contrib/irrXML/CXMLReaderImpl.h
@@ -15,6 +15,9 @@
 #include <cstdint>
 //using namespace Assimp;
 
+// locale free float number convert
+#include <sstream>
+#include <locale>
 
 #ifdef _DEBUG
 #define IRR_DEBUGPRINT(x) printf((x));
@@ -178,8 +181,11 @@ public:
 			return 0;
 
 		core::stringc c = attrvalue;
-        return static_cast<float>(atof(c.c_str()));
-		//return fast_atof(c.c_str());
+		std::istringstream sstr(c.c_str());
+		sstr.imbue(std::locale("C")); // Locale free number convert
+		double d;
+		sstr >> d;
+		return static_cast<float>(d);
 	}
 
 


### PR DESCRIPTION
On German locales, the systems expects numbers like ##,## instead of ##.## .

This will make a centimeter unit of 0.01 equal to 0.0 and finally breaks our transformation matricies.
Someone with more knowledge about core::stringc might be able to beautify this workaround.