### PR TITLE
BUG - use noexcept only for C++11 and more

### DIFF
--- a/include/assimp/defs.h
+++ b/include/assimp/defs.h
@@ -306,7 +306,11 @@ static const ai_real ai_epsilon = (ai_real) 0.00001;
 #define AI_MAX_ALLOC(type) ((256U * 1024 * 1024) / sizeof(type))
 
 #ifndef _MSC_VER
-#  define AI_NO_EXCEPT noexcept
+#  if __cplusplus >= 201103L // C++11
+#    define AI_NO_EXCEPT noexcept
+#  else
+#    define AI_NO_EXCEPT
+#  endif
 #else
 #  if (_MSC_VER >= 1915 )
 #    define AI_NO_EXCEPT noexcept


### PR DESCRIPTION
For C++98 setups, the compilation of some projects depending on assimp is failing due to the use of `noexcept` keyword on non-Windows compilers. This PR fixes the issue.