### PR TITLE
Update CXMLReaderImpl.h

### DIFF
--- a/contrib/irrXML/CXMLReaderImpl.h
+++ b/contrib/irrXML/CXMLReaderImpl.h
@@ -15,6 +15,9 @@
 #include <cstdint>
 //using namespace Assimp;
 
+// For locale independent number conversion
+#include <sstream>
+#include <locale>
 
 #ifdef _DEBUG
 #define IRR_DEBUGPRINT(x) printf((x));
@@ -178,8 +181,11 @@ public:
 			return 0;
 
 		core::stringc c = attrvalue;
-        return static_cast<float>(atof(c.c_str()));
-		//return fast_atof(c.c_str());
+		std::istringstream sstr(c.c_str());
+		sstr.imbue(std::locale("C")); // Locale free number convert
+		float fNum;
+		sstr >> fNum;
+		return fNum;
 	}
 
 


### PR DESCRIPTION
Issues with German locale number converter expecting German numbers.

In Germany we have numbers like #,## instead of #.## . Thus a unit conversion in COLLADA of 0.01 (centimeter) turned out to be 0.00.