### PR TITLE
Add function aiGetVersionPatch() to be able to display Assimp version as in Git tags

### DIFF
--- a/code/Common/Version.cpp
+++ b/code/Common/Version.cpp
@@ -67,6 +67,12 @@ ASSIMP_API const char*  aiGetLegalString  ()    {
 }
 
 // ------------------------------------------------------------------------------------------------
+// Get Assimp patch version
+ASSIMP_API unsigned int aiGetVersionPatch() {
+	return VER_PATCH;
+}
+
+// ------------------------------------------------------------------------------------------------
 // Get Assimp minor version
 ASSIMP_API unsigned int aiGetVersionMinor ()    {
     return VER_MINOR;

--- a/include/assimp/version.h
+++ b/include/assimp/version.h
@@ -63,6 +63,13 @@ extern "C" {
 ASSIMP_API const char*  aiGetLegalString  (void);
 
 // ---------------------------------------------------------------------------
+/** @brief Returns the current patch version number of Assimp.
+ *  @return Patch version of the Assimp runtime the application was
+ *    linked/built against
+ */
+ASSIMP_API unsigned int aiGetVersionPatch(void);
+
+// ---------------------------------------------------------------------------
 /** @brief Returns the current minor version number of Assimp.
  *  @return Minor version of the Assimp runtime the application was
  *    linked/built against


### PR DESCRIPTION
Hello,

Currently it is only possible to display "Assimp 5.0 (commit XXXXXXX)". The patch version (3rd number) is missing. This pull request just adds a function to be able to display "Assimp 5.0.0 (commit XXXXXXX)" (or "Assimp 4.0.1 (commit eb8639d)" like the Git tag of 28th July 2017).

Loïc