### PR TITLE
[WIP] FBX Implemented full pivot support without fake transforms

### DIFF
--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -603,6 +603,7 @@ ADD_ASSIMP_IMPORTER( FBX
   FBX/FBXUtil.h
   FBX/FBXUtil.cpp
   FBX/FBXDocument.h
+  FBX/FBXPose.cpp
   FBX/FBXDocument.cpp
   FBX/FBXProperties.h
   FBX/FBXProperties.cpp

--- a/code/FBX/FBXAnimation.cpp
+++ b/code/FBX/FBXAnimation.cpp
@@ -51,6 +51,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "FBXDocument.h"
 #include "FBXImporter.h"
 #include "FBXDocumentUtil.h"
+#include <iostream>
 
 namespace Assimp {
 namespace FBX {
@@ -167,6 +168,7 @@ const AnimationCurveMap& AnimationCurveNode::Curves() const
         // resolve attached animation curves
         const std::vector<const Connection*>& conns = doc.GetConnectionsByDestinationSequenced(ID(),"AnimationCurve");
 
+        std::cout << "================== connection processing ======================" << std::endl;
         for(const Connection* con : conns) {
 
             // link should go for a property
@@ -176,19 +178,21 @@ const AnimationCurveMap& AnimationCurveNode::Curves() const
 
             const Object* const ob = con->SourceObject();
             if(!ob) {
-                DOMWarning("failed to read source object for AnimationCurve->AnimationCurveNode link, ignoring",&element);
+                DOMWarning("failed to read source object for AnimationCurve->AnimationCurveNode link, ignoring", &element);
                 continue;
             }
 
             const AnimationCurve* const anim = dynamic_cast<const AnimationCurve*>(ob);
             if(!anim) {
-                DOMWarning("source object for ->AnimationCurveNode link is not an AnimationCurve",&element);
+                DOMWarning("source object for ->AnimationCurveNode link is not an AnimationCurve", &element);
                 continue;
             }
-
+            //std::cout << "property found " << con->PropertyName() << std::endl;
             curves[con->PropertyName()] = anim;
         }
     }
+
+    
 
     return curves;
 }

--- a/code/FBX/FBXCommon.h
+++ b/code/FBX/FBXCommon.h
@@ -50,10 +50,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace Assimp {
 namespace FBX
 {
-    const std::string NULL_RECORD = { // 25 null bytes in 64-bit and 13 null bytes in 32-bit
-        '\0','\0','\0','\0','\0','\0','\0','\0','\0','\0','\0','\0','\0',
-        '\0','\0','\0','\0','\0','\0','\0','\0','\0','\0','\0','\0'
-    }; // who knows why, it looks like two integers 32/64 bit (compressed and uncompressed sizes?) + 1 byte (might be compression type?)
+    const std::string NULL_RECORD = { // 13 null bytes
+        '\0','\0','\0','\0','\0','\0','\0','\0','\0','\0','\0','\0','\0'
+    }; // who knows why
     const std::string SEPARATOR = {'\x00', '\x01'}; // for use inside strings
     const std::string MAGIC_NODE_TAG = "_$AssimpFbx$"; // from import
     const int64_t SECOND = 46186158000; // FBX's kTime unit

--- a/code/FBX/FBXConverter.cpp
+++ b/code/FBX/FBXConverter.cpp
@@ -47,3689 +47,3303 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef ASSIMP_BUILD_NO_FBX_IMPORTER
 
 #include "FBXConverter.h"
-#include "FBXParser.h"
-#include "FBXMeshGeometry.h"
 #include "FBXDocument.h"
-#include "FBXUtil.h"
-#include "FBXProperties.h"
 #include "FBXImporter.h"
+#include "FBXMeshGeometry.h"
+#include "FBXParser.h"
+#include "FBXProperties.h"
+#include "FBXUtil.h"
 
-#include <assimp/StringComparison.h>
 #include <assimp/MathFunctions.h>
+#include <assimp/StringComparison.h>
 
 #include <assimp/scene.h>
 
 #include <assimp/CreateAnimMesh.h>
-#include <assimp/commonMetaData.h>
-#include <assimp/StringUtils.h>
 
-#include <tuple>
-#include <memory>
-#include <iterator>
-#include <vector>
-#include <sstream>
-#include <iomanip>
-#include <cstdint>
-#include <iostream>
 #include <stdlib.h>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <iterator>
+#include <memory>
+#include <sstream>
+#include <tuple>
+#include <vector>
 
 namespace Assimp {
-    namespace FBX {
+namespace FBX {
 
-        using namespace Util;
-
-#define MAGIC_NODE_TAG "_$AssimpFbx$"
+using namespace Util;
 
 #define CONVERT_FBX_TIME(time) static_cast<double>(time) / 46186158000LL
 
-        FBXConverter::FBXConverter(aiScene* out, const Document& doc, bool removeEmptyBones )
-        : defaultMaterialIndex()
-        , lights()
-        , cameras()
-        , textures()
-        , materials_converted()
-        , textures_converted()
-        , meshes_converted()
-        , node_anim_chain_bits()
-        , mNodeNames()
-        , anim_fps()
-        , out(out)
-        , doc(doc) {
-            // animations need to be converted first since this will
-            // populate the node_anim_chain_bits map, which is needed
-            // to determine which nodes need to be generated.
-            ConvertAnimations();
-            // Embedded textures in FBX could be connected to nothing but to itself,
-            // for instance Texture -> Video connection only but not to the main graph,
-            // The idea here is to traverse all objects to find these Textures and convert them,
-            // so later during material conversion it will find converted texture in the textures_converted array.
-            if (doc.Settings().readTextures)
-            {
-                ConvertOrphantEmbeddedTextures();
-            }
-            ConvertRootNode();
+FBXConverter::FBXConverter(aiScene *out, const Document &doc, bool removeEmptyBones) :
+		defaultMaterialIndex(), lights(), cameras(), textures(), materials_converted(), textures_converted(), meshes_converted(), node_anim_chain_bits(), mNodeNames(), anim_fps(), out(out), doc(doc) {
+	// animations need to be converted first since this will
+	// populate the node_anim_chain_bits map, which is needed
+	// to determine which nodes need to be generated.
+	ConvertAnimations();
+	// Embedded textures in FBX could be connected to nothing but to itself,
+	// for instance Texture -> Video connection only but not to the main graph,
+	// The idea here is to traverse all objects to find these Textures and convert them,
+	// so later during material conversion it will find converted texture in the textures_converted array.
+	if (doc.Settings().readTextures) {
+		ConvertOrphantEmbeddedTextures();
+	}
+	ConvertRootNode();
 
-            if (doc.Settings().readAllMaterials) {
-                // unfortunately this means we have to evaluate all objects
-                for (const ObjectMap::value_type& v : doc.Objects()) {
+	if (doc.Settings().readAllMaterials) {
+		// unfortunately this means we have to evaluate all objects
+		for (const ObjectMap::value_type &v : doc.Objects()) {
 
-                    const Object* ob = v.second->Get();
-                    if (!ob) {
-                        continue;
-                    }
+			const Object *ob = v.second->Get();
+			if (!ob) {
+				continue;
+			}
 
-                    const Material* mat = dynamic_cast<const Material*>(ob);
-                    if (mat) {
+			const Material *mat = dynamic_cast<const Material *>(ob);
+			if (mat) {
 
-                        if (materials_converted.find(mat) == materials_converted.end()) {
-                            ConvertMaterial(*mat, 0);
-                        }
-                    }
-                }
-            }
+				if (materials_converted.find(mat) == materials_converted.end()) {
+					ConvertMaterial(*mat, 0);
+				}
+			}
+		}
+	}
 
-            ConvertGlobalSettings();
-            TransferDataToScene();
+	ConvertGlobalSettings();
+	TransferDataToScene();
 
-            // if we didn't read any meshes set the AI_SCENE_FLAGS_INCOMPLETE
-            // to make sure the scene passes assimp's validation. FBX files
-            // need not contain geometry (i.e. camera animations, raw armatures).
-            if (out->mNumMeshes == 0) {
-                out->mFlags |= AI_SCENE_FLAGS_INCOMPLETE;
-            }
-        }
+	// if we didn't read any meshes set the AI_SCENE_FLAGS_INCOMPLETE
+	// to make sure the scene passes assimp's validation. FBX files
+	// need not contain geometry (i.e. camera animations, raw armatures).
+	if (out->mNumMeshes == 0) {
+		out->mFlags |= AI_SCENE_FLAGS_INCOMPLETE;
+	}
+}
 
+FBXConverter::~FBXConverter() {
+	std::for_each(meshes.begin(), meshes.end(), Util::delete_fun<aiMesh>());
+	std::for_each(materials.begin(), materials.end(), Util::delete_fun<aiMaterial>());
+	std::for_each(animations.begin(), animations.end(), Util::delete_fun<aiAnimation>());
+	std::for_each(lights.begin(), lights.end(), Util::delete_fun<aiLight>());
+	std::for_each(cameras.begin(), cameras.end(), Util::delete_fun<aiCamera>());
+	std::for_each(textures.begin(), textures.end(), Util::delete_fun<aiTexture>());
+}
 
-        FBXConverter::~FBXConverter() {
-            std::for_each(meshes.begin(), meshes.end(), Util::delete_fun<aiMesh>());
-            std::for_each(materials.begin(), materials.end(), Util::delete_fun<aiMaterial>());
-            std::for_each(animations.begin(), animations.end(), Util::delete_fun<aiAnimation>());
-            std::for_each(lights.begin(), lights.end(), Util::delete_fun<aiLight>());
-            std::for_each(cameras.begin(), cameras.end(), Util::delete_fun<aiCamera>());
-            std::for_each(textures.begin(), textures.end(), Util::delete_fun<aiTexture>());
-        }
+void FBXConverter::ConvertRootNode() {
+	out->mRootNode = new aiNode();
+	std::string unique_name;
+	GetUniqueName("RootNode", unique_name);
+	out->mRootNode->mName.Set(unique_name);
+	// populate our node animation stack lookup tool
+	GenerateAnimStack();
+	CacheNodeInformation(0L);
+	// root has ID 0
+	ConvertNodes(0L, out->mRootNode, out->mRootNode, aiMatrix4x4(), aiMatrix4x4());
+}
 
-        void FBXConverter::ConvertRootNode() {
-            out->mRootNode = new aiNode();
-            std::string unique_name;
-            GetUniqueName("RootNode", unique_name);
-            out->mRootNode->mName.Set(unique_name);
+static std::string getAncestorBaseName(const aiNode *node) {
+	const char *nodeName = nullptr;
+	size_t length = 0;
+	while (node && (!nodeName || length == 0)) {
+		nodeName = node->mName.C_Str();
+		length = node->mName.length;
+		node = node->mParent;
+	}
 
-            // root has ID 0
-            ConvertNodes(0L, out->mRootNode, out->mRootNode);
-        }
+	if (!nodeName || length == 0) {
+		return {};
+	}
+	// could be std::string_view if c++17 available
+	return std::string(nodeName, length);
+}
 
-        static std::string getAncestorBaseName(const aiNode* node)
+// Make unique name
+std::string FBXConverter::MakeUniqueNodeName(const Model *const model, const aiNode &parent) {
+	std::string original_name = FixNodeName(model->Name());
+	if (original_name.empty()) {
+		original_name = getAncestorBaseName(&parent);
+	}
+	std::string unique_name;
+	GetUniqueName(original_name, unique_name);
+	return unique_name;
+}
+
+void FBXConverter::GenerateAnimStack() {
+
+	for (aiAnimation* animation : animations) {
+		std::vector<aiNodeAnim *> nodes;
+		for (unsigned int nodeId = 0; nodeId < animation->mNumChannels; ++nodeId) {
+			aiNodeAnim *node_anim = animation->mChannels[nodeId];
+			nodes.push_back(node_anim);
+		}
+
+	}
+}
+
+std::vector<aiNodeAnim *> FBXConverter::GetNodeAnimsFromStack(const std::string &node_name) {
+
+	std::vector<aiNodeAnim *> list;
+
+	for (std::pair<aiAnimation *, std::vector<aiNodeAnim *> > pair : animation_stack) {
+
+		bool found_erase = false;
+		std::vector<aiNodeAnim *>::iterator iter;
+
+		for (iter = pair.second.begin(); iter != pair.second.end(); ++iter) {
+			aiNodeAnim *anim = *iter;
+			if (anim->mNodeName.C_Str() == node_name) {
+				std::cout << "added animation to GetNodeAnimsFromStack" << std::endl;
+				list.push_back(anim);
+				found_erase = true;
+				break;
+			}
+		}
+
+		// we have stored our value from stack we now must erase it
+		if (found_erase) {
+			std::cout << "found valid animation for stack erasing from stack: " << (*iter)->mNodeName.C_Str() << std::endl;
+			pair.second.erase(iter);
+		}
+	}
+
+	std::cout << "animation stack size: " << list.size() << std::endl;
+
+	return list;
+}
+
+void FBXConverter::ResampleAnimationsWithPivots(int64_t targetId, aiMatrix4x4 transform) {
+
+	// resample all animations, but only sample the nodes which we are looking for from the stack.
+	for (std::pair<aiNodeAnim*, int64_t> kvp : anim_target_map) {
+	    if(kvp.second != targetId)
         {
-            const char* nodeName = nullptr;
-            size_t length = 0;
-            while (node && (!nodeName || length == 0))
-            {
-                nodeName = node->mName.C_Str();
-                length = node->mName.length;
-                node = node->mParent;
-            }
-
-            if (!nodeName || length == 0)
-            {
-                return {};
-            }
-            // could be std::string_view if c++17 available
-            return std::string(nodeName, length);
+	        continue;
         }
 
-        // Make unique name
-        std::string FBXConverter::MakeUniqueNodeName(const Model* const model, const aiNode& parent)
+	    if(std::find(resampled_anim.begin(), resampled_anim.end(), targetId) != resampled_anim.end())
         {
-            std::string original_name = FixNodeName(model->Name());
-            if (original_name.empty())
-            {
-                original_name = getAncestorBaseName(&parent);
-            }
-            std::string unique_name;
-            GetUniqueName(original_name, unique_name);
-            return unique_name;
-        }
-        /// todo: pre-build node hierarchy
-        /// todo: get bone from stack
-        /// todo: make map of aiBone* to aiNode*
-        /// then update convert clusters to the new format
-        void FBXConverter::ConvertNodes(uint64_t id, aiNode *parent, aiNode *root_node) {
-            const std::vector<const Connection*>& conns = doc.GetConnectionsByDestinationSequenced(id, "Model");
-
-            std::vector<aiNode*> nodes;
-            nodes.reserve(conns.size());
-
-            std::vector<aiNode*> nodes_chain;
-            std::vector<aiNode*> post_nodes_chain;
-
-            try {
-                for (const Connection* con : conns) {
-                    // ignore object-property links
-                    if (con->PropertyName().length()) {
-                        // really important we document why this is ignored.
-                        FBXImporter::LogInfo("ignoring property link - no docs on why this is ignored");
-                        continue; //?
-                    }
-
-                    // convert connection source object into Object base class
-                    const Object* const object = con->SourceObject();
-                    if (nullptr == object) {
-                        FBXImporter::LogError("failed to convert source object for Model link");
-                        continue;
-                    }
-
-                    // FBX Model::Cube, Model::Bone001, etc elements
-                    // This detects if we can cast the object into this model structure.
-                    const Model* const model = dynamic_cast<const Model*>(object);
-
-                    if (nullptr != model) {
-                        nodes_chain.clear();
-                        post_nodes_chain.clear();
-
-                        aiMatrix4x4 new_abs_transform = parent->mTransformation;
-                        std::string node_name = FixNodeName(model->Name());
-                        // even though there is only a single input node, the design of
-                        // assimp (or rather: the complicated transformation chain that
-                        // is employed by fbx) means that we may need multiple aiNode's
-                        // to represent a fbx node's transformation.
-
-
-                        // generate node transforms - this includes pivot data
-                        // if need_additional_node is true then you t
-                        const bool need_additional_node = GenerateTransformationNodeChain(*model, node_name, nodes_chain, post_nodes_chain);
-
-                        // assert that for the current node we must have at least a single transform
-                        ai_assert(nodes_chain.size());
-
-                        if (need_additional_node) {
-                            nodes_chain.push_back(new aiNode(node_name));
-                        }
-
-                        //setup metadata on newest node
-                        SetupNodeMetadata(*model, *nodes_chain.back());
-
-                        // link all nodes in a row
-                        aiNode* last_parent = parent;
-                        for (aiNode* child : nodes_chain) {
-                            ai_assert(child);
-
-                            if (last_parent != parent) {
-                                last_parent->mNumChildren = 1;
-                                last_parent->mChildren = new aiNode*[1];
-                                last_parent->mChildren[0] = child;
-                            }
-
-                            child->mParent = last_parent;
-                            last_parent = child;
-
-                            new_abs_transform *= child->mTransformation;
-                        }
-
-                        // attach geometry
-                        ConvertModel(*model, nodes_chain.back(), root_node, new_abs_transform);
-
-                        // check if there will be any child nodes
-                        const std::vector<const Connection*>& child_conns
-                            = doc.GetConnectionsByDestinationSequenced(model->ID(), "Model");
-
-                        // if so, link the geometric transform inverse nodes
-                        // before we attach any child nodes
-                        if (child_conns.size()) {
-                            for (aiNode* postnode : post_nodes_chain) {
-                                ai_assert(postnode);
-
-                                if (last_parent != parent) {
-                                    last_parent->mNumChildren = 1;
-                                    last_parent->mChildren = new aiNode*[1];
-                                    last_parent->mChildren[0] = postnode;
-                                }
-
-                                postnode->mParent = last_parent;
-                                last_parent = postnode;
-
-                                new_abs_transform *= postnode->mTransformation;
-                            }
-                        }
-                        else {
-                            // free the nodes we allocated as we don't need them
-                            Util::delete_fun<aiNode> deleter;
-                            std::for_each(
-                                post_nodes_chain.begin(),
-                                post_nodes_chain.end(),
-                                deleter
-                            );
-                        }
-
-                        // recursion call - child nodes
-                        ConvertNodes(model->ID(), last_parent, root_node);
-
-                        if (doc.Settings().readLights) {
-                            ConvertLights(*model, node_name);
-                        }
-
-                        if (doc.Settings().readCameras) {
-                            ConvertCameras(*model, node_name);
-                        }
-
-                        nodes.push_back(nodes_chain.front());
-                        nodes_chain.clear();
-                    }
-                }
-
-                if (nodes.size()) {
-                    parent->mChildren = new aiNode*[nodes.size()]();
-                    parent->mNumChildren = static_cast<unsigned int>(nodes.size());
-
-                    std::swap_ranges(nodes.begin(), nodes.end(), parent->mChildren);
-                }
-                else
-                {
-                    parent->mNumChildren = 0;
-                    parent->mChildren = nullptr;
-                }
-                
-            }
-            catch (std::exception&) {
-                Util::delete_fun<aiNode> deleter;
-                std::for_each(nodes.begin(), nodes.end(), deleter);
-                std::for_each(nodes_chain.begin(), nodes_chain.end(), deleter);
-                std::for_each(post_nodes_chain.begin(), post_nodes_chain.end(), deleter);
-            }
+            std::cerr << "prevented duplicate resampling" << std::endl;
+	        continue;
         }
 
+	    std::cerr << "Resampling target " << targetId << " to pivot point." << std::endl;
 
-        void FBXConverter::ConvertLights(const Model& model, const std::string &orig_name) {
-            const std::vector<const NodeAttribute*>& node_attrs = model.GetAttributes();
-            for (const NodeAttribute* attr : node_attrs) {
-                const Light* const light = dynamic_cast<const Light*>(attr);
-                if (light) {
-                    ConvertLight(*light, orig_name);
-                }
-            }
-        }
+	    aiNodeAnim * node_anim = kvp.first;
+        // todo: fix this crashing use interpolate key logic here (lerp only)
+        // why: this causes meshes to explode currently if we resample during import we can remove
+        // this step entirely :)
+        // flip check below to increase compat
+        //if(node_anim->mNumPositionKeys == node_anim->mNumRotationKeys == node_anim->mNumScalingKeys) {
+        if(true) {
+            // now iterate and resample animations
+            for (unsigned int x = 0; x < node_anim->mNumPositionKeys; ++x) {
+                // todo: make this into interpolated keyframe
+                // todo: or make this import properly :D during the anim phase
+                aiQuaternion rot = node_anim->mRotationKeys[x].mValue;
+                aiVector3D scale = node_anim->mScalingKeys[x].mValue;
+                aiVector3D trans = node_anim->mPositionKeys[x].mValue;
 
-        void FBXConverter::ConvertCameras(const Model& model, const std::string &orig_name) {
-            const std::vector<const NodeAttribute*>& node_attrs = model.GetAttributes();
-            for (const NodeAttribute* attr : node_attrs) {
-                const Camera* const cam = dynamic_cast<const Camera*>(attr);
-                if (cam) {
-                    ConvertCamera(*cam, orig_name);
-                }
-            }
-        }
+                // TRS
+                aiMatrix4x4 final_matrix = aiMatrix4x4(scale, rot, trans);
+                std::cout << "anim node name: " << node_anim->mNodeName.C_Str() << std::endl;
 
-        void FBXConverter::ConvertLight(const Light& light, const std::string &orig_name) {
-            lights.push_back(new aiLight());
-            aiLight* const out_light = lights.back();
-
-            out_light->mName.Set(orig_name);
-
-            const float intensity = light.Intensity() / 100.0f;
-            const aiVector3D& col = light.Color();
-
-            out_light->mColorDiffuse = aiColor3D(col.x, col.y, col.z);
-            out_light->mColorDiffuse.r *= intensity;
-            out_light->mColorDiffuse.g *= intensity;
-            out_light->mColorDiffuse.b *= intensity;
-
-            out_light->mColorSpecular = out_light->mColorDiffuse;
-
-            //lights are defined along negative y direction
-            out_light->mPosition = aiVector3D(0.0f);
-            out_light->mDirection = aiVector3D(0.0f, -1.0f, 0.0f);
-            out_light->mUp = aiVector3D(0.0f, 0.0f, -1.0f);
-
-            switch (light.LightType())
-            {
-            case Light::Type_Point:
-                out_light->mType = aiLightSource_POINT;
-                break;
-
-            case Light::Type_Directional:
-                out_light->mType = aiLightSource_DIRECTIONAL;
-                break;
-
-            case Light::Type_Spot:
-                out_light->mType = aiLightSource_SPOT;
-                out_light->mAngleOuterCone = AI_DEG_TO_RAD(light.OuterAngle());
-                out_light->mAngleInnerCone = AI_DEG_TO_RAD(light.InnerAngle());
-                break;
-
-            case Light::Type_Area:
-                FBXImporter::LogWarn("cannot represent area light, set to UNDEFINED");
-                out_light->mType = aiLightSource_UNDEFINED;
-                break;
-
-            case Light::Type_Volume:
-                FBXImporter::LogWarn("cannot represent volume light, set to UNDEFINED");
-                out_light->mType = aiLightSource_UNDEFINED;
-                break;
-            default:
-                ai_assert(false);
-            }
-
-            float decay = light.DecayStart();
-            switch (light.DecayType())
-            {
-            case Light::Decay_None:
-                out_light->mAttenuationConstant = decay;
-                out_light->mAttenuationLinear = 0.0f;
-                out_light->mAttenuationQuadratic = 0.0f;
-                break;
-            case Light::Decay_Linear:
-                out_light->mAttenuationConstant = 0.0f;
-                out_light->mAttenuationLinear = 2.0f / decay;
-                out_light->mAttenuationQuadratic = 0.0f;
-                break;
-            case Light::Decay_Quadratic:
-                out_light->mAttenuationConstant = 0.0f;
-                out_light->mAttenuationLinear = 0.0f;
-                out_light->mAttenuationQuadratic = 2.0f / (decay * decay);
-                break;
-            case Light::Decay_Cubic:
-                FBXImporter::LogWarn("cannot represent cubic attenuation, set to Quadratic");
-                out_light->mAttenuationQuadratic = 1.0f;
-                break;
-            default:
-                ai_assert(false);
-                break;
-            }
-        }
-
-        void FBXConverter::ConvertCamera(const Camera& cam, const std::string &orig_name)
-        {
-            cameras.push_back(new aiCamera());
-            aiCamera* const out_camera = cameras.back();
-
-            out_camera->mName.Set(orig_name);
-
-            out_camera->mAspect = cam.AspectWidth() / cam.AspectHeight();
-
-            out_camera->mPosition = aiVector3D(0.0f);
-            out_camera->mLookAt = aiVector3D(1.0f, 0.0f, 0.0f);
-            out_camera->mUp = aiVector3D(0.0f, 1.0f, 0.0f);
-
-            out_camera->mHorizontalFOV = AI_DEG_TO_RAD(cam.FieldOfView());
-
-            out_camera->mClipPlaneNear = cam.NearPlane();
-            out_camera->mClipPlaneFar = cam.FarPlane();
-
-            out_camera->mHorizontalFOV = AI_DEG_TO_RAD(cam.FieldOfView());
-            out_camera->mClipPlaneNear = cam.NearPlane();
-            out_camera->mClipPlaneFar = cam.FarPlane();
-        }
-
-        void FBXConverter::GetUniqueName(const std::string &name, std::string &uniqueName)
-        {
-            uniqueName = name;
-            auto it_pair = mNodeNames.insert({ name, 0 }); // duplicate node name instance count
-            unsigned int& i = it_pair.first->second;
-            while (!it_pair.second)
-            {
-                i++;
-                std::ostringstream ext;
-                ext << name << std::setfill('0') << std::setw(3) << i;
-                uniqueName = ext.str();
-                it_pair = mNodeNames.insert({ uniqueName, 0 });
-            }
-        }
-
-        const char* FBXConverter::NameTransformationComp(TransformationComp comp) {
-            switch (comp) {
-            case TransformationComp_Translation:
-                return "Translation";
-            case TransformationComp_RotationOffset:
-                return "RotationOffset";
-            case TransformationComp_RotationPivot:
-                return "RotationPivot";
-            case TransformationComp_PreRotation:
-                return "PreRotation";
-            case TransformationComp_Rotation:
-                return "Rotation";
-            case TransformationComp_PostRotation:
-                return "PostRotation";
-            case TransformationComp_RotationPivotInverse:
-                return "RotationPivotInverse";
-            case TransformationComp_ScalingOffset:
-                return "ScalingOffset";
-            case TransformationComp_ScalingPivot:
-                return "ScalingPivot";
-            case TransformationComp_Scaling:
-                return "Scaling";
-            case TransformationComp_ScalingPivotInverse:
-                return "ScalingPivotInverse";
-            case TransformationComp_GeometricScaling:
-                return "GeometricScaling";
-            case TransformationComp_GeometricRotation:
-                return "GeometricRotation";
-            case TransformationComp_GeometricTranslation:
-                return "GeometricTranslation";
-            case TransformationComp_GeometricScalingInverse:
-                return "GeometricScalingInverse";
-            case TransformationComp_GeometricRotationInverse:
-                return "GeometricRotationInverse";
-            case TransformationComp_GeometricTranslationInverse:
-                return "GeometricTranslationInverse";
-            case TransformationComp_MAXIMUM: // this is to silence compiler warnings
-            default:
-                break;
-            }
-
-            ai_assert(false);
-
-            return nullptr;
-        }
-
-        const char* FBXConverter::NameTransformationCompProperty(TransformationComp comp) {
-            switch (comp) {
-            case TransformationComp_Translation:
-                return "Lcl Translation";
-            case TransformationComp_RotationOffset:
-                return "RotationOffset";
-            case TransformationComp_RotationPivot:
-                return "RotationPivot";
-            case TransformationComp_PreRotation:
-                return "PreRotation";
-            case TransformationComp_Rotation:
-                return "Lcl Rotation";
-            case TransformationComp_PostRotation:
-                return "PostRotation";
-            case TransformationComp_RotationPivotInverse:
-                return "RotationPivotInverse";
-            case TransformationComp_ScalingOffset:
-                return "ScalingOffset";
-            case TransformationComp_ScalingPivot:
-                return "ScalingPivot";
-            case TransformationComp_Scaling:
-                return "Lcl Scaling";
-            case TransformationComp_ScalingPivotInverse:
-                return "ScalingPivotInverse";
-            case TransformationComp_GeometricScaling:
-                return "GeometricScaling";
-            case TransformationComp_GeometricRotation:
-                return "GeometricRotation";
-            case TransformationComp_GeometricTranslation:
-                return "GeometricTranslation";
-            case TransformationComp_GeometricScalingInverse:
-                return "GeometricScalingInverse";
-            case TransformationComp_GeometricRotationInverse:
-                return "GeometricRotationInverse";
-            case TransformationComp_GeometricTranslationInverse:
-                return "GeometricTranslationInverse";
-            case TransformationComp_MAXIMUM: // this is to silence compiler warnings
-                break;
-            }
-
-            ai_assert(false);
-
-            return nullptr;
-        }
-
-        aiVector3D FBXConverter::TransformationCompDefaultValue(TransformationComp comp)
-        {
-            // XXX a neat way to solve the never-ending special cases for scaling
-            // would be to do everything in log space!
-            return comp == TransformationComp_Scaling ? aiVector3D(1.f, 1.f, 1.f) : aiVector3D();
-        }
-
-        void FBXConverter::GetRotationMatrix(Model::RotOrder mode, const aiVector3D& rotation, aiMatrix4x4& out)
-        {
-            if (mode == Model::RotOrder_SphericXYZ) {
-                FBXImporter::LogError("Unsupported RotationMode: SphericXYZ");
-                out = aiMatrix4x4();
-                return;
-            }
-
-            const float angle_epsilon = Math::getEpsilon<float>();
-
-            out = aiMatrix4x4();
-
-            bool is_id[3] = { true, true, true };
-
-            aiMatrix4x4 temp[3];
-            if (std::fabs(rotation.z) > angle_epsilon) {
-                aiMatrix4x4::RotationZ(AI_DEG_TO_RAD(rotation.z), temp[2]);
-                is_id[2] = false;
-            }
-            if (std::fabs(rotation.y) > angle_epsilon) {
-                aiMatrix4x4::RotationY(AI_DEG_TO_RAD(rotation.y), temp[1]);
-                is_id[1] = false;
-            }
-            if (std::fabs(rotation.x) > angle_epsilon) {
-                aiMatrix4x4::RotationX(AI_DEG_TO_RAD(rotation.x), temp[0]);
-                is_id[0] = false;
-            }
-
-            int order[3] = { -1, -1, -1 };
-
-            // note: rotation order is inverted since we're left multiplying as is usual in assimp
-            switch (mode)
-            {
-            case Model::RotOrder_EulerXYZ:
-                order[0] = 2;
-                order[1] = 1;
-                order[2] = 0;
-                break;
-
-            case Model::RotOrder_EulerXZY:
-                order[0] = 1;
-                order[1] = 2;
-                order[2] = 0;
-                break;
-
-            case Model::RotOrder_EulerYZX:
-                order[0] = 0;
-                order[1] = 2;
-                order[2] = 1;
-                break;
-
-            case Model::RotOrder_EulerYXZ:
-                order[0] = 2;
-                order[1] = 0;
-                order[2] = 1;
-                break;
-
-            case Model::RotOrder_EulerZXY:
-                order[0] = 1;
-                order[1] = 0;
-                order[2] = 2;
-                break;
-
-            case Model::RotOrder_EulerZYX:
-                order[0] = 0;
-                order[1] = 1;
-                order[2] = 2;
-                break;
-
-            default:
-                ai_assert(false);
-                break;
-            }
-
-            ai_assert(order[0] >= 0);
-            ai_assert(order[0] <= 2);
-            ai_assert(order[1] >= 0);
-            ai_assert(order[1] <= 2);
-            ai_assert(order[2] >= 0);
-            ai_assert(order[2] <= 2);
-
-            if (!is_id[order[0]]) {
-                out = temp[order[0]];
-            }
-
-            if (!is_id[order[1]]) {
-                out = out * temp[order[1]];
-            }
-
-            if (!is_id[order[2]]) {
-                out = out * temp[order[2]];
-            }
-        }
-
-        bool FBXConverter::NeedsComplexTransformationChain(const Model& model)
-        {
-            const PropertyTable& props = model.Props();
-            bool ok;
-
-            const float zero_epsilon = 1e-6f;
-            const aiVector3D all_ones(1.0f, 1.0f, 1.0f);
-            for (size_t i = 0; i < TransformationComp_MAXIMUM; ++i) {
-                const TransformationComp comp = static_cast<TransformationComp>(i);
-
-                if (comp == TransformationComp_Rotation || comp == TransformationComp_Scaling || comp == TransformationComp_Translation) {
+                // grab target mapping to determine if bone
+                int64_t internal_target_id = anim_target_map[node_anim];
+                std::cerr << "internal id: " << internal_target_id << std::endl;
+                if (IsBone(internal_target_id)) {
+                    std::cerr << "bone animation re-sample logic [skipping]" << std::endl;
                     continue;
+                } else {
+                    std::cerr << "normal aiNode detected" << std::endl;
+
                 }
+                final_matrix = transform * final_matrix;
+                final_matrix.Decompose(scale, rot, trans);
 
-                bool scale_compare = (comp == TransformationComp_GeometricScaling || comp == TransformationComp_Scaling);
-
-                const aiVector3D& v = PropertyGet<aiVector3D>(props, NameTransformationCompProperty(comp), ok);
-                if (ok && scale_compare) {
-                    if ((v - all_ones).SquareLength() > zero_epsilon) {
-                        return true;
-                    }
-                } else if (ok) {
-                    if (v.SquareLength() > zero_epsilon) {
-                        return true;
-                    }
-                }
-            }
-
-            return false;
-        }
-
-        std::string FBXConverter::NameTransformationChainNode(const std::string& name, TransformationComp comp)
-        {
-            return name + std::string(MAGIC_NODE_TAG) + "_" + NameTransformationComp(comp);
-        }
-
-        bool FBXConverter::GenerateTransformationNodeChain(const Model& model, const std::string& name, std::vector<aiNode*>& output_nodes,
-            std::vector<aiNode*>& post_output_nodes) {
-            const PropertyTable& props = model.Props();
-            const Model::RotOrder rot = model.RotationOrder();
-
-            bool ok;
-
-            aiMatrix4x4 chain[TransformationComp_MAXIMUM];
-
-            ai_assert(TransformationComp_MAXIMUM < 32);
-            std::uint32_t chainBits = 0;
-            // A node won't need a node chain if it only has these.
-            const std::uint32_t chainMaskSimple = (1 << TransformationComp_Translation) + (1 << TransformationComp_Scaling) + (1 << TransformationComp_Rotation);
-            // A node will need a node chain if it has any of these.
-            const std::uint32_t chainMaskComplex = ((1 << (TransformationComp_MAXIMUM)) - 1) - chainMaskSimple;
-
-            std::fill_n(chain, static_cast<unsigned int>(TransformationComp_MAXIMUM), aiMatrix4x4());
-
-            // generate transformation matrices for all the different transformation components
-            const float zero_epsilon = Math::getEpsilon<float>();
-            const aiVector3D all_ones(1.0f, 1.0f, 1.0f);
-
-            const aiVector3D& PreRotation = PropertyGet<aiVector3D>(props, "PreRotation", ok);
-            if (ok && PreRotation.SquareLength() > zero_epsilon) {
-                chainBits = chainBits | (1 << TransformationComp_PreRotation);
-
-                GetRotationMatrix(Model::RotOrder::RotOrder_EulerXYZ, PreRotation, chain[TransformationComp_PreRotation]);
-            }
-
-            const aiVector3D& PostRotation = PropertyGet<aiVector3D>(props, "PostRotation", ok);
-            if (ok && PostRotation.SquareLength() > zero_epsilon) {
-                chainBits = chainBits | (1 << TransformationComp_PostRotation);
-
-                GetRotationMatrix(Model::RotOrder::RotOrder_EulerXYZ, PostRotation, chain[TransformationComp_PostRotation]);
-            }
-
-            const aiVector3D& RotationPivot = PropertyGet<aiVector3D>(props, "RotationPivot", ok);
-            if (ok && RotationPivot.SquareLength() > zero_epsilon) {
-                chainBits = chainBits | (1 << TransformationComp_RotationPivot) | (1 << TransformationComp_RotationPivotInverse);
-
-                aiMatrix4x4::Translation(RotationPivot, chain[TransformationComp_RotationPivot]);
-                aiMatrix4x4::Translation(-RotationPivot, chain[TransformationComp_RotationPivotInverse]);
-            }
-
-            const aiVector3D& RotationOffset = PropertyGet<aiVector3D>(props, "RotationOffset", ok);
-            if (ok && RotationOffset.SquareLength() > zero_epsilon) {
-                chainBits = chainBits | (1 << TransformationComp_RotationOffset);
-
-                aiMatrix4x4::Translation(RotationOffset, chain[TransformationComp_RotationOffset]);
-            }
-
-            const aiVector3D& ScalingOffset = PropertyGet<aiVector3D>(props, "ScalingOffset", ok);
-            if (ok && ScalingOffset.SquareLength() > zero_epsilon) {
-                chainBits = chainBits | (1 << TransformationComp_ScalingOffset);
-
-                aiMatrix4x4::Translation(ScalingOffset, chain[TransformationComp_ScalingOffset]);
-            }
-
-            const aiVector3D& ScalingPivot = PropertyGet<aiVector3D>(props, "ScalingPivot", ok);
-            if (ok && ScalingPivot.SquareLength() > zero_epsilon) {
-                chainBits = chainBits | (1 << TransformationComp_ScalingPivot) | (1 << TransformationComp_ScalingPivotInverse);
-
-                aiMatrix4x4::Translation(ScalingPivot, chain[TransformationComp_ScalingPivot]);
-                aiMatrix4x4::Translation(-ScalingPivot, chain[TransformationComp_ScalingPivotInverse]);
-            }
-
-            const aiVector3D& Translation = PropertyGet<aiVector3D>(props, "Lcl Translation", ok);
-            if (ok && Translation.SquareLength() > zero_epsilon) {
-                chainBits = chainBits | (1 << TransformationComp_Translation);
-
-                aiMatrix4x4::Translation(Translation, chain[TransformationComp_Translation]);
-            }
-
-            const aiVector3D& Scaling = PropertyGet<aiVector3D>(props, "Lcl Scaling", ok);
-            if (ok && (Scaling - all_ones).SquareLength() > zero_epsilon) {
-                chainBits = chainBits | (1 << TransformationComp_Scaling);
-
-                aiMatrix4x4::Scaling(Scaling, chain[TransformationComp_Scaling]);
-            }
-
-            const aiVector3D& Rotation = PropertyGet<aiVector3D>(props, "Lcl Rotation", ok);
-            if (ok && Rotation.SquareLength() > zero_epsilon) {
-                chainBits = chainBits | (1 << TransformationComp_Rotation);
-
-                GetRotationMatrix(rot, Rotation, chain[TransformationComp_Rotation]);
-            }
-
-            const aiVector3D& GeometricScaling = PropertyGet<aiVector3D>(props, "GeometricScaling", ok);
-            if (ok && (GeometricScaling - all_ones).SquareLength() > zero_epsilon) {
-                chainBits = chainBits | (1 << TransformationComp_GeometricScaling);
-                aiMatrix4x4::Scaling(GeometricScaling, chain[TransformationComp_GeometricScaling]);
-                aiVector3D GeometricScalingInverse = GeometricScaling;
-                bool canscale = true;
-                for (unsigned int i = 0; i < 3; ++i) {
-                    if (std::fabs(GeometricScalingInverse[i]) > zero_epsilon) {
-                        GeometricScalingInverse[i] = 1.0f / GeometricScaling[i];
-                    }
-                    else {
-                        FBXImporter::LogError("cannot invert geometric scaling matrix with a 0.0 scale component");
-                        canscale = false;
-                        break;
-                    }
-                }
-                if (canscale) {
-                    chainBits = chainBits | (1 << TransformationComp_GeometricScalingInverse);
-                    aiMatrix4x4::Scaling(GeometricScalingInverse, chain[TransformationComp_GeometricScalingInverse]);
-                }
-            }
-
-            const aiVector3D& GeometricRotation = PropertyGet<aiVector3D>(props, "GeometricRotation", ok);
-            if (ok && GeometricRotation.SquareLength() > zero_epsilon) {
-                chainBits = chainBits | (1 << TransformationComp_GeometricRotation) | (1 << TransformationComp_GeometricRotationInverse);
-                GetRotationMatrix(rot, GeometricRotation, chain[TransformationComp_GeometricRotation]);
-                GetRotationMatrix(rot, GeometricRotation, chain[TransformationComp_GeometricRotationInverse]);
-                chain[TransformationComp_GeometricRotationInverse].Inverse();
-            }
-
-            const aiVector3D& GeometricTranslation = PropertyGet<aiVector3D>(props, "GeometricTranslation", ok);
-            if (ok && GeometricTranslation.SquareLength() > zero_epsilon) {
-                chainBits = chainBits | (1 << TransformationComp_GeometricTranslation) | (1 << TransformationComp_GeometricTranslationInverse);
-                aiMatrix4x4::Translation(GeometricTranslation, chain[TransformationComp_GeometricTranslation]);
-                aiMatrix4x4::Translation(-GeometricTranslation, chain[TransformationComp_GeometricTranslationInverse]);
-            }
-
-            // is_complex needs to be consistent with NeedsComplexTransformationChain()
-            // or the interplay between this code and the animation converter would
-            // not be guaranteed.
-            //ai_assert(NeedsComplexTransformationChain(model) == ((chainBits & chainMaskComplex) != 0));
-
-            // now, if we have more than just Translation, Scaling and Rotation,
-            // we need to generate a full node chain to accommodate for assimp's
-            // lack to express pivots and offsets.
-            if ((chainBits & chainMaskComplex) && doc.Settings().preservePivots) {
-                FBXImporter::LogInfo("generating full transformation chain for node: " + name);
-
-                // query the anim_chain_bits dictionary to find out which chain elements
-                // have associated node animation channels. These can not be dropped
-                // even if they have identity transform in bind pose.
-                NodeAnimBitMap::const_iterator it = node_anim_chain_bits.find(name);
-                const unsigned int anim_chain_bitmask = (it == node_anim_chain_bits.end() ? 0 : (*it).second);
-
-                unsigned int bit = 0x1;
-                for (size_t i = 0; i < TransformationComp_MAXIMUM; ++i, bit <<= 1) {
-                    const TransformationComp comp = static_cast<TransformationComp>(i);
-
-                    if ((chainBits & bit) == 0 && (anim_chain_bitmask & bit) == 0) {
-                        continue;
-                    }
-
-                    if (comp == TransformationComp_PostRotation) {
-                        chain[i] = chain[i].Inverse();
-                    }
-
-                    aiNode* nd = new aiNode();
-                    nd->mName.Set(NameTransformationChainNode(name, comp));
-                    nd->mTransformation = chain[i];
-
-                    // geometric inverses go in a post-node chain
-                    if (comp == TransformationComp_GeometricScalingInverse ||
-                        comp == TransformationComp_GeometricRotationInverse ||
-                        comp == TransformationComp_GeometricTranslationInverse
-                        ) {
-                        post_output_nodes.push_back(nd);
-                    }
-                    else {
-                        output_nodes.push_back(nd);
-                    }
-                }
-
-                ai_assert(output_nodes.size());
-                return true;
-            }
-
-            // else, we can just multiply the matrices together
-            aiNode* nd = new aiNode();
-            output_nodes.push_back(nd);
-
-            // name passed to the method is already unique
-            nd->mName.Set(name);
-
-            for (const auto &transform : chain) {
-                nd->mTransformation = nd->mTransformation * transform;
-            }
-            return false;
-        }
-
-        void FBXConverter::SetupNodeMetadata(const Model& model, aiNode& nd)
-        {
-            const PropertyTable& props = model.Props();
-            DirectPropertyMap unparsedProperties = props.GetUnparsedProperties();
-
-            // create metadata on node
-            const std::size_t numStaticMetaData = 2;
-            aiMetadata* data = aiMetadata::Alloc(static_cast<unsigned int>(unparsedProperties.size() + numStaticMetaData));
-            nd.mMetaData = data;
-            int index = 0;
-
-            // find user defined properties (3ds Max)
-            data->Set(index++, "UserProperties", aiString(PropertyGet<std::string>(props, "UDP3DSMAX", "")));
-            // preserve the info that a node was marked as Null node in the original file.
-            data->Set(index++, "IsNull", model.IsNull() ? true : false);
-
-            // add unparsed properties to the node's metadata
-            for (const DirectPropertyMap::value_type& prop : unparsedProperties) {
-                // Interpret the property as a concrete type
-                if (const TypedProperty<bool>* interpreted = prop.second->As<TypedProperty<bool> >()) {
-                    data->Set(index++, prop.first, interpreted->Value());
-                }
-                else if (const TypedProperty<int>* interpreted = prop.second->As<TypedProperty<int> >()) {
-                    data->Set(index++, prop.first, interpreted->Value());
-                }
-                else if (const TypedProperty<uint64_t>* interpreted = prop.second->As<TypedProperty<uint64_t> >()) {
-                    data->Set(index++, prop.first, interpreted->Value());
-                }
-                else if (const TypedProperty<float>* interpreted = prop.second->As<TypedProperty<float> >()) {
-                    data->Set(index++, prop.first, interpreted->Value());
-                }
-                else if (const TypedProperty<std::string>* interpreted = prop.second->As<TypedProperty<std::string> >()) {
-                    data->Set(index++, prop.first, aiString(interpreted->Value()));
-                }
-                else if (const TypedProperty<aiVector3D>* interpreted = prop.second->As<TypedProperty<aiVector3D> >()) {
-                    data->Set(index++, prop.first, interpreted->Value());
-                }
-                else {
-                    ai_assert(false);
-                }
+                // now overwrite with pivot point
+                node_anim->mRotationKeys[x].mValue = rot;
+                node_anim->mScalingKeys[x].mValue = scale;
+                node_anim->mPositionKeys[x].mValue = trans;
+                resampled_anim.push_back(internal_target_id);
             }
         }
+	}
+	//}
+}
 
-        void FBXConverter::ConvertModel(const Model &model, aiNode *parent, aiNode *root_node,
-                                        const aiMatrix4x4 &absolute_transform)
-        {
-            const std::vector<const Geometry*>& geos = model.GetGeometry();
+void FBXConverter::CacheNodeInformation(uint64_t id)
+{
+    const std::vector<const Connection *> &conns = doc.GetConnectionsByDestinationSequenced(id, "Model");
 
-            std::vector<unsigned int> meshes;
-            meshes.reserve(geos.size());
-
-            for (const Geometry* geo : geos) {
-
-                const MeshGeometry* const mesh = dynamic_cast<const MeshGeometry*>(geo);
-                const LineGeometry* const line = dynamic_cast<const LineGeometry*>(geo);
-                if (mesh) {
-                    const std::vector<unsigned int>& indices = ConvertMesh(*mesh, model, parent, root_node,
-                                                                           absolute_transform);
-                    std::copy(indices.begin(), indices.end(), std::back_inserter(meshes));
-                }
-                else if (line) {
-                    const std::vector<unsigned int>& indices = ConvertLine(*line, model, parent, root_node);
-                    std::copy(indices.begin(), indices.end(), std::back_inserter(meshes));
-                }
-                else {
-                    FBXImporter::LogWarn("ignoring unrecognized geometry: " + geo->Name());
-                }
-            }
-
-            if (meshes.size()) {
-                parent->mMeshes = new unsigned int[meshes.size()]();
-                parent->mNumMeshes = static_cast<unsigned int>(meshes.size());
-
-                std::swap_ranges(meshes.begin(), meshes.end(), parent->mMeshes);
-            }
+    for (const Connection *con : conns) {
+        // ignore object-property links
+        if (con->PropertyName().length()) {
+            // really important we document why this is ignored.
+            FBXImporter::LogInfo("ignoring property link - no docs on why this is ignored");
+            continue;
         }
 
-        std::vector<unsigned int>
-        FBXConverter::ConvertMesh(const MeshGeometry &mesh, const Model &model, aiNode *parent, aiNode *root_node,
-                                  const aiMatrix4x4 &absolute_transform)
-        {
-            std::vector<unsigned int> temp;
+        // convert connection source object into Object base class
+        const Object *const object = con->SourceObject();
 
-            MeshMap::const_iterator it = meshes_converted.find(&mesh);
-            if (it != meshes_converted.end()) {
-                std::copy((*it).second.begin(), (*it).second.end(), std::back_inserter(temp));
-                return temp;
-            }
-
-            const std::vector<aiVector3D>& vertices = mesh.GetVertices();
-            const std::vector<unsigned int>& faces = mesh.GetFaceIndexCounts();
-            if (vertices.empty() || faces.empty()) {
-                FBXImporter::LogWarn("ignoring empty geometry: " + mesh.Name());
-                return temp;
-            }
-
-            // one material per mesh maps easily to aiMesh. Multiple material
-            // meshes need to be split.
-            const MatIndexArray& mindices = mesh.GetMaterialIndices();
-            if (doc.Settings().readMaterials && !mindices.empty()) {
-                const MatIndexArray::value_type base = mindices[0];
-                for (MatIndexArray::value_type index : mindices) {
-                    if (index != base) {
-                        return ConvertMeshMultiMaterial(mesh, model, parent, root_node, absolute_transform);
-                    }
-                }
-            }
-
-            // faster code-path, just copy the data
-            temp.push_back(ConvertMeshSingleMaterial(mesh, model, absolute_transform, parent, root_node));
-            return temp;
+        if (nullptr == object) {
+            FBXImporter::LogError("failed to convert source object for Model link");
+            continue;
         }
 
-        std::vector<unsigned int> FBXConverter::ConvertLine(const LineGeometry& line, const Model& model,
-                                                            aiNode *parent, aiNode *root_node)
-        {
-            std::vector<unsigned int> temp;
+        // FBX Model::Cube, Model::Bone001, etc elements
+        // This detects if we can cast the object into this model structure.
+        const Model *const model = dynamic_cast<const Model *>(object);
 
-            const std::vector<aiVector3D>& vertices = line.GetVertices();
-            const std::vector<int>& indices = line.GetIndices();
-            if (vertices.empty() || indices.empty()) {
-                FBXImporter::LogWarn("ignoring empty line: " + line.Name());
-                return temp;
-            }
+        if (nullptr != model) {
+            std::string node_name = FixNodeName(model->Name());
 
-            aiMesh* const out_mesh = SetupEmptyMesh(line, root_node);
-            out_mesh->mPrimitiveTypes |= aiPrimitiveType_LINE;
+            // check if there will be any child nodes
+            const std::vector<const Connection *> &child_conns = doc.GetConnectionsByDestinationSequenced(model->ID(), "Model");
 
-            // copy vertices
-            out_mesh->mNumVertices = static_cast<unsigned int>(vertices.size());
-            out_mesh->mVertices = new aiVector3D[out_mesh->mNumVertices];
-            std::copy(vertices.begin(), vertices.end(), out_mesh->mVertices);
+            // recursion call - child nodes
+            CacheNodeInformation(model->ID());
 
-            //Number of line segments (faces) is "Number of Points - Number of Endpoints"
-            //N.B.: Endpoints in FbxLine are denoted by negative indices.
-            //If such an Index is encountered, add 1 and multiply by -1 to get the real index.
-            unsigned int epcount = 0;
-            for (unsigned i = 0; i < indices.size(); i++)
+            // Convert bone node attributes
+            FindAllBones(*model);
+        }
+    }
+
+
+}
+
+/// then update convert clusters to the new format
+void FBXConverter::ConvertNodes(uint64_t id,
+		aiNode *parent,
+		aiNode *root_node,
+		aiMatrix4x4 inverse_geometric_xform,
+		aiMatrix4x4 world_transform) {
+	const std::vector<const Connection *> &conns = doc.GetConnectionsByDestinationSequenced(id, "Model");
+
+	std::vector<aiNode *> nodes;
+	nodes.reserve(conns.size());
+
+	try {
+		for (const Connection *con : conns) {
+			// ignore object-property links
+			if (con->PropertyName().length()) {
+				// really important we document why this is ignored.
+				FBXImporter::LogInfo("ignoring property link - no docs on why this is ignored");
+				continue; //?
+			}
+
+			// convert connection source object into Object base class
+			const Object *const object = con->SourceObject();
+
+			if (nullptr == object) {
+				FBXImporter::LogError("failed to convert source object for Model link");
+				continue;
+			}
+
+			// FBX Model::Cube, Model::Bone001, etc elements
+			// This detects if we can cast the object into this model structure.
+			const Model *const model = dynamic_cast<const Model *>(object);
+
+			ai_assert(model);
+
+			if (nullptr != model) {
+				std::string node_name = FixNodeName(model->Name());
+
+				aiNode *node = new aiNode();
+				ai_assert(node);
+				node->mName.Set(node_name);
+				node->mParent = parent;
+
+				//setup metadata on newest node
+				SetupNodeMetadata(*model, node);
+
+				// Handle FBX pivot data (explicitly must be done all the time)
+				aiMatrix4x4 geometric_node;
+				std::cout << "Node Pivot lookup ID: " << model->ID() << std::endl;
+				aiMatrix4x4 pivot_xform = GeneratePivotTransform(*model,geometric_node);
+
+				// formula (world_space) * (model space * inverse previous model space)
+				//
+				// original formula pivot_xform * node_geometric_transform * geometric_transform
+
+
+				node->mTransformation = (pivot_xform * geometric_node) * inverse_geometric_xform;
+
+//				aiVector3D scale, pos, rot;
+//				node->mTransformation.Decompose(scale, rot, pos);
+				//std::cout << "[pivot] ======== \nscale: " << scale.ToString() << ", \nrot: " << rot.ToString() << " \npos: " << pos.ToString() << "\n======" << std::endl;
+				// link nodes in a row the old way
+				aiMatrix4x4 new_abs_transform = node->mTransformation;
+				ConvertModel(*model, node, root_node, node->mTransformation);
+
+
+				ResampleAnimationsWithPivots(model->ID(), node->mTransformation);
+
+				// Geometric pivot data application
+				// resamples the node animation
+				// todo: make this 'get anim from stack'
+				// todo: make this recreate ibm xform too... otherwise it will break scale of
+				// inversed bones :)
+				// otherwise multiple armatures will get broken probably
+
+				// check if there will be any child nodes
+				const std::vector<const Connection *> &child_conns = doc.GetConnectionsByDestinationSequenced(model->ID(), "Model");
+
+				// recursion call - child nodes
+				ConvertNodes(model->ID(), node, root_node, geometric_node.Inverse() * inverse_geometric_xform,
+						world_transform);
+
+				if (doc.Settings().readLights) {
+					ConvertLights(*model, node_name);
+				}
+
+				if (doc.Settings().readCameras) {
+					ConvertCameras(*model, node_name);
+				}
+
+				// Convert bone node attributes
+                FindAllBones(*model);
+
+
+				nodes.push_back(node);
+			}
+		}
+
+		if (nodes.size()) {
+			parent->mChildren = new aiNode *[nodes.size()]();
+			parent->mNumChildren = static_cast<unsigned int>(nodes.size());
+
+			std::swap_ranges(nodes.begin(), nodes.end(), parent->mChildren);
+		} else {
+			parent->mNumChildren = 0;
+			parent->mChildren = nullptr;
+		}
+
+	} catch (std::exception &) {
+		Util::delete_fun<aiNode> deleter;
+		std::for_each(nodes.begin(), nodes.end(), deleter);
+	}
+}
+
+void FBXConverter::ConvertLights(const Model &model, const std::string &orig_name) {
+	const std::vector<const NodeAttribute *> &node_attrs = model.GetAttributes();
+	for (const NodeAttribute *attr : node_attrs) {
+		const Light *const light = dynamic_cast<const Light *>(attr);
+		if (light) {
+			ConvertLight(*light, orig_name);
+		}
+	}
+}
+
+/* Finds all bones and adds them to the bone_id_map if they don't already exist */
+void FBXConverter::FindAllBones(const Model &model) {
+    int count = 0;
+    const std::vector<const NodeAttribute *> &node_attrs = model.GetAttributes();
+    for( const NodeAttribute *attr : node_attrs) {
+        // this is the inverse bind matrix container (so where the pivot xform is stored)
+        const LimbNode *const limb = dynamic_cast<const LimbNode *>(attr);
+        if (limb) {
+            int64_t id = model.ID();
+            std::cout << "model id: " << id << std::endl;
+            if(bone_id_map.count(id))
             {
-                if (indices[i] < 0) {
-                    epcount++;
-                }
-            }
-            unsigned int pcount = static_cast<unsigned int>( indices.size() );
-            unsigned int scount = out_mesh->mNumFaces = pcount - epcount;
-
-            aiFace* fac = out_mesh->mFaces = new aiFace[scount]();
-            for (unsigned int i = 0; i < pcount; ++i) {
-                if (indices[i] < 0) continue;
-                aiFace& f = *fac++;
-                f.mNumIndices = 2; //2 == aiPrimitiveType_LINE 
-                f.mIndices = new unsigned int[2];
-                f.mIndices[0] = indices[i];
-                int segid = indices[(i + 1 == pcount ? 0 : i + 1)];   //If we have reached he last point, wrap around
-                f.mIndices[1] = (segid < 0 ? (segid + 1)*-1 : segid); //Convert EndPoint Index to normal Index
-            }
-            temp.push_back(static_cast<unsigned int>(meshes.size() - 1));
-            return temp;
-        }
-
-        aiMesh* FBXConverter::SetupEmptyMesh(const Geometry& mesh, aiNode *parent)
-        {
-            aiMesh* const out_mesh = new aiMesh();
-            meshes.push_back(out_mesh);
-            meshes_converted[&mesh].push_back(static_cast<unsigned int>(meshes.size() - 1));
-
-            // set name
-            std::string name = mesh.Name();
-            if (name.substr(0, 10) == "Geometry::") {
-                name = name.substr(10);
-            }
-
-            if (name.length()) {
-                out_mesh->mName.Set(name);
-            }
-            else
-            {
-                out_mesh->mName = parent->mName;
-            }
-
-            return out_mesh;
-        }
-
-        unsigned int FBXConverter::ConvertMeshSingleMaterial(const MeshGeometry &mesh, const Model &model,
-                                                             const aiMatrix4x4 &absolute_transform, aiNode *parent,
-                                                             aiNode *root_node)
-        {
-            const MatIndexArray& mindices = mesh.GetMaterialIndices();
-            aiMesh* const out_mesh = SetupEmptyMesh(mesh, parent);
-
-            const std::vector<aiVector3D>& vertices = mesh.GetVertices();
-            const std::vector<unsigned int>& faces = mesh.GetFaceIndexCounts();
-
-            // copy vertices
-            out_mesh->mNumVertices = static_cast<unsigned int>(vertices.size());
-            out_mesh->mVertices = new aiVector3D[vertices.size()];
-
-            std::copy(vertices.begin(), vertices.end(), out_mesh->mVertices);
-
-            // generate dummy faces
-            out_mesh->mNumFaces = static_cast<unsigned int>(faces.size());
-            aiFace* fac = out_mesh->mFaces = new aiFace[faces.size()]();
-
-            unsigned int cursor = 0;
-            for (unsigned int pcount : faces) {
-                aiFace& f = *fac++;
-                f.mNumIndices = pcount;
-                f.mIndices = new unsigned int[pcount];
-                switch (pcount)
-                {
-                case 1:
-                    out_mesh->mPrimitiveTypes |= aiPrimitiveType_POINT;
-                    break;
-                case 2:
-                    out_mesh->mPrimitiveTypes |= aiPrimitiveType_LINE;
-                    break;
-                case 3:
-                    out_mesh->mPrimitiveTypes |= aiPrimitiveType_TRIANGLE;
-                    break;
-                default:
-                    out_mesh->mPrimitiveTypes |= aiPrimitiveType_POLYGON;
-                    break;
-                }
-                for (unsigned int i = 0; i < pcount; ++i) {
-                    f.mIndices[i] = cursor++;
-                }
-            }
-
-            // copy normals
-            const std::vector<aiVector3D>& normals = mesh.GetNormals();
-            if (normals.size()) {
-                ai_assert(normals.size() == vertices.size());
-
-                out_mesh->mNormals = new aiVector3D[vertices.size()];
-                std::copy(normals.begin(), normals.end(), out_mesh->mNormals);
-            }
-
-            // copy tangents - assimp requires both tangents and bitangents (binormals)
-            // to be present, or neither of them. Compute binormals from normals
-            // and tangents if needed.
-            const std::vector<aiVector3D>& tangents = mesh.GetTangents();
-            const std::vector<aiVector3D>* binormals = &mesh.GetBinormals();
-
-            if (tangents.size()) {
-                std::vector<aiVector3D> tempBinormals;
-                if (!binormals->size()) {
-                    if (normals.size()) {
-                        tempBinormals.resize(normals.size());
-                        for (unsigned int i = 0; i < tangents.size(); ++i) {
-                            tempBinormals[i] = normals[i] ^ tangents[i];
-                        }
-
-                        binormals = &tempBinormals;
-                    }
-                    else {
-                        binormals = nullptr;
-                    }
-                }
-
-                if (binormals) {
-                    ai_assert(tangents.size() == vertices.size());
-                    ai_assert(binormals->size() == vertices.size());
-
-                    out_mesh->mTangents = new aiVector3D[vertices.size()];
-                    std::copy(tangents.begin(), tangents.end(), out_mesh->mTangents);
-
-                    out_mesh->mBitangents = new aiVector3D[vertices.size()];
-                    std::copy(binormals->begin(), binormals->end(), out_mesh->mBitangents);
-                }
-            }
-
-            // copy texture coords
-            for (unsigned int i = 0; i < AI_MAX_NUMBER_OF_TEXTURECOORDS; ++i) {
-                const std::vector<aiVector2D>& uvs = mesh.GetTextureCoords(i);
-                if (uvs.empty()) {
-                    break;
-                }
-
-                aiVector3D* out_uv = out_mesh->mTextureCoords[i] = new aiVector3D[vertices.size()];
-                for (const aiVector2D& v : uvs) {
-                    *out_uv++ = aiVector3D(v.x, v.y, 0.0f);
-                }
-
-                out_mesh->mNumUVComponents[i] = 2;
-            }
-
-            // copy vertex colors
-            for (unsigned int i = 0; i < AI_MAX_NUMBER_OF_COLOR_SETS; ++i) {
-                const std::vector<aiColor4D>& colors = mesh.GetVertexColors(i);
-                if (colors.empty()) {
-                    break;
-                }
-
-                out_mesh->mColors[i] = new aiColor4D[vertices.size()];
-                std::copy(colors.begin(), colors.end(), out_mesh->mColors[i]);
-            }
-
-            if (!doc.Settings().readMaterials || mindices.empty()) {
-                FBXImporter::LogError("no material assigned to mesh, setting default material");
-                out_mesh->mMaterialIndex = GetDefaultMaterial();
-            }
-            else {
-                ConvertMaterialForMesh(out_mesh, model, mesh, mindices[0]);
-            }
-
-            if (doc.Settings().readWeights && mesh.DeformerSkin() != nullptr) {
-                ConvertWeights(out_mesh, model, mesh, absolute_transform, parent, root_node, NO_MATERIAL_SEPARATION,
-                               nullptr);
-            }
-
-            std::vector<aiAnimMesh*> animMeshes;
-            for (const BlendShape* blendShape : mesh.GetBlendShapes()) {
-                for (const BlendShapeChannel* blendShapeChannel : blendShape->BlendShapeChannels()) {
-                    const std::vector<const ShapeGeometry*>& shapeGeometries = blendShapeChannel->GetShapeGeometries();
-                    for (size_t i = 0; i < shapeGeometries.size(); i++) {
-                        aiAnimMesh *animMesh = aiCreateAnimMesh(out_mesh);
-                        const ShapeGeometry* shapeGeometry = shapeGeometries.at(i);
-                        const std::vector<aiVector3D>& vertices = shapeGeometry->GetVertices();
-                        const std::vector<aiVector3D>& normals = shapeGeometry->GetNormals();
-                        const std::vector<unsigned int>& indices = shapeGeometry->GetIndices();
-                        animMesh->mName.Set(FixAnimMeshName(shapeGeometry->Name()));
-                        for (size_t j = 0; j < indices.size(); j++) {
-                            unsigned int index = indices.at(j);
-                            aiVector3D vertex = vertices.at(j);
-                            aiVector3D normal = normals.at(j);
-                            unsigned int count = 0;
-                            const unsigned int* outIndices = mesh.ToOutputVertexIndex(index, count);
-                            for (unsigned int k = 0; k < count; k++) {
-                                unsigned int index = outIndices[k];
-                                animMesh->mVertices[index] += vertex;
-                                if (animMesh->mNormals != nullptr) {
-                                    animMesh->mNormals[index] += normal;
-                                    animMesh->mNormals[index].NormalizeSafe();
-                                }
-                            }
-                        }
-                        animMesh->mWeight = shapeGeometries.size() > 1 ? blendShapeChannel->DeformPercent() / 100.0f : 1.0f;
-                        animMeshes.push_back(animMesh);
-                    }
-                }
-            }
-            const size_t numAnimMeshes = animMeshes.size();
-            if (numAnimMeshes > 0) {
-                out_mesh->mNumAnimMeshes = static_cast<unsigned int>(numAnimMeshes);
-                out_mesh->mAnimMeshes = new aiAnimMesh*[numAnimMeshes];
-                for (size_t i = 0; i < numAnimMeshes; i++) {
-                    out_mesh->mAnimMeshes[i] = animMeshes.at(i);
-                }
-            }
-            return static_cast<unsigned int>(meshes.size() - 1);
-        }
-
-        std::vector<unsigned int>
-        FBXConverter::ConvertMeshMultiMaterial(const MeshGeometry &mesh, const Model &model, aiNode *parent,
-                                               aiNode *root_node,
-                                               const aiMatrix4x4 &absolute_transform)
-        {
-            const MatIndexArray& mindices = mesh.GetMaterialIndices();
-            ai_assert(mindices.size());
-
-            std::set<MatIndexArray::value_type> had;
-            std::vector<unsigned int> indices;
-
-            for (MatIndexArray::value_type index : mindices) {
-                if (had.find(index) == had.end()) {
-
-                    indices.push_back(ConvertMeshMultiMaterial(mesh, model, index, parent, root_node, absolute_transform));
-                    had.insert(index);
-                }
-            }
-
-            return indices;
-        }
-
-        unsigned int FBXConverter::ConvertMeshMultiMaterial(const MeshGeometry &mesh, const Model &model,
-                                                            MatIndexArray::value_type index,
-                                                            aiNode *parent, aiNode *root_node,
-                                                            const aiMatrix4x4 &absolute_transform)
-        {
-            aiMesh* const out_mesh = SetupEmptyMesh(mesh, parent);
-
-            const MatIndexArray& mindices = mesh.GetMaterialIndices();
-            const std::vector<aiVector3D>& vertices = mesh.GetVertices();
-            const std::vector<unsigned int>& faces = mesh.GetFaceIndexCounts();
-
-            const bool process_weights = doc.Settings().readWeights && mesh.DeformerSkin() != nullptr;
-
-            unsigned int count_faces = 0;
-            unsigned int count_vertices = 0;
-
-            // count faces
-            std::vector<unsigned int>::const_iterator itf = faces.begin();
-            for (MatIndexArray::const_iterator it = mindices.begin(),
-                end = mindices.end(); it != end; ++it, ++itf)
-            {
-                if ((*it) != index) {
-                    continue;
-                }
-                ++count_faces;
-                count_vertices += *itf;
-            }
-
-            ai_assert(count_faces);
-            ai_assert(count_vertices);
-
-            // mapping from output indices to DOM indexing, needed to resolve weights or blendshapes
-            std::vector<unsigned int> reverseMapping;
-            std::map<unsigned int, unsigned int> translateIndexMap;
-            if (process_weights || mesh.GetBlendShapes().size() > 0) {
-                reverseMapping.resize(count_vertices);
-            }
-
-            // allocate output data arrays, but don't fill them yet
-            out_mesh->mNumVertices = count_vertices;
-            out_mesh->mVertices = new aiVector3D[count_vertices];
-
-            out_mesh->mNumFaces = count_faces;
-            aiFace* fac = out_mesh->mFaces = new aiFace[count_faces]();
-
-
-            // allocate normals
-            const std::vector<aiVector3D>& normals = mesh.GetNormals();
-            if (normals.size()) {
-                ai_assert(normals.size() == vertices.size());
-                out_mesh->mNormals = new aiVector3D[vertices.size()];
-            }
-
-            // allocate tangents, binormals.
-            const std::vector<aiVector3D>& tangents = mesh.GetTangents();
-            const std::vector<aiVector3D>* binormals = &mesh.GetBinormals();
-            std::vector<aiVector3D> tempBinormals;
-
-            if (tangents.size()) {
-                if (!binormals->size()) {
-                    if (normals.size()) {
-                        // XXX this computes the binormals for the entire mesh, not only
-                        // the part for which we need them.
-                        tempBinormals.resize(normals.size());
-                        for (unsigned int i = 0; i < tangents.size(); ++i) {
-                            tempBinormals[i] = normals[i] ^ tangents[i];
-                        }
-
-                        binormals = &tempBinormals;
-                    }
-                    else {
-                        binormals = nullptr;
-                    }
-                }
-
-                if (binormals) {
-                    ai_assert(tangents.size() == vertices.size() && binormals->size() == vertices.size());
-
-                    out_mesh->mTangents = new aiVector3D[vertices.size()];
-                    out_mesh->mBitangents = new aiVector3D[vertices.size()];
-                }
-            }
-
-            // allocate texture coords
-            unsigned int num_uvs = 0;
-            for (unsigned int i = 0; i < AI_MAX_NUMBER_OF_TEXTURECOORDS; ++i, ++num_uvs) {
-                const std::vector<aiVector2D>& uvs = mesh.GetTextureCoords(i);
-                if (uvs.empty()) {
-                    break;
-                }
-
-                out_mesh->mTextureCoords[i] = new aiVector3D[vertices.size()];
-                out_mesh->mNumUVComponents[i] = 2;
-            }
-
-            // allocate vertex colors
-            unsigned int num_vcs = 0;
-            for (unsigned int i = 0; i < AI_MAX_NUMBER_OF_COLOR_SETS; ++i, ++num_vcs) {
-                const std::vector<aiColor4D>& colors = mesh.GetVertexColors(i);
-                if (colors.empty()) {
-                    break;
-                }
-
-                out_mesh->mColors[i] = new aiColor4D[vertices.size()];
-            }
-
-            unsigned int cursor = 0, in_cursor = 0;
-
-            itf = faces.begin();
-            for (MatIndexArray::const_iterator it = mindices.begin(), end = mindices.end(); it != end; ++it, ++itf)
-            {
-                const unsigned int pcount = *itf;
-                if ((*it) != index) {
-                    in_cursor += pcount;
-                    continue;
-                }
-
-                aiFace& f = *fac++;
-
-                f.mNumIndices = pcount;
-                f.mIndices = new unsigned int[pcount];
-                switch (pcount)
-                {
-                case 1:
-                    out_mesh->mPrimitiveTypes |= aiPrimitiveType_POINT;
-                    break;
-                case 2:
-                    out_mesh->mPrimitiveTypes |= aiPrimitiveType_LINE;
-                    break;
-                case 3:
-                    out_mesh->mPrimitiveTypes |= aiPrimitiveType_TRIANGLE;
-                    break;
-                default:
-                    out_mesh->mPrimitiveTypes |= aiPrimitiveType_POLYGON;
-                    break;
-                }
-                for (unsigned int i = 0; i < pcount; ++i, ++cursor, ++in_cursor) {
-                    f.mIndices[i] = cursor;
-
-                    if (reverseMapping.size()) {
-                        reverseMapping[cursor] = in_cursor;
-                        translateIndexMap[in_cursor] = cursor;
-                    }
-
-                    out_mesh->mVertices[cursor] = vertices[in_cursor];
-
-                    if (out_mesh->mNormals) {
-                        out_mesh->mNormals[cursor] = normals[in_cursor];
-                    }
-
-                    if (out_mesh->mTangents) {
-                        out_mesh->mTangents[cursor] = tangents[in_cursor];
-                        out_mesh->mBitangents[cursor] = (*binormals)[in_cursor];
-                    }
-
-                    for (unsigned int j = 0; j < num_uvs; ++j) {
-                        const std::vector<aiVector2D>& uvs = mesh.GetTextureCoords(j);
-                        out_mesh->mTextureCoords[j][cursor] = aiVector3D(uvs[in_cursor].x, uvs[in_cursor].y, 0.0f);
-                    }
-
-                    for (unsigned int j = 0; j < num_vcs; ++j) {
-                        const std::vector<aiColor4D>& cols = mesh.GetVertexColors(j);
-                        out_mesh->mColors[j][cursor] = cols[in_cursor];
-                    }
-                }
-            }
-
-            ConvertMaterialForMesh(out_mesh, model, mesh, index);
-
-            if (process_weights) {
-                ConvertWeights(out_mesh, model, mesh, absolute_transform, parent, root_node, index, &reverseMapping);
-            }
-
-            std::vector<aiAnimMesh*> animMeshes;
-            for (const BlendShape* blendShape : mesh.GetBlendShapes()) {
-                for (const BlendShapeChannel* blendShapeChannel : blendShape->BlendShapeChannels()) {
-                    const std::vector<const ShapeGeometry*>& shapeGeometries = blendShapeChannel->GetShapeGeometries();
-                    for (size_t i = 0; i < shapeGeometries.size(); i++) {
-                        aiAnimMesh* animMesh = aiCreateAnimMesh(out_mesh);
-                        const ShapeGeometry* shapeGeometry = shapeGeometries.at(i);
-                        const std::vector<aiVector3D>& vertices = shapeGeometry->GetVertices();
-                        const std::vector<aiVector3D>& normals = shapeGeometry->GetNormals();
-                        const std::vector<unsigned int>& indices = shapeGeometry->GetIndices();
-                        animMesh->mName.Set(FixAnimMeshName(shapeGeometry->Name()));
-                        for (size_t j = 0; j < indices.size(); j++) {
-                            unsigned int index = indices.at(j);
-                            aiVector3D vertex = vertices.at(j);
-                            aiVector3D normal = normals.at(j);
-                            unsigned int count = 0;
-                            const unsigned int* outIndices = mesh.ToOutputVertexIndex(index, count);
-                            for (unsigned int k = 0; k < count; k++) {
-                                unsigned int outIndex = outIndices[k];
-                                if (translateIndexMap.find(outIndex) == translateIndexMap.end())
-                                    continue;
-                                unsigned int index = translateIndexMap[outIndex];
-                                animMesh->mVertices[index] += vertex;
-                                if (animMesh->mNormals != nullptr) {
-                                    animMesh->mNormals[index] += normal;
-                                    animMesh->mNormals[index].NormalizeSafe();
-                                }
-                            }
-                        }
-                        animMesh->mWeight = shapeGeometries.size() > 1 ? blendShapeChannel->DeformPercent() / 100.0f : 1.0f;
-                        animMeshes.push_back(animMesh);
-                    }
-                }
-            }
-
-            const size_t numAnimMeshes = animMeshes.size();
-            if (numAnimMeshes > 0) {
-                out_mesh->mNumAnimMeshes = static_cast<unsigned int>(numAnimMeshes);
-                out_mesh->mAnimMeshes = new aiAnimMesh*[numAnimMeshes];
-                for (size_t i = 0; i < numAnimMeshes; i++) {
-                    out_mesh->mAnimMeshes[i] = animMeshes.at(i);
-                }
-            }
-
-            return static_cast<unsigned int>(meshes.size() - 1);
-        }
-
-        void FBXConverter::ConvertWeights(aiMesh *out, const Model &model, const MeshGeometry &geo,
-                                          const aiMatrix4x4 &absolute_transform,
-                                          aiNode *parent, aiNode *root_node, unsigned int materialIndex,
-                                          std::vector<unsigned int> *outputVertStartIndices)
-        {
-            ai_assert(geo.DeformerSkin());
-
-            std::vector<size_t> out_indices;
-            std::vector<size_t> index_out_indices;
-            std::vector<size_t> count_out_indices;
-
-            const Skin& sk = *geo.DeformerSkin();
-
-            std::vector<aiBone*> bones;
-
-            const bool no_mat_check = materialIndex == NO_MATERIAL_SEPARATION;
-            ai_assert(no_mat_check || outputVertStartIndices);
-
-            try {
-                // iterate over the sub deformers
-                for (const Cluster* cluster : sk.Clusters()) {
-                    ai_assert(cluster);
-
-                    const WeightIndexArray& indices = cluster->GetIndices();
-
-                    const MatIndexArray& mats = geo.GetMaterialIndices();
-
-                    const size_t no_index_sentinel = std::numeric_limits<size_t>::max();
-
-                    count_out_indices.clear();
-                    index_out_indices.clear();
-                    out_indices.clear();
-
-
-                    // now check if *any* of these weights is contained in the output mesh,
-                    // taking notes so we don't need to do it twice.
-                    for (WeightIndexArray::value_type index : indices) {
-
-                        unsigned int count = 0;
-                        const unsigned int* const out_idx = geo.ToOutputVertexIndex(index, count);
-                        // ToOutputVertexIndex only returns nullptr if index is out of bounds
-                        // which should never happen
-                        ai_assert(out_idx != nullptr);
-
-                        index_out_indices.push_back(no_index_sentinel);
-                        count_out_indices.push_back(0);
-
-                        for (unsigned int i = 0; i < count; ++i) {
-                            if (no_mat_check || static_cast<size_t>(mats[geo.FaceForVertexIndex(out_idx[i])]) == materialIndex) {
-
-                                if (index_out_indices.back() == no_index_sentinel) {
-                                    index_out_indices.back() = out_indices.size();
-                                }
-
-                                if (no_mat_check) {
-                                    out_indices.push_back(out_idx[i]);
-                                } else {
-                                    // this extra lookup is in O(logn), so the entire algorithm becomes O(nlogn)
-                                    const std::vector<unsigned int>::iterator it = std::lower_bound(
-                                        outputVertStartIndices->begin(),
-                                        outputVertStartIndices->end(),
-                                        out_idx[i]
-                                    );
-
-                                    out_indices.push_back(std::distance(outputVertStartIndices->begin(), it));
-                                }
-
-                                ++count_out_indices.back();                               
-                            }
-                        }
-                    }
-
-                    // if we found at least one, generate the output bones
-                    // XXX this could be heavily simplified by collecting the bone
-                    // data in a single step.
-                    ConvertCluster(bones, cluster, out_indices, index_out_indices,
-                                   count_out_indices, absolute_transform, parent, root_node);
-                }
-
-                bone_map.clear();
-            }
-            catch (std::exception&e) {
-                std::for_each(bones.begin(), bones.end(), Util::delete_fun<aiBone>());
-                throw;
-            }
-
-            if (bones.empty()) {
-                out->mBones = nullptr;
-                out->mNumBones = 0;
-                return;
+                continue;
             } else {
-                out->mBones = new aiBone *[bones.size()]();
-                out->mNumBones = static_cast<unsigned int>(bones.size());
-
-                std::swap_ranges(bones.begin(), bones.end(), out->mBones);
+                // limb->Props()
+                // rotation order: model
+                bone_id_map.insert(std::pair<int64_t, const LimbNode*>(id, limb));
             }
         }
-
-        const aiNode* FBXConverter::GetNodeByName( const aiString& name, aiNode *current_node )
-        {
-            aiNode * iter = current_node;
-            //printf("Child count: %d", iter->mNumChildren);
-            return iter;
-        }
-
-        void FBXConverter::ConvertCluster(std::vector<aiBone *> &local_mesh_bones, const Cluster *cl,
-                                          std::vector<size_t> &out_indices, std::vector<size_t> &index_out_indices,
-                                          std::vector<size_t> &count_out_indices, const aiMatrix4x4 &absolute_transform,
-                                          aiNode *parent, aiNode *root_node) {
-            ai_assert(cl); // make sure cluster valid
-            std::string deformer_name = cl->TargetNode()->Name();
-            aiString bone_name = aiString(FixNodeName(deformer_name));
-
-            aiBone *bone = nullptr;
-
-            if (bone_map.count(deformer_name)) {
-				ASSIMP_LOG_DEBUG_F("retrieved bone from lookup ", bone_name.C_Str(), ". Deformer:", deformer_name);
-				bone = bone_map[deformer_name];
-			} else {
-				ASSIMP_LOG_DEBUG_F("created new bone ", bone_name.C_Str(), ". Deformer: ", deformer_name);
-				bone = new aiBone();
-                bone->mName = bone_name;
-
-                // store local transform link for post processing
-                bone->mOffsetMatrix = cl->TransformLink();
-                bone->mOffsetMatrix.Inverse();
-
-                aiMatrix4x4 matrix = (aiMatrix4x4)absolute_transform;
-
-                bone->mOffsetMatrix = bone->mOffsetMatrix * matrix; // * mesh_offset
-
-
-                //
-                // Now calculate the aiVertexWeights
-                //
-
-                aiVertexWeight *cursor = nullptr;
-
-                bone->mNumWeights = static_cast<unsigned int>(out_indices.size());
-                cursor = bone->mWeights = new aiVertexWeight[out_indices.size()];
-
-                const size_t no_index_sentinel = std::numeric_limits<size_t>::max();
-                const WeightArray& weights = cl->GetWeights();
-
-                const size_t c = index_out_indices.size();
-                for (size_t i = 0; i < c; ++i) {
-                    const size_t index_index = index_out_indices[i];
-
-                    if (index_index == no_index_sentinel) {
-                        continue;
-                    }
-
-                    const size_t cc = count_out_indices[i];
-                    for (size_t j = 0; j < cc; ++j) {
-                        // cursor runs from first element relative to the start
-                        // or relative to the start of the next indexes.
-                        aiVertexWeight& out_weight = *cursor++;
-
-                        out_weight.mVertexId = static_cast<unsigned int>(out_indices[index_index + j]);
-                        out_weight.mWeight = weights[i];
-                    }
-                }
-
-                bone_map.insert(std::pair<const std::string, aiBone *>(deformer_name, bone));
-            }
-
-            ASSIMP_LOG_DEBUG_F("bone research: Indicies size: ", out_indices.size());
-
-            // lookup must be populated in case something goes wrong
-            // this also allocates bones to mesh instance outside
-            local_mesh_bones.push_back(bone);
-        }
-
-        void FBXConverter::ConvertMaterialForMesh(aiMesh* out, const Model& model, const MeshGeometry& geo,
-            MatIndexArray::value_type materialIndex)
-        {
-            // locate source materials for this mesh
-            const std::vector<const Material*>& mats = model.GetMaterials();
-            if (static_cast<unsigned int>(materialIndex) >= mats.size() || materialIndex < 0) {
-                FBXImporter::LogError("material index out of bounds, setting default material");
-                out->mMaterialIndex = GetDefaultMaterial();
-                return;
-            }
-
-            const Material* const mat = mats[materialIndex];
-            MaterialMap::const_iterator it = materials_converted.find(mat);
-            if (it != materials_converted.end()) {
-                out->mMaterialIndex = (*it).second;
-                return;
-            }
-
-            out->mMaterialIndex = ConvertMaterial(*mat, &geo);
-            materials_converted[mat] = out->mMaterialIndex;
-        }
-
-        unsigned int FBXConverter::GetDefaultMaterial()
-        {
-            if (defaultMaterialIndex) {
-                return defaultMaterialIndex - 1;
-            }
-
-            aiMaterial* out_mat = new aiMaterial();
-            materials.push_back(out_mat);
-
-            const aiColor3D diffuse = aiColor3D(0.8f, 0.8f, 0.8f);
-            out_mat->AddProperty(&diffuse, 1, AI_MATKEY_COLOR_DIFFUSE);
-
-            aiString s;
-            s.Set(AI_DEFAULT_MATERIAL_NAME);
-
-            out_mat->AddProperty(&s, AI_MATKEY_NAME);
-
-            defaultMaterialIndex = static_cast<unsigned int>(materials.size());
-            return defaultMaterialIndex - 1;
-        }
-
-
-        unsigned int FBXConverter::ConvertMaterial(const Material& material, const MeshGeometry* const mesh)
-        {
-            const PropertyTable& props = material.Props();
-
-            // generate empty output material
-            aiMaterial* out_mat = new aiMaterial();
-            materials_converted[&material] = static_cast<unsigned int>(materials.size());
-
-            materials.push_back(out_mat);
-
-            aiString str;
-
-            // strip Material:: prefix
-            std::string name = material.Name();
-            if (name.substr(0, 10) == "Material::") {
-                name = name.substr(10);
-            }
-
-            // set material name if not empty - this could happen
-            // and there should be no key for it in this case.
-            if (name.length()) {
-                str.Set(name);
-                out_mat->AddProperty(&str, AI_MATKEY_NAME);
-            }
-
-            // Set the shading mode as best we can: The FBX specification only mentions Lambert and Phong, and only Phong is mentioned in Assimp's aiShadingMode enum.
-            if (material.GetShadingModel() == "phong")
-            {
-                aiShadingMode shadingMode = aiShadingMode_Phong;
-                out_mat->AddProperty<aiShadingMode>(&shadingMode, 1, AI_MATKEY_SHADING_MODEL);               
-            }
-
-            // shading stuff and colors
-            SetShadingPropertiesCommon(out_mat, props);
-            SetShadingPropertiesRaw( out_mat, props, material.Textures(), mesh );
-
-            // texture assignments
-            SetTextureProperties(out_mat, material.Textures(), mesh);
-            SetTextureProperties(out_mat, material.LayeredTextures(), mesh);
-
-            return static_cast<unsigned int>(materials.size() - 1);
-        }
-
-        unsigned int FBXConverter::ConvertVideo(const Video& video)
-        {
-            // generate empty output texture
-            aiTexture* out_tex = new aiTexture();
-            textures.push_back(out_tex);
-
-            // assuming the texture is compressed
-            out_tex->mWidth = static_cast<unsigned int>(video.ContentLength()); // total data size
-            out_tex->mHeight = 0; // fixed to 0
-
-            // steal the data from the Video to avoid an additional copy
-            out_tex->pcData = reinterpret_cast<aiTexel*>(const_cast<Video&>(video).RelinquishContent());
-
-            // try to extract a hint from the file extension
-            const std::string& filename = video.RelativeFilename().empty() ? video.FileName() : video.RelativeFilename();
-            std::string ext = BaseImporter::GetExtension(filename);
-
-            if (ext == "jpeg") {
-                ext = "jpg";
-            }
-
-            if (ext.size() <= 3) {
-                memcpy(out_tex->achFormatHint, ext.c_str(), ext.size());
-            }
-
-            out_tex->mFilename.Set(filename.c_str());
-
-            return static_cast<unsigned int>(textures.size() - 1);
-        }
-
-        aiString FBXConverter::GetTexturePath(const Texture* tex)
-        {
-            aiString path;
-            path.Set(tex->RelativeFilename());
-
-            const Video* media = tex->Media();
-            if (media != nullptr) {
-                bool textureReady = false; //tells if our texture is ready (if it was loaded or if it was found)
-                unsigned int index;
-
-                VideoMap::const_iterator it = textures_converted.find(*media);
-                if (it != textures_converted.end()) {
-                    index = (*it).second;
-                    textureReady = true;
-                }
-                else {
-                    if (media->ContentLength() > 0) {
-                        index = ConvertVideo(*media);
-                        textures_converted[*media] = index;
-                        textureReady = true;
-                    }
-                }
-
-                // setup texture reference string (copied from ColladaLoader::FindFilenameForEffectTexture), if the texture is ready
-                if (doc.Settings().useLegacyEmbeddedTextureNaming) {
-                    if (textureReady) {
-                        // TODO: check the possibility of using the flag "AI_CONFIG_IMPORT_FBX_EMBEDDED_TEXTURES_LEGACY_NAMING"
-                        // In FBX files textures are now stored internally by Assimp with their filename included
-                        // Now Assimp can lookup through the loaded textures after all data is processed
-                        // We need to load all textures before referencing them, as FBX file format order may reference a texture before loading it
-                        // This may occur on this case too, it has to be studied
-                        path.data[0] = '*';
-                        path.length = 1 + ASSIMP_itoa10(path.data + 1, MAXLEN - 1, index);
-                    }
-                }
-            }
-
-            return path;
-        }
-
-        void FBXConverter::TrySetTextureProperties(aiMaterial* out_mat, const TextureMap& textures,
-                const std::string& propName,
-                aiTextureType target, const MeshGeometry* const mesh) {
-            TextureMap::const_iterator it = textures.find(propName);
-            if (it == textures.end()) {
-                return;
-            }
-
-            const Texture* const tex = (*it).second;
-            if (tex != 0)
-            {
-                aiString path = GetTexturePath(tex);
-                out_mat->AddProperty(&path, _AI_MATKEY_TEXTURE_BASE, target, 0);
-
-                aiUVTransform uvTrafo;
-                // XXX handle all kinds of UV transformations
-                uvTrafo.mScaling = tex->UVScaling();
-                uvTrafo.mTranslation = tex->UVTranslation();
-                out_mat->AddProperty(&uvTrafo, 1, _AI_MATKEY_UVTRANSFORM_BASE, target, 0);
-
-                const PropertyTable& props = tex->Props();
-
-                int uvIndex = 0;
-
-                bool ok;
-                const std::string& uvSet = PropertyGet<std::string>(props, "UVSet", ok);
-                if (ok) {
-                    // "default" is the name which usually appears in the FbxFileTexture template
-                    if (uvSet != "default" && uvSet.length()) {
-                        // this is a bit awkward - we need to find a mesh that uses this
-                        // material and scan its UV channels for the given UV name because
-                        // assimp references UV channels by index, not by name.
-
-                        // XXX: the case that UV channels may appear in different orders
-                        // in meshes is unhandled. A possible solution would be to sort
-                        // the UV channels alphabetically, but this would have the side
-                        // effect that the primary (first) UV channel would sometimes
-                        // be moved, causing trouble when users read only the first
-                        // UV channel and ignore UV channel assignments altogether.
-
-                        const unsigned int matIndex = static_cast<unsigned int>(std::distance(materials.begin(),
-                            std::find(materials.begin(), materials.end(), out_mat)
-                        ));
-
-
-                        uvIndex = -1;
-                        if (!mesh)
-                        {
-                            for (const MeshMap::value_type& v : meshes_converted) {
-                                const MeshGeometry* const meshGeom = dynamic_cast<const MeshGeometry*> (v.first);
-                                if (!meshGeom) {
-                                    continue;
-                                }
-
-                                const MatIndexArray& mats = meshGeom->GetMaterialIndices();
-                                if (std::find(mats.begin(), mats.end(), matIndex) == mats.end()) {
-                                    continue;
-                                }
-
-                                int index = -1;
-                                for (unsigned int i = 0; i < AI_MAX_NUMBER_OF_TEXTURECOORDS; ++i) {
-                                    if (meshGeom->GetTextureCoords(i).empty()) {
-                                        break;
-                                    }
-                                    const std::string& name = meshGeom->GetTextureCoordChannelName(i);
-                                    if (name == uvSet) {
-                                        index = static_cast<int>(i);
-                                        break;
-                                    }
-                                }
-                                if (index == -1) {
-                                    FBXImporter::LogWarn("did not find UV channel named " + uvSet + " in a mesh using this material");
-                                    continue;
-                                }
-
-                                if (uvIndex == -1) {
-                                    uvIndex = index;
-                                }
-                                else {
-                                    FBXImporter::LogWarn("the UV channel named " + uvSet +
-                                        " appears at different positions in meshes, results will be wrong");
-                                }
-                            }
-                        }
-                        else
-                        {
-                            int index = -1;
-                            for (unsigned int i = 0; i < AI_MAX_NUMBER_OF_TEXTURECOORDS; ++i) {
-                                if (mesh->GetTextureCoords(i).empty()) {
-                                    break;
-                                }
-                                const std::string& name = mesh->GetTextureCoordChannelName(i);
-                                if (name == uvSet) {
-                                    index = static_cast<int>(i);
-                                    break;
-                                }
-                            }
-                            if (index == -1) {
-                                FBXImporter::LogWarn("did not find UV channel named " + uvSet + " in a mesh using this material");
-                            }
-
-                            if (uvIndex == -1) {
-                                uvIndex = index;
-                            }
-                        }
-
-                        if (uvIndex == -1) {
-                            FBXImporter::LogWarn("failed to resolve UV channel " + uvSet + ", using first UV channel");
-                            uvIndex = 0;
-                        }
-                    }
-                }
-
-                out_mat->AddProperty(&uvIndex, 1, _AI_MATKEY_UVWSRC_BASE, target, 0);
-            }
-        }
-
-        void FBXConverter::TrySetTextureProperties(aiMaterial* out_mat, const LayeredTextureMap& layeredTextures,
-            const std::string& propName,
-            aiTextureType target, const MeshGeometry* const mesh) {
-            LayeredTextureMap::const_iterator it = layeredTextures.find(propName);
-            if (it == layeredTextures.end()) {
-                return;
-            }
-
-            int texCount = (*it).second->textureCount();
-
-            // Set the blend mode for layered textures
-            int blendmode = (*it).second->GetBlendMode();
-            out_mat->AddProperty(&blendmode, 1, _AI_MATKEY_TEXOP_BASE, target, 0);
-
-            for (int texIndex = 0; texIndex < texCount; texIndex++) {
-
-                const Texture* const tex = (*it).second->getTexture(texIndex);
-
-                aiString path = GetTexturePath(tex);
-                out_mat->AddProperty(&path, _AI_MATKEY_TEXTURE_BASE, target, texIndex);
-
-                aiUVTransform uvTrafo;
-                // XXX handle all kinds of UV transformations
-                uvTrafo.mScaling = tex->UVScaling();
-                uvTrafo.mTranslation = tex->UVTranslation();
-                out_mat->AddProperty(&uvTrafo, 1, _AI_MATKEY_UVTRANSFORM_BASE, target, texIndex);
-
-                const PropertyTable& props = tex->Props();
-
-                int uvIndex = 0;
-
-                bool ok;
-                const std::string& uvSet = PropertyGet<std::string>(props, "UVSet", ok);
-                if (ok) {
-                    // "default" is the name which usually appears in the FbxFileTexture template
-                    if (uvSet != "default" && uvSet.length()) {
-                        // this is a bit awkward - we need to find a mesh that uses this
-                        // material and scan its UV channels for the given UV name because
-                        // assimp references UV channels by index, not by name.
-
-                        // XXX: the case that UV channels may appear in different orders
-                        // in meshes is unhandled. A possible solution would be to sort
-                        // the UV channels alphabetically, but this would have the side
-                        // effect that the primary (first) UV channel would sometimes
-                        // be moved, causing trouble when users read only the first
-                        // UV channel and ignore UV channel assignments altogether.
-
-                        const unsigned int matIndex = static_cast<unsigned int>(std::distance(materials.begin(),
-                            std::find(materials.begin(), materials.end(), out_mat)
-                        ));
-
-                        uvIndex = -1;
-                        if (!mesh)
-                        {
-                            for (const MeshMap::value_type& v : meshes_converted) {
-                                const MeshGeometry* const meshGeom = dynamic_cast<const MeshGeometry*> (v.first);
-                                if (!meshGeom) {
-                                    continue;
-                                }
-
-                                const MatIndexArray& mats = meshGeom->GetMaterialIndices();
-                                if (std::find(mats.begin(), mats.end(), matIndex) == mats.end()) {
-                                    continue;
-                                }
-
-                                int index = -1;
-                                for (unsigned int i = 0; i < AI_MAX_NUMBER_OF_TEXTURECOORDS; ++i) {
-                                    if (meshGeom->GetTextureCoords(i).empty()) {
-                                        break;
-                                    }
-                                    const std::string& name = meshGeom->GetTextureCoordChannelName(i);
-                                    if (name == uvSet) {
-                                        index = static_cast<int>(i);
-                                        break;
-                                    }
-                                }
-                                if (index == -1) {
-                                    FBXImporter::LogWarn("did not find UV channel named " + uvSet + " in a mesh using this material");
-                                    continue;
-                                }
-
-                                if (uvIndex == -1) {
-                                    uvIndex = index;
-                                }
-                                else {
-                                    FBXImporter::LogWarn("the UV channel named " + uvSet +
-                                        " appears at different positions in meshes, results will be wrong");
-                                }
-                            }
-                        }
-                        else
-                        {
-                            int index = -1;
-                            for (unsigned int i = 0; i < AI_MAX_NUMBER_OF_TEXTURECOORDS; ++i) {
-                                if (mesh->GetTextureCoords(i).empty()) {
-                                    break;
-                                }
-                                const std::string& name = mesh->GetTextureCoordChannelName(i);
-                                if (name == uvSet) {
-                                    index = static_cast<int>(i);
-                                    break;
-                                }
-                            }
-                            if (index == -1) {
-                                FBXImporter::LogWarn("did not find UV channel named " + uvSet + " in a mesh using this material");
-                            }
-
-                            if (uvIndex == -1) {
-                                uvIndex = index;
-                            }
-                        }
-
-                        if (uvIndex == -1) {
-                            FBXImporter::LogWarn("failed to resolve UV channel " + uvSet + ", using first UV channel");
-                            uvIndex = 0;
-                        }
-                    }
-                }
-
-                out_mat->AddProperty(&uvIndex, 1, _AI_MATKEY_UVWSRC_BASE, target, texIndex);
-            }
-        }
-
-        void FBXConverter::SetTextureProperties(aiMaterial* out_mat, const TextureMap& textures, const MeshGeometry* const mesh)
-        {
-            TrySetTextureProperties(out_mat, textures, "DiffuseColor", aiTextureType_DIFFUSE, mesh);
-            TrySetTextureProperties(out_mat, textures, "AmbientColor", aiTextureType_AMBIENT, mesh);
-            TrySetTextureProperties(out_mat, textures, "EmissiveColor", aiTextureType_EMISSIVE, mesh);
-            TrySetTextureProperties(out_mat, textures, "SpecularColor", aiTextureType_SPECULAR, mesh);
-            TrySetTextureProperties(out_mat, textures, "SpecularFactor", aiTextureType_SPECULAR, mesh);
-            TrySetTextureProperties(out_mat, textures, "TransparentColor", aiTextureType_OPACITY, mesh);
-            TrySetTextureProperties(out_mat, textures, "ReflectionColor", aiTextureType_REFLECTION, mesh);
-            TrySetTextureProperties(out_mat, textures, "DisplacementColor", aiTextureType_DISPLACEMENT, mesh);
-            TrySetTextureProperties(out_mat, textures, "NormalMap", aiTextureType_NORMALS, mesh);
-            TrySetTextureProperties(out_mat, textures, "Bump", aiTextureType_HEIGHT, mesh);
-            TrySetTextureProperties(out_mat, textures, "ShininessExponent", aiTextureType_SHININESS, mesh);
-			TrySetTextureProperties( out_mat, textures, "TransparencyFactor", aiTextureType_OPACITY, mesh );
-			TrySetTextureProperties( out_mat, textures, "EmissiveFactor", aiTextureType_EMISSIVE, mesh );
-            //Maya counterparts
-            TrySetTextureProperties(out_mat, textures, "Maya|DiffuseTexture", aiTextureType_DIFFUSE, mesh);
-            TrySetTextureProperties(out_mat, textures, "Maya|NormalTexture", aiTextureType_NORMALS, mesh);
-            TrySetTextureProperties(out_mat, textures, "Maya|SpecularTexture", aiTextureType_SPECULAR, mesh);
-            TrySetTextureProperties(out_mat, textures, "Maya|FalloffTexture", aiTextureType_OPACITY, mesh);
-            TrySetTextureProperties(out_mat, textures, "Maya|ReflectionMapTexture", aiTextureType_REFLECTION, mesh);
-            
-            // Maya PBR
-            TrySetTextureProperties(out_mat, textures, "Maya|baseColor|file", aiTextureType_BASE_COLOR, mesh);
-            TrySetTextureProperties(out_mat, textures, "Maya|normalCamera|file", aiTextureType_NORMAL_CAMERA, mesh);
-            TrySetTextureProperties(out_mat, textures, "Maya|emissionColor|file", aiTextureType_EMISSION_COLOR, mesh);
-            TrySetTextureProperties(out_mat, textures, "Maya|metalness|file", aiTextureType_METALNESS, mesh);
-            TrySetTextureProperties(out_mat, textures, "Maya|diffuseRoughness|file", aiTextureType_DIFFUSE_ROUGHNESS, mesh);
-            
-            // Maya stingray
-            TrySetTextureProperties(out_mat, textures, "Maya|TEX_color_map|file", aiTextureType_BASE_COLOR, mesh);
-            TrySetTextureProperties(out_mat, textures, "Maya|TEX_normal_map|file", aiTextureType_NORMAL_CAMERA, mesh);
-            TrySetTextureProperties(out_mat, textures, "Maya|TEX_emissive_map|file", aiTextureType_EMISSION_COLOR, mesh);
-            TrySetTextureProperties(out_mat, textures, "Maya|TEX_metallic_map|file", aiTextureType_METALNESS, mesh);
-            TrySetTextureProperties(out_mat, textures, "Maya|TEX_roughness_map|file", aiTextureType_DIFFUSE_ROUGHNESS, mesh);
-            TrySetTextureProperties(out_mat, textures, "Maya|TEX_ao_map|file", aiTextureType_AMBIENT_OCCLUSION, mesh);            
-        }
-
-        void FBXConverter::SetTextureProperties(aiMaterial* out_mat, const LayeredTextureMap& layeredTextures, const MeshGeometry* const mesh)
-        {
-            TrySetTextureProperties(out_mat, layeredTextures, "DiffuseColor", aiTextureType_DIFFUSE, mesh);
-            TrySetTextureProperties(out_mat, layeredTextures, "AmbientColor", aiTextureType_AMBIENT, mesh);
-            TrySetTextureProperties(out_mat, layeredTextures, "EmissiveColor", aiTextureType_EMISSIVE, mesh);
-            TrySetTextureProperties(out_mat, layeredTextures, "SpecularColor", aiTextureType_SPECULAR, mesh);
-            TrySetTextureProperties(out_mat, layeredTextures, "SpecularFactor", aiTextureType_SPECULAR, mesh);
-            TrySetTextureProperties(out_mat, layeredTextures, "TransparentColor", aiTextureType_OPACITY, mesh);
-            TrySetTextureProperties(out_mat, layeredTextures, "ReflectionColor", aiTextureType_REFLECTION, mesh);
-            TrySetTextureProperties(out_mat, layeredTextures, "DisplacementColor", aiTextureType_DISPLACEMENT, mesh);
-            TrySetTextureProperties(out_mat, layeredTextures, "NormalMap", aiTextureType_NORMALS, mesh);
-            TrySetTextureProperties(out_mat, layeredTextures, "Bump", aiTextureType_HEIGHT, mesh);
-            TrySetTextureProperties(out_mat, layeredTextures, "ShininessExponent", aiTextureType_SHININESS, mesh);
-			TrySetTextureProperties( out_mat, layeredTextures, "EmissiveFactor", aiTextureType_EMISSIVE, mesh );
-			TrySetTextureProperties( out_mat, layeredTextures, "TransparencyFactor", aiTextureType_OPACITY, mesh );
-        }
-
-        aiColor3D FBXConverter::GetColorPropertyFactored(const PropertyTable& props, const std::string& colorName,
-            const std::string& factorName, bool& result, bool useTemplate)
-        {
-            result = true;
-
-            bool ok;
-            aiVector3D BaseColor = PropertyGet<aiVector3D>(props, colorName, ok, useTemplate);
-            if (!ok) {
-                result = false;
-                return aiColor3D(0.0f, 0.0f, 0.0f);
-            }
-
-            // if no factor name, return the colour as is
-            if (factorName.empty()) {
-                return aiColor3D(BaseColor.x, BaseColor.y, BaseColor.z);
-            }
-
-            // otherwise it should be multiplied by the factor, if found.
-            float factor = PropertyGet<float>(props, factorName, ok, useTemplate);
-            if (ok) {
-                BaseColor *= factor;
-            }
-            return aiColor3D(BaseColor.x, BaseColor.y, BaseColor.z);
-        }
-
-        aiColor3D FBXConverter::GetColorPropertyFromMaterial(const PropertyTable& props, const std::string& baseName,
-            bool& result)
-        {
-            return GetColorPropertyFactored(props, baseName + "Color", baseName + "Factor", result, true);
-        }
-
-        aiColor3D FBXConverter::GetColorProperty(const PropertyTable& props, const std::string& colorName,
-            bool& result, bool useTemplate)
-        {
-            result = true;
-            bool ok;
-            const aiVector3D& ColorVec = PropertyGet<aiVector3D>(props, colorName, ok, useTemplate);
-            if (!ok) {
-                result = false;
-                return aiColor3D(0.0f, 0.0f, 0.0f);
-            }
-            return aiColor3D(ColorVec.x, ColorVec.y, ColorVec.z);
-        }
-
-        void FBXConverter::SetShadingPropertiesCommon(aiMaterial* out_mat, const PropertyTable& props)
-        {
-            // Set shading properties.
-            // Modern FBX Files have two separate systems for defining these,
-            // with only the more comprehensive one described in the property template.
-            // Likely the other values are a legacy system,
-            // which is still always exported by the official FBX SDK.
-            //
-            // Blender's FBX import and export mostly ignore this legacy system,
-            // and as we only support recent versions of FBX anyway, we can do the same.
-            bool ok;
-
-            const aiColor3D& Diffuse = GetColorPropertyFromMaterial(props, "Diffuse", ok);
-            if (ok) {
-                out_mat->AddProperty(&Diffuse, 1, AI_MATKEY_COLOR_DIFFUSE);
-            }
-
-            const aiColor3D& Emissive = GetColorPropertyFromMaterial(props, "Emissive", ok);
-            if (ok) {
-                out_mat->AddProperty(&Emissive, 1, AI_MATKEY_COLOR_EMISSIVE);
-            }
-
-            const aiColor3D& Ambient = GetColorPropertyFromMaterial(props, "Ambient", ok);
-            if (ok) {
-                out_mat->AddProperty(&Ambient, 1, AI_MATKEY_COLOR_AMBIENT);
-            }
-
-            // we store specular factor as SHININESS_STRENGTH, so just get the color
-            const aiColor3D& Specular = GetColorProperty(props, "SpecularColor", ok, true);
-            if (ok) {
-                out_mat->AddProperty(&Specular, 1, AI_MATKEY_COLOR_SPECULAR);
-            }
-
-            // and also try to get SHININESS_STRENGTH
-            const float SpecularFactor = PropertyGet<float>(props, "SpecularFactor", ok, true);
-            if (ok) {
-                out_mat->AddProperty(&SpecularFactor, 1, AI_MATKEY_SHININESS_STRENGTH);
-            }
-
-            // and the specular exponent
-            const float ShininessExponent = PropertyGet<float>(props, "ShininessExponent", ok);
-            if (ok) {
-                out_mat->AddProperty(&ShininessExponent, 1, AI_MATKEY_SHININESS);
-            }
-
-            // TransparentColor / TransparencyFactor... gee thanks FBX :rolleyes:
-            const aiColor3D& Transparent = GetColorPropertyFactored(props, "TransparentColor", "TransparencyFactor", ok);
-            float CalculatedOpacity = 1.0f;
-            if (ok) {
-                out_mat->AddProperty(&Transparent, 1, AI_MATKEY_COLOR_TRANSPARENT);
-                // as calculated by FBX SDK 2017:
-                CalculatedOpacity = 1.0f - ((Transparent.r + Transparent.g + Transparent.b) / 3.0f);
-            }
-
-            // try to get the transparency factor
-            const float TransparencyFactor = PropertyGet<float>(props, "TransparencyFactor", ok);
-            if (ok) {
-                out_mat->AddProperty(&TransparencyFactor, 1, AI_MATKEY_TRANSPARENCYFACTOR);
-            }
-
-            // use of TransparencyFactor is inconsistent.
-            // Maya always stores it as 1.0,
-            // so we can't use it to set AI_MATKEY_OPACITY.
-            // Blender is more sensible and stores it as the alpha value.
-            // However both the FBX SDK and Blender always write an additional
-            // legacy "Opacity" field, so we can try to use that.
-            //
-            // If we can't find it,
-            // we can fall back to the value which the FBX SDK calculates
-            // from transparency colour (RGB) and factor (F) as
-            // 1.0 - F*((R+G+B)/3).
-            //
-            // There's no consistent way to interpret this opacity value,
-            // so it's up to clients to do the correct thing.
-            const float Opacity = PropertyGet<float>(props, "Opacity", ok);
-            if (ok) {
-                out_mat->AddProperty(&Opacity, 1, AI_MATKEY_OPACITY);
-            }
-            else if (CalculatedOpacity != 1.0) {
-                out_mat->AddProperty(&CalculatedOpacity, 1, AI_MATKEY_OPACITY);
-            }
-
-            // reflection color and factor are stored separately
-            const aiColor3D& Reflection = GetColorProperty(props, "ReflectionColor", ok, true);
-            if (ok) {
-                out_mat->AddProperty(&Reflection, 1, AI_MATKEY_COLOR_REFLECTIVE);
-            }
-
-            float ReflectionFactor = PropertyGet<float>(props, "ReflectionFactor", ok, true);
-            if (ok) {
-                out_mat->AddProperty(&ReflectionFactor, 1, AI_MATKEY_REFLECTIVITY);
-            }
-
-            const float BumpFactor = PropertyGet<float>(props, "BumpFactor", ok);
-            if (ok) {
-                out_mat->AddProperty(&BumpFactor, 1, AI_MATKEY_BUMPSCALING);
-            }
-
-            const float DispFactor = PropertyGet<float>(props, "DisplacementFactor", ok);
-            if (ok) {
-                out_mat->AddProperty(&DispFactor, 1, "$mat.displacementscaling", 0, 0);
     }
 }
 
+void FBXConverter::ConvertCameras(const Model &model, const std::string &orig_name) {
+	const std::vector<const NodeAttribute *> &node_attrs = model.GetAttributes();
+	for (const NodeAttribute *attr : node_attrs) {
+		const Camera *const cam = dynamic_cast<const Camera *>(attr);
+		if (cam) {
+			ConvertCamera(*cam, orig_name);
+		}
+	}
+}
 
-void FBXConverter::SetShadingPropertiesRaw(aiMaterial* out_mat, const PropertyTable& props, const TextureMap& textures, const MeshGeometry* const mesh)
-{
-    // Add all the unparsed properties with a "$raw." prefix
+void FBXConverter::ConvertLight(const Light &light, const std::string &orig_name) {
+	lights.push_back(new aiLight());
+	aiLight *const out_light = lights.back();
 
-    const std::string prefix = "$raw.";
+	out_light->mName.Set(orig_name);
 
-    for (const DirectPropertyMap::value_type& prop : props.GetUnparsedProperties()) {
+	const float intensity = light.Intensity() / 100.0f;
+	const aiVector3D &col = light.Color();
 
-        std::string name = prefix + prop.first;
+	out_light->mColorDiffuse = aiColor3D(col.x, col.y, col.z);
+	out_light->mColorDiffuse.r *= intensity;
+	out_light->mColorDiffuse.g *= intensity;
+	out_light->mColorDiffuse.b *= intensity;
 
-        if (const TypedProperty<aiVector3D>* interpreted = prop.second->As<TypedProperty<aiVector3D> >())
+
+	out_light->mColorSpecular = out_light->mColorDiffuse;
+
+	//lights are defined along negative y direction
+	out_light->mPosition = aiVector3D(0.0f);
+	out_light->mDirection = aiVector3D(0.0f, -1.0f, 0.0f);
+	out_light->mUp = aiVector3D(0.0f, 0.0f, -1.0f);
+
+	switch (light.LightType()) {
+		case Light::Type_Point:
+			out_light->mType = aiLightSource_POINT;
+			break;
+
+		case Light::Type_Directional:
+			out_light->mType = aiLightSource_DIRECTIONAL;
+			break;
+
+		case Light::Type_Spot:
+			out_light->mType = aiLightSource_SPOT;
+			out_light->mAngleOuterCone = AI_DEG_TO_RAD(light.OuterAngle());
+			out_light->mAngleInnerCone = AI_DEG_TO_RAD(light.InnerAngle());
+			break;
+
+		case Light::Type_Area:
+			FBXImporter::LogWarn("cannot represent area light, set to UNDEFINED");
+			out_light->mType = aiLightSource_UNDEFINED;
+			break;
+
+		case Light::Type_Volume:
+			FBXImporter::LogWarn("cannot represent volume light, set to UNDEFINED");
+			out_light->mType = aiLightSource_UNDEFINED;
+			break;
+		default:
+			ai_assert(false);
+	}
+
+	float decay = light.DecayStart();
+	switch (light.DecayType()) {
+		case Light::Decay_None:
+			out_light->mAttenuationConstant = decay;
+			out_light->mAttenuationLinear = 0.0f;
+			out_light->mAttenuationQuadratic = 0.0f;
+			break;
+		case Light::Decay_Linear:
+			out_light->mAttenuationConstant = 0.0f;
+			out_light->mAttenuationLinear = 2.0f / decay;
+			out_light->mAttenuationQuadratic = 0.0f;
+			break;
+		case Light::Decay_Quadratic:
+			out_light->mAttenuationConstant = 0.0f;
+			out_light->mAttenuationLinear = 0.0f;
+			out_light->mAttenuationQuadratic = 2.0f / (decay * decay);
+			break;
+		case Light::Decay_Cubic:
+			FBXImporter::LogWarn("cannot represent cubic attenuation, set to Quadratic");
+			out_light->mAttenuationQuadratic = 1.0f;
+			break;
+		default:
+			ai_assert(false);
+			break;
+	}
+}
+
+void FBXConverter::ConvertCamera(const Camera &cam, const std::string &orig_name) {
+	cameras.push_back(new aiCamera());
+	aiCamera *const out_camera = cameras.back();
+
+	out_camera->mName.Set(orig_name);
+
+	out_camera->mAspect = cam.AspectWidth() / cam.AspectHeight();
+
+	out_camera->mPosition = aiVector3D(0.0f);
+	out_camera->mLookAt = aiVector3D(1.0f, 0.0f, 0.0f);
+	out_camera->mUp = aiVector3D(0.0f, 1.0f, 0.0f);
+
+	out_camera->mHorizontalFOV = AI_DEG_TO_RAD(cam.FieldOfView());
+
+	out_camera->mClipPlaneNear = cam.NearPlane();
+	out_camera->mClipPlaneFar = cam.FarPlane();
+
+	out_camera->mHorizontalFOV = AI_DEG_TO_RAD(cam.FieldOfView());
+	out_camera->mClipPlaneNear = cam.NearPlane();
+	out_camera->mClipPlaneFar = cam.FarPlane();
+}
+
+void FBXConverter::GetUniqueName(const std::string &name, std::string &uniqueName) {
+	uniqueName = name;
+	auto it_pair = mNodeNames.insert({ name, 0 }); // duplicate node name instance count
+	unsigned int &i = it_pair.first->second;
+	while (!it_pair.second) {
+		i++;
+		std::ostringstream ext;
+		ext << name << std::setfill('0') << std::setw(3) << i;
+		uniqueName = ext.str();
+		it_pair = mNodeNames.insert({ uniqueName, 0 });
+	}
+}
+
+const char *FBXConverter::NameTransformationComp(TransformationComp comp) {
+	switch (comp) {
+		case TransformationComp_Translation:
+			return "Translation";
+		case TransformationComp_RotationOffset:
+			return "RotationOffset";
+		case TransformationComp_RotationPivot:
+			return "RotationPivot";
+		case TransformationComp_PreRotation:
+			return "PreRotation";
+		case TransformationComp_Rotation:
+			return "Rotation";
+		case TransformationComp_PostRotation:
+			return "PostRotation";
+		case TransformationComp_ScalingOffset:
+			return "ScalingOffset";
+		case TransformationComp_ScalingPivot:
+			return "ScalingPivot";
+		case TransformationComp_Scaling:
+			return "Scaling";
+		case TransformationComp_GeometricScaling:
+			return "GeometricScaling";
+		case TransformationComp_GeometricRotation:
+			return "GeometricRotation";
+		case TransformationComp_GeometricTranslation:
+			return "GeometricTranslation";
+		case TransformationComp_MAXIMUM: // this is to silence compiler warnings
+		default:
+			break;
+	}
+
+	ai_assert(false);
+
+	return nullptr;
+}
+
+const char *FBXConverter::NameTransformationCompProperty(TransformationComp comp) {
+	switch (comp) {
+		case TransformationComp_Translation:
+			return "Lcl Translation";
+		case TransformationComp_RotationOffset:
+			return "RotationOffset";
+		case TransformationComp_RotationPivot:
+			return "RotationPivot";
+		case TransformationComp_PreRotation:
+			return "PreRotation";
+		case TransformationComp_Rotation:
+			return "Lcl Rotation";
+		case TransformationComp_PostRotation:
+			return "PostRotation";
+		case TransformationComp_ScalingOffset:
+			return "ScalingOffset";
+		case TransformationComp_ScalingPivot:
+			return "ScalingPivot";
+		case TransformationComp_Scaling:
+			return "Lcl Scaling";
+		case TransformationComp_GeometricScaling:
+			return "GeometricScaling";
+		case TransformationComp_GeometricRotation:
+			return "GeometricRotation";
+		case TransformationComp_GeometricTranslation:
+			return "GeometricTranslation";
+		case TransformationComp_MAXIMUM: // this is to silence compiler warnings
+			break;
+	}
+
+	ai_assert(false);
+
+	return nullptr;
+}
+
+aiVector3D FBXConverter::TransformationCompDefaultValue(TransformationComp comp) {
+	// XXX a neat way to solve the never-ending special cases for scaling
+	// would be to do everything in log space!
+	return comp == TransformationComp_Scaling ? aiVector3D(1.f, 1.f, 1.f) : aiVector3D();
+}
+
+void FBXConverter::GetRotationMatrix(Model::RotOrder mode, const aiVector3D &rotation, aiMatrix4x4 &out) {
+	if (mode == Model::RotOrder_SphericXYZ) {
+		FBXImporter::LogError("Unsupported RotationMode: SphericXYZ");
+		out = aiMatrix4x4();
+		return;
+	}
+
+	const float angle_epsilon = Math::getEpsilon<float>();
+
+	out = aiMatrix4x4();
+
+	bool is_id[3] = { true, true, true };
+
+	aiMatrix4x4 temp[3];
+	if (std::fabs(rotation.z) > angle_epsilon) {
+		aiMatrix4x4::RotationZ(AI_DEG_TO_RAD(rotation.z), temp[2]);
+		is_id[2] = false;
+	}
+	if (std::fabs(rotation.y) > angle_epsilon) {
+		aiMatrix4x4::RotationY(AI_DEG_TO_RAD(rotation.y), temp[1]);
+		is_id[1] = false;
+	}
+	if (std::fabs(rotation.x) > angle_epsilon) {
+		aiMatrix4x4::RotationX(AI_DEG_TO_RAD(rotation.x), temp[0]);
+		is_id[0] = false;
+	}
+
+	int order[3] = { -1, -1, -1 };
+
+	// note: rotation order is inverted since we're left multiplying as is usual in assimp
+	switch (mode) {
+		case Model::RotOrder_EulerXYZ:
+			order[0] = 2;
+			order[1] = 1;
+			order[2] = 0;
+			break;
+
+		case Model::RotOrder_EulerXZY:
+			order[0] = 1;
+			order[1] = 2;
+			order[2] = 0;
+			break;
+
+		case Model::RotOrder_EulerYZX:
+			order[0] = 0;
+			order[1] = 2;
+			order[2] = 1;
+			break;
+
+		case Model::RotOrder_EulerYXZ:
+			order[0] = 2;
+			order[1] = 0;
+			order[2] = 1;
+			break;
+
+		case Model::RotOrder_EulerZXY:
+			order[0] = 1;
+			order[1] = 0;
+			order[2] = 2;
+			break;
+
+		case Model::RotOrder_EulerZYX:
+			order[0] = 0;
+			order[1] = 1;
+			order[2] = 2;
+			break;
+
+		default:
+			ai_assert(false);
+			break;
+	}
+
+	ai_assert(order[0] >= 0);
+	ai_assert(order[0] <= 2);
+	ai_assert(order[1] >= 0);
+	ai_assert(order[1] <= 2);
+	ai_assert(order[2] >= 0);
+	ai_assert(order[2] <= 2);
+
+	if (!is_id[order[0]]) {
+		out = temp[order[0]];
+	}
+
+	if (!is_id[order[1]]) {
+		out = out * temp[order[1]];
+	}
+
+	if (!is_id[order[2]]) {
+		out = out * temp[order[2]];
+	}
+}
+
+bool FBXConverter::NeedsComplexTransformationChain(const Model &model) {
+	const PropertyTable &props = model.Props();
+	bool ok;
+
+	const float zero_epsilon = 1e-6f;
+	const aiVector3D all_ones(1.0f, 1.0f, 1.0f);
+	for (size_t i = 0; i < TransformationComp_MAXIMUM; ++i) {
+		const TransformationComp comp = static_cast<TransformationComp>(i);
+
+		if (comp == TransformationComp_Rotation || comp == TransformationComp_Scaling || comp == TransformationComp_Translation) {
+			continue;
+		}
+
+		bool scale_compare = (comp == TransformationComp_GeometricScaling || comp == TransformationComp_Scaling);
+
+		const aiVector3D &v = PropertyGet<aiVector3D>(props, NameTransformationCompProperty(comp), ok);
+		if (ok && scale_compare) {
+			if ((v - all_ones).SquareLength() > zero_epsilon) {
+				return true;
+			}
+		} else if (ok) {
+			if (v.SquareLength() > zero_epsilon) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+void FBXConverter::MagicPivotAlgorithm(
+		aiMatrix4x4 chain[TransformationComp_MAXIMUM],
+		aiMatrix4x4 &result,
+		aiMatrix4x4 &geometric_transform) {
+
+	// Maya pivots
+	aiMatrix4x4 T = chain[TransformationComp_Translation];
+	aiMatrix4x4 Roff = chain[TransformationComp_RotationOffset];
+	aiMatrix4x4 Rp = chain[TransformationComp_RotationPivot];
+	aiMatrix4x4 Rpre = chain[TransformationComp_PreRotation];
+	aiMatrix4x4 R = chain[TransformationComp_Rotation];
+	aiMatrix4x4 Rpost = chain[TransformationComp_PostRotation];
+	aiMatrix4x4 Soff = chain[TransformationComp_ScalingOffset];
+	aiMatrix4x4 Sp = chain[TransformationComp_ScalingPivot];
+	aiMatrix4x4 S = chain[TransformationComp_Scaling];
+
+	// 3DS Max Pivots
+	aiMatrix4x4 OT = chain[TransformationComp_GeometricTranslation];
+	aiMatrix4x4 OR = chain[TransformationComp_GeometricRotation];
+	aiMatrix4x4 OS = chain[TransformationComp_GeometricScaling];
+
+	// Calculate standard maya pivots
+	result = T * Roff * Rp * Rpre * R * Rpost.Inverse() * Rp.Inverse() * Soff * Sp * S * Sp.Inverse();
+	//result = Sp.Inverse() * S * Sp * Soff * Rp.Inverse() * Rpost.Inverse() * R * Rpre * Rp * Roff * T;
+	// Calculate 3DS max pivot transform - use geometric space (e.g doesn't effect children nodes only the current node)
+	geometric_transform = OT * OR * OS;
+	//result = Sp.Inverse() * S * Sp * Soff * Rp.Inverse() * Rpost.Inverse() * R * Rpre * Rp * Roff * T;
+}
+
+aiMatrix4x4 FBXConverter::GeneratePivotTransform( const Model& model, aiMatrix4x4 &geometric_transform ){
+    return GeneratePivotTransform(model.Props(), model.RotationOrder(), geometric_transform);
+}
+
+aiMatrix4x4 FBXConverter::GeneratePivotTransform(const PropertyTable &props, const Model::RotOrder &rot,
+                                                 aiMatrix4x4 &geometric_transform) {
+//	const PropertyTable &props = model.Props();
+//	const Model::RotOrder rot = model.RotationOrder();
+
+	bool ok = false;
+
+	aiMatrix4x4 chain[TransformationComp_MAXIMUM];
+
+	// Identity everything
+	for (int x = 0; x < TransformationComp_MAXIMUM; x++) {
+		chain[x] = aiMatrix4x4();
+	}
+
+	// generate transformation matrices for all the different transformation components
+	const aiVector3D &PreRotation = PropertyGet<aiVector3D>(props, "PreRotation", ok);
+	if (ok) {
+		GetRotationMatrix(rot, PreRotation, chain[TransformationComp_PreRotation]);
+	}
+
+	const aiVector3D &PostRotation = PropertyGet<aiVector3D>(props, "PostRotation", ok);
+	if (ok) {
+		GetRotationMatrix(rot, PostRotation, chain[TransformationComp_PostRotation]);
+	}
+
+	const aiVector3D &RotationPivot = PropertyGet<aiVector3D>(props, "RotationPivot", ok);
+	if (ok) {
+		aiMatrix4x4::Translation(RotationPivot, chain[TransformationComp_RotationPivot]);
+	}
+
+	const aiVector3D &RotationOffset = PropertyGet<aiVector3D>(props, "RotationOffset", ok);
+	if (ok) {
+		aiMatrix4x4::Translation(RotationOffset, chain[TransformationComp_RotationOffset]);
+	}
+
+	const aiVector3D &ScalingOffset = PropertyGet<aiVector3D>(props, "ScalingOffset", ok);
+	if (ok) {
+		aiMatrix4x4::Translation(ScalingOffset, chain[TransformationComp_ScalingOffset]);
+	}
+
+	const aiVector3D &ScalingPivot = PropertyGet<aiVector3D>(props, "ScalingPivot", ok);
+	if (ok) {
+		aiMatrix4x4::Translation(ScalingPivot, chain[TransformationComp_ScalingPivot]);
+	}
+
+	const aiVector3D &Translation = PropertyGet<aiVector3D>(props, "Lcl Translation", ok);
+	if (ok) {
+		aiMatrix4x4::Translation(Translation, chain[TransformationComp_Translation]);
+	}
+
+	const aiVector3D &Scaling = PropertyGet<aiVector3D>(props, "Lcl Scaling", ok);
+	if (ok) {
+		aiMatrix4x4::Scaling(Scaling, chain[TransformationComp_Scaling]);
+	}
+
+	const aiVector3D &Rotation = PropertyGet<aiVector3D>(props, "Lcl Rotation", ok);
+	if (ok) {
+		GetRotationMatrix(rot, Rotation, chain[TransformationComp_Rotation]);
+	}
+
+	const aiVector3D &GeometricScaling = PropertyGet<aiVector3D>(props, "GeometricScaling", ok);
+	if (ok) {
+		aiMatrix4x4::Scaling(GeometricScaling, chain[TransformationComp_GeometricScaling]);
+	}
+
+	const aiVector3D &GeometricRotation = PropertyGet<aiVector3D>(props, "GeometricRotation", ok);
+	if (ok) {
+		GetRotationMatrix(rot, GeometricRotation, chain[TransformationComp_GeometricRotation]);
+	}
+
+	const aiVector3D &GeometricTranslation = PropertyGet<aiVector3D>(props, "GeometricTranslation", ok);
+	if (ok) {
+		aiMatrix4x4::Translation(GeometricTranslation, chain[TransformationComp_GeometricTranslation]);
+	}
+
+	aiMatrix4x4 transform;
+
+	MagicPivotAlgorithm(chain, transform, geometric_transform);
+
+	return transform;
+}
+
+void FBXConverter::SetupNodeMetadata(const Model &model, aiNode *nd) {
+	const PropertyTable &props = model.Props();
+	DirectPropertyMap unparsedProperties = props.GetUnparsedProperties();
+
+	// create metadata on node
+	const std::size_t numStaticMetaData = 2;
+	aiMetadata *data = aiMetadata::Alloc(static_cast<unsigned int>(unparsedProperties.size() + numStaticMetaData));
+	nd->mMetaData = data;
+	int index = 0;
+
+	// find user defined properties (3ds Max)
+	data->Set(index++, "UserProperties", aiString(PropertyGet<std::string>(props, "UDP3DSMAX", "")));
+	// preserve the info that a node was marked as Null node in the original file.
+	data->Set(index++, "IsNull", model.IsNull() ? true : false);
+
+	// add unparsed properties to the node's metadata
+	for (const DirectPropertyMap::value_type &prop : unparsedProperties) {
+		// Interpret the property as a concrete type
+		if (const TypedProperty<bool> *interpreted = prop.second->As<TypedProperty<bool> >()) {
+			data->Set(index++, prop.first, interpreted->Value());
+		} else if (const TypedProperty<int> *interpreted = prop.second->As<TypedProperty<int> >()) {
+			data->Set(index++, prop.first, interpreted->Value());
+		} else if (const TypedProperty<uint64_t> *interpreted = prop.second->As<TypedProperty<uint64_t> >()) {
+			data->Set(index++, prop.first, interpreted->Value());
+		} else if (const TypedProperty<float> *interpreted = prop.second->As<TypedProperty<float> >()) {
+			data->Set(index++, prop.first, interpreted->Value());
+		} else if (const TypedProperty<std::string> *interpreted = prop.second->As<TypedProperty<std::string> >()) {
+			data->Set(index++, prop.first, aiString(interpreted->Value()));
+		} else if (const TypedProperty<aiVector3D> *interpreted = prop.second->As<TypedProperty<aiVector3D> >()) {
+			data->Set(index++, prop.first, interpreted->Value());
+		} else {
+			ai_assert(false);
+		}
+	}
+}
+
+void FBXConverter::ConvertModel(const Model &model, aiNode *parent, aiNode *root_node,
+		const aiMatrix4x4 &absolute_transform) {
+	const std::vector<const Geometry *> &geos = model.GetGeometry();
+
+	std::vector<unsigned int> meshes;
+	meshes.reserve(geos.size());
+
+	for (const Geometry *geo : geos) {
+
+		const MeshGeometry *const mesh = dynamic_cast<const MeshGeometry *>(geo);
+		const LineGeometry *const line = dynamic_cast<const LineGeometry *>(geo);
+		if (mesh) {
+			const std::vector<unsigned int> &indices = ConvertMesh(*mesh, model, parent, root_node,
+					absolute_transform);
+			std::copy(indices.begin(), indices.end(), std::back_inserter(meshes));
+		} else if (line) {
+			const std::vector<unsigned int> &indices = ConvertLine(*line, model, parent, root_node);
+			std::copy(indices.begin(), indices.end(), std::back_inserter(meshes));
+		} else {
+			FBXImporter::LogWarn("ignoring unrecognized geometry: " + geo->Name());
+		}
+	}
+
+	if (meshes.size()) {
+		parent->mMeshes = new unsigned int[meshes.size()]();
+		parent->mNumMeshes = static_cast<unsigned int>(meshes.size());
+
+		std::swap_ranges(meshes.begin(), meshes.end(), parent->mMeshes);
+	}
+}
+
+std::vector<unsigned int> FBXConverter::ConvertMesh(
+        const MeshGeometry &mesh,
+        const Model &model,
+        aiNode *parent,
+        aiNode *root_node,
+		const aiMatrix4x4 &absolute_transform) {
+	std::vector<unsigned int> temp;
+
+	MeshMap::const_iterator it = meshes_converted.find(&mesh);
+	if (it != meshes_converted.end()) {
+		std::copy((*it).second.begin(), (*it).second.end(), std::back_inserter(temp));
+		return temp;
+	}
+
+	const std::vector<aiVector3D> &vertices = mesh.GetVertices();
+	const std::vector<unsigned int> &faces = mesh.GetFaceIndexCounts();
+	if (vertices.empty() || faces.empty()) {
+		FBXImporter::LogWarn("ignoring empty geometry: " + mesh.Name());
+		return temp;
+	}
+
+	// one material per mesh maps easily to aiMesh. Multiple material
+	// meshes need to be split.
+	const MatIndexArray &mindices = mesh.GetMaterialIndices();
+	if (doc.Settings().readMaterials && !mindices.empty()) {
+		const MatIndexArray::value_type base = mindices[0];
+		for (MatIndexArray::value_type index : mindices) {
+			if (index != base) {
+				return ConvertMeshMultiMaterial(mesh, model, parent, root_node, absolute_transform);
+			}
+		}
+	}
+
+	// faster code-path, just copy the data
+	temp.push_back(ConvertMeshSingleMaterial(mesh, model, absolute_transform, parent, root_node));
+	return temp;
+}
+
+std::vector<unsigned int> FBXConverter::ConvertLine(const LineGeometry &line, const Model &model,
+		aiNode *parent, aiNode *root_node) {
+	std::vector<unsigned int> temp;
+
+	const std::vector<aiVector3D> &vertices = line.GetVertices();
+	const std::vector<int> &indices = line.GetIndices();
+	if (vertices.empty() || indices.empty()) {
+		FBXImporter::LogWarn("ignoring empty line: " + line.Name());
+		return temp;
+	}
+
+	aiMesh *const out_mesh = SetupEmptyMesh(line, root_node);
+	out_mesh->mPrimitiveTypes |= aiPrimitiveType_LINE;
+
+	// copy vertices
+	out_mesh->mNumVertices = static_cast<unsigned int>(vertices.size());
+	out_mesh->mVertices = new aiVector3D[out_mesh->mNumVertices];
+	std::copy(vertices.begin(), vertices.end(), out_mesh->mVertices);
+
+	//Number of line segments (faces) is "Number of Points - Number of Endpoints"
+	//N.B.: Endpoints in FbxLine are denoted by negative indices.
+	//If such an Index is encountered, add 1 and multiply by -1 to get the real index.
+	unsigned int epcount = 0;
+	for (unsigned i = 0; i < indices.size(); i++) {
+		if (indices[i] < 0) {
+			epcount++;
+		}
+	}
+	unsigned int pcount = static_cast<unsigned int>(indices.size());
+	unsigned int scount = out_mesh->mNumFaces = pcount - epcount;
+
+	aiFace *fac = out_mesh->mFaces = new aiFace[scount]();
+	for (unsigned int i = 0; i < pcount; ++i) {
+		if (indices[i] < 0) continue;
+		aiFace &f = *fac++;
+		f.mNumIndices = 2; //2 == aiPrimitiveType_LINE
+		f.mIndices = new unsigned int[2];
+		f.mIndices[0] = indices[i];
+		int segid = indices[(i + 1 == pcount ? 0 : i + 1)]; //If we have reached he last point, wrap around
+		f.mIndices[1] = (segid < 0 ? (segid + 1) * -1 : segid); //Convert EndPoint Index to normal Index
+	}
+	temp.push_back(static_cast<unsigned int>(meshes.size() - 1));
+	return temp;
+}
+
+aiMesh *FBXConverter::SetupEmptyMesh(const Geometry &mesh, aiNode *parent) {
+	aiMesh *const out_mesh = new aiMesh();
+	meshes.push_back(out_mesh);
+	meshes_converted[&mesh].push_back(static_cast<unsigned int>(meshes.size() - 1));
+
+	// set name
+	std::string name = mesh.Name();
+	if (name.substr(0, 10) == "Geometry::") {
+		name = name.substr(10);
+	}
+
+	if (name.length()) {
+		out_mesh->mName.Set(name);
+	} else {
+		out_mesh->mName = parent->mName;
+	}
+
+	return out_mesh;
+}
+
+unsigned int FBXConverter::ConvertMeshSingleMaterial(const MeshGeometry &mesh, const Model &model,
+		const aiMatrix4x4 &absolute_transform, aiNode *parent,
+		aiNode *root_node) {
+	const MatIndexArray &mindices = mesh.GetMaterialIndices();
+	aiMesh *const out_mesh = SetupEmptyMesh(mesh, parent);
+
+	const std::vector<aiVector3D> &vertices = mesh.GetVertices();
+	const std::vector<unsigned int> &faces = mesh.GetFaceIndexCounts();
+
+	// copy vertices
+	out_mesh->mNumVertices = static_cast<unsigned int>(vertices.size());
+	out_mesh->mVertices = new aiVector3D[vertices.size()];
+
+	std::copy(vertices.begin(), vertices.end(), out_mesh->mVertices);
+
+	// generate dummy faces
+	out_mesh->mNumFaces = static_cast<unsigned int>(faces.size());
+	aiFace *fac = out_mesh->mFaces = new aiFace[faces.size()]();
+
+	unsigned int cursor = 0;
+	for (unsigned int pcount : faces) {
+		aiFace &f = *fac++;
+		f.mNumIndices = pcount;
+		f.mIndices = new unsigned int[pcount];
+		switch (pcount) {
+			case 1:
+				out_mesh->mPrimitiveTypes |= aiPrimitiveType_POINT;
+				break;
+			case 2:
+				out_mesh->mPrimitiveTypes |= aiPrimitiveType_LINE;
+				break;
+			case 3:
+				out_mesh->mPrimitiveTypes |= aiPrimitiveType_TRIANGLE;
+				break;
+			default:
+				out_mesh->mPrimitiveTypes |= aiPrimitiveType_POLYGON;
+				break;
+		}
+		for (unsigned int i = 0; i < pcount; ++i) {
+			f.mIndices[i] = cursor++;
+		}
+	}
+
+	// copy normals
+	const std::vector<aiVector3D> &normals = mesh.GetNormals();
+	if (normals.size()) {
+		ai_assert(normals.size() == vertices.size());
+
+		out_mesh->mNormals = new aiVector3D[vertices.size()];
+		std::copy(normals.begin(), normals.end(), out_mesh->mNormals);
+	}
+
+	// copy tangents - assimp requires both tangents and bitangents (binormals)
+	// to be present, or neither of them. Compute binormals from normals
+	// and tangents if needed.
+	const std::vector<aiVector3D> &tangents = mesh.GetTangents();
+	const std::vector<aiVector3D> *binormals = &mesh.GetBinormals();
+
+	if (tangents.size()) {
+		std::vector<aiVector3D> tempBinormals;
+		if (!binormals->size()) {
+			if (normals.size()) {
+				tempBinormals.resize(normals.size());
+				for (unsigned int i = 0; i < tangents.size(); ++i) {
+					tempBinormals[i] = normals[i] ^ tangents[i];
+				}
+
+				binormals = &tempBinormals;
+			} else {
+				binormals = nullptr;
+			}
+		}
+
+		if (binormals) {
+			ai_assert(tangents.size() == vertices.size());
+			ai_assert(binormals->size() == vertices.size());
+
+			out_mesh->mTangents = new aiVector3D[vertices.size()];
+			std::copy(tangents.begin(), tangents.end(), out_mesh->mTangents);
+
+			out_mesh->mBitangents = new aiVector3D[vertices.size()];
+			std::copy(binormals->begin(), binormals->end(), out_mesh->mBitangents);
+		}
+	}
+
+	// copy texture coords
+	for (unsigned int i = 0; i < AI_MAX_NUMBER_OF_TEXTURECOORDS; ++i) {
+		const std::vector<aiVector2D> &uvs = mesh.GetTextureCoords(i);
+		if (uvs.empty()) {
+			break;
+		}
+
+		aiVector3D *out_uv = out_mesh->mTextureCoords[i] = new aiVector3D[vertices.size()];
+		for (const aiVector2D &v : uvs) {
+			*out_uv++ = aiVector3D(v.x, v.y, 0.0f);
+		}
+
+		out_mesh->mNumUVComponents[i] = 2;
+	}
+
+	// copy vertex colors
+	for (unsigned int i = 0; i < AI_MAX_NUMBER_OF_COLOR_SETS; ++i) {
+		const std::vector<aiColor4D> &colors = mesh.GetVertexColors(i);
+		if (colors.empty()) {
+			break;
+		}
+
+		out_mesh->mColors[i] = new aiColor4D[vertices.size()];
+		std::copy(colors.begin(), colors.end(), out_mesh->mColors[i]);
+	}
+
+	if (!doc.Settings().readMaterials || mindices.empty()) {
+		FBXImporter::LogError("no material assigned to mesh, setting default material");
+		out_mesh->mMaterialIndex = GetDefaultMaterial();
+	} else {
+		ConvertMaterialForMesh(out_mesh, model, mesh, mindices[0]);
+	}
+
+	if (doc.Settings().readWeights && mesh.DeformerSkin() != nullptr) {
+		ConvertWeights(out_mesh, model, mesh, absolute_transform, parent, root_node, NO_MATERIAL_SEPARATION,
+				nullptr);
+	}
+
+	std::vector<aiAnimMesh *> animMeshes;
+	for (const BlendShape *blendShape : mesh.GetBlendShapes()) {
+		for (const BlendShapeChannel *blendShapeChannel : blendShape->BlendShapeChannels()) {
+			const std::vector<const ShapeGeometry *> &shapeGeometries = blendShapeChannel->GetShapeGeometries();
+			for (size_t i = 0; i < shapeGeometries.size(); i++) {
+				aiAnimMesh *animMesh = aiCreateAnimMesh(out_mesh);
+				const ShapeGeometry *shapeGeometry = shapeGeometries.at(i);
+				const std::vector<aiVector3D> &vertices = shapeGeometry->GetVertices();
+				const std::vector<aiVector3D> &normals = shapeGeometry->GetNormals();
+				const std::vector<unsigned int> &indices = shapeGeometry->GetIndices();
+				animMesh->mName.Set(FixAnimMeshName(shapeGeometry->Name()));
+				for (size_t j = 0; j < indices.size(); j++) {
+					unsigned int index = indices.at(j);
+					aiVector3D vertex = vertices.at(j);
+					aiVector3D normal = normals.at(j);
+					unsigned int count = 0;
+					const unsigned int *outIndices = mesh.ToOutputVertexIndex(index, count);
+					for (unsigned int k = 0; k < count; k++) {
+						unsigned int index = outIndices[k];
+						animMesh->mVertices[index] += vertex;
+						if (animMesh->mNormals != nullptr) {
+							animMesh->mNormals[index] += normal;
+							animMesh->mNormals[index].NormalizeSafe();
+						}
+					}
+				}
+				animMesh->mWeight = shapeGeometries.size() > 1 ? blendShapeChannel->DeformPercent() / 100.0f : 1.0f;
+				animMeshes.push_back(animMesh);
+			}
+		}
+	}
+	const size_t numAnimMeshes = animMeshes.size();
+	if (numAnimMeshes > 0) {
+		out_mesh->mNumAnimMeshes = static_cast<unsigned int>(numAnimMeshes);
+		out_mesh->mAnimMeshes = new aiAnimMesh *[numAnimMeshes];
+		for (size_t i = 0; i < numAnimMeshes; i++) {
+			out_mesh->mAnimMeshes[i] = animMeshes.at(i);
+		}
+	}
+	return static_cast<unsigned int>(meshes.size() - 1);
+}
+
+std::vector<unsigned int>
+FBXConverter::ConvertMeshMultiMaterial(const MeshGeometry &mesh, const Model &model, aiNode *parent,
+		aiNode *root_node,
+		const aiMatrix4x4 &absolute_transform) {
+	const MatIndexArray &mindices = mesh.GetMaterialIndices();
+	ai_assert(mindices.size());
+
+	std::set<MatIndexArray::value_type> had;
+	std::vector<unsigned int> indices;
+
+	for (MatIndexArray::value_type index : mindices) {
+		if (had.find(index) == had.end()) {
+
+			indices.push_back(ConvertMeshMultiMaterial(mesh, model, index, parent, root_node, absolute_transform));
+			had.insert(index);
+		}
+	}
+
+	return indices;
+}
+
+unsigned int FBXConverter::ConvertMeshMultiMaterial(const MeshGeometry &mesh, const Model &model,
+		MatIndexArray::value_type index,
+		aiNode *parent, aiNode *root_node,
+		const aiMatrix4x4 &absolute_transform) {
+	aiMesh *const out_mesh = SetupEmptyMesh(mesh, parent);
+
+	const MatIndexArray &mindices = mesh.GetMaterialIndices();
+	const std::vector<aiVector3D> &vertices = mesh.GetVertices();
+	const std::vector<unsigned int> &faces = mesh.GetFaceIndexCounts();
+
+	const bool process_weights = doc.Settings().readWeights && mesh.DeformerSkin() != nullptr;
+
+	unsigned int count_faces = 0;
+	unsigned int count_vertices = 0;
+
+	// count faces
+	std::vector<unsigned int>::const_iterator itf = faces.begin();
+	for (MatIndexArray::const_iterator it = mindices.begin(),
+									   end = mindices.end();
+			it != end; ++it, ++itf) {
+		if ((*it) != index) {
+			continue;
+		}
+		++count_faces;
+		count_vertices += *itf;
+	}
+
+	ai_assert(count_faces);
+	ai_assert(count_vertices);
+
+	// mapping from output indices to DOM indexing, needed to resolve weights or blendshapes
+	std::vector<unsigned int> reverseMapping;
+	std::map<unsigned int, unsigned int> translateIndexMap;
+	if (process_weights || mesh.GetBlendShapes().size() > 0) {
+		reverseMapping.resize(count_vertices);
+	}
+
+	// allocate output data arrays, but don't fill them yet
+	out_mesh->mNumVertices = count_vertices;
+	out_mesh->mVertices = new aiVector3D[count_vertices];
+
+	out_mesh->mNumFaces = count_faces;
+	aiFace *fac = out_mesh->mFaces = new aiFace[count_faces]();
+
+	// allocate normals
+	const std::vector<aiVector3D> &normals = mesh.GetNormals();
+	if (normals.size()) {
+		ai_assert(normals.size() == vertices.size());
+		out_mesh->mNormals = new aiVector3D[vertices.size()];
+	}
+
+	// allocate tangents, binormals.
+	const std::vector<aiVector3D> &tangents = mesh.GetTangents();
+	const std::vector<aiVector3D> *binormals = &mesh.GetBinormals();
+	std::vector<aiVector3D> tempBinormals;
+
+	if (tangents.size()) {
+		if (!binormals->size()) {
+			if (normals.size()) {
+				// XXX this computes the binormals for the entire mesh, not only
+				// the part for which we need them.
+				tempBinormals.resize(normals.size());
+				for (unsigned int i = 0; i < tangents.size(); ++i) {
+					tempBinormals[i] = normals[i] ^ tangents[i];
+				}
+
+				binormals = &tempBinormals;
+			} else {
+				binormals = nullptr;
+			}
+		}
+
+		if (binormals) {
+			ai_assert(tangents.size() == vertices.size() && binormals->size() == vertices.size());
+
+			out_mesh->mTangents = new aiVector3D[vertices.size()];
+			out_mesh->mBitangents = new aiVector3D[vertices.size()];
+		}
+	}
+
+	// allocate texture coords
+	unsigned int num_uvs = 0;
+	for (unsigned int i = 0; i < AI_MAX_NUMBER_OF_TEXTURECOORDS; ++i, ++num_uvs) {
+		const std::vector<aiVector2D> &uvs = mesh.GetTextureCoords(i);
+		if (uvs.empty()) {
+			break;
+		}
+
+		out_mesh->mTextureCoords[i] = new aiVector3D[vertices.size()];
+		out_mesh->mNumUVComponents[i] = 2;
+	}
+
+	// allocate vertex colors
+	unsigned int num_vcs = 0;
+	for (unsigned int i = 0; i < AI_MAX_NUMBER_OF_COLOR_SETS; ++i, ++num_vcs) {
+		const std::vector<aiColor4D> &colors = mesh.GetVertexColors(i);
+		if (colors.empty()) {
+			break;
+		}
+
+		out_mesh->mColors[i] = new aiColor4D[vertices.size()];
+	}
+
+	unsigned int cursor = 0, in_cursor = 0;
+
+	itf = faces.begin();
+	for (MatIndexArray::const_iterator it = mindices.begin(), end = mindices.end(); it != end; ++it, ++itf) {
+		const unsigned int pcount = *itf;
+		if ((*it) != index) {
+			in_cursor += pcount;
+			continue;
+		}
+
+		aiFace &f = *fac++;
+
+		f.mNumIndices = pcount;
+		f.mIndices = new unsigned int[pcount];
+		switch (pcount) {
+			case 1:
+				out_mesh->mPrimitiveTypes |= aiPrimitiveType_POINT;
+				break;
+			case 2:
+				out_mesh->mPrimitiveTypes |= aiPrimitiveType_LINE;
+				break;
+			case 3:
+				out_mesh->mPrimitiveTypes |= aiPrimitiveType_TRIANGLE;
+				break;
+			default:
+				out_mesh->mPrimitiveTypes |= aiPrimitiveType_POLYGON;
+				break;
+		}
+		for (unsigned int i = 0; i < pcount; ++i, ++cursor, ++in_cursor) {
+			f.mIndices[i] = cursor;
+
+			if (reverseMapping.size()) {
+				reverseMapping[cursor] = in_cursor;
+				translateIndexMap[in_cursor] = cursor;
+			}
+
+			out_mesh->mVertices[cursor] = vertices[in_cursor];
+
+			if (out_mesh->mNormals) {
+				out_mesh->mNormals[cursor] = normals[in_cursor];
+			}
+
+			if (out_mesh->mTangents) {
+				out_mesh->mTangents[cursor] = tangents[in_cursor];
+				out_mesh->mBitangents[cursor] = (*binormals)[in_cursor];
+			}
+
+			for (unsigned int j = 0; j < num_uvs; ++j) {
+				const std::vector<aiVector2D> &uvs = mesh.GetTextureCoords(j);
+				out_mesh->mTextureCoords[j][cursor] = aiVector3D(uvs[in_cursor].x, uvs[in_cursor].y, 0.0f);
+			}
+
+			for (unsigned int j = 0; j < num_vcs; ++j) {
+				const std::vector<aiColor4D> &cols = mesh.GetVertexColors(j);
+				out_mesh->mColors[j][cursor] = cols[in_cursor];
+			}
+		}
+	}
+
+	ConvertMaterialForMesh(out_mesh, model, mesh, index);
+
+	if (process_weights) {
+		ConvertWeights(out_mesh, model, mesh, absolute_transform, parent, root_node, index, &reverseMapping);
+	}
+
+	std::vector<aiAnimMesh *> animMeshes;
+	for (const BlendShape *blendShape : mesh.GetBlendShapes()) {
+		for (const BlendShapeChannel *blendShapeChannel : blendShape->BlendShapeChannels()) {
+			const std::vector<const ShapeGeometry *> &shapeGeometries = blendShapeChannel->GetShapeGeometries();
+			for (size_t i = 0; i < shapeGeometries.size(); i++) {
+				aiAnimMesh *animMesh = aiCreateAnimMesh(out_mesh);
+				const ShapeGeometry *shapeGeometry = shapeGeometries.at(i);
+				const std::vector<aiVector3D> &vertices = shapeGeometry->GetVertices();
+				const std::vector<aiVector3D> &normals = shapeGeometry->GetNormals();
+				const std::vector<unsigned int> &indices = shapeGeometry->GetIndices();
+				animMesh->mName.Set(FixAnimMeshName(shapeGeometry->Name()));
+				for (size_t j = 0; j < indices.size(); j++) {
+					unsigned int index = indices.at(j);
+					aiVector3D vertex = vertices.at(j);
+					aiVector3D normal = normals.at(j);
+					unsigned int count = 0;
+					const unsigned int *outIndices = mesh.ToOutputVertexIndex(index, count);
+					for (unsigned int k = 0; k < count; k++) {
+						unsigned int outIndex = outIndices[k];
+						if (translateIndexMap.find(outIndex) == translateIndexMap.end())
+							continue;
+						unsigned int index = translateIndexMap[outIndex];
+						animMesh->mVertices[index] += vertex;
+						if (animMesh->mNormals != nullptr) {
+							animMesh->mNormals[index] += normal;
+							animMesh->mNormals[index].NormalizeSafe();
+						}
+					}
+				}
+				animMesh->mWeight = shapeGeometries.size() > 1 ? blendShapeChannel->DeformPercent() / 100.0f : 1.0f;
+				animMeshes.push_back(animMesh);
+			}
+		}
+	}
+
+	const size_t numAnimMeshes = animMeshes.size();
+	if (numAnimMeshes > 0) {
+		out_mesh->mNumAnimMeshes = static_cast<unsigned int>(numAnimMeshes);
+		out_mesh->mAnimMeshes = new aiAnimMesh *[numAnimMeshes];
+		for (size_t i = 0; i < numAnimMeshes; i++) {
+			out_mesh->mAnimMeshes[i] = animMeshes.at(i);
+		}
+	}
+
+	return static_cast<unsigned int>(meshes.size() - 1);
+}
+
+void FBXConverter::ConvertWeights(aiMesh *out, const Model &model, const MeshGeometry &geo,
+		const aiMatrix4x4 &absolute_transform,
+		aiNode *parent, aiNode *root_node, unsigned int materialIndex,
+		std::vector<unsigned int> *outputVertStartIndices) {
+	ai_assert(geo.DeformerSkin());
+
+	std::vector<size_t> out_indices;
+	std::vector<size_t> index_out_indices;
+	std::vector<size_t> count_out_indices;
+
+	const Skin &sk = *geo.DeformerSkin();
+
+	std::cout << "Skin id" << sk.ID() << " name: " << sk.Name() << std::endl;
+
+	// if skin doesn't exist create it?
+
+	std::vector<aiBone *> bones;
+
+	const bool no_mat_check = materialIndex == NO_MATERIAL_SEPARATION;
+	ai_assert(no_mat_check || outputVertStartIndices);
+
+	try {
+
+		// iterate over the sub deformers
+		for (const Cluster *cluster : sk.Clusters()) {
+		    std::cout << "cluster name: "<< cluster->Name() << ", target: " << cluster->TargetNode()->Name() << std::endl;
+			ai_assert(cluster);
+
+			const WeightIndexArray &indices = cluster->GetIndices();
+
+			const MatIndexArray &mats = geo.GetMaterialIndices();
+
+			const size_t no_index_sentinel = std::numeric_limits<size_t>::max();
+
+			count_out_indices.clear();
+			index_out_indices.clear();
+			out_indices.clear();
+
+			// now check if *any* of these weights is contained in the output mesh,
+			// taking notes so we don't need to do it twice.
+			for (WeightIndexArray::value_type index : indices) {
+
+				unsigned int count = 0;
+				const unsigned int *const out_idx = geo.ToOutputVertexIndex(index, count);
+				// ToOutputVertexIndex only returns nullptr if index is out of bounds
+				// which should never happen
+				//ai_assert(out_idx != nullptr);
+				if (out_idx == nullptr) continue;
+
+				index_out_indices.push_back(no_index_sentinel);
+				count_out_indices.push_back(0);
+
+				for (unsigned int i = 0; i < count; ++i) {
+					if (no_mat_check || static_cast<size_t>(mats[geo.FaceForVertexIndex(out_idx[i])]) == materialIndex) {
+
+						if (index_out_indices.back() == no_index_sentinel) {
+							index_out_indices.back() = out_indices.size();
+						}
+
+						if (no_mat_check) {
+							out_indices.push_back(out_idx[i]);
+						} else {
+							// this extra lookup is in O(logn), so the entire algorithm becomes O(nlogn)
+							const std::vector<unsigned int>::iterator it = std::lower_bound(
+									outputVertStartIndices->begin(),
+									outputVertStartIndices->end(),
+									out_idx[i]);
+
+							out_indices.push_back(std::distance(outputVertStartIndices->begin(), it));
+						}
+
+						++count_out_indices.back();
+					}
+				}
+			}
+
+			// if we found at least one, generate the output bones
+			// XXX this could be heavily simplified by collecting the bone
+			// data in a single step.
+			ConvertCluster(model, bones, cluster, out_indices, index_out_indices,
+					count_out_indices, absolute_transform, parent, root_node);
+		}
+
+		bone_map.clear();
+	} catch (std::exception &e) {
+		std::for_each(bones.begin(), bones.end(), Util::delete_fun<aiBone>());
+		throw;
+	}
+
+	if (bones.empty()) {
+		out->mBones = nullptr;
+		out->mNumBones = 0;
+		return;
+	} else {
+		out->mBones = new aiBone *[bones.size()]();
+		out->mNumBones = static_cast<unsigned int>(bones.size());
+
+		std::swap_ranges(bones.begin(), bones.end(), out->mBones);
+	}
+}
+
+const aiNode *FBXConverter::GetNodeByName(const aiString &name, aiNode *current_node) {
+	aiNode *iter = current_node;
+	//printf("Child count: %d", iter->mNumChildren);
+	return iter;
+}
+
+void FBXConverter::ConvertCluster(const Model &model, std::vector<aiBone *> &local_mesh_bones, const Cluster *cl,
+		std::vector<size_t> &out_indices, std::vector<size_t> &index_out_indices,
+		std::vector<size_t> &count_out_indices, const aiMatrix4x4 &absolute_transform,
+		aiNode *parent, aiNode *root_node) {
+	ai_assert(cl); // make sure cluster valid
+	std::string deformer_name = cl->TargetNode()->Name();
+	aiString bone_name = aiString(FixNodeName(deformer_name));
+
+	aiBone *bone = nullptr;
+
+	//std::cout << "created new bone " << bone_name.C_Str() << ". Deformer: " << deformer_name << std::endl;
+	bone = new aiBone();
+	bone->mName = bone_name;
+
+	// store local transform link for post processing
+	bone->mOffsetMatrix = aiMatrix4x4();
+
+	bone->mOffsetMatrix = cl->TransformLink();
+	bone->mOffsetMatrix.Inverse();
+	bone->mOffsetMatrix *= absolute_transform;
+
+	//
+	// Now calculate the aiVertexWeights
+	//
+
+	aiVertexWeight *cursor = nullptr;
+
+	bone->mNumWeights = static_cast<unsigned int>(out_indices.size());
+	cursor = bone->mWeights = new aiVertexWeight[out_indices.size()];
+
+	const size_t no_index_sentinel = std::numeric_limits<size_t>::max();
+	const WeightArray &weights = cl->GetWeights();
+
+	const size_t c = index_out_indices.size();
+	for (size_t i = 0; i < c; ++i) {
+		const size_t index_index = index_out_indices[i];
+
+		if (index_index == no_index_sentinel) {
+			continue;
+		}
+
+		const size_t cc = count_out_indices[i];
+		for (size_t j = 0; j < cc; ++j) {
+			// cursor runs from first element relative to the start
+			// or relative to the start of the next indexes.
+			aiVertexWeight &out_weight = *cursor++;
+
+			out_weight.mVertexId = static_cast<unsigned int>(out_indices[index_index + j]);
+			out_weight.mWeight = weights[i];
+		}
+	}
+
+	    std::cout << "bone research: Indicies size: " << out_indices.size() << std::endl;
+
+//	 lookup must be populated in case something goes wrong
+//	 this also allocates bones to mesh instance outside
+	local_mesh_bones.push_back(bone);
+}
+
+void FBXConverter::ConvertMaterialForMesh(aiMesh *out, const Model &model, const MeshGeometry &geo,
+		MatIndexArray::value_type materialIndex) {
+	// locate source materials for this mesh
+	const std::vector<const Material *> &mats = model.GetMaterials();
+	if (static_cast<unsigned int>(materialIndex) >= mats.size() || materialIndex < 0) {
+		FBXImporter::LogError("material index out of bounds, setting default material");
+		out->mMaterialIndex = GetDefaultMaterial();
+		return;
+	}
+
+	const Material *const mat = mats[materialIndex];
+	MaterialMap::const_iterator it = materials_converted.find(mat);
+	if (it != materials_converted.end()) {
+		out->mMaterialIndex = (*it).second;
+		return;
+	}
+
+	out->mMaterialIndex = ConvertMaterial(*mat, &geo);
+	materials_converted[mat] = out->mMaterialIndex;
+}
+
+unsigned int FBXConverter::GetDefaultMaterial() {
+	if (defaultMaterialIndex) {
+		return defaultMaterialIndex - 1;
+	}
+
+	aiMaterial *out_mat = new aiMaterial();
+	materials.push_back(out_mat);
+
+	const aiColor3D diffuse = aiColor3D(0.8f, 0.8f, 0.8f);
+	out_mat->AddProperty(&diffuse, 1, AI_MATKEY_COLOR_DIFFUSE);
+
+	aiString s;
+	s.Set(AI_DEFAULT_MATERIAL_NAME);
+
+	out_mat->AddProperty(&s, AI_MATKEY_NAME);
+
+	defaultMaterialIndex = static_cast<unsigned int>(materials.size());
+	return defaultMaterialIndex - 1;
+}
+
+unsigned int FBXConverter::ConvertMaterial(const Material &material, const MeshGeometry *const mesh) {
+	const PropertyTable &props = material.Props();
+
+	// generate empty output material
+	aiMaterial *out_mat = new aiMaterial();
+	materials_converted[&material] = static_cast<unsigned int>(materials.size());
+
+	materials.push_back(out_mat);
+
+	aiString str;
+
+	// strip Material:: prefix
+	std::string name = material.Name();
+	if (name.substr(0, 10) == "Material::") {
+		name = name.substr(10);
+	}
+
+	// set material name if not empty - this could happen
+	// and there should be no key for it in this case.
+	if (name.length()) {
+		str.Set(name);
+		out_mat->AddProperty(&str, AI_MATKEY_NAME);
+	}
+
+	// Set the shading mode as best we can: The FBX specification only mentions Lambert and Phong, and only Phong is mentioned in Assimp's aiShadingMode enum.
+	if (material.GetShadingModel() == "phong") {
+		aiShadingMode shadingMode = aiShadingMode_Phong;
+		out_mat->AddProperty<aiShadingMode>(&shadingMode, 1, AI_MATKEY_SHADING_MODEL);
+	}
+
+	// shading stuff and colors
+	SetShadingPropertiesCommon(out_mat, props);
+	SetShadingPropertiesRaw(out_mat, props, material.Textures(), mesh);
+
+	// texture assignments
+	SetTextureProperties(out_mat, material.Textures(), mesh);
+	SetTextureProperties(out_mat, material.LayeredTextures(), mesh);
+
+	return static_cast<unsigned int>(materials.size() - 1);
+}
+
+unsigned int FBXConverter::ConvertVideo(const Video &video) {
+	// generate empty output texture
+	aiTexture *out_tex = new aiTexture();
+	textures.push_back(out_tex);
+
+	// assuming the texture is compressed
+	out_tex->mWidth = static_cast<unsigned int>(video.ContentLength()); // total data size
+	out_tex->mHeight = 0; // fixed to 0
+
+	// steal the data from the Video to avoid an additional copy
+	out_tex->pcData = reinterpret_cast<aiTexel *>(const_cast<Video &>(video).RelinquishContent());
+
+	// try to extract a hint from the file extension
+	const std::string &filename = video.RelativeFilename().empty() ? video.FileName() : video.RelativeFilename();
+	std::string ext = BaseImporter::GetExtension(filename);
+
+	if (ext == "jpeg") {
+		ext = "jpg";
+	}
+
+	if (ext.size() <= 3) {
+		memcpy(out_tex->achFormatHint, ext.c_str(), ext.size());
+	}
+
+	out_tex->mFilename.Set(filename.c_str());
+
+	return static_cast<unsigned int>(textures.size() - 1);
+}
+
+aiString FBXConverter::GetTexturePath(const Texture *tex) {
+	aiString path;
+	path.Set(tex->RelativeFilename());
+
+	const Video *media = tex->Media();
+	if (media != nullptr) {
+		bool textureReady = false; //tells if our texture is ready (if it was loaded or if it was found)
+		unsigned int index;
+
+		VideoMap::const_iterator it = textures_converted.find(*media);
+		if (it != textures_converted.end()) {
+			index = (*it).second;
+			textureReady = true;
+		} else {
+			if (media->ContentLength() > 0) {
+				index = ConvertVideo(*media);
+				textures_converted[*media] = index;
+				textureReady = true;
+			}
+		}
+
+		// setup texture reference string (copied from ColladaLoader::FindFilenameForEffectTexture), if the texture is ready
+		if (doc.Settings().useLegacyEmbeddedTextureNaming) {
+			if (textureReady) {
+				// TODO: check the possibility of using the flag "AI_CONFIG_IMPORT_FBX_EMBEDDED_TEXTURES_LEGACY_NAMING"
+				// In FBX files textures are now stored internally by Assimp with their filename included
+				// Now Assimp can lookup through the loaded textures after all data is processed
+				// We need to load all textures before referencing them, as FBX file format order may reference a texture before loading it
+				// This may occur on this case too, it has to be studied
+				path.data[0] = '*';
+				path.length = 1 + ASSIMP_itoa10(path.data + 1, MAXLEN - 1, index);
+			}
+		}
+	}
+
+	return path;
+}
+
+void FBXConverter::TrySetTextureProperties(aiMaterial *out_mat, const TextureMap &textures,
+		const std::string &propName,
+		aiTextureType target, const MeshGeometry *const mesh) {
+	TextureMap::const_iterator it = textures.find(propName);
+	if (it == textures.end()) {
+		return;
+	}
+
+	const Texture *const tex = (*it).second;
+	if (tex != 0) {
+		aiString path = GetTexturePath(tex);
+		out_mat->AddProperty(&path, _AI_MATKEY_TEXTURE_BASE, target, 0);
+
+		aiUVTransform uvTrafo;
+		// XXX handle all kinds of UV transformations
+		uvTrafo.mScaling = tex->UVScaling();
+		uvTrafo.mTranslation = tex->UVTranslation();
+		out_mat->AddProperty(&uvTrafo, 1, _AI_MATKEY_UVTRANSFORM_BASE, target, 0);
+
+		const PropertyTable &props = tex->Props();
+
+		int uvIndex = 0;
+
+		bool ok;
+		const std::string &uvSet = PropertyGet<std::string>(props, "UVSet", ok);
+		if (ok) {
+			// "default" is the name which usually appears in the FbxFileTexture template
+			if (uvSet != "default" && uvSet.length()) {
+				// this is a bit awkward - we need to find a mesh that uses this
+				// material and scan its UV channels for the given UV name because
+				// assimp references UV channels by index, not by name.
+
+				// XXX: the case that UV channels may appear in different orders
+				// in meshes is unhandled. A possible solution would be to sort
+				// the UV channels alphabetically, but this would have the side
+				// effect that the primary (first) UV channel would sometimes
+				// be moved, causing trouble when users read only the first
+				// UV channel and ignore UV channel assignments altogether.
+
+				const unsigned int matIndex = static_cast<unsigned int>(std::distance(materials.begin(),
+						std::find(materials.begin(), materials.end(), out_mat)));
+
+				uvIndex = -1;
+				if (!mesh) {
+					for (const MeshMap::value_type &v : meshes_converted) {
+						const MeshGeometry *const meshGeom = dynamic_cast<const MeshGeometry *>(v.first);
+						if (!meshGeom) {
+							continue;
+						}
+
+						const MatIndexArray &mats = meshGeom->GetMaterialIndices();
+						if (std::find(mats.begin(), mats.end(), matIndex) == mats.end()) {
+							continue;
+						}
+
+						int index = -1;
+						for (unsigned int i = 0; i < AI_MAX_NUMBER_OF_TEXTURECOORDS; ++i) {
+							if (meshGeom->GetTextureCoords(i).empty()) {
+								break;
+							}
+							const std::string &name = meshGeom->GetTextureCoordChannelName(i);
+							if (name == uvSet) {
+								index = static_cast<int>(i);
+								break;
+							}
+						}
+						if (index == -1) {
+							FBXImporter::LogWarn("did not find UV channel named " + uvSet + " in a mesh using this material");
+							continue;
+						}
+
+						if (uvIndex == -1) {
+							uvIndex = index;
+						} else {
+							FBXImporter::LogWarn("the UV channel named " + uvSet +
+												 " appears at different positions in meshes, results will be wrong");
+						}
+					}
+				} else {
+					int index = -1;
+					for (unsigned int i = 0; i < AI_MAX_NUMBER_OF_TEXTURECOORDS; ++i) {
+						if (mesh->GetTextureCoords(i).empty()) {
+							break;
+						}
+						const std::string &name = mesh->GetTextureCoordChannelName(i);
+						if (name == uvSet) {
+							index = static_cast<int>(i);
+							break;
+						}
+					}
+					if (index == -1) {
+						FBXImporter::LogWarn("did not find UV channel named " + uvSet + " in a mesh using this material");
+					}
+
+					if (uvIndex == -1) {
+						uvIndex = index;
+					}
+				}
+
+				if (uvIndex == -1) {
+					FBXImporter::LogWarn("failed to resolve UV channel " + uvSet + ", using first UV channel");
+					uvIndex = 0;
+				}
+			}
+		}
+
+		out_mat->AddProperty(&uvIndex, 1, _AI_MATKEY_UVWSRC_BASE, target, 0);
+	}
+}
+
+void FBXConverter::TrySetTextureProperties(aiMaterial *out_mat, const LayeredTextureMap &layeredTextures,
+		const std::string &propName,
+		aiTextureType target, const MeshGeometry *const mesh) {
+	LayeredTextureMap::const_iterator it = layeredTextures.find(propName);
+	if (it == layeredTextures.end()) {
+		return;
+	}
+
+	int texCount = (*it).second->textureCount();
+
+	// Set the blend mode for layered textures
+	int blendmode = (*it).second->GetBlendMode();
+	out_mat->AddProperty(&blendmode, 1, _AI_MATKEY_TEXOP_BASE, target, 0);
+
+	for (int texIndex = 0; texIndex < texCount; texIndex++) {
+
+		const Texture *const tex = (*it).second->getTexture(texIndex);
+
+		aiString path = GetTexturePath(tex);
+		out_mat->AddProperty(&path, _AI_MATKEY_TEXTURE_BASE, target, texIndex);
+
+		aiUVTransform uvTrafo;
+		// XXX handle all kinds of UV transformations
+		uvTrafo.mScaling = tex->UVScaling();
+		uvTrafo.mTranslation = tex->UVTranslation();
+		out_mat->AddProperty(&uvTrafo, 1, _AI_MATKEY_UVTRANSFORM_BASE, target, texIndex);
+
+		const PropertyTable &props = tex->Props();
+
+		int uvIndex = 0;
+
+		bool ok;
+		const std::string &uvSet = PropertyGet<std::string>(props, "UVSet", ok);
+		if (ok) {
+			// "default" is the name which usually appears in the FbxFileTexture template
+			if (uvSet != "default" && uvSet.length()) {
+				// this is a bit awkward - we need to find a mesh that uses this
+				// material and scan its UV channels for the given UV name because
+				// assimp references UV channels by index, not by name.
+
+				// XXX: the case that UV channels may appear in different orders
+				// in meshes is unhandled. A possible solution would be to sort
+				// the UV channels alphabetically, but this would have the side
+				// effect that the primary (first) UV channel would sometimes
+				// be moved, causing trouble when users read only the first
+				// UV channel and ignore UV channel assignments altogether.
+
+				const unsigned int matIndex = static_cast<unsigned int>(std::distance(materials.begin(),
+						std::find(materials.begin(), materials.end(), out_mat)));
+
+				uvIndex = -1;
+				if (!mesh) {
+					for (const MeshMap::value_type &v : meshes_converted) {
+						const MeshGeometry *const meshGeom = dynamic_cast<const MeshGeometry *>(v.first);
+						if (!meshGeom) {
+							continue;
+						}
+
+						const MatIndexArray &mats = meshGeom->GetMaterialIndices();
+						if (std::find(mats.begin(), mats.end(), matIndex) == mats.end()) {
+							continue;
+						}
+
+						int index = -1;
+						for (unsigned int i = 0; i < AI_MAX_NUMBER_OF_TEXTURECOORDS; ++i) {
+							if (meshGeom->GetTextureCoords(i).empty()) {
+								break;
+							}
+							const std::string &name = meshGeom->GetTextureCoordChannelName(i);
+							if (name == uvSet) {
+								index = static_cast<int>(i);
+								break;
+							}
+						}
+						if (index == -1) {
+							FBXImporter::LogWarn("did not find UV channel named " + uvSet + " in a mesh using this material");
+							continue;
+						}
+
+						if (uvIndex == -1) {
+							uvIndex = index;
+						} else {
+							FBXImporter::LogWarn("the UV channel named " + uvSet +
+												 " appears at different positions in meshes, results will be wrong");
+						}
+					}
+				} else {
+					int index = -1;
+					for (unsigned int i = 0; i < AI_MAX_NUMBER_OF_TEXTURECOORDS; ++i) {
+						if (mesh->GetTextureCoords(i).empty()) {
+							break;
+						}
+						const std::string &name = mesh->GetTextureCoordChannelName(i);
+						if (name == uvSet) {
+							index = static_cast<int>(i);
+							break;
+						}
+					}
+					if (index == -1) {
+						FBXImporter::LogWarn("did not find UV channel named " + uvSet + " in a mesh using this material");
+					}
+
+					if (uvIndex == -1) {
+						uvIndex = index;
+					}
+				}
+
+				if (uvIndex == -1) {
+					FBXImporter::LogWarn("failed to resolve UV channel " + uvSet + ", using first UV channel");
+					uvIndex = 0;
+				}
+			}
+		}
+
+		out_mat->AddProperty(&uvIndex, 1, _AI_MATKEY_UVWSRC_BASE, target, texIndex);
+	}
+}
+
+void FBXConverter::SetTextureProperties(aiMaterial *out_mat, const TextureMap &textures, const MeshGeometry *const mesh) {
+	TrySetTextureProperties(out_mat, textures, "DiffuseColor", aiTextureType_DIFFUSE, mesh);
+	TrySetTextureProperties(out_mat, textures, "AmbientColor", aiTextureType_AMBIENT, mesh);
+	TrySetTextureProperties(out_mat, textures, "EmissiveColor", aiTextureType_EMISSIVE, mesh);
+	TrySetTextureProperties(out_mat, textures, "SpecularColor", aiTextureType_SPECULAR, mesh);
+	TrySetTextureProperties(out_mat, textures, "SpecularFactor", aiTextureType_SPECULAR, mesh);
+	TrySetTextureProperties(out_mat, textures, "TransparentColor", aiTextureType_OPACITY, mesh);
+	TrySetTextureProperties(out_mat, textures, "ReflectionColor", aiTextureType_REFLECTION, mesh);
+	TrySetTextureProperties(out_mat, textures, "DisplacementColor", aiTextureType_DISPLACEMENT, mesh);
+	TrySetTextureProperties(out_mat, textures, "NormalMap", aiTextureType_NORMALS, mesh);
+	TrySetTextureProperties(out_mat, textures, "Bump", aiTextureType_HEIGHT, mesh);
+	TrySetTextureProperties(out_mat, textures, "ShininessExponent", aiTextureType_SHININESS, mesh);
+	TrySetTextureProperties(out_mat, textures, "TransparencyFactor", aiTextureType_OPACITY, mesh);
+	TrySetTextureProperties(out_mat, textures, "EmissiveFactor", aiTextureType_EMISSIVE, mesh);
+	//Maya counterparts
+	TrySetTextureProperties(out_mat, textures, "Maya|DiffuseTexture", aiTextureType_DIFFUSE, mesh);
+	TrySetTextureProperties(out_mat, textures, "Maya|NormalTexture", aiTextureType_NORMALS, mesh);
+	TrySetTextureProperties(out_mat, textures, "Maya|SpecularTexture", aiTextureType_SPECULAR, mesh);
+	TrySetTextureProperties(out_mat, textures, "Maya|FalloffTexture", aiTextureType_OPACITY, mesh);
+	TrySetTextureProperties(out_mat, textures, "Maya|ReflectionMapTexture", aiTextureType_REFLECTION, mesh);
+
+	// Maya PBR
+	TrySetTextureProperties(out_mat, textures, "Maya|baseColor|file", aiTextureType_BASE_COLOR, mesh);
+	TrySetTextureProperties(out_mat, textures, "Maya|normalCamera|file", aiTextureType_NORMAL_CAMERA, mesh);
+	TrySetTextureProperties(out_mat, textures, "Maya|emissionColor|file", aiTextureType_EMISSION_COLOR, mesh);
+	TrySetTextureProperties(out_mat, textures, "Maya|metalness|file", aiTextureType_METALNESS, mesh);
+	TrySetTextureProperties(out_mat, textures, "Maya|diffuseRoughness|file", aiTextureType_DIFFUSE_ROUGHNESS, mesh);
+
+	// Maya stingray
+	TrySetTextureProperties(out_mat, textures, "Maya|TEX_color_map|file", aiTextureType_BASE_COLOR, mesh);
+	TrySetTextureProperties(out_mat, textures, "Maya|TEX_normal_map|file", aiTextureType_NORMAL_CAMERA, mesh);
+	TrySetTextureProperties(out_mat, textures, "Maya|TEX_emissive_map|file", aiTextureType_EMISSION_COLOR, mesh);
+	TrySetTextureProperties(out_mat, textures, "Maya|TEX_metallic_map|file", aiTextureType_METALNESS, mesh);
+	TrySetTextureProperties(out_mat, textures, "Maya|TEX_roughness_map|file", aiTextureType_DIFFUSE_ROUGHNESS, mesh);
+	TrySetTextureProperties(out_mat, textures, "Maya|TEX_ao_map|file", aiTextureType_AMBIENT_OCCLUSION, mesh);
+}
+
+void FBXConverter::SetTextureProperties(aiMaterial *out_mat, const LayeredTextureMap &layeredTextures, const MeshGeometry *const mesh) {
+	TrySetTextureProperties(out_mat, layeredTextures, "DiffuseColor", aiTextureType_DIFFUSE, mesh);
+	TrySetTextureProperties(out_mat, layeredTextures, "AmbientColor", aiTextureType_AMBIENT, mesh);
+	TrySetTextureProperties(out_mat, layeredTextures, "EmissiveColor", aiTextureType_EMISSIVE, mesh);
+	TrySetTextureProperties(out_mat, layeredTextures, "SpecularColor", aiTextureType_SPECULAR, mesh);
+	TrySetTextureProperties(out_mat, layeredTextures, "SpecularFactor", aiTextureType_SPECULAR, mesh);
+	TrySetTextureProperties(out_mat, layeredTextures, "TransparentColor", aiTextureType_OPACITY, mesh);
+	TrySetTextureProperties(out_mat, layeredTextures, "ReflectionColor", aiTextureType_REFLECTION, mesh);
+	TrySetTextureProperties(out_mat, layeredTextures, "DisplacementColor", aiTextureType_DISPLACEMENT, mesh);
+	TrySetTextureProperties(out_mat, layeredTextures, "NormalMap", aiTextureType_NORMALS, mesh);
+	TrySetTextureProperties(out_mat, layeredTextures, "Bump", aiTextureType_HEIGHT, mesh);
+	TrySetTextureProperties(out_mat, layeredTextures, "ShininessExponent", aiTextureType_SHININESS, mesh);
+	TrySetTextureProperties(out_mat, layeredTextures, "EmissiveFactor", aiTextureType_EMISSIVE, mesh);
+	TrySetTextureProperties(out_mat, layeredTextures, "TransparencyFactor", aiTextureType_OPACITY, mesh);
+}
+
+aiColor3D FBXConverter::GetColorPropertyFactored(const PropertyTable &props, const std::string &colorName,
+		const std::string &factorName, bool &result, bool useTemplate) {
+	result = true;
+
+	bool ok;
+	aiVector3D BaseColor = PropertyGet<aiVector3D>(props, colorName, ok, useTemplate);
+	if (!ok) {
+		result = false;
+		return aiColor3D(0.0f, 0.0f, 0.0f);
+	}
+
+	// if no factor name, return the colour as is
+	if (factorName.empty()) {
+		return aiColor3D(BaseColor.x, BaseColor.y, BaseColor.z);
+	}
+
+	// otherwise it should be multiplied by the factor, if found.
+	float factor = PropertyGet<float>(props, factorName, ok, useTemplate);
+	if (ok) {
+		BaseColor *= factor;
+	}
+	return aiColor3D(BaseColor.x, BaseColor.y, BaseColor.z);
+}
+
+aiColor3D FBXConverter::GetColorPropertyFromMaterial(const PropertyTable &props, const std::string &baseName,
+		bool &result) {
+	return GetColorPropertyFactored(props, baseName + "Color", baseName + "Factor", result, true);
+}
+
+aiColor3D FBXConverter::GetColorProperty(const PropertyTable &props, const std::string &colorName,
+		bool &result, bool useTemplate) {
+	result = true;
+	bool ok;
+	const aiVector3D &ColorVec = PropertyGet<aiVector3D>(props, colorName, ok, useTemplate);
+	if (!ok) {
+		result = false;
+		return aiColor3D(0.0f, 0.0f, 0.0f);
+	}
+	return aiColor3D(ColorVec.x, ColorVec.y, ColorVec.z);
+}
+
+void FBXConverter::SetShadingPropertiesCommon(aiMaterial *out_mat, const PropertyTable &props) {
+	// Set shading properties.
+	// Modern FBX Files have two separate systems for defining these,
+	// with only the more comprehensive one described in the property template.
+	// Likely the other values are a legacy system,
+	// which is still always exported by the official FBX SDK.
+	//
+	// Blender's FBX import and export mostly ignore this legacy system,
+	// and as we only support recent versions of FBX anyway, we can do the same.
+	bool ok;
+
+	const aiColor3D &Diffuse = GetColorPropertyFromMaterial(props, "Diffuse", ok);
+	if (ok) {
+		out_mat->AddProperty(&Diffuse, 1, AI_MATKEY_COLOR_DIFFUSE);
+	}
+
+	const aiColor3D &Emissive = GetColorPropertyFromMaterial(props, "Emissive", ok);
+	if (ok) {
+		out_mat->AddProperty(&Emissive, 1, AI_MATKEY_COLOR_EMISSIVE);
+	}
+
+	const aiColor3D &Ambient = GetColorPropertyFromMaterial(props, "Ambient", ok);
+	if (ok) {
+		out_mat->AddProperty(&Ambient, 1, AI_MATKEY_COLOR_AMBIENT);
+	}
+
+	// we store specular factor as SHININESS_STRENGTH, so just get the color
+	const aiColor3D &Specular = GetColorProperty(props, "SpecularColor", ok, true);
+	if (ok) {
+		out_mat->AddProperty(&Specular, 1, AI_MATKEY_COLOR_SPECULAR);
+	}
+
+	// and also try to get SHININESS_STRENGTH
+	const float SpecularFactor = PropertyGet<float>(props, "SpecularFactor", ok, true);
+	if (ok) {
+		out_mat->AddProperty(&SpecularFactor, 1, AI_MATKEY_SHININESS_STRENGTH);
+	}
+
+	// and the specular exponent
+	const float ShininessExponent = PropertyGet<float>(props, "ShininessExponent", ok);
+	if (ok) {
+		out_mat->AddProperty(&ShininessExponent, 1, AI_MATKEY_SHININESS);
+	}
+
+	// TransparentColor / TransparencyFactor... gee thanks FBX :rolleyes:
+	const aiColor3D &Transparent = GetColorPropertyFactored(props, "TransparentColor", "TransparencyFactor", ok);
+	float CalculatedOpacity = 1.0f;
+	if (ok) {
+		out_mat->AddProperty(&Transparent, 1, AI_MATKEY_COLOR_TRANSPARENT);
+		// as calculated by FBX SDK 2017:
+		CalculatedOpacity = 1.0f - ((Transparent.r + Transparent.g + Transparent.b) / 3.0f);
+	}
+
+	// try to get the transparency factor
+	const float TransparencyFactor = PropertyGet<float>(props, "TransparencyFactor", ok);
+	if (ok) {
+		out_mat->AddProperty(&TransparencyFactor, 1, AI_MATKEY_TRANSPARENCYFACTOR);
+	}
+
+	// use of TransparencyFactor is inconsistent.
+	// Maya always stores it as 1.0,
+	// so we can't use it to set AI_MATKEY_OPACITY.
+	// Blender is more sensible and stores it as the alpha value.
+	// However both the FBX SDK and Blender always write an additional
+	// legacy "Opacity" field, so we can try to use that.
+	//
+	// If we can't find it,
+	// we can fall back to the value which the FBX SDK calculates
+	// from transparency colour (RGB) and factor (F) as
+	// 1.0 - F*((R+G+B)/3).
+	//
+	// There's no consistent way to interpret this opacity value,
+	// so it's up to clients to do the correct thing.
+	const float Opacity = PropertyGet<float>(props, "Opacity", ok);
+	if (ok) {
+		out_mat->AddProperty(&Opacity, 1, AI_MATKEY_OPACITY);
+	} else if (CalculatedOpacity != 1.0) {
+		out_mat->AddProperty(&CalculatedOpacity, 1, AI_MATKEY_OPACITY);
+	}
+
+	// reflection color and factor are stored separately
+	const aiColor3D &Reflection = GetColorProperty(props, "ReflectionColor", ok, true);
+	if (ok) {
+		out_mat->AddProperty(&Reflection, 1, AI_MATKEY_COLOR_REFLECTIVE);
+	}
+
+	float ReflectionFactor = PropertyGet<float>(props, "ReflectionFactor", ok, true);
+	if (ok) {
+		out_mat->AddProperty(&ReflectionFactor, 1, AI_MATKEY_REFLECTIVITY);
+	}
+
+	const float BumpFactor = PropertyGet<float>(props, "BumpFactor", ok);
+	if (ok) {
+		out_mat->AddProperty(&BumpFactor, 1, AI_MATKEY_BUMPSCALING);
+	}
+
+	const float DispFactor = PropertyGet<float>(props, "DisplacementFactor", ok);
+	if (ok) {
+		out_mat->AddProperty(&DispFactor, 1, "$mat.displacementscaling", 0, 0);
+	}
+}
+
+void FBXConverter::SetShadingPropertiesRaw(aiMaterial *out_mat, const PropertyTable &props, const TextureMap &textures, const MeshGeometry *const mesh) {
+	// Add all the unparsed properties with a "$raw." prefix
+
+	const std::string prefix = "$raw.";
+
+	for (const DirectPropertyMap::value_type &prop : props.GetUnparsedProperties()) {
+
+		std::string name = prefix + prop.first;
+
+		if (const TypedProperty<aiVector3D> *interpreted = prop.second->As<TypedProperty<aiVector3D> >()) {
+			out_mat->AddProperty(&interpreted->Value(), 1, name.c_str(), 0, 0);
+		} else if (const TypedProperty<aiColor3D> *interpreted = prop.second->As<TypedProperty<aiColor3D> >()) {
+			out_mat->AddProperty(&interpreted->Value(), 1, name.c_str(), 0, 0);
+		} else if (const TypedProperty<aiColor4D> *interpreted = prop.second->As<TypedProperty<aiColor4D> >()) {
+			out_mat->AddProperty(&interpreted->Value(), 1, name.c_str(), 0, 0);
+		} else if (const TypedProperty<float> *interpreted = prop.second->As<TypedProperty<float> >()) {
+			out_mat->AddProperty(&interpreted->Value(), 1, name.c_str(), 0, 0);
+		} else if (const TypedProperty<int> *interpreted = prop.second->As<TypedProperty<int> >()) {
+			out_mat->AddProperty(&interpreted->Value(), 1, name.c_str(), 0, 0);
+		} else if (const TypedProperty<bool> *interpreted = prop.second->As<TypedProperty<bool> >()) {
+			int value = interpreted->Value() ? 1 : 0;
+			out_mat->AddProperty(&value, 1, name.c_str(), 0, 0);
+		} else if (const TypedProperty<std::string> *interpreted = prop.second->As<TypedProperty<std::string> >()) {
+			const aiString value = aiString(interpreted->Value());
+			out_mat->AddProperty(&value, name.c_str(), 0, 0);
+		}
+	}
+
+	// Add the textures' properties
+
+	for (TextureMap::const_iterator it = textures.begin(); it != textures.end(); it++) {
+
+		std::string name = prefix + it->first;
+
+		const Texture *const tex = (*it).second;
+		if (tex != nullptr) {
+			aiString path;
+			path.Set(tex->RelativeFilename());
+
+			const Video *media = tex->Media();
+			if (media != nullptr && media->ContentLength() > 0) {
+				unsigned int index;
+
+				VideoMap::const_iterator it = textures_converted.find(*media);
+				if (it != textures_converted.end()) {
+					index = (*it).second;
+				} else {
+					index = ConvertVideo(*media);
+					textures_converted[*media] = index;
+				}
+
+				// setup texture reference string (copied from ColladaLoader::FindFilenameForEffectTexture)
+				path.data[0] = '*';
+				path.length = 1 + ASSIMP_itoa10(path.data + 1, MAXLEN - 1, index);
+			}
+
+			out_mat->AddProperty(&path, (name + "|file").c_str(), aiTextureType_UNKNOWN, 0);
+
+			aiUVTransform uvTrafo;
+			// XXX handle all kinds of UV transformations
+			uvTrafo.mScaling = tex->UVScaling();
+			uvTrafo.mTranslation = tex->UVTranslation();
+			out_mat->AddProperty(&uvTrafo, 1, (name + "|uvtrafo").c_str(), aiTextureType_UNKNOWN, 0);
+
+			int uvIndex = 0;
+
+			bool uvFound = false;
+			const std::string &uvSet = PropertyGet<std::string>(tex->Props(), "UVSet", uvFound);
+			if (uvFound) {
+				// "default" is the name which usually appears in the FbxFileTexture template
+				if (uvSet != "default" && uvSet.length()) {
+					// this is a bit awkward - we need to find a mesh that uses this
+					// material and scan its UV channels for the given UV name because
+					// assimp references UV channels by index, not by name.
+
+					// XXX: the case that UV channels may appear in different orders
+					// in meshes is unhandled. A possible solution would be to sort
+					// the UV channels alphabetically, but this would have the side
+					// effect that the primary (first) UV channel would sometimes
+					// be moved, causing trouble when users read only the first
+					// UV channel and ignore UV channel assignments altogether.
+
+					std::vector<aiMaterial *>::iterator materialIt = std::find(materials.begin(), materials.end(), out_mat);
+					const unsigned int matIndex = static_cast<unsigned int>(std::distance(materials.begin(), materialIt));
+
+					uvIndex = -1;
+					if (!mesh) {
+						for (const MeshMap::value_type &v : meshes_converted) {
+							const MeshGeometry *const meshGeom = dynamic_cast<const MeshGeometry *>(v.first);
+							if (!meshGeom) {
+								continue;
+							}
+
+							const MatIndexArray &mats = meshGeom->GetMaterialIndices();
+							if (std::find(mats.begin(), mats.end(), matIndex) == mats.end()) {
+								continue;
+							}
+
+							int index = -1;
+							for (unsigned int i = 0; i < AI_MAX_NUMBER_OF_TEXTURECOORDS; ++i) {
+								if (meshGeom->GetTextureCoords(i).empty()) {
+									break;
+								}
+								const std::string &name = meshGeom->GetTextureCoordChannelName(i);
+								if (name == uvSet) {
+									index = static_cast<int>(i);
+									break;
+								}
+							}
+							if (index == -1) {
+								FBXImporter::LogWarn("did not find UV channel named " + uvSet + " in a mesh using this material");
+								continue;
+							}
+
+							if (uvIndex == -1) {
+								uvIndex = index;
+							} else {
+								FBXImporter::LogWarn("the UV channel named " + uvSet + " appears at different positions in meshes, results will be wrong");
+							}
+						}
+					} else {
+						int index = -1;
+						for (unsigned int i = 0; i < AI_MAX_NUMBER_OF_TEXTURECOORDS; ++i) {
+							if (mesh->GetTextureCoords(i).empty()) {
+								break;
+							}
+							const std::string &name = mesh->GetTextureCoordChannelName(i);
+							if (name == uvSet) {
+								index = static_cast<int>(i);
+								break;
+							}
+						}
+						if (index == -1) {
+							FBXImporter::LogWarn("did not find UV channel named " + uvSet + " in a mesh using this material");
+						}
+
+						if (uvIndex == -1) {
+							uvIndex = index;
+						}
+					}
+
+					if (uvIndex == -1) {
+						FBXImporter::LogWarn("failed to resolve UV channel " + uvSet + ", using first UV channel");
+						uvIndex = 0;
+					}
+				}
+			}
+
+			out_mat->AddProperty(&uvIndex, 1, (name + "|uvwsrc").c_str(), aiTextureType_UNKNOWN, 0);
+		}
+	}
+}
+
+double FBXConverter::FrameRateToDouble(FileGlobalSettings::FrameRate fp, double customFPSVal) {
+	switch (fp) {
+		case FileGlobalSettings::FrameRate_DEFAULT:
+			return 1.0;
+
+		case FileGlobalSettings::FrameRate_120:
+			return 120.0;
+
+		case FileGlobalSettings::FrameRate_100:
+			return 100.0;
+
+		case FileGlobalSettings::FrameRate_60:
+			return 60.0;
+
+		case FileGlobalSettings::FrameRate_50:
+			return 50.0;
+
+		case FileGlobalSettings::FrameRate_48:
+			return 48.0;
+
+		case FileGlobalSettings::FrameRate_30:
+		case FileGlobalSettings::FrameRate_30_DROP:
+			return 30.0;
+
+		case FileGlobalSettings::FrameRate_NTSC_DROP_FRAME:
+		case FileGlobalSettings::FrameRate_NTSC_FULL_FRAME:
+			return 29.9700262;
+
+		case FileGlobalSettings::FrameRate_PAL:
+			return 25.0;
+
+		case FileGlobalSettings::FrameRate_CINEMA:
+			return 24.0;
+
+		case FileGlobalSettings::FrameRate_1000:
+			return 1000.0;
+
+		case FileGlobalSettings::FrameRate_CINEMA_ND:
+			return 23.976;
+
+		case FileGlobalSettings::FrameRate_CUSTOM:
+			return customFPSVal;
+
+		case FileGlobalSettings::FrameRate_MAX: // this is to silence compiler warnings
+			break;
+	}
+
+	ai_assert(false);
+
+	return -1.0f;
+}
+
+void FBXConverter::ConvertAnimations() {
+	// first of all determine framerate
+	const FileGlobalSettings::FrameRate fps = doc.GlobalSettings().TimeMode();
+	const float custom = doc.GlobalSettings().CustomFrameRate();
+	anim_fps = FrameRateToDouble(fps, custom);
+
+	const std::vector<const AnimationStack *> &animations = doc.AnimationStacks();
+	for (const AnimationStack *stack : animations) {
+		ConvertAnimationStack(*stack);
+	}
+}
+
+std::string FBXConverter::FixNodeName(const std::string &name) {
+	// strip Model:: prefix, avoiding ambiguities (i.e. don't strip if
+	// this causes ambiguities, well possible between empty identifiers,
+	// such as "Model::" and ""). Make sure the behaviour is consistent
+	// across multiple calls to FixNodeName().
+	if (name.substr(0, 7) == "Model::") {
+		std::string temp = name.substr(7);
+		return temp;
+	}
+
+	return name;
+}
+
+std::string FBXConverter::FixAnimMeshName(const std::string &name) {
+	if (name.length()) {
+		size_t indexOf = name.find_first_of("::");
+		if (indexOf != std::string::npos && indexOf < name.size() - 2) {
+			return name.substr(indexOf + 2);
+		}
+	}
+	return name.length() ? name : "AnimMesh";
+}
+
+void FBXConverter::ConvertAnimationStack(const AnimationStack &st) {
+	const AnimationLayerList &layers = st.Layers();
+	if (layers.empty()) {
+		return;
+	}
+
+	aiAnimation *const anim = new aiAnimation();
+	animations.push_back(anim);
+
+	// strip AnimationStack:: prefix
+	std::string name = st.Name();
+	std::cout << "name of animation stack: " << name << std::endl;
+	if (name.substr(0, 16) == "AnimationStack::") {
+		name = name.substr(16);
+	} else if (name.substr(0, 11) == "AnimStack::") {
+		name = name.substr(11);
+	}
+
+	anim->mName.Set(name);
+	//typedef std::map<std::string, std::vector<const AnimationCurveNode *> > NodeMap;
+	// need to find all nodes for which we need to generate node animations -
+	// it may happen that we need to merge multiple layers, though.
+
+	// after
+	std::vector<AnimNodeItem *> AnimNodes;
+	//NodeMap node_map;
+
+	// reverse mapping from curves to layers, much faster than querying
+	// the FBX DOM for it.
+	LayerMap layer_map;
+
+	std::map<std::string, morphAnimData *> morphAnimDatas;
+
+	// generate node animations
+	std::vector<aiNodeAnim *> node_anims;
+
+	double min_time = 1e10;
+	double max_time = -1e10;
+
+	int64_t start_time = st.LocalStart();
+	int64_t stop_time = st.LocalStop();
+	bool has_local_startstop = start_time != 0 || stop_time != 0;
+	if (!has_local_startstop) {
+		// no time range given, so accept every keyframe and use the actual min/max time
+		// the numbers are INT64_MIN/MAX, the 20000 is for safety because GenerateNodeAnimations uses an epsilon of 10000
+		start_time = -9223372036854775807ll + 20000;
+		stop_time = 9223372036854775807ll - 20000;
+	}
+
+	for (const AnimationLayer *layer : layers) {
+		std::cout << "animation layer change: " << layer->Name() << std::endl;
+		ai_assert(layer);
+
+		uint64_t last_target_id = 0;
+		std::string last_name;
+
+		AnimationCurveNodeList valid_target_node;
+		AnimationCurveNodeList layer_list = layer->Nodes();
+		if (layer_list.size()) {
+			const AnimationCurveNode *back_node = layer_list.back();
+			for (const AnimationCurveNode *node : layer_list) {
+
+				ai_assert(node);
+				const Model *const model = node->TargetAsModel();
+				if (model) {
+					const std::string &model_name = FixNodeName(model->Name());
+					std::cout << "==============================================================================================================" << std::endl;
+					std::cout << "Anim curve node: id " << node->ID() << " name: " << node->Name() << " layer: " << model_name << std::endl;
+
+					if (node->Target()->ID() == model->ID()) {
+						std::cout << "curveID: " << node->ID() << ", tgt: " << node->TargetProperty() << ", tgt name: " << node->Target()->Name() << ", tgt id: " << node->Target()->ID() << std::endl;
+						//std::cout << "this is valid target!" << std::endl;
+
+						// if the target has changed since last iteration finalize and process the animations
+						if (last_target_id != node->Target()->ID() && last_target_id != 0) {
+
+							if (valid_target_node.size()) {
+								try {
+									std::cout << "Processing animations together:" << std::endl;
+									aiMatrix4x4 geometric_pivot;
+									GenerateNodeAnimations(node_anims,
+											last_name,
+											valid_target_node,
+											layer_map,
+											start_time, stop_time,
+											max_time,
+											min_time,
+											geometric_pivot);
+
+									// clear combined target nodes (they've been joined together)
+									valid_target_node.clear();
+
+								} catch (std::exception &) {
+									std::for_each(node_anims.begin(), node_anims.end(), Util::delete_fun<aiNodeAnim>());
+									throw;
+								}
+							} else {
+								std::cout << "Error: target was not found in curves!" << std::endl;
+							}
+						}
+						last_name = model_name;
+						last_target_id = node->Target()->ID();
+
+						valid_target_node.push_back(node);
+					}
+
+					// force last element to process now
+					if (node == back_node) {
+						if (valid_target_node.size()) {
+							try {
+								std::cout << "(end force) Processing animations together:" << std::endl;
+								aiMatrix4x4 geometric_pivot;
+								GenerateNodeAnimations(node_anims,
+										model_name,
+										valid_target_node,
+										layer_map,
+										start_time, stop_time,
+										max_time,
+										min_time,
+										geometric_pivot);
+
+								// clear combined target nodes (they've been joined together)
+								valid_target_node.clear();
+
+							} catch (std::exception &) {
+								std::for_each(node_anims.begin(), node_anims.end(), Util::delete_fun<aiNodeAnim>());
+								throw;
+							}
+						} else {
+							std::cout << "Error: target was not found in curves!" << std::endl;
+						}
+					}
+
+					layer_map[node] = layer;
+				}
+				const BlendShapeChannel *const bsc = dynamic_cast<const BlendShapeChannel *>(node->Target());
+				if (bsc) {
+					ProcessMorphAnimDatas(&morphAnimDatas, bsc, node);
+				}
+			}
+		}
+	}
+
+	if (node_anims.size() || morphAnimDatas.size()) {
+		if (node_anims.size()) {
+			anim->mChannels = new aiNodeAnim *[node_anims.size()]();
+			anim->mNumChannels = static_cast<unsigned int>(node_anims.size());
+			std::swap_ranges(node_anims.begin(), node_anims.end(), anim->mChannels);
+		} else {
+			anim->mNumChannels = 0;
+			anim->mChannels = nullptr;
+		}
+
+		if (morphAnimDatas.size()) {
+			unsigned int numMorphMeshChannels = static_cast<unsigned int>(morphAnimDatas.size());
+			anim->mMorphMeshChannels = new aiMeshMorphAnim *[numMorphMeshChannels];
+			anim->mNumMorphMeshChannels = numMorphMeshChannels;
+			unsigned int i = 0;
+			for (auto morphAnimIt : morphAnimDatas) {
+				morphAnimData *animData = morphAnimIt.second;
+				unsigned int numKeys = static_cast<unsigned int>(animData->size());
+				aiMeshMorphAnim *meshMorphAnim = new aiMeshMorphAnim();
+				meshMorphAnim->mName.Set(morphAnimIt.first);
+				meshMorphAnim->mNumKeys = numKeys;
+				meshMorphAnim->mKeys = new aiMeshMorphKey[numKeys];
+				unsigned int j = 0;
+				for (auto animIt : *animData) {
+					morphKeyData *keyData = animIt.second;
+					unsigned int numValuesAndWeights = static_cast<unsigned int>(keyData->values.size());
+					meshMorphAnim->mKeys[j].mNumValuesAndWeights = numValuesAndWeights;
+					meshMorphAnim->mKeys[j].mValues = new unsigned int[numValuesAndWeights];
+					meshMorphAnim->mKeys[j].mWeights = new double[numValuesAndWeights];
+					meshMorphAnim->mKeys[j].mTime = CONVERT_FBX_TIME(animIt.first) * anim_fps;
+					for (unsigned int k = 0; k < numValuesAndWeights; k++) {
+						meshMorphAnim->mKeys[j].mValues[k] = keyData->values.at(k);
+						meshMorphAnim->mKeys[j].mWeights[k] = keyData->weights.at(k);
+					}
+					j++;
+				}
+				anim->mMorphMeshChannels[i++] = meshMorphAnim;
+			}
+		} else {
+			anim->mNumMorphMeshChannels = 0;
+			anim->mMorphMeshChannels = nullptr;
+		}
+	} else {
+		// empty animations would fail validation, so drop them
+		delete anim;
+		animations.pop_back();
+		FBXImporter::LogInfo("ignoring empty AnimationStack (using IK?): " + name);
+		return;
+	}
+
+	double start_time_fps = has_local_startstop ? (CONVERT_FBX_TIME(start_time) * anim_fps) : min_time;
+	double stop_time_fps = has_local_startstop ? (CONVERT_FBX_TIME(stop_time) * anim_fps) : max_time;
+
+	// adjust relative timing for animation
+	for (unsigned int c = 0; c < anim->mNumChannels; c++) {
+		aiNodeAnim *channel = anim->mChannels[c];
+		for (uint32_t i = 0; i < channel->mNumPositionKeys; i++) {
+			channel->mPositionKeys[i].mTime -= start_time_fps;
+		}
+		for (uint32_t i = 0; i < channel->mNumRotationKeys; i++) {
+			channel->mRotationKeys[i].mTime -= start_time_fps;
+		}
+		for (uint32_t i = 0; i < channel->mNumScalingKeys; i++) {
+			channel->mScalingKeys[i].mTime -= start_time_fps;
+		}
+	}
+	for (unsigned int c = 0; c < anim->mNumMorphMeshChannels; c++) {
+		aiMeshMorphAnim *channel = anim->mMorphMeshChannels[c];
+		for (uint32_t i = 0; i < channel->mNumKeys; i++) {
+			channel->mKeys[i].mTime -= start_time_fps;
+		}
+	}
+
+	// for some mysterious reason, mDuration is simply the maximum key -- the
+	// validator always assumes animations to start at zero.
+	anim->mDuration = stop_time_fps - start_time_fps;
+	anim->mTicksPerSecond = anim_fps;
+}
+
+// ------------------------------------------------------------------------------------------------
+void FBXConverter::ProcessMorphAnimDatas(std::map<std::string, morphAnimData *> *morphAnimDatas, const BlendShapeChannel *bsc, const AnimationCurveNode *node) {
+	std::vector<const Connection *> bscConnections = doc.GetConnectionsBySourceSequenced(bsc->ID(), "Deformer");
+	for (const Connection *bscConnection : bscConnections) {
+		auto bs = dynamic_cast<const BlendShape *>(bscConnection->DestinationObject());
+		if (bs) {
+			auto channelIt = std::find(bs->BlendShapeChannels().begin(), bs->BlendShapeChannels().end(), bsc);
+			if (channelIt != bs->BlendShapeChannels().end()) {
+				auto channelIndex = static_cast<unsigned int>(std::distance(bs->BlendShapeChannels().begin(), channelIt));
+				std::vector<const Connection *> bsConnections = doc.GetConnectionsBySourceSequenced(bs->ID(), "Geometry");
+				for (const Connection *bsConnection : bsConnections) {
+					auto geo = dynamic_cast<const Geometry *>(bsConnection->DestinationObject());
+					if (geo) {
+						std::vector<const Connection *> geoConnections = doc.GetConnectionsBySourceSequenced(geo->ID(), "Model");
+						for (const Connection *geoConnection : geoConnections) {
+							auto model = dynamic_cast<const Model *>(geoConnection->DestinationObject());
+							if (model) {
+								auto geoIt = std::find(model->GetGeometry().begin(), model->GetGeometry().end(), geo);
+								auto geoIndex = static_cast<unsigned int>(std::distance(model->GetGeometry().begin(), geoIt));
+								auto name = aiString(FixNodeName(model->Name() + "*"));
+								name.length = 1 + ASSIMP_itoa10(name.data + name.length, MAXLEN - 1, geoIndex);
+								morphAnimData *animData;
+								auto animIt = morphAnimDatas->find(name.C_Str());
+								if (animIt == morphAnimDatas->end()) {
+									animData = new morphAnimData();
+									morphAnimDatas->insert(std::make_pair(name.C_Str(), animData));
+								} else {
+									animData = animIt->second;
+								}
+								for (std::pair<std::string, const AnimationCurve *> curvesIt : node->Curves()) {
+									if (curvesIt.first == "d|DeformPercent") {
+										const AnimationCurve *animationCurve = curvesIt.second;
+										const KeyTimeList &keys = animationCurve->GetKeys();
+										const KeyValueList &values = animationCurve->GetValues();
+										unsigned int k = 0;
+										for (auto key : keys) {
+											morphKeyData *keyData;
+											auto keyIt = animData->find(key);
+											if (keyIt == animData->end()) {
+												keyData = new morphKeyData();
+												animData->insert(std::make_pair(key, keyData));
+											} else {
+												keyData = keyIt->second;
+											}
+											keyData->values.push_back(channelIndex);
+											keyData->weights.push_back(values.at(k) / 100.0f);
+											k++;
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// ------------------------------------------------------------------------------------------------
+#ifdef ASSIMP_BUILD_DEBUG
+// ------------------------------------------------------------------------------------------------
+// sanity check whether the input is ok
+static void validateAnimCurveNodes(const std::vector<const AnimationCurveNode *> &curves,
+		bool strictMode) {
+	const Object *target(nullptr);
+	for (const AnimationCurveNode *node : curves) {
+		if (!target) {
+			target = node->Target();
+		}
+		if (node->Target() != target) {
+			FBXImporter::LogWarn("Node target is nullptr type.");
+		}
+		if (strictMode) {
+			ai_assert(node->Target() == target);
+		}
+	}
+}
+#endif // ASSIMP_BUILD_DEBUG
+
+// ------------------------------------------------------------------------------------------------
+void FBXConverter::GenerateNodeAnimations(
+		std::vector<aiNodeAnim *> &node_anims,
+		const std::string &fixed_name,
+		const std::vector<const AnimationCurveNode *> &curves,
+		const LayerMap &layer_map,
+		int64_t start, int64_t stop,
+		double &max_time,
+		double &min_time,
+		aiMatrix4x4 geometric_pivot_data) {
+
+	std::unique_ptr<aiNodeAnim> na(new aiNodeAnim());
+	na->mNodeName.Set(fixed_name);
+
+	std::vector<std::pair<std::string, std::vector<const AnimationCurveNode *> > > node_property_map;
+
+	if (curves.size() == 0) return;
+
+#ifdef ASSIMP_BUILD_DEBUG
+	validateAnimCurveNodes(curves, doc.Settings().strictMode);
+#endif
+
+	std::vector<const AnimationCurveNode *> scaling;
+	std::vector<const AnimationCurveNode *> translation;
+	std::vector<const AnimationCurveNode *> rotation;
+
+	const AnimationCurveNode *curve_node = nullptr;
+	for (const AnimationCurveNode *node : curves) {
+		ai_assert(node);
+
+		if (node->TargetProperty().empty()) {
+			FBXImporter::LogWarn("target property for animation curve not set: " + node->Name());
+			continue;
+		}
+
+		if (curve_node == nullptr) {
+			curve_node = node;
+		}
+
+		std::cout << "[" << node->ID() << "] valid curve node: " << node->Name() << ", prop: " << node->TargetProperty() << ", target id: " << node->TargetAsModel()->ID() << std::endl;
+
+		std::string property_type = node->TargetProperty();
+		const AnimationCurveMap &curves = node->Curves();
+//
+//        for (auto cake : node->Curves()) {
+//            std::cout << "[sub curve curve] Debug curve: " << cake.second->Name() << std::endl;
+//        }
+
+		if (property_type == "Lcl Rotation") {
+			rotation.push_back(node);
+		} else if (property_type == "Lcl Translation") {
+			translation.push_back(node);
+		} else if (property_type == "Lcl Scaling") {
+			scaling.push_back(node);
+		} else
         {
-            out_mat->AddProperty(&interpreted->Value(), 1, name.c_str(), 0, 0);
+		    std::cerr << "[" << node->ID() << ":" << node->Name() << "] unhandled fbx property curve: " << property_type << std::endl;
         }
-        else if (const TypedProperty<aiColor3D>* interpreted = prop.second->As<TypedProperty<aiColor3D> >())
-        {
-            out_mat->AddProperty(&interpreted->Value(), 1, name.c_str(), 0, 0);
-        }
-        else if (const TypedProperty<aiColor4D>* interpreted = prop.second->As<TypedProperty<aiColor4D> >())
-        {
-            out_mat->AddProperty(&interpreted->Value(), 1, name.c_str(), 0, 0);
-        }
-        else if (const TypedProperty<float>* interpreted = prop.second->As<TypedProperty<float> >())
-        {
-            out_mat->AddProperty(&interpreted->Value(), 1, name.c_str(), 0, 0);
-        }
-        else if (const TypedProperty<int>* interpreted = prop.second->As<TypedProperty<int> >())
-        {
-            out_mat->AddProperty(&interpreted->Value(), 1, name.c_str(), 0, 0);
-        }
-        else if (const TypedProperty<bool>* interpreted = prop.second->As<TypedProperty<bool> >())
-        {
-            int value = interpreted->Value() ? 1 : 0;
-            out_mat->AddProperty(&value, 1, name.c_str(), 0, 0);
-        }
-        else if (const TypedProperty<std::string>* interpreted = prop.second->As<TypedProperty<std::string> >())
-        {
-            const aiString value = aiString(interpreted->Value());
-            out_mat->AddProperty(&value, name.c_str(), 0, 0);
+	}
+	KeyFrameListList scalingKeys, rotationKeys, translationKeys;
+
+	if (scaling.size()) {
+		scalingKeys = GetKeyframeList(scaling, start, stop);
+	}
+
+	if (rotation.size()) {
+		rotationKeys = GetKeyframeList(rotation, start, stop);
+	}
+
+	if (translation.size()) {
+		translationKeys = GetKeyframeList(translation, start, stop);
+	}
+
+	ai_assert(curve_node);
+	ai_assert(curve_node->TargetAsModel());
+
+	const Model &target = *curve_node->TargetAsModel();
+
+
+	aiVector3D def_scale = aiVector3D::NORMAL();//PropertyGet(target.Props(), "Lcl Scaling", aiVector3D(1.f, 1.f, 1.f));
+	aiVector3D def_translate = aiVector3D::ZERO();//PropertyGet(target.Props(), "Lcl Translation", aiVector3D(0.f, 0.f, 0.f));
+	aiVector3D def_rot = aiVector3D::ZERO(); // PropertyGet(target.Props(), "Lcl Rotation", aiVector3D(0.f, 0.f, 0.f));
+	aiMatrix4x4 geometric_pivot;
+	aiMatrix4x4 pivot_xform = GeneratePivotTransform(target, geometric_pivot);
+	pivot_xform = pivot_xform * geometric_pivot;
+	pivot_xform.Decompose(def_scale,def_rot, def_translate);
+
+	KeyFrameListList joined;
+
+	joined.insert(joined.end(), scalingKeys.begin(), scalingKeys.end());
+	joined.insert(joined.end(), rotationKeys.begin(), rotationKeys.end());
+	joined.insert(joined.end(), translationKeys.begin(), translationKeys.end());
+
+	const KeyTimeList &times = GetKeyTimeList(joined);
+
+	aiQuatKey *out_quat = new aiQuatKey[times.size()];
+	aiVectorKey *out_scale = new aiVectorKey[times.size()];
+	aiVectorKey *out_translation = new aiVectorKey[times.size()];
+
+	if (times.size()) {
+		ConvertTransformOrder_TRStoSRT(out_quat, out_scale, out_translation,
+				scalingKeys,
+				translationKeys,
+				rotationKeys,
+				times,
+				max_time,
+				min_time,
+				target.RotationOrder(),
+				def_scale,
+				def_translate,
+				def_rot);
+	} else
+    {
+	    std::cerr << "[severe] No keyframes for animation: " << fixed_name << std::endl;
+    }
+
+	//std::vector<aiNodeAnim *> anims = GetNodeAnimsFromStack(node_name);
+	//ResampleAnimationsWithPivots(anims, node->mTransformation);
+
+	na->mNumScalingKeys = static_cast<unsigned int>(times.size());
+	na->mNumRotationKeys = na->mNumScalingKeys;
+	na->mNumPositionKeys = na->mNumScalingKeys;
+
+	na->mScalingKeys = out_scale;
+	na->mRotationKeys = out_quat;
+	na->mPositionKeys = out_translation;
+
+    aiNodeAnim *nd = na.release();
+
+	ai_assert(nd);
+	if (nd->mNumPositionKeys == 0 && nd->mNumRotationKeys == 0 && nd->mNumScalingKeys == 0) {
+		delete nd;
+	} else {
+        // cache target mapping
+        anim_target_map[nd] = curve_node->Target()->ID();
+		node_anims.push_back(nd);
+	}
+}
+
+bool FBXConverter::IsRedundantAnimationData(const Model &target,
+		TransformationComp comp,
+		const std::vector<const AnimationCurveNode *> &curves) {
+	ai_assert(curves.size());
+
+	// look for animation nodes with
+	//  * sub channels for all relevant components set
+	//  * one key/value pair per component
+	//  * combined values match up the corresponding value in the bind pose node transformation
+	// only such nodes are 'redundant' for this function.
+
+	if (curves.size() > 1) {
+		return false;
+	}
+
+	const AnimationCurveNode &nd = *curves.front();
+	const AnimationCurveMap &sub_curves = nd.Curves();
+
+	const AnimationCurveMap::const_iterator dx = sub_curves.find("d|X");
+	const AnimationCurveMap::const_iterator dy = sub_curves.find("d|Y");
+	const AnimationCurveMap::const_iterator dz = sub_curves.find("d|Z");
+
+	if (dx == sub_curves.end() || dy == sub_curves.end() || dz == sub_curves.end()) {
+		return false;
+	}
+
+	const KeyValueList &vx = (*dx).second->GetValues();
+	const KeyValueList &vy = (*dy).second->GetValues();
+	const KeyValueList &vz = (*dz).second->GetValues();
+
+	if (vx.size() != 1 || vy.size() != 1 || vz.size() != 1) {
+		return false;
+	}
+
+	const aiVector3D dyn_val = aiVector3D(vx[0], vy[0], vz[0]);
+	const aiVector3D &static_val = PropertyGet<aiVector3D>(target.Props(),
+			NameTransformationCompProperty(comp),
+			TransformationCompDefaultValue(comp));
+
+	const float epsilon = Math::getEpsilon<float>();
+	return (dyn_val - static_val).SquareLength() < epsilon;
+}
+
+FBXConverter::KeyFrameListList FBXConverter::GetKeyframeList(const std::vector<const AnimationCurveNode *> &nodes,
+		int64_t start, int64_t stop) {
+	KeyFrameListList inputs;
+	inputs.reserve(nodes.size() * 3);
+
+	//give some breathing room for rounding errors
+	int64_t adj_start = start - 10000;
+	int64_t adj_stop = stop + 10000;
+
+	for (const AnimationCurveNode *node : nodes) {
+		ai_assert(node);
+
+		const AnimationCurveMap &curves = node->Curves();
+		for (const AnimationCurveMap::value_type &kv : curves) {
+
+			unsigned int mapto;
+			if (kv.first == "d|X") {
+				mapto = 0;
+			} else if (kv.first == "d|Y") {
+				mapto = 1;
+			} else if (kv.first == "d|Z") {
+				mapto = 2;
+			} else {
+				std::cout << "invalid component: " << kv.first << std::endl;
+				FBXImporter::LogWarn("ignoring scale animation curve, did not recognize target component");
+				continue;
+			}
+
+			const AnimationCurve *const curve = kv.second;
+			ai_assert(curve->GetKeys().size() == curve->GetValues().size() && curve->GetKeys().size());
+
+			//get values within the start/stop time window
+			std::shared_ptr<KeyTimeList> Keys(new KeyTimeList());
+			std::shared_ptr<KeyValueList> Values(new KeyValueList());
+			const size_t count = curve->GetKeys().size();
+			Keys->reserve(count);
+			Values->reserve(count);
+			for (size_t n = 0; n < count; n++) {
+				int64_t k = curve->GetKeys().at(n);
+				if (k >= adj_start && k <= adj_stop) {
+					Keys->push_back(k);
+					Values->push_back(curve->GetValues().at(n));
+				}
+			}
+
+			inputs.push_back(std::make_tuple(Keys, Values, mapto));
+		}
+	}
+	return inputs;
+}
+
+KeyTimeList FBXConverter::GetKeyTimeList(const KeyFrameListList &inputs) {
+
+	if (inputs.empty()) {
+		return std::vector<int64_t>();
+	}
+
+	// reserve some space upfront - it is likely that the key-frame lists
+	// have matching time values, so max(of all key-frame lists) should
+	// be a good estimate.
+	KeyTimeList keys;
+
+	size_t estimate = 0;
+	for (const KeyFrameList &kfl : inputs) {
+		estimate = std::max(estimate, std::get<0>(kfl)->size());
+	}
+
+	keys.reserve(estimate);
+
+	std::vector<unsigned int> next_pos;
+	next_pos.resize(inputs.size(), 0);
+
+	const size_t count = inputs.size();
+	while (true) {
+
+		int64_t min_tick = std::numeric_limits<int64_t>::max();
+		for (size_t i = 0; i < count; ++i) {
+			const KeyFrameList &kfl = inputs[i];
+
+			if (std::get<0>(kfl)->size() > next_pos[i] && std::get<0>(kfl)->at(next_pos[i]) < min_tick) {
+				min_tick = std::get<0>(kfl)->at(next_pos[i]);
+			}
+		}
+
+		if (min_tick == std::numeric_limits<int64_t>::max()) {
+			break;
+		}
+		keys.push_back(min_tick);
+
+		for (size_t i = 0; i < count; ++i) {
+			const KeyFrameList &kfl = inputs[i];
+
+			while (std::get<0>(kfl)->size() > next_pos[i] && std::get<0>(kfl)->at(next_pos[i]) == min_tick) {
+				++next_pos[i];
+			}
+		}
+	}
+
+	return keys;
+}
+
+void FBXConverter::InterpolateKeys(aiVectorKey *valOut, const KeyTimeList &keys, const KeyFrameListList &inputs,
+		const aiVector3D &def_value,
+		double &max_time,
+		double &min_time) {
+	ai_assert(!keys.empty());
+	ai_assert(nullptr != valOut);
+
+	std::vector<unsigned int> next_pos;
+	const size_t count(inputs.size());
+
+	next_pos.resize(inputs.size(), 0);
+
+	for (KeyTimeList::value_type time : keys) {
+		ai_real result[3] = { def_value.x, def_value.y, def_value.z };
+
+		for (size_t i = 0; i < count; ++i) {
+			const KeyFrameList &kfl = inputs[i];
+
+			const size_t ksize = std::get<0>(kfl)->size();
+			if (ksize == 0) {
+				continue;
+			}
+			if (ksize > next_pos[i] && std::get<0>(kfl)->at(next_pos[i]) == time) {
+				++next_pos[i];
+			}
+
+			const size_t id0 = next_pos[i] > 0 ? next_pos[i] - 1 : 0;
+			const size_t id1 = next_pos[i] == ksize ? ksize - 1 : next_pos[i];
+
+			// use lerp for interpolation
+			const KeyValueList::value_type valueA = std::get<1>(kfl)->at(id0);
+			const KeyValueList::value_type valueB = std::get<1>(kfl)->at(id1);
+
+			const KeyTimeList::value_type timeA = std::get<0>(kfl)->at(id0);
+			const KeyTimeList::value_type timeB = std::get<0>(kfl)->at(id1);
+
+			const ai_real factor = timeB == timeA ? ai_real(0.) : static_cast<ai_real>((time - timeA)) / (timeB - timeA);
+			const ai_real interpValue = static_cast<ai_real>(valueA + (valueB - valueA) * factor);
+
+			result[std::get<2>(kfl)] = interpValue;
+		}
+
+		// magic value to convert fbx times to seconds
+		valOut->mTime = CONVERT_FBX_TIME(time) * anim_fps;
+
+		min_time = std::min(min_time, valOut->mTime);
+		max_time = std::max(max_time, valOut->mTime);
+
+		valOut->mValue.x = result[0];
+		valOut->mValue.y = result[1];
+		valOut->mValue.z = result[2];
+
+		++valOut;
+	}
+}
+
+void FBXConverter::InterpolateKeys(aiQuatKey *valOut, const KeyTimeList &keys, const KeyFrameListList &inputs,
+		const aiVector3D &def_value,
+		double &maxTime,
+		double &minTime,
+		Model::RotOrder order) {
+	ai_assert(!keys.empty());
+	ai_assert(nullptr != valOut);
+
+	std::unique_ptr<aiVectorKey[]> temp(new aiVectorKey[keys.size()]);
+	InterpolateKeys(temp.get(), keys, inputs, def_value, maxTime, minTime);
+
+	aiMatrix4x4 m;
+
+	aiQuaternion lastq;
+
+	for (size_t i = 0, c = keys.size(); i < c; ++i) {
+
+		valOut[i].mTime = temp[i].mTime;
+
+		GetRotationMatrix(order, temp[i].mValue, m);
+		aiQuaternion quat = aiQuaternion(aiMatrix3x3(m));
+
+//		 take shortest path by checking the inner product
+//		 http://www.3dkingdoms.com/weekly/weekly.php?a=36
+		 if (quat.x * lastq.x + quat.y * lastq.y + quat.z * lastq.z + quat.w * lastq.w < 0) {
+		 	quat.x = -quat.x;
+		 	quat.y = -quat.y;
+		 	quat.z = -quat.z;
+		 	quat.w = -quat.w;
+		 }
+		lastq = quat;
+
+		valOut[i].mValue = quat;
+	}
+}
+
+void FBXConverter::ConvertTransformOrder_TRStoSRT(aiQuatKey *out_quat, aiVectorKey *out_scale,
+		aiVectorKey *out_translation,
+		const KeyFrameListList &scaling,
+		const KeyFrameListList &translation,
+		const KeyFrameListList &rotation,
+		const KeyTimeList &times,
+		double &maxTime,
+		double &minTime,
+		Model::RotOrder order,
+		const aiVector3D &def_scale,
+		const aiVector3D &def_translate,
+		const aiVector3D &def_rotation) {
+	// todo refactor to use matrix transform and extract scale from caller :)
+	if (rotation.size()) {
+		InterpolateKeys(out_quat, times, rotation, def_rotation, maxTime, minTime, order);
+	} else
+    {
+        for (size_t i = 0; i < times.size(); ++i) {
+            out_quat[i].mTime = CONVERT_FBX_TIME(times[i]) * anim_fps;
+            out_quat[i].mValue = EulerToQuaternion(def_rotation, order);
         }
     }
 
-    // Add the textures' properties
-
-    for (TextureMap::const_iterator it = textures.begin(); it != textures.end(); it++) {
-
-        std::string name = prefix + it->first;
-
-        const Texture* const tex = (*it).second;
-        if (tex != nullptr)
-        {
-            aiString path;
-            path.Set(tex->RelativeFilename());
-
-            const Video* media = tex->Media();
-            if (media != nullptr && media->ContentLength() > 0) {
-                unsigned int index;
-
-                VideoMap::const_iterator it = textures_converted.find(*media);
-                if (it != textures_converted.end()) {
-                    index = (*it).second;
-                }
-                else {
-                    index = ConvertVideo(*media);
-                    textures_converted[*media] = index;
-                }
-
-                // setup texture reference string (copied from ColladaLoader::FindFilenameForEffectTexture)
-                path.data[0] = '*';
-                path.length = 1 + ASSIMP_itoa10(path.data + 1, MAXLEN - 1, index);
-            }
-
-            out_mat->AddProperty(&path, (name + "|file").c_str(), aiTextureType_UNKNOWN, 0);
-
-            aiUVTransform uvTrafo;
-            // XXX handle all kinds of UV transformations
-            uvTrafo.mScaling = tex->UVScaling();
-            uvTrafo.mTranslation = tex->UVTranslation();
-            out_mat->AddProperty(&uvTrafo, 1, (name + "|uvtrafo").c_str(), aiTextureType_UNKNOWN, 0);
- 
-            int uvIndex = 0;
-
-            bool uvFound = false;
-            const std::string& uvSet = PropertyGet<std::string>(tex->Props(), "UVSet", uvFound);
-            if (uvFound) {
-                // "default" is the name which usually appears in the FbxFileTexture template
-                if (uvSet != "default" && uvSet.length()) {
-                    // this is a bit awkward - we need to find a mesh that uses this
-                    // material and scan its UV channels for the given UV name because
-                    // assimp references UV channels by index, not by name.
-
-                    // XXX: the case that UV channels may appear in different orders
-                    // in meshes is unhandled. A possible solution would be to sort
-                    // the UV channels alphabetically, but this would have the side
-                    // effect that the primary (first) UV channel would sometimes
-                    // be moved, causing trouble when users read only the first
-                    // UV channel and ignore UV channel assignments altogether.
-
-                    std::vector<aiMaterial*>::iterator materialIt = std::find(materials.begin(), materials.end(), out_mat);
-                    const unsigned int matIndex = static_cast<unsigned int>(std::distance(materials.begin(), materialIt));
-
-                    uvIndex = -1;
-                    if (!mesh)
-                    {
-                        for (const MeshMap::value_type& v : meshes_converted) {
-                            const MeshGeometry* const meshGeom = dynamic_cast<const MeshGeometry*>(v.first);
-                            if (!meshGeom) {
-                                continue;
-                            }
-
-                            const MatIndexArray& mats = meshGeom->GetMaterialIndices();
-                            if (std::find(mats.begin(), mats.end(), matIndex) == mats.end()) {
-                                continue;
-                            }
-
-                            int index = -1;
-                            for (unsigned int i = 0; i < AI_MAX_NUMBER_OF_TEXTURECOORDS; ++i) {
-                                if (meshGeom->GetTextureCoords(i).empty()) {
-                                    break;
-                                }
-                                const std::string& name = meshGeom->GetTextureCoordChannelName(i);
-                                if (name == uvSet) {
-                                    index = static_cast<int>(i);
-                                    break;
-                                }
-                            }
-                            if (index == -1) {
-                                FBXImporter::LogWarn("did not find UV channel named " + uvSet + " in a mesh using this material");
-                                continue;
-                            }
-
-                            if (uvIndex == -1) {
-                                uvIndex = index;
-                            }
-                            else {
-                                FBXImporter::LogWarn("the UV channel named " + uvSet + " appears at different positions in meshes, results will be wrong");
-                            }
-                        }
-                    }
-                    else
-                    {
-                        int index = -1;
-                        for (unsigned int i = 0; i < AI_MAX_NUMBER_OF_TEXTURECOORDS; ++i) {
-                            if (mesh->GetTextureCoords(i).empty()) {
-                                break;
-                            }
-                            const std::string& name = mesh->GetTextureCoordChannelName(i);
-                            if (name == uvSet) {
-                                index = static_cast<int>(i);
-                                break;
-                            }
-                        }
-                        if (index == -1) {
-                            FBXImporter::LogWarn("did not find UV channel named " + uvSet + " in a mesh using this material");
-                        }
-
-                        if (uvIndex == -1) {
-                            uvIndex = index;
-                        }
-                    }
-
-                    if (uvIndex == -1) {
-                        FBXImporter::LogWarn("failed to resolve UV channel " + uvSet + ", using first UV channel");
-                        uvIndex = 0;
-                    }
-                }
-            }
-
-            out_mat->AddProperty(&uvIndex, 1, (name + "|uvwsrc").c_str(), aiTextureType_UNKNOWN, 0);
+	if (scaling.size()) {
+		InterpolateKeys(out_scale, times, scaling, def_scale, maxTime, minTime);
+	} else
+    {
+        for (size_t i = 0; i < times.size(); ++i) {
+            out_scale[i].mTime = CONVERT_FBX_TIME(times[i]) * anim_fps;
+            out_scale[i].mValue = def_scale;
         }
-            }
+    }
+
+	if (translation.size()) {
+		InterpolateKeys(out_translation, times, translation, def_translate, maxTime, minTime);
+	} else
+    {
+        for (size_t i = 0; i < times.size(); ++i) {
+            out_translation[i].mTime = CONVERT_FBX_TIME(times[i]) * anim_fps;
+            out_translation[i].mValue = def_translate;
         }
-
-
-        double FBXConverter::FrameRateToDouble(FileGlobalSettings::FrameRate fp, double customFPSVal) {
-            switch (fp) {
-            case FileGlobalSettings::FrameRate_DEFAULT:
-                return 1.0;
-
-            case FileGlobalSettings::FrameRate_120:
-                return 120.0;
-
-            case FileGlobalSettings::FrameRate_100:
-                return 100.0;
-
-            case FileGlobalSettings::FrameRate_60:
-                return 60.0;
-
-            case FileGlobalSettings::FrameRate_50:
-                return 50.0;
-
-            case FileGlobalSettings::FrameRate_48:
-                return 48.0;
-
-            case FileGlobalSettings::FrameRate_30:
-            case FileGlobalSettings::FrameRate_30_DROP:
-                return 30.0;
-
-            case FileGlobalSettings::FrameRate_NTSC_DROP_FRAME:
-            case FileGlobalSettings::FrameRate_NTSC_FULL_FRAME:
-                return 29.9700262;
-
-            case FileGlobalSettings::FrameRate_PAL:
-                return 25.0;
-
-            case FileGlobalSettings::FrameRate_CINEMA:
-                return 24.0;
-
-            case FileGlobalSettings::FrameRate_1000:
-                return 1000.0;
-
-            case FileGlobalSettings::FrameRate_CINEMA_ND:
-                return 23.976;
-
-            case FileGlobalSettings::FrameRate_CUSTOM:
-                return customFPSVal;
-
-            case FileGlobalSettings::FrameRate_MAX: // this is to silence compiler warnings
-                break;
-            }
-
-            ai_assert(false);
-
-            return -1.0f;
-        }
-
-
-        void FBXConverter::ConvertAnimations()
-        {
-            // first of all determine framerate
-            const FileGlobalSettings::FrameRate fps = doc.GlobalSettings().TimeMode();
-            const float custom = doc.GlobalSettings().CustomFrameRate();
-            anim_fps = FrameRateToDouble(fps, custom);
-
-            const std::vector<const AnimationStack*>& animations = doc.AnimationStacks();
-            for (const AnimationStack* stack : animations) {
-                ConvertAnimationStack(*stack);
-            }
-        }
-
-        std::string FBXConverter::FixNodeName(const std::string& name) {
-            // strip Model:: prefix, avoiding ambiguities (i.e. don't strip if
-            // this causes ambiguities, well possible between empty identifiers,
-            // such as "Model::" and ""). Make sure the behaviour is consistent
-            // across multiple calls to FixNodeName().
-            if (name.substr(0, 7) == "Model::") {
-                std::string temp = name.substr(7);
-                return temp;
-            }
-
-            return name;
-        }
-
-        std::string FBXConverter::FixAnimMeshName(const std::string& name) {
-            if (name.length()) {
-                size_t indexOf = name.find_first_of("::");
-                if (indexOf != std::string::npos && indexOf < name.size() - 2) {
-                    return name.substr(indexOf + 2);
-                }
-            }
-            return name.length() ? name : "AnimMesh";
-        }
-
-        void FBXConverter::ConvertAnimationStack(const AnimationStack& st)
-        {
-            const AnimationLayerList& layers = st.Layers();
-            if (layers.empty()) {
-                return;
-            }
-
-            aiAnimation* const anim = new aiAnimation();
-            animations.push_back(anim);
-
-            // strip AnimationStack:: prefix
-            std::string name = st.Name();
-            if (name.substr(0, 16) == "AnimationStack::") {
-                name = name.substr(16);
-            }
-            else if (name.substr(0, 11) == "AnimStack::") {
-                name = name.substr(11);
-            }
-
-            anim->mName.Set(name);
-
-            // need to find all nodes for which we need to generate node animations -
-            // it may happen that we need to merge multiple layers, though.
-            NodeMap node_map;
-
-            // reverse mapping from curves to layers, much faster than querying
-            // the FBX DOM for it.
-            LayerMap layer_map;
-
-            const char* prop_whitelist[] = {
-                "Lcl Scaling",
-                "Lcl Rotation",
-                "Lcl Translation",
-                "DeformPercent"
-            };
-
-            std::map<std::string, morphAnimData*> morphAnimDatas;
-
-            for (const AnimationLayer* layer : layers) {
-                ai_assert(layer);
-                const AnimationCurveNodeList& nodes = layer->Nodes(prop_whitelist, 4);
-                for (const AnimationCurveNode* node : nodes) {
-                    ai_assert(node);
-                    const Model* const model = dynamic_cast<const Model*>(node->Target());
-                    if (model) {
-                        const std::string& name = FixNodeName(model->Name());
-                        node_map[name].push_back(node);
-                        layer_map[node] = layer;
-                        continue;
-                    }
-                    const BlendShapeChannel* const bsc = dynamic_cast<const BlendShapeChannel*>(node->Target());
-                    if (bsc) {
-                        ProcessMorphAnimDatas(&morphAnimDatas, bsc, node);
-                    }
-                }
-            }
-
-            // generate node animations
-            std::vector<aiNodeAnim*> node_anims;
-
-            double min_time = 1e10;
-            double max_time = -1e10;
-
-            int64_t start_time = st.LocalStart();
-            int64_t stop_time = st.LocalStop();
-            bool has_local_startstop = start_time != 0 || stop_time != 0;
-            if (!has_local_startstop) {
-                // no time range given, so accept every keyframe and use the actual min/max time
-                // the numbers are INT64_MIN/MAX, the 20000 is for safety because GenerateNodeAnimations uses an epsilon of 10000
-                start_time = -9223372036854775807ll + 20000;
-                stop_time = 9223372036854775807ll - 20000;
-            }
-
-            try {
-                for (const NodeMap::value_type& kv : node_map) {
-                    GenerateNodeAnimations(node_anims,
-                        kv.first,
-                        kv.second,
-                        layer_map,
-                        start_time, stop_time,
-                        max_time,
-                        min_time);
-                }
-            }
-            catch (std::exception&) {
-                std::for_each(node_anims.begin(), node_anims.end(), Util::delete_fun<aiNodeAnim>());
-                throw;
-            }
-
-            if (node_anims.size() || morphAnimDatas.size()) {
-                if (node_anims.size()) {
-                    anim->mChannels = new aiNodeAnim*[node_anims.size()]();
-                    anim->mNumChannels = static_cast<unsigned int>(node_anims.size());
-                    std::swap_ranges(node_anims.begin(), node_anims.end(), anim->mChannels);
-                }
-                if (morphAnimDatas.size()) {
-                    unsigned int numMorphMeshChannels = static_cast<unsigned int>(morphAnimDatas.size());
-                    anim->mMorphMeshChannels = new aiMeshMorphAnim*[numMorphMeshChannels];
-                    anim->mNumMorphMeshChannels = numMorphMeshChannels;
-                    unsigned int i = 0;
-                    for (auto morphAnimIt : morphAnimDatas) {
-                        morphAnimData* animData = morphAnimIt.second;
-                        unsigned int numKeys = static_cast<unsigned int>(animData->size());
-                        aiMeshMorphAnim* meshMorphAnim = new aiMeshMorphAnim();
-                        meshMorphAnim->mName.Set(morphAnimIt.first);
-                        meshMorphAnim->mNumKeys = numKeys;
-                        meshMorphAnim->mKeys = new aiMeshMorphKey[numKeys];
-                        unsigned int j = 0;
-                        for (auto animIt : *animData) {
-                            morphKeyData* keyData = animIt.second;
-                            unsigned int numValuesAndWeights = static_cast<unsigned int>(keyData->values.size());
-                            meshMorphAnim->mKeys[j].mNumValuesAndWeights = numValuesAndWeights;
-                            meshMorphAnim->mKeys[j].mValues = new unsigned int[numValuesAndWeights];
-                            meshMorphAnim->mKeys[j].mWeights = new double[numValuesAndWeights];
-                            meshMorphAnim->mKeys[j].mTime = CONVERT_FBX_TIME(animIt.first) * anim_fps;
-                            for (unsigned int k = 0; k < numValuesAndWeights; k++) {
-                                meshMorphAnim->mKeys[j].mValues[k] = keyData->values.at(k);
-                                meshMorphAnim->mKeys[j].mWeights[k] = keyData->weights.at(k);
-                            }
-                            j++;
-                        }
-                        anim->mMorphMeshChannels[i++] = meshMorphAnim;
-                    }
-                }
-            }
-            else {
-                // empty animations would fail validation, so drop them
-                delete anim;
-                animations.pop_back();
-                FBXImporter::LogInfo("ignoring empty AnimationStack (using IK?): " + name);
-                return;
-            }
-
-            double start_time_fps = has_local_startstop ? (CONVERT_FBX_TIME(start_time) * anim_fps) : min_time;
-            double stop_time_fps = has_local_startstop ? (CONVERT_FBX_TIME(stop_time) * anim_fps) : max_time;
-
-            // adjust relative timing for animation
-            for (unsigned int c = 0; c < anim->mNumChannels; c++) {
-                aiNodeAnim* channel = anim->mChannels[c];
-                for (uint32_t i = 0; i < channel->mNumPositionKeys; i++) {
-                    channel->mPositionKeys[i].mTime -= start_time_fps;
-                }
-                for (uint32_t i = 0; i < channel->mNumRotationKeys; i++) {
-                    channel->mRotationKeys[i].mTime -= start_time_fps;
-                }
-                for (uint32_t i = 0; i < channel->mNumScalingKeys; i++) {
-                    channel->mScalingKeys[i].mTime -= start_time_fps;
-                }
-            }
-            for (unsigned int c = 0; c < anim->mNumMorphMeshChannels; c++) {
-                aiMeshMorphAnim* channel = anim->mMorphMeshChannels[c];
-                for (uint32_t i = 0; i < channel->mNumKeys; i++) {
-                    channel->mKeys[i].mTime -= start_time_fps;
-                }
-            }
-
-            // for some mysterious reason, mDuration is simply the maximum key -- the
-            // validator always assumes animations to start at zero.
-            anim->mDuration = stop_time_fps - start_time_fps;
-            anim->mTicksPerSecond = anim_fps;
-        }
-
-        // ------------------------------------------------------------------------------------------------
-        void FBXConverter::ProcessMorphAnimDatas(std::map<std::string, morphAnimData*>* morphAnimDatas, const BlendShapeChannel* bsc, const AnimationCurveNode* node) {
-            std::vector<const Connection*> bscConnections = doc.GetConnectionsBySourceSequenced(bsc->ID(), "Deformer");
-            for (const Connection* bscConnection : bscConnections) {
-                auto bs = dynamic_cast<const BlendShape*>(bscConnection->DestinationObject());
-                if (bs) {
-                    auto channelIt = std::find(bs->BlendShapeChannels().begin(), bs->BlendShapeChannels().end(), bsc);
-                    if (channelIt != bs->BlendShapeChannels().end()) {
-                        auto channelIndex = static_cast<unsigned int>(std::distance(bs->BlendShapeChannels().begin(), channelIt));
-                        std::vector<const Connection*> bsConnections = doc.GetConnectionsBySourceSequenced(bs->ID(), "Geometry");
-                        for (const Connection* bsConnection : bsConnections) {
-                            auto geo = dynamic_cast<const Geometry*>(bsConnection->DestinationObject());
-                            if (geo) {
-                                std::vector<const Connection*> geoConnections = doc.GetConnectionsBySourceSequenced(geo->ID(), "Model");
-                                for (const Connection* geoConnection : geoConnections) {
-                                    auto model = dynamic_cast<const Model*>(geoConnection->DestinationObject());
-                                    if (model) {
-                                        auto geoIt = std::find(model->GetGeometry().begin(), model->GetGeometry().end(), geo);
-                                        auto geoIndex = static_cast<unsigned int>(std::distance(model->GetGeometry().begin(), geoIt));
-                                        auto name = aiString(FixNodeName(model->Name() + "*"));
-                                        name.length = 1 + ASSIMP_itoa10(name.data + name.length, MAXLEN - 1, geoIndex);
-                                        morphAnimData* animData;
-                                        auto animIt = morphAnimDatas->find(name.C_Str());
-                                        if (animIt == morphAnimDatas->end()) {
-                                            animData = new morphAnimData();
-                                            morphAnimDatas->insert(std::make_pair(name.C_Str(), animData));
-                                        }
-                                        else {
-                                            animData = animIt->second;
-                                        }
-                                        for (std::pair<std::string, const AnimationCurve*> curvesIt : node->Curves()) {
-                                            if (curvesIt.first == "d|DeformPercent") {
-                                                const AnimationCurve* animationCurve = curvesIt.second;
-                                                const KeyTimeList& keys = animationCurve->GetKeys();
-                                                const KeyValueList& values = animationCurve->GetValues();
-                                                unsigned int k = 0;
-                                                for (auto key : keys) {
-                                                    morphKeyData* keyData;
-                                                    auto keyIt = animData->find(key);
-                                                    if (keyIt == animData->end()) {
-                                                        keyData = new morphKeyData();
-                                                        animData->insert(std::make_pair(key, keyData));
-                                                    }
-                                                    else {
-                                                        keyData = keyIt->second;
-                                                    }
-                                                    keyData->values.push_back(channelIndex);
-                                                    keyData->weights.push_back(values.at(k) / 100.0f);
-                                                    k++;
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        // ------------------------------------------------------------------------------------------------
-#ifdef ASSIMP_BUILD_DEBUG
-        // ------------------------------------------------------------------------------------------------
-        // sanity check whether the input is ok
-        static void validateAnimCurveNodes(const std::vector<const AnimationCurveNode*>& curves,
-            bool strictMode) {
-            const Object* target(nullptr);
-            for (const AnimationCurveNode* node : curves) {
-                if (!target) {
-                    target = node->Target();
-                }
-                if (node->Target() != target) {
-                    FBXImporter::LogWarn("Node target is nullptr type.");
-                }
-                if (strictMode) {
-                    ai_assert(node->Target() == target);
-                }
-            }
-        }
-#endif // ASSIMP_BUILD_DEBUG
-
-        // ------------------------------------------------------------------------------------------------
-        void FBXConverter::GenerateNodeAnimations(std::vector<aiNodeAnim*>& node_anims,
-            const std::string& fixed_name,
-            const std::vector<const AnimationCurveNode*>& curves,
-            const LayerMap& layer_map,
-            int64_t start, int64_t stop,
-            double& max_time,
-            double& min_time)
-        {
-
-            NodeMap node_property_map;
-            ai_assert(curves.size());
-
-#ifdef ASSIMP_BUILD_DEBUG
-            validateAnimCurveNodes(curves, doc.Settings().strictMode);
-#endif
-            const AnimationCurveNode* curve_node = nullptr;
-            for (const AnimationCurveNode* node : curves) {
-                ai_assert(node);
-
-                if (node->TargetProperty().empty()) {
-                    FBXImporter::LogWarn("target property for animation curve not set: " + node->Name());
-                    continue;
-                }
-
-                curve_node = node;
-                if (node->Curves().empty()) {
-                    FBXImporter::LogWarn("no animation curves assigned to AnimationCurveNode: " + node->Name());
-                    continue;
-                }
-
-                node_property_map[node->TargetProperty()].push_back(node);
-            }
-
-            ai_assert(curve_node);
-            ai_assert(curve_node->TargetAsModel());
-
-            const Model& target = *curve_node->TargetAsModel();
-
-            // check for all possible transformation components
-            NodeMap::const_iterator chain[TransformationComp_MAXIMUM];
-
-            bool has_any = false;
-            bool has_complex = false;
-
-            for (size_t i = 0; i < TransformationComp_MAXIMUM; ++i) {
-                const TransformationComp comp = static_cast<TransformationComp>(i);
-
-                // inverse pivots don't exist in the input, we just generate them
-                if (comp == TransformationComp_RotationPivotInverse || comp == TransformationComp_ScalingPivotInverse) {
-                    chain[i] = node_property_map.end();
-                    continue;
-                }
-
-                chain[i] = node_property_map.find(NameTransformationCompProperty(comp));
-                if (chain[i] != node_property_map.end()) {
-
-                    // check if this curves contains redundant information by looking
-                    // up the corresponding node's transformation chain.
-                    if (doc.Settings().optimizeEmptyAnimationCurves &&
-                        IsRedundantAnimationData(target, comp, (*chain[i]).second)) {
-
-                        FBXImporter::LogDebug("dropping redundant animation channel for node " + target.Name());
-                        continue;
-                    }
-
-                    has_any = true;
-
-                    if (comp != TransformationComp_Rotation && comp != TransformationComp_Scaling && comp != TransformationComp_Translation)
-                    {
-                        has_complex = true;
-                    }
-                }
-            }
-
-            if (!has_any) {
-                FBXImporter::LogWarn("ignoring node animation, did not find any transformation key frames");
-                return;
-            }
-
-            // this needs to play nicely with GenerateTransformationNodeChain() which will
-            // be invoked _later_ (animations come first). If this node has only rotation,
-            // scaling and translation _and_ there are no animated other components either,
-            // we can use a single node and also a single node animation channel.
-            if (!has_complex && !NeedsComplexTransformationChain(target)) {
-
-                aiNodeAnim* const nd = GenerateSimpleNodeAnim(fixed_name, target, chain,
-                    node_property_map.end(),
-                    layer_map,
-                    start, stop,
-                    max_time,
-                    min_time,
-                    true // input is TRS order, assimp is SRT
-                );
-
-                ai_assert(nd);
-                if (nd->mNumPositionKeys == 0 && nd->mNumRotationKeys == 0 && nd->mNumScalingKeys == 0) {
-                    delete nd;
-                }
-                else {
-                    node_anims.push_back(nd);
-                }
-                return;
-            }
-
-            // otherwise, things get gruesome and we need separate animation channels
-            // for each part of the transformation chain. Remember which channels
-            // we generated and pass this information to the node conversion
-            // code to avoid nodes that have identity transform, but non-identity
-            // animations, being dropped.
-            unsigned int flags = 0, bit = 0x1;
-            for (size_t i = 0; i < TransformationComp_MAXIMUM; ++i, bit <<= 1) {
-                const TransformationComp comp = static_cast<TransformationComp>(i);
-
-                if (chain[i] != node_property_map.end()) {
-                    flags |= bit;
-
-                    ai_assert(comp != TransformationComp_RotationPivotInverse);
-                    ai_assert(comp != TransformationComp_ScalingPivotInverse);
-
-                    const std::string& chain_name = NameTransformationChainNode(fixed_name, comp);
-
-                    aiNodeAnim* na = nullptr;
-                    switch (comp)
-                    {
-                    case TransformationComp_Rotation:
-                    case TransformationComp_PreRotation:
-                    case TransformationComp_PostRotation:
-                    case TransformationComp_GeometricRotation:
-                        na = GenerateRotationNodeAnim(chain_name,
-                            target,
-                            (*chain[i]).second,
-                            layer_map,
-                            start, stop,
-                            max_time,
-                            min_time);
-
-                        break;
-
-                    case TransformationComp_RotationOffset:
-                    case TransformationComp_RotationPivot:
-                    case TransformationComp_ScalingOffset:
-                    case TransformationComp_ScalingPivot:
-                    case TransformationComp_Translation:
-                    case TransformationComp_GeometricTranslation:
-                        na = GenerateTranslationNodeAnim(chain_name,
-                            target,
-                            (*chain[i]).second,
-                            layer_map,
-                            start, stop,
-                            max_time,
-                            min_time);
-
-                        // pivoting requires us to generate an implicit inverse channel to undo the pivot translation
-                        if (comp == TransformationComp_RotationPivot) {
-                            const std::string& invName = NameTransformationChainNode(fixed_name,
-                                TransformationComp_RotationPivotInverse);
-
-                            aiNodeAnim* const inv = GenerateTranslationNodeAnim(invName,
-                                target,
-                                (*chain[i]).second,
-                                layer_map,
-                                start, stop,
-                                max_time,
-                                min_time,
-                                true);
-
-                            ai_assert(inv);
-                            if (inv->mNumPositionKeys == 0 && inv->mNumRotationKeys == 0 && inv->mNumScalingKeys == 0) {
-                                delete inv;
-                            }
-                            else {
-                                node_anims.push_back(inv);
-                            }
-
-                            ai_assert(TransformationComp_RotationPivotInverse > i);
-                            flags |= bit << (TransformationComp_RotationPivotInverse - i);
-                        }
-                        else if (comp == TransformationComp_ScalingPivot) {
-                            const std::string& invName = NameTransformationChainNode(fixed_name,
-                                TransformationComp_ScalingPivotInverse);
-
-                            aiNodeAnim* const inv = GenerateTranslationNodeAnim(invName,
-                                target,
-                                (*chain[i]).second,
-                                layer_map,
-                                start, stop,
-                                max_time,
-                                min_time,
-                                true);
-
-                            ai_assert(inv);
-                            if (inv->mNumPositionKeys == 0 && inv->mNumRotationKeys == 0 && inv->mNumScalingKeys == 0) {
-                                delete inv;
-                            }
-                            else {
-                                node_anims.push_back(inv);
-                            }
-
-                            ai_assert(TransformationComp_RotationPivotInverse > i);
-                            flags |= bit << (TransformationComp_RotationPivotInverse - i);
-                        }
-
-                        break;
-
-                    case TransformationComp_Scaling:
-                    case TransformationComp_GeometricScaling:
-                        na = GenerateScalingNodeAnim(chain_name,
-                            target,
-                            (*chain[i]).second,
-                            layer_map,
-                            start, stop,
-                            max_time,
-                            min_time);
-
-                        break;
-
-                    default:
-                        ai_assert(false);
-                    }
-
-                    ai_assert(na);
-                    if (na->mNumPositionKeys == 0 && na->mNumRotationKeys == 0 && na->mNumScalingKeys == 0) {
-                        delete na;
-                    }
-                    else {
-                        node_anims.push_back(na);
-                    }
-                    continue;
-                }
-            }
-
-            node_anim_chain_bits[fixed_name] = flags;
-        }
-
-
-        bool FBXConverter::IsRedundantAnimationData(const Model& target,
-            TransformationComp comp,
-            const std::vector<const AnimationCurveNode*>& curves) {
-            ai_assert(curves.size());
-
-            // look for animation nodes with
-            //  * sub channels for all relevant components set
-            //  * one key/value pair per component
-            //  * combined values match up the corresponding value in the bind pose node transformation
-            // only such nodes are 'redundant' for this function.
-
-            if (curves.size() > 1) {
-                return false;
-            }
-
-            const AnimationCurveNode& nd = *curves.front();
-            const AnimationCurveMap& sub_curves = nd.Curves();
-
-            const AnimationCurveMap::const_iterator dx = sub_curves.find("d|X");
-            const AnimationCurveMap::const_iterator dy = sub_curves.find("d|Y");
-            const AnimationCurveMap::const_iterator dz = sub_curves.find("d|Z");
-
-            if (dx == sub_curves.end() || dy == sub_curves.end() || dz == sub_curves.end()) {
-                return false;
-            }
-
-            const KeyValueList& vx = (*dx).second->GetValues();
-            const KeyValueList& vy = (*dy).second->GetValues();
-            const KeyValueList& vz = (*dz).second->GetValues();
-
-            if (vx.size() != 1 || vy.size() != 1 || vz.size() != 1) {
-                return false;
-            }
-
-            const aiVector3D dyn_val = aiVector3D(vx[0], vy[0], vz[0]);
-            const aiVector3D& static_val = PropertyGet<aiVector3D>(target.Props(),
-                NameTransformationCompProperty(comp),
-                TransformationCompDefaultValue(comp)
-                );
-
-            const float epsilon = Math::getEpsilon<float>();
-            return (dyn_val - static_val).SquareLength() < epsilon;
-        }
-
-
-        aiNodeAnim* FBXConverter::GenerateRotationNodeAnim(const std::string& name,
-            const Model& target,
-            const std::vector<const AnimationCurveNode*>& curves,
-            const LayerMap& layer_map,
-            int64_t start, int64_t stop,
-            double& max_time,
-            double& min_time)
-        {
-            std::unique_ptr<aiNodeAnim> na(new aiNodeAnim());
-            na->mNodeName.Set(name);
-
-            ConvertRotationKeys(na.get(), curves, layer_map, start, stop, max_time, min_time, target.RotationOrder());
-
-            // dummy scaling key
-            na->mScalingKeys = new aiVectorKey[1];
-            na->mNumScalingKeys = 1;
-
-            na->mScalingKeys[0].mTime = 0.;
-            na->mScalingKeys[0].mValue = aiVector3D(1.0f, 1.0f, 1.0f);
-
-            // dummy position key
-            na->mPositionKeys = new aiVectorKey[1];
-            na->mNumPositionKeys = 1;
-
-            na->mPositionKeys[0].mTime = 0.;
-            na->mPositionKeys[0].mValue = aiVector3D();
-
-            return na.release();
-        }
-
-        aiNodeAnim* FBXConverter::GenerateScalingNodeAnim(const std::string& name,
-            const Model& /*target*/,
-            const std::vector<const AnimationCurveNode*>& curves,
-            const LayerMap& layer_map,
-            int64_t start, int64_t stop,
-            double& max_time,
-            double& min_time)
-        {
-            std::unique_ptr<aiNodeAnim> na(new aiNodeAnim());
-            na->mNodeName.Set(name);
-
-            ConvertScaleKeys(na.get(), curves, layer_map, start, stop, max_time, min_time);
-
-            // dummy rotation key
-            na->mRotationKeys = new aiQuatKey[1];
-            na->mNumRotationKeys = 1;
-
-            na->mRotationKeys[0].mTime = 0.;
-            na->mRotationKeys[0].mValue = aiQuaternion();
-
-            // dummy position key
-            na->mPositionKeys = new aiVectorKey[1];
-            na->mNumPositionKeys = 1;
-
-            na->mPositionKeys[0].mTime = 0.;
-            na->mPositionKeys[0].mValue = aiVector3D();
-
-            return na.release();
-        }
-
-        aiNodeAnim* FBXConverter::GenerateTranslationNodeAnim(const std::string& name,
-            const Model& /*target*/,
-            const std::vector<const AnimationCurveNode*>& curves,
-            const LayerMap& layer_map,
-            int64_t start, int64_t stop,
-            double& max_time,
-            double& min_time,
-            bool inverse) {
-            std::unique_ptr<aiNodeAnim> na(new aiNodeAnim());
-            na->mNodeName.Set(name);
-
-            ConvertTranslationKeys(na.get(), curves, layer_map, start, stop, max_time, min_time);
-
-            if (inverse) {
-                for (unsigned int i = 0; i < na->mNumPositionKeys; ++i) {
-                    na->mPositionKeys[i].mValue *= -1.0f;
-                }
-            }
-
-            // dummy scaling key
-            na->mScalingKeys = new aiVectorKey[1];
-            na->mNumScalingKeys = 1;
-
-            na->mScalingKeys[0].mTime = 0.;
-            na->mScalingKeys[0].mValue = aiVector3D(1.0f, 1.0f, 1.0f);
-
-            // dummy rotation key
-            na->mRotationKeys = new aiQuatKey[1];
-            na->mNumRotationKeys = 1;
-
-            na->mRotationKeys[0].mTime = 0.;
-            na->mRotationKeys[0].mValue = aiQuaternion();
-
-            return na.release();
-        }
-
-        aiNodeAnim* FBXConverter::GenerateSimpleNodeAnim(const std::string& name,
-            const Model& target,
-            NodeMap::const_iterator chain[TransformationComp_MAXIMUM],
-            NodeMap::const_iterator iter_end,
-            const LayerMap& layer_map,
-            int64_t start, int64_t stop,
-            double& max_time,
-            double& min_time,
-            bool reverse_order)
-
-        {
-            std::unique_ptr<aiNodeAnim> na(new aiNodeAnim());
-            na->mNodeName.Set(name);
-
-            const PropertyTable& props = target.Props();
-
-            // need to convert from TRS order to SRT?
-            if (reverse_order) {
-
-                aiVector3D def_scale = PropertyGet(props, "Lcl Scaling", aiVector3D(1.f, 1.f, 1.f));
-                aiVector3D def_translate = PropertyGet(props, "Lcl Translation", aiVector3D(0.f, 0.f, 0.f));
-                aiVector3D def_rot = PropertyGet(props, "Lcl Rotation", aiVector3D(0.f, 0.f, 0.f));
-
-                KeyFrameListList scaling;
-                KeyFrameListList translation;
-                KeyFrameListList rotation;
-
-                if (chain[TransformationComp_Scaling] != iter_end) {
-                    scaling = GetKeyframeList((*chain[TransformationComp_Scaling]).second, start, stop);
-                }
-
-                if (chain[TransformationComp_Translation] != iter_end) {
-                    translation = GetKeyframeList((*chain[TransformationComp_Translation]).second, start, stop);
-                }
-
-                if (chain[TransformationComp_Rotation] != iter_end) {
-                    rotation = GetKeyframeList((*chain[TransformationComp_Rotation]).second, start, stop);
-                }
-
-                KeyFrameListList joined;
-                joined.insert(joined.end(), scaling.begin(), scaling.end());
-                joined.insert(joined.end(), translation.begin(), translation.end());
-                joined.insert(joined.end(), rotation.begin(), rotation.end());
-
-                const KeyTimeList& times = GetKeyTimeList(joined);
-
-                aiQuatKey* out_quat = new aiQuatKey[times.size()];
-                aiVectorKey* out_scale = new aiVectorKey[times.size()];
-                aiVectorKey* out_translation = new aiVectorKey[times.size()];
-
-                if (times.size())
-                {
-                    ConvertTransformOrder_TRStoSRT(out_quat, out_scale, out_translation,
-                        scaling,
-                        translation,
-                        rotation,
-                        times,
-                        max_time,
-                        min_time,
-                        target.RotationOrder(),
-                        def_scale,
-                        def_translate,
-                        def_rot);
-                }
-
-                // XXX remove duplicates / redundant keys which this operation did
-                // likely produce if not all three channels were equally dense.
-
-                na->mNumScalingKeys = static_cast<unsigned int>(times.size());
-                na->mNumRotationKeys = na->mNumScalingKeys;
-                na->mNumPositionKeys = na->mNumScalingKeys;
-
-                na->mScalingKeys = out_scale;
-                na->mRotationKeys = out_quat;
-                na->mPositionKeys = out_translation;
-            }
-            else {
-
-                // if a particular transformation is not given, grab it from
-                // the corresponding node to meet the semantics of aiNodeAnim,
-                // which requires all of rotation, scaling and translation
-                // to be set.
-                if (chain[TransformationComp_Scaling] != iter_end) {
-                    ConvertScaleKeys(na.get(), (*chain[TransformationComp_Scaling]).second,
-                        layer_map,
-                        start, stop,
-                        max_time,
-                        min_time);
-                }
-                else {
-                    na->mScalingKeys = new aiVectorKey[1];
-                    na->mNumScalingKeys = 1;
-
-                    na->mScalingKeys[0].mTime = 0.;
-                    na->mScalingKeys[0].mValue = PropertyGet(props, "Lcl Scaling",
-                        aiVector3D(1.f, 1.f, 1.f));
-                }
-
-                if (chain[TransformationComp_Rotation] != iter_end) {
-                    ConvertRotationKeys(na.get(), (*chain[TransformationComp_Rotation]).second,
-                        layer_map,
-                        start, stop,
-                        max_time,
-                        min_time,
-                        target.RotationOrder());
-                }
-                else {
-                    na->mRotationKeys = new aiQuatKey[1];
-                    na->mNumRotationKeys = 1;
-
-                    na->mRotationKeys[0].mTime = 0.;
-                    na->mRotationKeys[0].mValue = EulerToQuaternion(
-                        PropertyGet(props, "Lcl Rotation", aiVector3D(0.f, 0.f, 0.f)),
-                        target.RotationOrder());
-                }
-
-                if (chain[TransformationComp_Translation] != iter_end) {
-                    ConvertTranslationKeys(na.get(), (*chain[TransformationComp_Translation]).second,
-                        layer_map,
-                        start, stop,
-                        max_time,
-                        min_time);
-                }
-                else {
-                    na->mPositionKeys = new aiVectorKey[1];
-                    na->mNumPositionKeys = 1;
-
-                    na->mPositionKeys[0].mTime = 0.;
-                    na->mPositionKeys[0].mValue = PropertyGet(props, "Lcl Translation",
-                        aiVector3D(0.f, 0.f, 0.f));
-                }
-
-            }
-            return na.release();
-        }
-
-        FBXConverter::KeyFrameListList FBXConverter::GetKeyframeList(const std::vector<const AnimationCurveNode*>& nodes, int64_t start, int64_t stop)
-        {
-            KeyFrameListList inputs;
-            inputs.reserve(nodes.size() * 3);
-
-            //give some breathing room for rounding errors
-            int64_t adj_start = start - 10000;
-            int64_t adj_stop = stop + 10000;
-
-            for (const AnimationCurveNode* node : nodes) {
-                ai_assert(node);
-
-                const AnimationCurveMap& curves = node->Curves();
-                for (const AnimationCurveMap::value_type& kv : curves) {
-
-                    unsigned int mapto;
-                    if (kv.first == "d|X") {
-                        mapto = 0;
-                    }
-                    else if (kv.first == "d|Y") {
-                        mapto = 1;
-                    }
-                    else if (kv.first == "d|Z") {
-                        mapto = 2;
-                    }
-                    else {
-                        FBXImporter::LogWarn("ignoring scale animation curve, did not recognize target component");
-                        continue;
-                    }
-
-                    const AnimationCurve* const curve = kv.second;
-                    ai_assert(curve->GetKeys().size() == curve->GetValues().size() && curve->GetKeys().size());
-
-                    //get values within the start/stop time window
-                    std::shared_ptr<KeyTimeList> Keys(new KeyTimeList());
-                    std::shared_ptr<KeyValueList> Values(new KeyValueList());
-                    const size_t count = curve->GetKeys().size();
-                    Keys->reserve(count);
-                    Values->reserve(count);
-                    for (size_t n = 0; n < count; n++)
-                    {
-                        int64_t k = curve->GetKeys().at(n);
-                        if (k >= adj_start && k <= adj_stop)
-                        {
-                            Keys->push_back(k);
-                            Values->push_back(curve->GetValues().at(n));
-                        }
-                    }
-
-                    inputs.push_back(std::make_tuple(Keys, Values, mapto));
-                }
-            }
-            return inputs; // pray for NRVO :-)
-        }
-
-
-        KeyTimeList FBXConverter::GetKeyTimeList(const KeyFrameListList& inputs) {
-            ai_assert(!inputs.empty());
-
-            // reserve some space upfront - it is likely that the key-frame lists
-            // have matching time values, so max(of all key-frame lists) should
-            // be a good estimate.
-            KeyTimeList keys;
-
-            size_t estimate = 0;
-            for (const KeyFrameList& kfl : inputs) {
-                estimate = std::max(estimate, std::get<0>(kfl)->size());
-            }
-
-            keys.reserve(estimate);
-
-            std::vector<unsigned int> next_pos;
-            next_pos.resize(inputs.size(), 0);
-
-            const size_t count = inputs.size();
-            while (true) {
-
-                int64_t min_tick = std::numeric_limits<int64_t>::max();
-                for (size_t i = 0; i < count; ++i) {
-                    const KeyFrameList& kfl = inputs[i];
-
-                    if (std::get<0>(kfl)->size() > next_pos[i] && std::get<0>(kfl)->at(next_pos[i]) < min_tick) {
-                        min_tick = std::get<0>(kfl)->at(next_pos[i]);
-                    }
-                }
-
-                if (min_tick == std::numeric_limits<int64_t>::max()) {
-                    break;
-                }
-                keys.push_back(min_tick);
-
-                for (size_t i = 0; i < count; ++i) {
-                    const KeyFrameList& kfl = inputs[i];
-
-
-                    while (std::get<0>(kfl)->size() > next_pos[i] && std::get<0>(kfl)->at(next_pos[i]) == min_tick) {
-                        ++next_pos[i];
-                    }
-                }
-            }
-
-            return keys;
-        }
-
-        void FBXConverter::InterpolateKeys(aiVectorKey* valOut, const KeyTimeList& keys, const KeyFrameListList& inputs,
-            const aiVector3D& def_value,
-            double& max_time,
-            double& min_time) {
-            ai_assert(!keys.empty());
-            ai_assert(nullptr != valOut);
-
-            std::vector<unsigned int> next_pos;
-            const size_t count(inputs.size());
-
-            next_pos.resize(inputs.size(), 0);
-
-            for (KeyTimeList::value_type time : keys) {
-                ai_real result[3] = { def_value.x, def_value.y, def_value.z };
-
-                for (size_t i = 0; i < count; ++i) {
-                    const KeyFrameList& kfl = inputs[i];
-
-                    const size_t ksize = std::get<0>(kfl)->size();
-                    if (ksize == 0) {
-                        continue;
-                    }
-                    if (ksize > next_pos[i] && std::get<0>(kfl)->at(next_pos[i]) == time) {
-                        ++next_pos[i];
-                    }
-
-                    const size_t id0 = next_pos[i] > 0 ? next_pos[i] - 1 : 0;
-                    const size_t id1 = next_pos[i] == ksize ? ksize - 1 : next_pos[i];
-
-                    // use lerp for interpolation
-                    const KeyValueList::value_type valueA = std::get<1>(kfl)->at(id0);
-                    const KeyValueList::value_type valueB = std::get<1>(kfl)->at(id1);
-
-                    const KeyTimeList::value_type timeA = std::get<0>(kfl)->at(id0);
-                    const KeyTimeList::value_type timeB = std::get<0>(kfl)->at(id1);
-
-                    const ai_real factor = timeB == timeA ? ai_real(0.) : static_cast<ai_real>((time - timeA)) / (timeB - timeA);
-                    const ai_real interpValue = static_cast<ai_real>(valueA + (valueB - valueA) * factor);
-
-                    result[std::get<2>(kfl)] = interpValue;
-                }
-
-                // magic value to convert fbx times to seconds
-                valOut->mTime = CONVERT_FBX_TIME(time) * anim_fps;
-
-                min_time = std::min(min_time, valOut->mTime);
-                max_time = std::max(max_time, valOut->mTime);
-
-                valOut->mValue.x = result[0];
-                valOut->mValue.y = result[1];
-                valOut->mValue.z = result[2];
-
-                ++valOut;
-            }
-        }
-
-        void FBXConverter::InterpolateKeys(aiQuatKey* valOut, const KeyTimeList& keys, const KeyFrameListList& inputs,
-            const aiVector3D& def_value,
-            double& maxTime,
-            double& minTime,
-            Model::RotOrder order)
-        {
-            ai_assert(!keys.empty());
-            ai_assert(nullptr != valOut);
-
-            std::unique_ptr<aiVectorKey[]> temp(new aiVectorKey[keys.size()]);
-            InterpolateKeys(temp.get(), keys, inputs, def_value, maxTime, minTime);
-
-            aiMatrix4x4 m;
-
-            aiQuaternion lastq;
-
-            for (size_t i = 0, c = keys.size(); i < c; ++i) {
-
-                valOut[i].mTime = temp[i].mTime;
-
-                GetRotationMatrix(order, temp[i].mValue, m);
-                aiQuaternion quat = aiQuaternion(aiMatrix3x3(m));
-
-                // take shortest path by checking the inner product
-                // http://www.3dkingdoms.com/weekly/weekly.php?a=36
-                if (quat.x * lastq.x + quat.y * lastq.y + quat.z * lastq.z + quat.w * lastq.w < 0)
-                {
-                    quat.x = -quat.x;
-                    quat.y = -quat.y;
-                    quat.z = -quat.z;
-                    quat.w = -quat.w;
-                }
-                lastq = quat;
-
-                valOut[i].mValue = quat;
-            }
-        }
-
-        void FBXConverter::ConvertTransformOrder_TRStoSRT(aiQuatKey* out_quat, aiVectorKey* out_scale,
-            aiVectorKey* out_translation,
-            const KeyFrameListList& scaling,
-            const KeyFrameListList& translation,
-            const KeyFrameListList& rotation,
-            const KeyTimeList& times,
-            double& maxTime,
-            double& minTime,
-            Model::RotOrder order,
-            const aiVector3D& def_scale,
-            const aiVector3D& def_translate,
-            const aiVector3D& def_rotation)
-        {
-            if (rotation.size()) {
-                InterpolateKeys(out_quat, times, rotation, def_rotation, maxTime, minTime, order);
-            }
-            else {
-                for (size_t i = 0; i < times.size(); ++i) {
-                    out_quat[i].mTime = CONVERT_FBX_TIME(times[i]) * anim_fps;
-                    out_quat[i].mValue = EulerToQuaternion(def_rotation, order);
-                }
-            }
-
-            if (scaling.size()) {
-                InterpolateKeys(out_scale, times, scaling, def_scale, maxTime, minTime);
-            }
-            else {
-                for (size_t i = 0; i < times.size(); ++i) {
-                    out_scale[i].mTime = CONVERT_FBX_TIME(times[i]) * anim_fps;
-                    out_scale[i].mValue = def_scale;
-                }
-            }
-
-            if (translation.size()) {
-                InterpolateKeys(out_translation, times, translation, def_translate, maxTime, minTime);
-            }
-            else {
-                for (size_t i = 0; i < times.size(); ++i) {
-                    out_translation[i].mTime = CONVERT_FBX_TIME(times[i]) * anim_fps;
-                    out_translation[i].mValue = def_translate;
-                }
-            }
-
-            const size_t count = times.size();
-            for (size_t i = 0; i < count; ++i) {
-                aiQuaternion& r = out_quat[i].mValue;
-                aiVector3D& s = out_scale[i].mValue;
-                aiVector3D& t = out_translation[i].mValue;
-
-                aiMatrix4x4 mat, temp;
-                aiMatrix4x4::Translation(t, mat);
-                mat *= aiMatrix4x4(r.GetMatrix());
-                mat *= aiMatrix4x4::Scaling(s, temp);
-
-                mat.Decompose(s, r, t);
-            }
-        }
-
-        aiQuaternion FBXConverter::EulerToQuaternion(const aiVector3D& rot, Model::RotOrder order)
-        {
-            aiMatrix4x4 m;
-            GetRotationMatrix(order, rot, m);
-
-            return aiQuaternion(aiMatrix3x3(m));
-        }
-
-        void FBXConverter::ConvertScaleKeys(aiNodeAnim* na, const std::vector<const AnimationCurveNode*>& nodes, const LayerMap& /*layers*/,
-            int64_t start, int64_t stop,
-            double& maxTime,
-            double& minTime)
-        {
-            ai_assert(nodes.size());
-
-            // XXX for now, assume scale should be blended geometrically (i.e. two
-            // layers should be multiplied with each other). There is a FBX
-            // property in the layer to specify the behaviour, though.
-
-            const KeyFrameListList& inputs = GetKeyframeList(nodes, start, stop);
-            const KeyTimeList& keys = GetKeyTimeList(inputs);
-
-            na->mNumScalingKeys = static_cast<unsigned int>(keys.size());
-            na->mScalingKeys = new aiVectorKey[keys.size()];
-            if (keys.size() > 0) {
-                InterpolateKeys(na->mScalingKeys, keys, inputs, aiVector3D(1.0f, 1.0f, 1.0f), maxTime, minTime);
-            }
-        }
-
-        void FBXConverter::ConvertTranslationKeys(aiNodeAnim* na, const std::vector<const AnimationCurveNode*>& nodes,
-            const LayerMap& /*layers*/,
-            int64_t start, int64_t stop,
-            double& maxTime,
-            double& minTime)
-        {
-            ai_assert(nodes.size());
-
-            // XXX see notes in ConvertScaleKeys()
-            const KeyFrameListList& inputs = GetKeyframeList(nodes, start, stop);
-            const KeyTimeList& keys = GetKeyTimeList(inputs);
-
-            na->mNumPositionKeys = static_cast<unsigned int>(keys.size());
-            na->mPositionKeys = new aiVectorKey[keys.size()];
-            if (keys.size() > 0)
-                InterpolateKeys(na->mPositionKeys, keys, inputs, aiVector3D(0.0f, 0.0f, 0.0f), maxTime, minTime);
-        }
-
-        void FBXConverter::ConvertRotationKeys(aiNodeAnim* na, const std::vector<const AnimationCurveNode*>& nodes,
-            const LayerMap& /*layers*/,
-            int64_t start, int64_t stop,
-            double& maxTime,
-            double& minTime,
-            Model::RotOrder order)
-        {
-            ai_assert(nodes.size());
-
-            // XXX see notes in ConvertScaleKeys()
-            const std::vector< KeyFrameList >& inputs = GetKeyframeList(nodes, start, stop);
-            const KeyTimeList& keys = GetKeyTimeList(inputs);
-
-            na->mNumRotationKeys = static_cast<unsigned int>(keys.size());
-            na->mRotationKeys = new aiQuatKey[keys.size()];
-            if (!keys.empty()) {
-                InterpolateKeys(na->mRotationKeys, keys, inputs, aiVector3D(0.0f, 0.0f, 0.0f), maxTime, minTime, order);
-            }
-        }
-
-        void FBXConverter::ConvertGlobalSettings() {
-            if (nullptr == out) {
-                return;
-            }
-
-            const bool hasGenerator = !doc.Creator().empty();
-
-            out->mMetaData = aiMetadata::Alloc(16 + (hasGenerator ? 1 : 0));
-            out->mMetaData->Set(0, "UpAxis", doc.GlobalSettings().UpAxis());
-            out->mMetaData->Set(1, "UpAxisSign", doc.GlobalSettings().UpAxisSign());
-            out->mMetaData->Set(2, "FrontAxis", doc.GlobalSettings().FrontAxis());
-            out->mMetaData->Set(3, "FrontAxisSign", doc.GlobalSettings().FrontAxisSign());
-            out->mMetaData->Set(4, "CoordAxis", doc.GlobalSettings().CoordAxis());
-            out->mMetaData->Set(5, "CoordAxisSign", doc.GlobalSettings().CoordAxisSign());
-            out->mMetaData->Set(6, "OriginalUpAxis", doc.GlobalSettings().OriginalUpAxis());
-            out->mMetaData->Set(7, "OriginalUpAxisSign", doc.GlobalSettings().OriginalUpAxisSign());
-            out->mMetaData->Set(8, "UnitScaleFactor", (double)doc.GlobalSettings().UnitScaleFactor());
-            out->mMetaData->Set(9, "OriginalUnitScaleFactor", doc.GlobalSettings().OriginalUnitScaleFactor());
-            out->mMetaData->Set(10, "AmbientColor", doc.GlobalSettings().AmbientColor());
-            out->mMetaData->Set(11, "FrameRate", (int)doc.GlobalSettings().TimeMode());
-            out->mMetaData->Set(12, "TimeSpanStart", doc.GlobalSettings().TimeSpanStart());
-            out->mMetaData->Set(13, "TimeSpanStop", doc.GlobalSettings().TimeSpanStop());
-            out->mMetaData->Set(14, "CustomFrameRate", doc.GlobalSettings().CustomFrameRate());
-            out->mMetaData->Set(15, AI_METADATA_SOURCE_FORMAT_VERSION, aiString(to_string(doc.FBXVersion())));
-            if (hasGenerator)
-            {
-                out->mMetaData->Set(16, AI_METADATA_SOURCE_GENERATOR, aiString(doc.Creator()));
-            }
-        }
-
-        void FBXConverter::TransferDataToScene()
-        {
-            ai_assert(!out->mMeshes);
-            ai_assert(!out->mNumMeshes);
-
-            // note: the trailing () ensures initialization with nullptr - not
-            // many C++ users seem to know this, so pointing it out to avoid
-            // confusion why this code works.
-
-            if (meshes.size()) {
-                out->mMeshes = new aiMesh*[meshes.size()]();
-                out->mNumMeshes = static_cast<unsigned int>(meshes.size());
-
-                std::swap_ranges(meshes.begin(), meshes.end(), out->mMeshes);
-            }
-
-            if (materials.size()) {
-                out->mMaterials = new aiMaterial*[materials.size()]();
-                out->mNumMaterials = static_cast<unsigned int>(materials.size());
-
-                std::swap_ranges(materials.begin(), materials.end(), out->mMaterials);
-            }
-
-            if (animations.size()) {
-                out->mAnimations = new aiAnimation*[animations.size()]();
-                out->mNumAnimations = static_cast<unsigned int>(animations.size());
-
-                std::swap_ranges(animations.begin(), animations.end(), out->mAnimations);
-            }
-
-            if (lights.size()) {
-                out->mLights = new aiLight*[lights.size()]();
-                out->mNumLights = static_cast<unsigned int>(lights.size());
-
-                std::swap_ranges(lights.begin(), lights.end(), out->mLights);
-            }
-
-            if (cameras.size()) {
-                out->mCameras = new aiCamera*[cameras.size()]();
-                out->mNumCameras = static_cast<unsigned int>(cameras.size());
-
-                std::swap_ranges(cameras.begin(), cameras.end(), out->mCameras);
-            }
-
-            if (textures.size()) {
-                out->mTextures = new aiTexture*[textures.size()]();
-                out->mNumTextures = static_cast<unsigned int>(textures.size());
-
-                std::swap_ranges(textures.begin(), textures.end(), out->mTextures);
-            }
-        }
-
-        void FBXConverter::ConvertOrphantEmbeddedTextures()
-        {
-            // in C++14 it could be:
-            // for (auto&& [id, object] : objects)
-            for (auto&& id_and_object : doc.Objects())
-            {
-                auto&& id = std::get<0>(id_and_object);
-                auto&& object = std::get<1>(id_and_object);
-                // If an object doesn't have parent
-                if (doc.ConnectionsBySource().count(id) == 0)
-                {
-                    const Texture* realTexture = nullptr;
-                    try
-                    {
-                        const auto& element = object->GetElement();
-                        const Token& key = element.KeyToken();
-                        const char* obtype = key.begin();
-                        const size_t length = static_cast<size_t>(key.end() - key.begin());
-                        if (strncmp(obtype, "Texture", length) == 0)
-                        {
-                            const Texture* texture = static_cast<const Texture*>(object->Get());
-                            if (texture->Media() && texture->Media()->ContentLength() > 0)
-                            {
-                                realTexture = texture;
-                            }
-                        }
-                    }
-                    catch (...)
-                    {
-                        // do nothing
-                    }
-                    if (realTexture)
-                    {
-                        const Video* media = realTexture->Media();
-                        unsigned int index = ConvertVideo(*media);
-                        textures_converted[*media] = index;
-                    }
-                }
-            }
-        }
-
-        // ------------------------------------------------------------------------------------------------
-        void ConvertToAssimpScene(aiScene* out, const Document& doc, bool removeEmptyBones)
-        {
-            FBXConverter converter(out, doc, removeEmptyBones);
-        }
-
-    } // !FBX
-} // !Assimp
+    }
+}
+
+aiQuaternion FBXConverter::EulerToQuaternion(const aiVector3D &rot, Model::RotOrder order) {
+	aiMatrix4x4 m;
+	GetRotationMatrix(order, rot, m);
+
+	return aiQuaternion(aiMatrix3x3(m));
+}
+
+void FBXConverter::ConvertScaleKeys(aiNodeAnim *na, const std::vector<const AnimationCurveNode *> &nodes, const LayerMap & /*layers*/,
+		int64_t start, int64_t stop,
+		double &maxTime,
+		double &minTime) {
+	ai_assert(nodes.size());
+	ai_assert(na);
+
+	// XXX for now, assume scale should be blended geometrically (i.e. two
+	// layers should be multiplied with each other). There is a FBX
+	// property in the layer to specify the behaviour, though.
+
+	const KeyFrameListList &inputs = GetKeyframeList(nodes, start, stop);
+	const KeyTimeList &keys = GetKeyTimeList(inputs);
+
+	na->mNumScalingKeys = static_cast<unsigned int>(keys.size());
+	na->mScalingKeys = new aiVectorKey[keys.size()];
+	if (keys.size() > 0) {
+		InterpolateKeys(na->mScalingKeys, keys, inputs, aiVector3D(1.0f, 1.0f, 1.0f), maxTime, minTime);
+	}
+}
+
+void FBXConverter::ConvertTranslationKeys(aiNodeAnim *na, const std::vector<const AnimationCurveNode *> &nodes,
+		const LayerMap & /*layers*/,
+		int64_t start, int64_t stop,
+		double &maxTime,
+		double &minTime) {
+	ai_assert(nodes.size());
+	ai_assert(na);
+	// XXX see notes in ConvertScaleKeys()
+	const KeyFrameListList &inputs = GetKeyframeList(nodes, start, stop);
+	const KeyTimeList &keys = GetKeyTimeList(inputs);
+
+	na->mNumPositionKeys = static_cast<unsigned int>(keys.size());
+	na->mPositionKeys = new aiVectorKey[keys.size()];
+	if (keys.size() > 0)
+		InterpolateKeys(na->mPositionKeys, keys, inputs, aiVector3D(0.0f, 0.0f, 0.0f), maxTime, minTime);
+}
+
+void FBXConverter::ConvertRotationKeys(aiNodeAnim *na, const std::vector<const AnimationCurveNode *> &nodes,
+		const LayerMap & /*layers*/,
+		int64_t start, int64_t stop,
+		double &maxTime,
+		double &minTime,
+		Model::RotOrder order) {
+	ai_assert(nodes.size());
+	ai_assert(na);
+
+	// XXX see notes in ConvertScaleKeys()
+	const std::vector<KeyFrameList> &inputs = GetKeyframeList(nodes, start, stop);
+	const KeyTimeList &keys = GetKeyTimeList(inputs);
+
+	na->mNumRotationKeys = static_cast<unsigned int>(keys.size());
+	na->mRotationKeys = new aiQuatKey[keys.size()];
+	if (!keys.empty()) {
+		InterpolateKeys(na->mRotationKeys, keys, inputs, aiVector3D(0.0f, 0.0f, 0.0f), maxTime, minTime, order);
+	}
+}
+
+void FBXConverter::ConvertGlobalSettings() {
+	if (nullptr == out) {
+		return;
+	}
+
+	out->mMetaData = aiMetadata::Alloc(15);
+	out->mMetaData->Set(0, "UpAxis", doc.GlobalSettings().UpAxis());
+	out->mMetaData->Set(1, "UpAxisSign", doc.GlobalSettings().UpAxisSign());
+	out->mMetaData->Set(2, "FrontAxis", doc.GlobalSettings().FrontAxis());
+	out->mMetaData->Set(3, "FrontAxisSign", doc.GlobalSettings().FrontAxisSign());
+	out->mMetaData->Set(4, "CoordAxis", doc.GlobalSettings().CoordAxis());
+	out->mMetaData->Set(5, "CoordAxisSign", doc.GlobalSettings().CoordAxisSign());
+	out->mMetaData->Set(6, "OriginalUpAxis", doc.GlobalSettings().OriginalUpAxis());
+	out->mMetaData->Set(7, "OriginalUpAxisSign", doc.GlobalSettings().OriginalUpAxisSign());
+	out->mMetaData->Set(8, "UnitScaleFactor", (double)doc.GlobalSettings().UnitScaleFactor());
+	out->mMetaData->Set(9, "OriginalUnitScaleFactor", doc.GlobalSettings().OriginalUnitScaleFactor());
+	out->mMetaData->Set(10, "AmbientColor", doc.GlobalSettings().AmbientColor());
+	out->mMetaData->Set(11, "FrameRate", (int)doc.GlobalSettings().TimeMode());
+	out->mMetaData->Set(12, "TimeSpanStart", doc.GlobalSettings().TimeSpanStart());
+	out->mMetaData->Set(13, "TimeSpanStop", doc.GlobalSettings().TimeSpanStop());
+	out->mMetaData->Set(14, "CustomFrameRate", doc.GlobalSettings().CustomFrameRate());
+}
+
+void FBXConverter::TransferDataToScene() {
+	ai_assert(!out->mMeshes);
+	ai_assert(!out->mNumMeshes);
+
+	// note: the trailing () ensures initialization with nullptr - not
+	// many C++ users seem to know this, so pointing it out to avoid
+	// confusion why this code works.
+
+	if (meshes.size()) {
+		out->mMeshes = new aiMesh *[meshes.size()]();
+		out->mNumMeshes = static_cast<unsigned int>(meshes.size());
+
+		std::swap_ranges(meshes.begin(), meshes.end(), out->mMeshes);
+	}
+
+	if (materials.size()) {
+		out->mMaterials = new aiMaterial *[materials.size()]();
+		out->mNumMaterials = static_cast<unsigned int>(materials.size());
+
+		std::swap_ranges(materials.begin(), materials.end(), out->mMaterials);
+	}
+
+	if (animations.size()) {
+		out->mAnimations = new aiAnimation *[animations.size()]();
+		out->mNumAnimations = static_cast<unsigned int>(animations.size());
+
+		std::swap_ranges(animations.begin(), animations.end(), out->mAnimations);
+	}
+
+	if (lights.size()) {
+		out->mLights = new aiLight *[lights.size()]();
+		out->mNumLights = static_cast<unsigned int>(lights.size());
+
+		std::swap_ranges(lights.begin(), lights.end(), out->mLights);
+	}
+
+	if (cameras.size()) {
+		out->mCameras = new aiCamera *[cameras.size()]();
+		out->mNumCameras = static_cast<unsigned int>(cameras.size());
+
+		std::swap_ranges(cameras.begin(), cameras.end(), out->mCameras);
+	}
+
+	if (textures.size()) {
+		out->mTextures = new aiTexture *[textures.size()]();
+		out->mNumTextures = static_cast<unsigned int>(textures.size());
+
+		std::swap_ranges(textures.begin(), textures.end(), out->mTextures);
+	}
+}
+
+void FBXConverter::ConvertOrphantEmbeddedTextures() {
+	// in C++14 it could be:
+	// for (auto&& [id, object] : objects)
+	for (auto &&id_and_object : doc.Objects()) {
+		auto &&id = std::get<0>(id_and_object);
+		auto &&object = std::get<1>(id_and_object);
+		// If an object doesn't have parent
+		if (doc.ConnectionsBySource().count(id) == 0) {
+			const Texture *realTexture = nullptr;
+			try {
+				const auto &element = object->GetElement();
+				const Token &key = element.KeyToken();
+				const char *obtype = key.begin();
+				const size_t length = static_cast<size_t>(key.end() - key.begin());
+				if (strncmp(obtype, "Texture", length) == 0) {
+					const Texture *texture = static_cast<const Texture *>(object->Get());
+					if (texture->Media() && texture->Media()->ContentLength() > 0) {
+						realTexture = texture;
+					}
+				}
+			} catch (...) {
+				// do nothing
+			}
+			if (realTexture) {
+				const Video *media = realTexture->Media();
+				unsigned int index = ConvertVideo(*media);
+				textures_converted[*media] = index;
+			}
+		}
+	}
+}
+
+// ------------------------------------------------------------------------------------------------
+void ConvertToAssimpScene(aiScene *out, const Document &doc, bool removeEmptyBones) {
+	FBXConverter converter(out, doc, removeEmptyBones);
+}
+
+} // namespace FBX
+} // namespace Assimp
 
 #endif

--- a/code/FBX/FBXConverter.h
+++ b/code/FBX/FBXConverter.h
@@ -46,19 +46,20 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef INCLUDED_AI_FBX_CONVERTER_H
 #define INCLUDED_AI_FBX_CONVERTER_H
 
-#include "FBXParser.h"
-#include "FBXMeshGeometry.h"
 #include "FBXDocument.h"
-#include "FBXUtil.h"
-#include "FBXProperties.h"
 #include "FBXImporter.h"
+#include "FBXMeshGeometry.h"
+#include "FBXParser.h"
+#include "FBXProperties.h"
+#include "FBXUtil.h"
 
-#include <assimp/anim.h>
-#include <assimp/material.h>
-#include <assimp/light.h>
-#include <assimp/texture.h>
-#include <assimp/camera.h>
 #include <assimp/StringComparison.h>
+#include <assimp/anim.h>
+#include <assimp/camera.h>
+#include <assimp/light.h>
+#include <assimp/material.h>
+#include <assimp/texture.h>
+#include <iostream>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -67,10 +68,10 @@ struct aiNode;
 struct aiMaterial;
 
 struct morphKeyData {
-    std::vector<unsigned int> values;
-    std::vector<float> weights;
+	std::vector<unsigned int> values;
+	std::vector<float> weights;
 };
-typedef std::map<int64_t, morphKeyData*> morphAnimData;
+typedef std::map<int64_t, morphKeyData *> morphAnimData;
 
 namespace Assimp {
 namespace FBX {
@@ -82,412 +83,416 @@ class Document;
  *  @param doc Parsed FBX document
  *  @param removeEmptyBones Will remove bones, which do not have any references to vertices.
  */
-void ConvertToAssimpScene(aiScene* out, const Document& doc, bool removeEmptyBones);
+void ConvertToAssimpScene(aiScene *out, const Document &doc, bool removeEmptyBones);
 
 /** Dummy class to encapsulate the conversion process */
 class FBXConverter {
 public:
-    /**
+	/**
     *  The different parts that make up the final local transformation of a fbx-node
     */
-    enum TransformationComp {
-        TransformationComp_GeometricScalingInverse = 0,
-        TransformationComp_GeometricRotationInverse,
-        TransformationComp_GeometricTranslationInverse,
-        TransformationComp_Translation,
-        TransformationComp_RotationOffset,
-        TransformationComp_RotationPivot,
-        TransformationComp_PreRotation,
-        TransformationComp_Rotation,
-        TransformationComp_PostRotation,
-        TransformationComp_RotationPivotInverse,
-        TransformationComp_ScalingOffset,
-        TransformationComp_ScalingPivot,
-        TransformationComp_Scaling,
-        TransformationComp_ScalingPivotInverse,
-        TransformationComp_GeometricTranslation,
-        TransformationComp_GeometricRotation,
-        TransformationComp_GeometricScaling,
+	enum TransformationComp {
+		TransformationComp_Translation,
+		TransformationComp_Scaling,
+		TransformationComp_Rotation,
+		TransformationComp_RotationOffset,
+		TransformationComp_RotationPivot,
+		TransformationComp_PreRotation,
+		TransformationComp_PostRotation,
+		TransformationComp_ScalingOffset,
+		TransformationComp_ScalingPivot,
+		TransformationComp_GeometricTranslation,
+		TransformationComp_GeometricRotation,
+		TransformationComp_GeometricScaling,
+		TransformationComp_MAXIMUM
+	};
 
-        TransformationComp_MAXIMUM
-    };
+	enum PivotStatus {
+		PivotStatus_Active = 0, // this means that the pivot has to be used for animation sampling and basic transform data
+		PivotStatus_Reference = 1, // For lamens this means that the value exists
+		// but should not be used in computation for animations or nodes.
+	};
 
 public:
-    FBXConverter(aiScene* out, const Document& doc, bool removeEmptyBones);
-    ~FBXConverter();
+	FBXConverter(aiScene *out, const Document &doc, bool removeEmptyBones);
+	~FBXConverter();
 
 private:
-    // ------------------------------------------------------------------------------------------------
-    // find scene root and trigger recursive scene conversion
-    void ConvertRootNode();
+	//
+	// Animation stack used for pivot calculations
+	// very important for resampling the right node, if there are duplicates
+	void GenerateAnimStack();
+	void ResampleAnimationsWithPivots(int64_t targetId, aiMatrix4x4 transform);
+	std::vector<aiNodeAnim *> GetNodeAnimsFromStack(const std::string &node_name);
 
-    // ------------------------------------------------------------------------------------------------
-    // collect and assign child nodes
-    void ConvertNodes(uint64_t id, aiNode *parent, aiNode *root_node);
+	// pass into resample
+	// input of ResampleFunction
+	// list of the first node
+	// from each animation
 
-    // ------------------------------------------------------------------------------------------------
-    void ConvertLights(const Model& model, const std::string &orig_name );
+	std::map<aiAnimation *, std::vector<aiNodeAnim *> > animation_stack;
 
-    // ------------------------------------------------------------------------------------------------
-    void ConvertCameras(const Model& model, const std::string &orig_name );
+	// we must still overwrite their node counterparts though.
 
-    // ------------------------------------------------------------------------------------------------
-    void ConvertLight( const Light& light, const std::string &orig_name );
+	bool IsBone(const int64_t& element_id) {
+	    if(bone_id_map.empty())
+        {
+	        std::cout << "warning: bone list is empty so can't check for bones!" << std::endl;
+        }
 
-    // ------------------------------------------------------------------------------------------------
-    void ConvertCamera( const Camera& cam, const std::string &orig_name );
+	    return bone_id_map.count(element_id) > 0;
+	}
 
-    // ------------------------------------------------------------------------------------------------
-    void GetUniqueName( const std::string &name, std::string& uniqueName );
+	// ------------------------------------------------------------------------------------------------
+	// find scene root and trigger recursive scene conversion
+	void ConvertRootNode();
 
-    // ------------------------------------------------------------------------------------------------
-    // this returns unified names usable within assimp identifiers (i.e. no space characters -
-    // while these would be allowed, they are a potential trouble spot so better not use them).
-    const char* NameTransformationComp(TransformationComp comp);
+	// ------------------------------------------------------------------------------------------------
+	// collect and assign child nodes
+    void ConvertNodes(uint64_t id, aiNode *parent, aiNode *root_node, aiMatrix4x4 inverse_geometric_xform,
+                      aiMatrix4x4 world_transform);
 
-    // ------------------------------------------------------------------------------------------------
-    // Returns an unique name for a node or traverses up a hierarchy until a non-empty name is found and
-    // then makes this name unique
-    std::string MakeUniqueNodeName(const Model* const model, const aiNode& parent);
+	// ------------------------------------------------------------------------------------------------
+	void ConvertLights(const Model &model, const std::string &orig_name);
 
-    // ------------------------------------------------------------------------------------------------
-    // note: this returns the REAL fbx property names
-    const char* NameTransformationCompProperty(TransformationComp comp);
+	// ------------------------------------------------------------------------------------------------
+	void ConvertCameras(const Model &model, const std::string &orig_name);
 
-    // ------------------------------------------------------------------------------------------------
-    aiVector3D TransformationCompDefaultValue(TransformationComp comp);
+	// ------------------------------------------------------------------------------------------------
+	void ConvertLight(const Light &light, const std::string &orig_name);
 
-    // ------------------------------------------------------------------------------------------------
-    void GetRotationMatrix(Model::RotOrder mode, const aiVector3D& rotation, aiMatrix4x4& out);
-    // ------------------------------------------------------------------------------------------------
-    /**
+	// ------------------------------------------------------------------------------------------------
+	void ConvertCamera(const Camera &cam, const std::string &orig_name);
+
+	// ------------------------------------------------------------------------------------------------
+	void GetUniqueName(const std::string &name, std::string &uniqueName);
+
+	// ------------------------------------------------------------------------------------------------
+	// this returns unified names usable within assimp identifiers (i.e. no space characters -
+	// while these would be allowed, they are a potential trouble spot so better not use them).
+	const char *NameTransformationComp(TransformationComp comp);
+
+	// ------------------------------------------------------------------------------------------------
+	// Returns an unique name for a node or traverses up a hierarchy until a non-empty name is found and
+	// then makes this name unique
+	std::string MakeUniqueNodeName(const Model *const model, const aiNode &parent);
+
+	// ------------------------------------------------------------------------------------------------
+	// note: this returns the REAL fbx property names
+	const char *NameTransformationCompProperty(TransformationComp comp);
+
+	// ------------------------------------------------------------------------------------------------
+	aiVector3D TransformationCompDefaultValue(TransformationComp comp);
+
+	// ------------------------------------------------------------------------------------------------
+	void GetRotationMatrix(Model::RotOrder mode, const aiVector3D &rotation, aiMatrix4x4 &out);
+	// ------------------------------------------------------------------------------------------------
+	/**
     *  checks if a node has more than just scaling, rotation and translation components
     */
-    bool NeedsComplexTransformationChain(const Model& model);
+	bool NeedsComplexTransformationChain(const Model &model);
 
-    // ------------------------------------------------------------------------------------------------
-    // note: name must be a FixNodeName() result
-    std::string NameTransformationChainNode(const std::string& name, TransformationComp comp);
+	aiMatrix4x4 GeneratePivotTransform( const Model& model, aiMatrix4x4 &geometric_transform );
 
-    // ------------------------------------------------------------------------------------------------
-    /**
-    *  note: memory for output_nodes will be managed by the caller
-    */
-    bool GenerateTransformationNodeChain(const Model& model, const std::string& name, std::vector<aiNode*>& output_nodes, std::vector<aiNode*>& post_output_nodes);
+	aiMatrix4x4 GeneratePivotTransform(const PropertyTable &props, const Model::RotOrder &rot,
+                                       aiMatrix4x4 &geometric_transform);
 
-    // ------------------------------------------------------------------------------------------------
-    void SetupNodeMetadata(const Model& model, aiNode& nd);
+	void MagicPivotAlgorithm(
+			aiMatrix4x4 chain[TransformationComp_MAXIMUM],
+			aiMatrix4x4 &result,
+			aiMatrix4x4 &geometric_transform);
 
-    // ------------------------------------------------------------------------------------------------
-    void ConvertModel(const Model &model, aiNode *parent, aiNode *root_node,
-                      const aiMatrix4x4 &absolute_transform);
-    
-    // ------------------------------------------------------------------------------------------------
-    // MeshGeometry -> aiMesh, return mesh index + 1 or 0 if the conversion failed
-    std::vector<unsigned int>
-    ConvertMesh(const MeshGeometry &mesh, const Model &model, aiNode *parent, aiNode *root_node,
-                const aiMatrix4x4 &absolute_transform);
+	// ------------------------------------------------------------------------------------------------
+	void SetupNodeMetadata(const Model &model, aiNode *nd);
 
-    // ------------------------------------------------------------------------------------------------
-    std::vector<unsigned int> ConvertLine(const LineGeometry& line, const Model& model,
-                                          aiNode *parent, aiNode *root_node);
+	// ------------------------------------------------------------------------------------------------
+	void ConvertModel(const Model &model, aiNode *parent, aiNode *root_node,
+			const aiMatrix4x4 &absolute_transform);
 
-    // ------------------------------------------------------------------------------------------------
-    aiMesh* SetupEmptyMesh(const Geometry& mesh, aiNode *parent);
+	// ------------------------------------------------------------------------------------------------
+	// MeshGeometry -> aiMesh, return mesh index + 1 or 0 if the conversion failed
+	std::vector<unsigned int>
+	ConvertMesh(const MeshGeometry &mesh, const Model &model, aiNode *parent, aiNode *root_node,
+			const aiMatrix4x4 &absolute_transform);
 
-    // ------------------------------------------------------------------------------------------------
-    unsigned int ConvertMeshSingleMaterial(const MeshGeometry &mesh, const Model &model,
-                                           const aiMatrix4x4 &absolute_transform, aiNode *parent,
-                                           aiNode *root_node);
+	// ------------------------------------------------------------------------------------------------
+	std::vector<unsigned int> ConvertLine(const LineGeometry &line, const Model &model,
+			aiNode *parent, aiNode *root_node);
 
-    // ------------------------------------------------------------------------------------------------
-    std::vector<unsigned int>
-    ConvertMeshMultiMaterial(const MeshGeometry &mesh, const Model &model, aiNode *parent, aiNode *root_node,
-                             const aiMatrix4x4 &absolute_transform);
+	// ------------------------------------------------------------------------------------------------
+	aiMesh *SetupEmptyMesh(const Geometry &mesh, aiNode *parent);
 
-    // ------------------------------------------------------------------------------------------------
-    unsigned int ConvertMeshMultiMaterial(const MeshGeometry &mesh, const Model &model, MatIndexArray::value_type index,
-                                          aiNode *parent, aiNode *root_node, const aiMatrix4x4 &absolute_transform);
+	// ------------------------------------------------------------------------------------------------
+	unsigned int ConvertMeshSingleMaterial(const MeshGeometry &mesh, const Model &model,
+			const aiMatrix4x4 &absolute_transform, aiNode *parent,
+			aiNode *root_node);
 
-    // ------------------------------------------------------------------------------------------------
-    static const unsigned int NO_MATERIAL_SEPARATION = /* std::numeric_limits<unsigned int>::max() */
-        static_cast<unsigned int>(-1);
+	// ------------------------------------------------------------------------------------------------
+	std::vector<unsigned int>
+	ConvertMeshMultiMaterial(const MeshGeometry &mesh, const Model &model, aiNode *parent, aiNode *root_node,
+			const aiMatrix4x4 &absolute_transform);
 
-    // ------------------------------------------------------------------------------------------------
-    /**
+	// ------------------------------------------------------------------------------------------------
+	unsigned int ConvertMeshMultiMaterial(const MeshGeometry &mesh, const Model &model, MatIndexArray::value_type index,
+			aiNode *parent, aiNode *root_node, const aiMatrix4x4 &absolute_transform);
+
+	// ------------------------------------------------------------------------------------------------
+	static const unsigned int NO_MATERIAL_SEPARATION = /* std::numeric_limits<unsigned int>::max() */
+			static_cast<unsigned int>(-1);
+
+	// ------------------------------------------------------------------------------------------------
+	/**
     *  - if materialIndex == NO_MATERIAL_SEPARATION, materials are not taken into
     *    account when determining which weights to include.
     *  - outputVertStartIndices is only used when a material index is specified, it gives for
     *    each output vertex the DOM index it maps to.
     */
-    void ConvertWeights(aiMesh *out, const Model &model, const MeshGeometry &geo, const aiMatrix4x4 &absolute_transform,
-                        aiNode *parent = NULL, aiNode *root_node = NULL,
-                        unsigned int materialIndex = NO_MATERIAL_SEPARATION,
-                        std::vector<unsigned int> *outputVertStartIndices = NULL);
-    // lookup
-    static const aiNode* GetNodeByName( const aiString& name, aiNode *current_node );
-    // ------------------------------------------------------------------------------------------------
-    void ConvertCluster(std::vector<aiBone *> &local_mesh_bones, const Cluster *cl,
-                        std::vector<size_t> &out_indices, std::vector<size_t> &index_out_indices,
-                        std::vector<size_t> &count_out_indices, const aiMatrix4x4 &absolute_transform,
-                        aiNode *parent, aiNode *root_node);
+	void ConvertWeights(aiMesh *out, const Model &model, const MeshGeometry &geo, const aiMatrix4x4 &absolute_transform,
+			aiNode *parent = NULL, aiNode *root_node = NULL,
+			unsigned int materialIndex = NO_MATERIAL_SEPARATION,
+			std::vector<unsigned int> *outputVertStartIndices = NULL);
+	// lookup
+	static const aiNode *GetNodeByName(const aiString &name, aiNode *current_node);
+	// ------------------------------------------------------------------------------------------------
+	void ConvertCluster(const Model &model, std::vector<aiBone *> &local_mesh_bones, const Cluster *cl,
+			std::vector<size_t> &out_indices, std::vector<size_t> &index_out_indices,
+			std::vector<size_t> &count_out_indices, const aiMatrix4x4 &absolute_transform,
+			aiNode *parent, aiNode *root_node);
 
-    // ------------------------------------------------------------------------------------------------
-    void ConvertMaterialForMesh(aiMesh* out, const Model& model, const MeshGeometry& geo,
-        MatIndexArray::value_type materialIndex);
+	// ------------------------------------------------------------------------------------------------
+	void ConvertMaterialForMesh(aiMesh *out, const Model &model, const MeshGeometry &geo,
+			MatIndexArray::value_type materialIndex);
 
-    // ------------------------------------------------------------------------------------------------
-    unsigned int GetDefaultMaterial();
+	// ------------------------------------------------------------------------------------------------
+	unsigned int GetDefaultMaterial();
 
-    // ------------------------------------------------------------------------------------------------
-    // Material -> aiMaterial
-    unsigned int ConvertMaterial(const Material& material, const MeshGeometry* const mesh);
+	// ------------------------------------------------------------------------------------------------
+	// Material -> aiMaterial
+	unsigned int ConvertMaterial(const Material &material, const MeshGeometry *const mesh);
 
-    // ------------------------------------------------------------------------------------------------
-    // Video -> aiTexture
-    unsigned int ConvertVideo(const Video& video);
+	// ------------------------------------------------------------------------------------------------
+	// Video -> aiTexture
+	unsigned int ConvertVideo(const Video &video);
 
-    // ------------------------------------------------------------------------------------------------
-    // convert embedded texture if necessary and return actual texture path
-    aiString GetTexturePath(const Texture* tex);
+	// ------------------------------------------------------------------------------------------------
+	// convert embedded texture if necessary and return actual texture path
+	aiString GetTexturePath(const Texture *tex);
 
-    // ------------------------------------------------------------------------------------------------
-    void TrySetTextureProperties(aiMaterial* out_mat, const TextureMap& textures,
-        const std::string& propName,
-        aiTextureType target, const MeshGeometry* const mesh);
+	// ------------------------------------------------------------------------------------------------
+	void TrySetTextureProperties(aiMaterial *out_mat, const TextureMap &textures,
+			const std::string &propName,
+			aiTextureType target, const MeshGeometry *const mesh);
 
-    // ------------------------------------------------------------------------------------------------
-    void TrySetTextureProperties(aiMaterial* out_mat, const LayeredTextureMap& layeredTextures,
-        const std::string& propName,
-        aiTextureType target, const MeshGeometry* const mesh);
+	// ------------------------------------------------------------------------------------------------
+	void TrySetTextureProperties(aiMaterial *out_mat, const LayeredTextureMap &layeredTextures,
+			const std::string &propName,
+			aiTextureType target, const MeshGeometry *const mesh);
 
-    // ------------------------------------------------------------------------------------------------
-    void SetTextureProperties(aiMaterial* out_mat, const TextureMap& textures, const MeshGeometry* const mesh);
+	// ------------------------------------------------------------------------------------------------
+	void SetTextureProperties(aiMaterial *out_mat, const TextureMap &textures, const MeshGeometry *const mesh);
 
-    // ------------------------------------------------------------------------------------------------
-    void SetTextureProperties(aiMaterial* out_mat, const LayeredTextureMap& layeredTextures, const MeshGeometry* const mesh);
+	// ------------------------------------------------------------------------------------------------
+	void SetTextureProperties(aiMaterial *out_mat, const LayeredTextureMap &layeredTextures, const MeshGeometry *const mesh);
 
-    // ------------------------------------------------------------------------------------------------
-    aiColor3D GetColorPropertyFromMaterial(const PropertyTable& props, const std::string& baseName,
-        bool& result);
-    aiColor3D GetColorPropertyFactored(const PropertyTable& props, const std::string& colorName,
-        const std::string& factorName, bool& result, bool useTemplate = true);
-    aiColor3D GetColorProperty(const PropertyTable& props, const std::string& colorName,
-        bool& result, bool useTemplate = true);
+	// ------------------------------------------------------------------------------------------------
+	aiColor3D GetColorPropertyFromMaterial(const PropertyTable &props, const std::string &baseName,
+			bool &result);
+	aiColor3D GetColorPropertyFactored(const PropertyTable &props, const std::string &colorName,
+			const std::string &factorName, bool &result, bool useTemplate = true);
+	aiColor3D GetColorProperty(const PropertyTable &props, const std::string &colorName,
+			bool &result, bool useTemplate = true);
 
-    // ------------------------------------------------------------------------------------------------
-    void SetShadingPropertiesCommon(aiMaterial* out_mat, const PropertyTable& props);
-    void SetShadingPropertiesRaw(aiMaterial* out_mat, const PropertyTable& props, const TextureMap& textures, const MeshGeometry* const mesh);
+	// ------------------------------------------------------------------------------------------------
+	void SetShadingPropertiesCommon(aiMaterial *out_mat, const PropertyTable &props);
+	void SetShadingPropertiesRaw(aiMaterial *out_mat, const PropertyTable &props, const TextureMap &textures, const MeshGeometry *const mesh);
 
-    // ------------------------------------------------------------------------------------------------
-    // get the number of fps for a FrameRate enumerated value
-    static double FrameRateToDouble(FileGlobalSettings::FrameRate fp, double customFPSVal = -1.0);
+	// ------------------------------------------------------------------------------------------------
+	// get the number of fps for a FrameRate enumerated value
+	static double FrameRateToDouble(FileGlobalSettings::FrameRate fp, double customFPSVal = -1.0);
 
-    // ------------------------------------------------------------------------------------------------
-    // convert animation data to aiAnimation et al
-    void ConvertAnimations();
+	// ------------------------------------------------------------------------------------------------
+	// convert animation data to aiAnimation et al
+	void ConvertAnimations();
 
-    // ------------------------------------------------------------------------------------------------
-    // takes a fbx node name and returns the identifier to be used in the assimp output scene.
-    // the function is guaranteed to provide consistent results over multiple invocations
-    // UNLESS RenameNode() is called for a particular node name.
-    std::string FixNodeName(const std::string& name);
-    std::string FixAnimMeshName(const std::string& name);
+	// ------------------------------------------------------------------------------------------------
+	// takes a fbx node name and returns the identifier to be used in the assimp output scene.
+	// the function is guaranteed to provide consistent results over multiple invocations
+	// UNLESS RenameNode() is called for a particular node name.
+	std::string FixNodeName(const std::string &name);
+	std::string FixAnimMeshName(const std::string &name);
 
-    typedef std::map<const AnimationCurveNode*, const AnimationLayer*> LayerMap;
+	typedef std::map<const AnimationCurveNode *, const AnimationLayer *> LayerMap;
 
-    // XXX: better use multi_map ..
-    typedef std::map<std::string, std::vector<const AnimationCurveNode*> > NodeMap;
+	// anim node item for list of anim curves
+	struct AnimNodeItem {
+		AnimNodeItem(const std::string &_name, std::vector<const AnimationCurveNode *> &_curves) :
+				name(_name),
+				curves(_curves) {}
+		std::string name;
+		std::vector<const AnimationCurveNode *> &curves;
+	};
 
-    // ------------------------------------------------------------------------------------------------
-    void ConvertAnimationStack(const AnimationStack& st);
+	// ------------------------------------------------------------------------------------------------
+	void ConvertAnimationStack(const AnimationStack &st);
 
-    // ------------------------------------------------------------------------------------------------
-    void ProcessMorphAnimDatas(std::map<std::string, morphAnimData*>* morphAnimDatas, const BlendShapeChannel* bsc, const AnimationCurveNode* node);
+	// ------------------------------------------------------------------------------------------------
+	void ProcessMorphAnimDatas(std::map<std::string, morphAnimData *> *morphAnimDatas, const BlendShapeChannel *bsc, const AnimationCurveNode *node);
 
-    // ------------------------------------------------------------------------------------------------
-    void GenerateNodeAnimations(std::vector<aiNodeAnim*>& node_anims,
-        const std::string& fixed_name,
-        const std::vector<const AnimationCurveNode*>& curves,
-        const LayerMap& layer_map,
-        int64_t start, int64_t stop,
-        double& max_time,
-        double& min_time);
+	// ------------------------------------------------------------------------------------------------
+	void GenerateNodeAnimations(
+			std::vector<aiNodeAnim *> &node_anims,
+			const std::string &fixed_name,
+			const std::vector<const AnimationCurveNode *> &curves,
+			const LayerMap &layer_map,
+			int64_t start, int64_t stop,
+			double &max_time,
+			double &min_time,
+			aiMatrix4x4 geometric_pivot_data);
 
-    // ------------------------------------------------------------------------------------------------
-    bool IsRedundantAnimationData(const Model& target,
-        TransformationComp comp,
-        const std::vector<const AnimationCurveNode*>& curves);
+	// ------------------------------------------------------------------------------------------------
+	bool IsRedundantAnimationData(const Model &target,
+			TransformationComp comp,
+			const std::vector<const AnimationCurveNode *> &curves);
 
-    // ------------------------------------------------------------------------------------------------
-    aiNodeAnim* GenerateRotationNodeAnim(const std::string& name,
-        const Model& target,
-        const std::vector<const AnimationCurveNode*>& curves,
-        const LayerMap& layer_map,
-        int64_t start, int64_t stop,
-        double& max_time,
-        double& min_time);
+	// key (time), value, mapto (component index)
+	typedef std::tuple<std::shared_ptr<KeyTimeList>, std::shared_ptr<KeyValueList>, unsigned int> KeyFrameList;
+	typedef std::vector<KeyFrameList> KeyFrameListList;
 
-    // ------------------------------------------------------------------------------------------------
-    aiNodeAnim* GenerateScalingNodeAnim(const std::string& name,
-        const Model& /*target*/,
-        const std::vector<const AnimationCurveNode*>& curves,
-        const LayerMap& layer_map,
-        int64_t start, int64_t stop,
-        double& max_time,
-        double& min_time);
+	// ------------------------------------------------------------------------------------------------
+	KeyFrameListList GetKeyframeList(const std::vector<const AnimationCurveNode *> &nodes, int64_t start, int64_t stop);
 
-    // ------------------------------------------------------------------------------------------------
-    aiNodeAnim* GenerateTranslationNodeAnim(const std::string& name,
-        const Model& /*target*/,
-        const std::vector<const AnimationCurveNode*>& curves,
-        const LayerMap& layer_map,
-        int64_t start, int64_t stop,
-        double& max_time,
-        double& min_time,
-        bool inverse = false);
+	// ------------------------------------------------------------------------------------------------
+	KeyTimeList GetKeyTimeList(const KeyFrameListList &inputs);
 
-    // ------------------------------------------------------------------------------------------------
-    // generate node anim, extracting only Rotation, Scaling and Translation from the given chain
-    aiNodeAnim* GenerateSimpleNodeAnim(const std::string& name,
-        const Model& target,
-        NodeMap::const_iterator chain[TransformationComp_MAXIMUM],
-        NodeMap::const_iterator iter_end,
-        const LayerMap& layer_map,
-        int64_t start, int64_t stop,
-        double& max_time,
-        double& min_time,
-        bool reverse_order = false);
+	// ------------------------------------------------------------------------------------------------
+	void InterpolateKeys(aiVectorKey *valOut, const KeyTimeList &keys, const KeyFrameListList &inputs,
+			const aiVector3D &def_value,
+			double &max_time,
+			double &min_time);
 
-    // key (time), value, mapto (component index)
-    typedef std::tuple<std::shared_ptr<KeyTimeList>, std::shared_ptr<KeyValueList>, unsigned int > KeyFrameList;
-    typedef std::vector<KeyFrameList> KeyFrameListList;
+	// ------------------------------------------------------------------------------------------------
+	void InterpolateKeys(aiQuatKey *valOut, const KeyTimeList &keys, const KeyFrameListList &inputs,
+			const aiVector3D &def_value,
+			double &maxTime,
+			double &minTime,
+			Model::RotOrder order);
 
-    // ------------------------------------------------------------------------------------------------
-    KeyFrameListList GetKeyframeList(const std::vector<const AnimationCurveNode*>& nodes, int64_t start, int64_t stop);
+	// ------------------------------------------------------------------------------------------------
+	void ConvertTransformOrder_TRStoSRT(aiQuatKey *out_quat, aiVectorKey *out_scale,
+			aiVectorKey *out_translation,
+			const KeyFrameListList &scaling,
+			const KeyFrameListList &translation,
+			const KeyFrameListList &rotation,
+			const KeyTimeList &times,
+			double &maxTime,
+			double &minTime,
+			Model::RotOrder order,
+			const aiVector3D &def_scale,
+			const aiVector3D &def_translate,
+			const aiVector3D &def_rotation);
 
-    // ------------------------------------------------------------------------------------------------
-    KeyTimeList GetKeyTimeList(const KeyFrameListList& inputs);
+	// ------------------------------------------------------------------------------------------------
+	// euler xyz -> quat
+	aiQuaternion EulerToQuaternion(const aiVector3D &rot, Model::RotOrder order);
 
-    // ------------------------------------------------------------------------------------------------
-    void InterpolateKeys(aiVectorKey* valOut, const KeyTimeList& keys, const KeyFrameListList& inputs,
-        const aiVector3D& def_value,
-        double& max_time,
-        double& min_time);
+	// ------------------------------------------------------------------------------------------------
+	void ConvertScaleKeys(aiNodeAnim *na, const std::vector<const AnimationCurveNode *> &nodes, const LayerMap & /*layers*/,
+			int64_t start, int64_t stop,
+			double &maxTime,
+			double &minTime);
 
-    // ------------------------------------------------------------------------------------------------
-    void InterpolateKeys(aiQuatKey* valOut, const KeyTimeList& keys, const KeyFrameListList& inputs,
-        const aiVector3D& def_value,
-        double& maxTime,
-        double& minTime,
-        Model::RotOrder order);
+	// ------------------------------------------------------------------------------------------------
+	void ConvertTranslationKeys(aiNodeAnim *na, const std::vector<const AnimationCurveNode *> &nodes,
+			const LayerMap & /*layers*/,
+			int64_t start, int64_t stop,
+			double &maxTime,
+			double &minTime);
 
-    // ------------------------------------------------------------------------------------------------
-    void ConvertTransformOrder_TRStoSRT(aiQuatKey* out_quat, aiVectorKey* out_scale,
-        aiVectorKey* out_translation,
-        const KeyFrameListList& scaling,
-        const KeyFrameListList& translation,
-        const KeyFrameListList& rotation,
-        const KeyTimeList& times,
-        double& maxTime,
-        double& minTime,
-        Model::RotOrder order,
-        const aiVector3D& def_scale,
-        const aiVector3D& def_translate,
-        const aiVector3D& def_rotation);
+	// ------------------------------------------------------------------------------------------------
+	void ConvertRotationKeys(aiNodeAnim *na, const std::vector<const AnimationCurveNode *> &nodes,
+			const LayerMap & /*layers*/,
+			int64_t start, int64_t stop,
+			double &maxTime,
+			double &minTime,
+			Model::RotOrder order);
 
-    // ------------------------------------------------------------------------------------------------
-    // euler xyz -> quat
-    aiQuaternion EulerToQuaternion(const aiVector3D& rot, Model::RotOrder order);
+	void ConvertGlobalSettings();
 
-    // ------------------------------------------------------------------------------------------------
-    void ConvertScaleKeys(aiNodeAnim* na, const std::vector<const AnimationCurveNode*>& nodes, const LayerMap& /*layers*/,
-        int64_t start, int64_t stop,
-        double& maxTime,
-        double& minTime);
+	// ------------------------------------------------------------------------------------------------
+	// copy generated meshes, animations, lights, cameras and textures to the output scene
+	void TransferDataToScene();
 
-    // ------------------------------------------------------------------------------------------------
-    void ConvertTranslationKeys(aiNodeAnim* na, const std::vector<const AnimationCurveNode*>& nodes,
-        const LayerMap& /*layers*/,
-        int64_t start, int64_t stop,
-        double& maxTime,
-        double& minTime);
-
-    // ------------------------------------------------------------------------------------------------
-    void ConvertRotationKeys(aiNodeAnim* na, const std::vector<const AnimationCurveNode*>& nodes,
-        const LayerMap& /*layers*/,
-        int64_t start, int64_t stop,
-        double& maxTime,
-        double& minTime,
-        Model::RotOrder order);
-
-    // ------------------------------------------------------------------------------------------------
-    // Copy global geometric data and some information about the source asset into scene metadata.
-    void ConvertGlobalSettings();
-
-    // ------------------------------------------------------------------------------------------------
-    // copy generated meshes, animations, lights, cameras and textures to the output scene
-    void TransferDataToScene();
-
-    // ------------------------------------------------------------------------------------------------
-    // FBX file could have embedded textures not connected to anything
-    void ConvertOrphantEmbeddedTextures();
+	// ------------------------------------------------------------------------------------------------
+	// FBX file could have embedded textures not connected to anything
+	void ConvertOrphantEmbeddedTextures();
 
 private:
-    // 0: not assigned yet, others: index is value - 1
-    unsigned int defaultMaterialIndex;
+	// 0: not assigned yet, others: index is value - 1
+	unsigned int defaultMaterialIndex;
 
-    std::vector<aiMesh*> meshes;
-    std::vector<aiMaterial*> materials;
-    std::vector<aiAnimation*> animations;
-    std::vector<aiLight*> lights;
-    std::vector<aiCamera*> cameras;
-    std::vector<aiTexture*> textures;
+	std::vector<aiMesh *> meshes;
+	std::vector<aiMaterial *> materials;
+	std::vector<aiAnimation *> animations;
+	std::map<int64_t, const LimbNode*> bone_id_map;
+	// anim target mapping to allow us to lookup direct node anims.
+	std::map<aiNodeAnim*, int64_t> anim_target_map;
 
-    using MaterialMap = std::fbx_unordered_map<const Material*, unsigned int>;
-    MaterialMap materials_converted;
+	std::vector<int64_t> resampled_anim;
 
-    using VideoMap = std::fbx_unordered_map<const Video, unsigned int>;
-    VideoMap textures_converted;
+	//std::map<int64_t, aiSkin *> skin_id_map;
+	std::vector<aiLight *> lights;
+	std::vector<aiCamera *> cameras;
+	std::vector<aiTexture *> textures;
 
-    using MeshMap = std::fbx_unordered_map<const Geometry*, std::vector<unsigned int> >;
-    MeshMap meshes_converted;
+	using MaterialMap = std::fbx_unordered_map<const Material *, unsigned int>;
+	MaterialMap materials_converted;
 
-    // fixed node name -> which trafo chain components have animations?
-    using NodeAnimBitMap = std::fbx_unordered_map<std::string, unsigned int> ;
-    NodeAnimBitMap node_anim_chain_bits;
+	using VideoMap = std::fbx_unordered_map<const Video, unsigned int>;
+	VideoMap textures_converted;
 
-    // number of nodes with the same name
-    using NodeNameCache = std::fbx_unordered_map<std::string, unsigned int>;
-    NodeNameCache mNodeNames;
+	using MeshMap = std::fbx_unordered_map<const Geometry *, std::vector<unsigned int> >;
+	MeshMap meshes_converted;
 
-    // Deformer name is not the same as a bone name - it does contain the bone name though :)
-    // Deformer names in FBX are always unique in an FBX file.
-    std::map<const std::string, aiBone *> bone_map;
+	// fixed node name -> which trafo chain components have animations?
+	using NodeAnimBitMap = std::fbx_unordered_map<std::string, unsigned int>;
+	NodeAnimBitMap node_anim_chain_bits;
 
-    double anim_fps;
+	// number of nodes with the same name
+	using NodeNameCache = std::fbx_unordered_map<std::string, unsigned int>;
+	NodeNameCache mNodeNames;
 
-    aiScene* const out;
-    const FBX::Document& doc;
+	// Deformer name is not the same as a bone name - it does contain the bone name though :)
+	// Deformer names in FBX are always unique in an FBX file.
+	std::map<const std::string, aiBone *> bone_map;
 
-    static void BuildBoneList(aiNode *current_node, const aiNode *root_node, const aiScene *scene,
-                             std::vector<aiBone*>& bones);
 
-    void BuildBoneStack(aiNode *current_node, const aiNode *root_node, const aiScene *scene,
-                   const std::vector<aiBone *> &bones,
-                   std::map<aiBone *, aiNode *> &bone_stack,
-                   std::vector<aiNode*> &node_stack );
+	double anim_fps;
 
-    static void BuildNodeList(aiNode *current_node, std::vector<aiNode *> &nodes);
+	aiScene *const out;
+	const FBX::Document &doc;
 
-    static aiNode *GetNodeFromStack(const aiString &node_name, std::vector<aiNode *> &nodes);
+	static void BuildBoneList(aiNode *current_node, const aiNode *root_node, const aiScene *scene,
+			std::vector<aiBone *> &bones);
 
-    static aiNode *GetArmatureRoot(aiNode *bone_node, std::vector<aiBone*> &bone_list);
+	void BuildBoneStack(aiNode *current_node, const aiNode *root_node, const aiScene *scene,
+			const std::vector<aiBone *> &bones,
+			std::map<aiBone *, aiNode *> &bone_stack,
+			std::vector<aiNode *> &node_stack);
 
-    static bool IsBoneNode(const aiString &bone_name, std::vector<aiBone *> &bones);
+	static void BuildNodeList(aiNode *current_node, std::vector<aiNode *> &nodes);
+
+	static aiNode *GetNodeFromStack(const aiString &node_name, std::vector<aiNode *> &nodes);
+
+	static aiNode *GetArmatureRoot(aiNode *bone_node, std::vector<aiBone *> &bone_list);
+
+	static bool IsBoneNode(const aiString &bone_name, std::vector<aiBone *> &bones);
+
+    void FindAllBones(const Model &model);
+
+    void CacheNodeInformation(uint64_t id);
 };
 
-}
-}
+} // namespace FBX
+} // namespace Assimp
 
 #endif // INCLUDED_AI_FBX_CONVERTER_H

--- a/code/FBX/FBXDeformer.cpp
+++ b/code/FBX/FBXDeformer.cpp
@@ -52,6 +52,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "FBXImporter.h"
 #include "FBXDocumentUtil.h"
 
+#include <iostream>
+
 namespace Assimp {
 namespace FBX {
 
@@ -74,7 +76,6 @@ Deformer::~Deformer()
 
 }
 
-
 // ------------------------------------------------------------------------------------------------
 Cluster::Cluster(uint64_t id, const Element& element, const Document& doc, const std::string& name)
 : Deformer(id,element,doc,name)
@@ -82,11 +83,29 @@ Cluster::Cluster(uint64_t id, const Element& element, const Document& doc, const
 {
     const Scope& sc = GetRequiredScope(element);
 
+//    for( auto element : sc.Elements())
+//    {
+//        std::cout << "cluster element: " << element.first << std::endl;
+//    }
+//
+//    element: Indexes
+//    element: Transform
+//    element: TransformAssociateModel
+//    element: TransformLink
+//    element: UserData
+//    element: Version
+//    element: Weights
+
+
     const Element* const Indexes = sc["Indexes"];
     const Element* const Weights = sc["Weights"];
 
     const Element& Transform = GetRequiredElement(sc,"Transform",&element);
     const Element& TransformLink = GetRequiredElement(sc,"TransformLink",&element);
+
+    // todo: check if we need this
+    //const Element& TransformAssociateModel = GetRequiredElement(sc, "TransformAssociateModel", &element);
+
 
     transform = ReadMatrix(Transform);
     transformLink = ReadMatrix(TransformLink);
@@ -133,6 +152,12 @@ Skin::Skin(uint64_t id, const Element& element, const Document& doc, const std::
 : Deformer(id,element,doc,name)
 , accuracy( 0.0f ) {
     const Scope& sc = GetRequiredScope(element);
+
+
+    for( auto element : sc.Elements())
+    {
+        std::cout << "skin element: " << element.first << std::endl;
+    }
 
     const Element* const Link_DeformAcuracy = sc["Link_DeformAcuracy"];
     if(Link_DeformAcuracy) {

--- a/code/FBX/FBXDocument.cpp
+++ b/code/FBX/FBXDocument.cpp
@@ -58,6 +58,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <memory>
 #include <functional>
 #include <map>
+#include <iostream>
 
 namespace Assimp {
 namespace FBX {
@@ -158,6 +159,8 @@ const Object* LazyObject::Get(bool dieOnError)
                 object.reset(new Null(id,element,doc,name));
             }
             else if (!strcmp(classtag.c_str(),"LimbNode")) {
+                // This is an older format for bones
+                // this is what blender uses I believe
                 object.reset(new LimbNode(id,element,doc,name));
             }
         }
@@ -206,6 +209,17 @@ const Object* LazyObject::Get(bool dieOnError)
         else if (!strncmp(obtype,"AnimationCurveNode",length)) {
             object.reset(new AnimationCurveNode(id,element,name,doc));
         }
+        else if( !strncmp(obtype, "Pose", length))
+        {
+            object.reset( new FbxPose( id, element, doc, name ));
+        }
+        else
+        {
+            std::cout << "!important objtype: " << obtype << std::endl;
+            //dumpObjectClassInfo( objtype, classtag );
+            ASSIMP_LOG_WARN_F("Unsupported node from fbx: type: ", obtype, " tag: ", classtag, "name: ", name );
+        }
+        
     }
     catch(std::exception& ex) {
         flags &= ~BEING_CONSTRUCTED;
@@ -237,6 +251,14 @@ Object::Object(uint64_t id, const Element& element, const std::string& name)
 , id(id)
 {
     // empty
+//
+//    const Scope& sc = GetRequiredScope(element);
+//
+//
+//    for( auto element : sc.Elements())
+//    {
+//        std::cout << " element: " << element.first << std::endl;
+//    }
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/code/FBX/FBXDocument.h
+++ b/code/FBX/FBXDocument.h
@@ -46,14 +46,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef INCLUDED_AI_FBX_DOCUMENT_H
 #define INCLUDED_AI_FBX_DOCUMENT_H
 
-#include <numeric>
-#include <stdint.h>
-#include <assimp/mesh.h>
-#include "FBXProperties.h"
 #include "FBXParser.h"
+#include "FBXProperties.h"
+#include <assimp/mesh.h>
+#include <stdint.h>
+#include <numeric>
 
-#define _AI_CONCAT(a,b)  a ## b
-#define  AI_CONCAT(a,b)  _AI_CONCAT(a,b)
+#define _AI_CONCAT(a, b) a##b
+#define AI_CONCAT(a, b) _AI_CONCAT(a, b)
 
 namespace Assimp {
 namespace FBX {
@@ -61,6 +61,7 @@ namespace FBX {
 class Parser;
 class Object;
 struct ImportSettings;
+class Connection;
 
 class PropertyTable;
 class Document;
@@ -81,621 +82,615 @@ class BlendShape;
 class Skin;
 class Cluster;
 
-
 /** Represents a delay-parsed FBX objects. Many objects in the scene
  *  are not needed by assimp, so it makes no sense to parse them
  *  upfront. */
 class LazyObject {
 public:
-    LazyObject(uint64_t id, const Element& element, const Document& doc);
+	LazyObject(uint64_t id, const Element &element, const Document &doc);
 
-    ~LazyObject();
+	~LazyObject();
 
-    const Object* Get(bool dieOnError = false);
+	const Object *Get(bool dieOnError = false);
 
-    template <typename T>
-    const T* Get(bool dieOnError = false) {
-        const Object* const ob = Get(dieOnError);
-        return ob ? dynamic_cast<const T*>(ob) : NULL;
-    }
+	template <typename T>
+	const T *Get(bool dieOnError = false) {
+		const Object *const ob = Get(dieOnError);
+		return ob ? dynamic_cast<const T *>(ob) : NULL;
+	}
 
-    uint64_t ID() const {
-        return id;
-    }
+	uint64_t ID() const {
+		return id;
+	}
 
-    bool IsBeingConstructed() const {
-        return (flags & BEING_CONSTRUCTED) != 0;
-    }
+	bool IsBeingConstructed() const {
+		return (flags & BEING_CONSTRUCTED) != 0;
+	}
 
-    bool FailedToConstruct() const {
-        return (flags & FAILED_TO_CONSTRUCT) != 0;
-    }
+	bool FailedToConstruct() const {
+		return (flags & FAILED_TO_CONSTRUCT) != 0;
+	}
 
-    const Element& GetElement() const {
-        return element;
-    }
+	const Element &GetElement() const {
+		return element;
+	}
 
-    const Document& GetDocument() const {
-        return doc;
-    }
+	const Document &GetDocument() const {
+		return doc;
+	}
 
 private:
-    const Document& doc;
-    const Element& element;
-    std::unique_ptr<const Object> object;
+	const Document &doc;
+	const Element &element;
+	std::unique_ptr<const Object> object;
 
-    const uint64_t id;
+	const uint64_t id;
 
-    enum Flags {
-        BEING_CONSTRUCTED = 0x1,
-        FAILED_TO_CONSTRUCT = 0x2
-    };
+	enum Flags {
+		BEING_CONSTRUCTED = 0x1,
+		FAILED_TO_CONSTRUCT = 0x2
+	};
 
-    unsigned int flags;
+	unsigned int flags;
 };
 
 /** Base class for in-memory (DOM) representations of FBX objects */
 class Object {
 public:
-    Object(uint64_t id, const Element& element, const std::string& name);
+	Object(uint64_t id, const Element &element, const std::string &name);
 
-    virtual ~Object();
+	virtual ~Object();
 
-    const Element& SourceElement() const {
-        return element;
-    }
+	const Element &SourceElement() const {
+		return element;
+	}
 
-    const std::string& Name() const {
-        return name;
-    }
+	const std::string &Name() const {
+		return name;
+	}
 
-    uint64_t ID() const {
-        return id;
-    }
+	uint64_t ID() const {
+		return id;
+	}
 
 protected:
-    const Element& element;
-    const std::string name;
-    const uint64_t id;
+	const Element &element;
+	const std::string name;
+	const uint64_t id;
+};
+
+class FbxPose : public Object {
+public:
+    FbxPose(uint64_t id, const Element &element, const Document &doc, const std::string &name);
+
+    virtual ~FbxPose();
+
 };
 
 /** DOM class for generic FBX NoteAttribute blocks. NoteAttribute's just hold a property table,
  *  fixed members are added by deriving classes. */
 class NodeAttribute : public Object {
 public:
-    NodeAttribute(uint64_t id, const Element& element, const Document& doc, const std::string& name);
+	NodeAttribute(uint64_t id, const Element &element, const Document &doc, const std::string &name);
 
-    virtual ~NodeAttribute();
+	virtual ~NodeAttribute();
 
-    const PropertyTable& Props() const {
-        ai_assert(props.get());
-        return *props.get();
-    }
+	const PropertyTable &Props() const {
+		ai_assert(props.get());
+		return *props.get();
+	}
 
 private:
-    std::shared_ptr<const PropertyTable> props;
+	std::shared_ptr<const PropertyTable> props;
 };
 
 /** DOM base class for FBX camera settings attached to a node */
 class CameraSwitcher : public NodeAttribute {
 public:
-    CameraSwitcher(uint64_t id, const Element& element, const Document& doc, const std::string& name);
+	CameraSwitcher(uint64_t id, const Element &element, const Document &doc, const std::string &name);
 
-    virtual ~CameraSwitcher();
+	virtual ~CameraSwitcher();
 
-    int CameraID() const {
-        return cameraId;
-    }
+	int CameraID() const {
+		return cameraId;
+	}
 
-    const std::string& CameraName() const {
-        return cameraName;
-    }
+	const std::string &CameraName() const {
+		return cameraName;
+	}
 
-    const std::string& CameraIndexName() const {
-        return cameraIndexName;
-    }
+	const std::string &CameraIndexName() const {
+		return cameraIndexName;
+	}
 
 private:
-    int cameraId;
-    std::string cameraName;
-    std::string cameraIndexName;
+	int cameraId;
+	std::string cameraName;
+	std::string cameraIndexName;
 };
 
 #define fbx_stringize(a) #a
 
-#define fbx_simple_property(name, type, default_value) \
-    type name() const { \
-        return PropertyGet<type>(Props(), fbx_stringize(name), (default_value)); \
-    }
+#define fbx_simple_property(name, type, default_value)                           \
+	type name() const {                                                          \
+		return PropertyGet<type>(Props(), fbx_stringize(name), (default_value)); \
+	}
 
 // XXX improve logging
-#define fbx_simple_enum_property(name, type, default_value) \
-    type name() const { \
-        const int ival = PropertyGet<int>(Props(), fbx_stringize(name), static_cast<int>(default_value)); \
-        if (ival < 0 || ival >= AI_CONCAT(type, _MAX)) { \
-            ai_assert(static_cast<int>(default_value) >= 0 && static_cast<int>(default_value) < AI_CONCAT(type, _MAX)); \
-            return static_cast<type>(default_value); \
-        } \
-        return static_cast<type>(ival); \
-}
-
+#define fbx_simple_enum_property(name, type, default_value)                                                             \
+	type name() const {                                                                                                 \
+		const int ival = PropertyGet<int>(Props(), fbx_stringize(name), static_cast<int>(default_value));               \
+		if (ival < 0 || ival >= AI_CONCAT(type, _MAX)) {                                                                \
+			ai_assert(static_cast<int>(default_value) >= 0 && static_cast<int>(default_value) < AI_CONCAT(type, _MAX)); \
+			return static_cast<type>(default_value);                                                                    \
+		}                                                                                                               \
+		return static_cast<type>(ival);                                                                                 \
+	}
 
 /** DOM base class for FBX cameras attached to a node */
 class Camera : public NodeAttribute {
 public:
-    Camera(uint64_t id, const Element& element, const Document& doc, const std::string& name);
+	Camera(uint64_t id, const Element &element, const Document &doc, const std::string &name);
 
-    virtual  ~Camera();
+	virtual ~Camera();
 
-    fbx_simple_property(Position, aiVector3D, aiVector3D(0,0,0))
-    fbx_simple_property(UpVector, aiVector3D, aiVector3D(0,1,0))
-    fbx_simple_property(InterestPosition, aiVector3D, aiVector3D(0,0,0))
+	fbx_simple_property(Position, aiVector3D, aiVector3D(0, 0, 0));
+	fbx_simple_property(UpVector, aiVector3D, aiVector3D(0, 1, 0));
+	fbx_simple_property(InterestPosition, aiVector3D, aiVector3D(0, 0, 0));
 
-    fbx_simple_property(AspectWidth, float, 1.0f)
-    fbx_simple_property(AspectHeight, float, 1.0f)
-    fbx_simple_property(FilmWidth, float, 1.0f)
-    fbx_simple_property(FilmHeight, float, 1.0f)
+	fbx_simple_property(AspectWidth, float, 1.0f);
+	fbx_simple_property(AspectHeight, float, 1.0f);
+	fbx_simple_property(FilmWidth, float, 1.0f);
+	fbx_simple_property(FilmHeight, float, 1.0f);
 
-    fbx_simple_property(NearPlane, float, 0.1f)
-    fbx_simple_property(FarPlane, float, 100.0f)
+	fbx_simple_property(NearPlane, float, 0.1f);
+	fbx_simple_property(FarPlane, float, 100.0f);
 
-    fbx_simple_property(FilmAspectRatio, float, 1.0f)
-    fbx_simple_property(ApertureMode, int, 0)
+	fbx_simple_property(FilmAspectRatio, float, 1.0f);
+	fbx_simple_property(ApertureMode, int, 0);
 
-    fbx_simple_property(FieldOfView, float, 1.0f)
-    fbx_simple_property(FocalLength, float, 1.0f)
+	fbx_simple_property(FieldOfView, float, 1.0f);
+	fbx_simple_property(FocalLength, float, 1.0f);
 };
 
 /** DOM base class for FBX null markers attached to a node */
 class Null : public NodeAttribute {
 public:
-    Null(uint64_t id, const Element& element, const Document& doc, const std::string& name);
-    virtual ~Null();
+	Null(uint64_t id, const Element &element, const Document &doc, const std::string &name);
+	virtual ~Null();
 };
 
 /** DOM base class for FBX limb node markers attached to a node */
 class LimbNode : public NodeAttribute {
 public:
-    LimbNode(uint64_t id, const Element& element, const Document& doc, const std::string& name);
-    virtual ~LimbNode();
+	LimbNode(uint64_t id, const Element &element, const Document &doc, const std::string &name);
+	virtual ~LimbNode();
 };
 
 /** DOM base class for FBX lights attached to a node */
 class Light : public NodeAttribute {
 public:
-    Light(uint64_t id, const Element& element, const Document& doc, const std::string& name);
-    virtual ~Light();
+	Light(uint64_t id, const Element &element, const Document &doc, const std::string &name);
+	virtual ~Light();
 
-    enum Type
-    {
-        Type_Point,
-        Type_Directional,
-        Type_Spot,
-        Type_Area,
-        Type_Volume,
+	enum Type {
+		Type_Point,
+		Type_Directional,
+		Type_Spot,
+		Type_Area,
+		Type_Volume,
 
-        Type_MAX // end-of-enum sentinel
-    };
+		Type_MAX // end-of-enum sentinel
+	};
 
-    enum Decay
-    {
-        Decay_None,
-        Decay_Linear,
-        Decay_Quadratic,
-        Decay_Cubic,
+	enum Decay {
+		Decay_None,
+		Decay_Linear,
+		Decay_Quadratic,
+		Decay_Cubic,
 
-        Decay_MAX // end-of-enum sentinel
-    };
+		Decay_MAX // end-of-enum sentinel
+	};
 
-    fbx_simple_property(Color, aiVector3D, aiVector3D(1,1,1))
-    fbx_simple_enum_property(LightType, Type, 0)
-    fbx_simple_property(CastLightOnObject, bool, false)
-    fbx_simple_property(DrawVolumetricLight, bool, true)
-    fbx_simple_property(DrawGroundProjection, bool, true)
-    fbx_simple_property(DrawFrontFacingVolumetricLight, bool, false)
-    fbx_simple_property(Intensity, float, 100.0f)
-    fbx_simple_property(InnerAngle, float, 0.0f)
-    fbx_simple_property(OuterAngle, float, 45.0f)
-    fbx_simple_property(Fog, int, 50)
-    fbx_simple_enum_property(DecayType, Decay, 2)
-    fbx_simple_property(DecayStart, float, 1.0f)
-    fbx_simple_property(FileName, std::string, "")
+	fbx_simple_property(Color, aiVector3D, aiVector3D(1, 1, 1));
+	fbx_simple_enum_property(LightType, Type, 0);
+	fbx_simple_property(CastLightOnObject, bool, false);
+	fbx_simple_property(DrawVolumetricLight, bool, true);
+	fbx_simple_property(DrawGroundProjection, bool, true);
+	fbx_simple_property(DrawFrontFacingVolumetricLight, bool, false);
+	fbx_simple_property(Intensity, float, 100.0f);
+	fbx_simple_property(InnerAngle, float, 0.0f);
+	fbx_simple_property(OuterAngle, float, 45.0f);
+	fbx_simple_property(Fog, int, 50);
+	fbx_simple_enum_property(DecayType, Decay, 2);
+	fbx_simple_property(DecayStart, float, 1.0f);
+	fbx_simple_property(FileName, std::string, "");
 
-    fbx_simple_property(EnableNearAttenuation, bool, false)
-    fbx_simple_property(NearAttenuationStart, float, 0.0f)
-    fbx_simple_property(NearAttenuationEnd, float, 0.0f)
-    fbx_simple_property(EnableFarAttenuation, bool, false)
-    fbx_simple_property(FarAttenuationStart, float, 0.0f)
-    fbx_simple_property(FarAttenuationEnd, float, 0.0f)
+	fbx_simple_property(EnableNearAttenuation, bool, false);
+	fbx_simple_property(NearAttenuationStart, float, 0.0f);
+	fbx_simple_property(NearAttenuationEnd, float, 0.0f);
+	fbx_simple_property(EnableFarAttenuation, bool, false);
+	fbx_simple_property(FarAttenuationStart, float, 0.0f);
+	fbx_simple_property(FarAttenuationEnd, float, 0.0f);
 
-    fbx_simple_property(CastShadows, bool, true)
-    fbx_simple_property(ShadowColor, aiVector3D, aiVector3D(0,0,0))
+	fbx_simple_property(CastShadows, bool, true);
+	fbx_simple_property(ShadowColor, aiVector3D, aiVector3D(0, 0, 0));
 
-    fbx_simple_property(AreaLightShape, int, 0)
+	fbx_simple_property(AreaLightShape, int, 0);
 
-    fbx_simple_property(LeftBarnDoor, float, 20.0f)
-    fbx_simple_property(RightBarnDoor, float, 20.0f)
-    fbx_simple_property(TopBarnDoor, float, 20.0f)
-    fbx_simple_property(BottomBarnDoor, float, 20.0f)
-    fbx_simple_property(EnableBarnDoor, bool, true)
+	fbx_simple_property(LeftBarnDoor, float, 20.0f);
+	fbx_simple_property(RightBarnDoor, float, 20.0f);
+	fbx_simple_property(TopBarnDoor, float, 20.0f);
+	fbx_simple_property(BottomBarnDoor, float, 20.0f);
+	fbx_simple_property(EnableBarnDoor, bool, true);
 };
 
 /** DOM base class for FBX models (even though its semantics are more "node" than "model" */
 class Model : public Object {
 public:
-    enum RotOrder {
-        RotOrder_EulerXYZ = 0,
-        RotOrder_EulerXZY,
-        RotOrder_EulerYZX,
-        RotOrder_EulerYXZ,
-        RotOrder_EulerZXY,
-        RotOrder_EulerZYX,
+	enum RotOrder {
+		RotOrder_EulerXYZ = 0,
+		RotOrder_EulerXZY,
+		RotOrder_EulerYZX,
+		RotOrder_EulerYXZ,
+		RotOrder_EulerZXY,
+		RotOrder_EulerZYX,
 
-        RotOrder_SphericXYZ,
+		RotOrder_SphericXYZ,
 
-        RotOrder_MAX // end-of-enum sentinel
-    };
+		RotOrder_MAX // end-of-enum sentinel
+	};
 
-    enum TransformInheritance {
-        TransformInheritance_RrSs = 0,
-        TransformInheritance_RSrs,
-        TransformInheritance_Rrs,
+	enum TransformInheritance {
+		TransformInheritance_RrSs = 0,
+		TransformInheritance_RSrs,
+		TransformInheritance_Rrs,
 
-        TransformInheritance_MAX // end-of-enum sentinel
-    };
+		TransformInheritance_MAX // end-of-enum sentinel
+	};
 
-    Model(uint64_t id, const Element& element, const Document& doc, const std::string& name);
+	Model(uint64_t id, const Element &element, const Document &doc, const std::string &name);
 
-    virtual ~Model();
+	virtual ~Model();
 
-    fbx_simple_property(QuaternionInterpolate, int, 0)
+	fbx_simple_property(QuaternionInterpolate, int, 0);
 
-    fbx_simple_property(RotationOffset, aiVector3D, aiVector3D())
-    fbx_simple_property(RotationPivot, aiVector3D, aiVector3D())
-    fbx_simple_property(ScalingOffset, aiVector3D, aiVector3D())
-    fbx_simple_property(ScalingPivot, aiVector3D, aiVector3D())
-    fbx_simple_property(TranslationActive, bool, false)
+	fbx_simple_property(RotationOffset, aiVector3D, aiVector3D::ZERO());
+	fbx_simple_property(RotationPivot, aiVector3D, aiVector3D::ZERO());
+	fbx_simple_property(ScalingOffset, aiVector3D, aiVector3D::ZERO());
+	fbx_simple_property(ScalingPivot, aiVector3D, aiVector3D::ZERO());
+	fbx_simple_property(TranslationActive, bool, false);
+	fbx_simple_property(TranslationMin, aiVector3D, aiVector3D());
+	fbx_simple_property(TranslationMax, aiVector3D, aiVector3D());
 
-    fbx_simple_property(TranslationMin, aiVector3D, aiVector3D())
-    fbx_simple_property(TranslationMax, aiVector3D, aiVector3D())
+	fbx_simple_property(TranslationMinX, bool, false);
+	fbx_simple_property(TranslationMaxX, bool, false);
+	fbx_simple_property(TranslationMinY, bool, false);
+	fbx_simple_property(TranslationMaxY, bool, false);
+	fbx_simple_property(TranslationMinZ, bool, false);
+	fbx_simple_property(TranslationMaxZ, bool, false);
 
-    fbx_simple_property(TranslationMinX, bool, false)
-    fbx_simple_property(TranslationMaxX, bool, false)
-    fbx_simple_property(TranslationMinY, bool, false)
-    fbx_simple_property(TranslationMaxY, bool, false)
-    fbx_simple_property(TranslationMinZ, bool, false)
-    fbx_simple_property(TranslationMaxZ, bool, false)
+	fbx_simple_enum_property(RotationOrder, RotOrder, 0);
+	fbx_simple_property(RotationSpaceForLimitOnly, bool, false);
+	fbx_simple_property(RotationStiffnessX, float, 0.0f);
+	fbx_simple_property(RotationStiffnessY, float, 0.0f);
+	fbx_simple_property(RotationStiffnessZ, float, 0.0f);
+	fbx_simple_property(AxisLen, float, 0.0f);
 
-    fbx_simple_enum_property(RotationOrder, RotOrder, 0)
-    fbx_simple_property(RotationSpaceForLimitOnly, bool, false)
-    fbx_simple_property(RotationStiffnessX, float, 0.0f)
-    fbx_simple_property(RotationStiffnessY, float, 0.0f)
-    fbx_simple_property(RotationStiffnessZ, float, 0.0f)
-    fbx_simple_property(AxisLen, float, 0.0f)
+	fbx_simple_property(PreRotation, aiVector3D, aiVector3D());
+	fbx_simple_property(PostRotation, aiVector3D, aiVector3D());
+	fbx_simple_property(RotationActive, bool, false);
 
-    fbx_simple_property(PreRotation, aiVector3D, aiVector3D())
-    fbx_simple_property(PostRotation, aiVector3D, aiVector3D())
-    fbx_simple_property(RotationActive, bool, false)
+	fbx_simple_property(RotationMin, aiVector3D, aiVector3D());
+	fbx_simple_property(RotationMax, aiVector3D, aiVector3D());
 
-    fbx_simple_property(RotationMin, aiVector3D, aiVector3D())
-    fbx_simple_property(RotationMax, aiVector3D, aiVector3D())
+	fbx_simple_property(RotationMinX, bool, false);
+	fbx_simple_property(RotationMaxX, bool, false);
+	fbx_simple_property(RotationMinY, bool, false);
+	fbx_simple_property(RotationMaxY, bool, false);
+	fbx_simple_property(RotationMinZ, bool, false);
+	fbx_simple_property(RotationMaxZ, bool, false);
+	fbx_simple_enum_property(InheritType, TransformInheritance, 0);
 
-    fbx_simple_property(RotationMinX, bool, false)
-    fbx_simple_property(RotationMaxX, bool, false)
-    fbx_simple_property(RotationMinY, bool, false)
-    fbx_simple_property(RotationMaxY, bool, false)
-    fbx_simple_property(RotationMinZ, bool, false)
-    fbx_simple_property(RotationMaxZ, bool, false)
-    fbx_simple_enum_property(InheritType, TransformInheritance, 0)
+	fbx_simple_property(ScalingActive, bool, false);
+	fbx_simple_property(ScalingMin, aiVector3D, aiVector3D());
+	fbx_simple_property(ScalingMax, aiVector3D, aiVector3D(1.f, 1.f, 1.f));
+	fbx_simple_property(ScalingMinX, bool, false);
+	fbx_simple_property(ScalingMaxX, bool, false);
+	fbx_simple_property(ScalingMinY, bool, false);
+	fbx_simple_property(ScalingMaxY, bool, false);
+	fbx_simple_property(ScalingMinZ, bool, false);
+	fbx_simple_property(ScalingMaxZ, bool, false);
 
-    fbx_simple_property(ScalingActive, bool, false)
-    fbx_simple_property(ScalingMin, aiVector3D, aiVector3D())
-    fbx_simple_property(ScalingMax, aiVector3D, aiVector3D(1.f,1.f,1.f))
-    fbx_simple_property(ScalingMinX, bool, false)
-    fbx_simple_property(ScalingMaxX, bool, false)
-    fbx_simple_property(ScalingMinY, bool, false)
-    fbx_simple_property(ScalingMaxY, bool, false)
-    fbx_simple_property(ScalingMinZ, bool, false)
-    fbx_simple_property(ScalingMaxZ, bool, false)
+	fbx_simple_property(GeometricTranslation, aiVector3D, aiVector3D());
+	fbx_simple_property(GeometricRotation, aiVector3D, aiVector3D());
+	fbx_simple_property(GeometricScaling, aiVector3D, aiVector3D::NORMAL());
 
-    fbx_simple_property(GeometricTranslation, aiVector3D, aiVector3D())
-    fbx_simple_property(GeometricRotation, aiVector3D, aiVector3D())
-    fbx_simple_property(GeometricScaling, aiVector3D, aiVector3D(1.f, 1.f, 1.f))
+	fbx_simple_property(MinDampRangeX, float, 0.0f);
+	fbx_simple_property(MinDampRangeY, float, 0.0f);
+	fbx_simple_property(MinDampRangeZ, float, 0.0f);
+	fbx_simple_property(MaxDampRangeX, float, 0.0f);
+	fbx_simple_property(MaxDampRangeY, float, 0.0f);
+	fbx_simple_property(MaxDampRangeZ, float, 0.0f);
 
-    fbx_simple_property(MinDampRangeX, float, 0.0f)
-    fbx_simple_property(MinDampRangeY, float, 0.0f)
-    fbx_simple_property(MinDampRangeZ, float, 0.0f)
-    fbx_simple_property(MaxDampRangeX, float, 0.0f)
-    fbx_simple_property(MaxDampRangeY, float, 0.0f)
-    fbx_simple_property(MaxDampRangeZ, float, 0.0f)
+	fbx_simple_property(MinDampStrengthX, float, 0.0f);
+	fbx_simple_property(MinDampStrengthY, float, 0.0f);
+	fbx_simple_property(MinDampStrengthZ, float, 0.0f);
+	fbx_simple_property(MaxDampStrengthX, float, 0.0f);
+	fbx_simple_property(MaxDampStrengthY, float, 0.0f);
+	fbx_simple_property(MaxDampStrengthZ, float, 0.0f);
 
-    fbx_simple_property(MinDampStrengthX, float, 0.0f)
-    fbx_simple_property(MinDampStrengthY, float, 0.0f)
-    fbx_simple_property(MinDampStrengthZ, float, 0.0f)
-    fbx_simple_property(MaxDampStrengthX, float, 0.0f)
-    fbx_simple_property(MaxDampStrengthY, float, 0.0f)
-    fbx_simple_property(MaxDampStrengthZ, float, 0.0f)
+	fbx_simple_property(PreferredAngleX, float, 0.0f);
+	fbx_simple_property(PreferredAngleY, float, 0.0f);
+	fbx_simple_property(PreferredAngleZ, float, 0.0f);
 
-    fbx_simple_property(PreferredAngleX, float, 0.0f)
-    fbx_simple_property(PreferredAngleY, float, 0.0f)
-    fbx_simple_property(PreferredAngleZ, float, 0.0f)
+	fbx_simple_property(Show, bool, true);
+	fbx_simple_property(LODBox, bool, false);
+	fbx_simple_property(Freeze, bool, false);
 
-    fbx_simple_property(Show, bool, true)
-    fbx_simple_property(LODBox, bool, false)
-    fbx_simple_property(Freeze, bool, false)
+	const std::string &Shading() const {
+		return shading;
+	}
 
-    const std::string& Shading() const {
-        return shading;
-    }
+	const std::string &Culling() const {
+		return culling;
+	}
 
-    const std::string& Culling() const {
-        return culling;
-    }
+	const PropertyTable &Props() const {
+		ai_assert(props.get());
+		return *props.get();
+	}
 
-    const PropertyTable& Props() const {
-        ai_assert(props.get());
-        return *props.get();
-    }
+	/** Get material links */
+	const std::vector<const Material *> &GetMaterials() const {
+		return materials;
+	}
 
-    /** Get material links */
-    const std::vector<const Material*>& GetMaterials() const {
-        return materials;
-    }
+	/** Get geometry links */
+	const std::vector<const Geometry *> &GetGeometry() const {
+		return geometry;
+	}
 
-    /** Get geometry links */
-    const std::vector<const Geometry*>& GetGeometry() const {
-        return geometry;
-    }
+	/** Get node attachments */
+	const std::vector<const NodeAttribute *> &GetAttributes() const {
+		return attributes;
+	}
 
-    /** Get node attachments */
-    const std::vector<const NodeAttribute*>& GetAttributes() const {
-        return attributes;
-    }
-
-    /** convenience method to check if the node has a Null node marker */
-    bool IsNull() const;
-
-private:
-    void ResolveLinks(const Element& element, const Document& doc);
+	/** convenience method to check if the node has a Null node marker */
+	bool IsNull() const;
 
 private:
-    std::vector<const Material*> materials;
-    std::vector<const Geometry*> geometry;
-    std::vector<const NodeAttribute*> attributes;
+	void ResolveLinks(const Element &element, const Document &doc);
 
-    std::string shading;
-    std::string culling;
-    std::shared_ptr<const PropertyTable> props;
+private:
+	std::vector<const Material *> materials;
+	std::vector<const Geometry *> geometry;
+	std::vector<const NodeAttribute *> attributes;
+
+	std::string shading;
+	std::string culling;
+	std::shared_ptr<const PropertyTable> props;
 };
 
 /** DOM class for generic FBX textures */
 class Texture : public Object {
 public:
-    Texture(uint64_t id, const Element& element, const Document& doc, const std::string& name);
+	Texture(uint64_t id, const Element &element, const Document &doc, const std::string &name);
 
-    virtual ~Texture();
+	virtual ~Texture();
 
-    const std::string& Type() const {
-        return type;
-    }
+	const std::string &Type() const {
+		return type;
+	}
 
-    const std::string& FileName() const {
-        return fileName;
-    }
+	const std::string &FileName() const {
+		return fileName;
+	}
 
-    const std::string& RelativeFilename() const {
-        return relativeFileName;
-    }
+	const std::string &RelativeFilename() const {
+		return relativeFileName;
+	}
 
-    const std::string& AlphaSource() const {
-        return alphaSource;
-    }
+	const std::string &AlphaSource() const {
+		return alphaSource;
+	}
 
-    const aiVector2D& UVTranslation() const {
-        return uvTrans;
-    }
+	const aiVector2D &UVTranslation() const {
+		return uvTrans;
+	}
 
-    const aiVector2D& UVScaling() const {
-        return uvScaling;
-    }
+	const aiVector2D &UVScaling() const {
+		return uvScaling;
+	}
 
-    const PropertyTable& Props() const {
-        ai_assert(props.get());
-        return *props.get();
-    }
+	const PropertyTable &Props() const {
+		ai_assert(props.get());
+		return *props.get();
+	}
 
-    // return a 4-tuple
-    const unsigned int* Crop() const {
-        return crop;
-    }
+	// return a 4-tuple
+	const unsigned int *Crop() const {
+		return crop;
+	}
 
-    const Video* Media() const {
-        return media;
-    }
+	const Video *Media() const {
+		return media;
+	}
 
 private:
-    aiVector2D uvTrans;
-    aiVector2D uvScaling;
+	aiVector2D uvTrans;
+	aiVector2D uvScaling;
 
-    std::string type;
-    std::string relativeFileName;
-    std::string fileName;
-    std::string alphaSource;
-    std::shared_ptr<const PropertyTable> props;
+	std::string type;
+	std::string relativeFileName;
+	std::string fileName;
+	std::string alphaSource;
+	std::shared_ptr<const PropertyTable> props;
 
-    unsigned int crop[4];
+	unsigned int crop[4];
 
-    const Video* media;
+	const Video *media;
 };
 
 /** DOM class for layered FBX textures */
 class LayeredTexture : public Object {
 public:
-    LayeredTexture(uint64_t id, const Element& element, const Document& doc, const std::string& name);
-    virtual ~LayeredTexture();
+	LayeredTexture(uint64_t id, const Element &element, const Document &doc, const std::string &name);
+	virtual ~LayeredTexture();
 
-    // Can only be called after construction of the layered texture object due to construction flag.
-    void fillTexture(const Document& doc);
+	// Can only be called after construction of the layered texture object due to construction flag.
+	void fillTexture(const Document &doc);
 
-    enum BlendMode {
-        BlendMode_Translucent,
-        BlendMode_Additive,
-        BlendMode_Modulate,
-        BlendMode_Modulate2,
-        BlendMode_Over,
-        BlendMode_Normal,
-        BlendMode_Dissolve,
-        BlendMode_Darken,
-        BlendMode_ColorBurn,
-        BlendMode_LinearBurn,
-        BlendMode_DarkerColor,
-        BlendMode_Lighten,
-        BlendMode_Screen,
-        BlendMode_ColorDodge,
-        BlendMode_LinearDodge,
-        BlendMode_LighterColor,
-        BlendMode_SoftLight,
-        BlendMode_HardLight,
-        BlendMode_VividLight,
-        BlendMode_LinearLight,
-        BlendMode_PinLight,
-        BlendMode_HardMix,
-        BlendMode_Difference,
-        BlendMode_Exclusion,
-        BlendMode_Subtract,
-        BlendMode_Divide,
-        BlendMode_Hue,
-        BlendMode_Saturation,
-        BlendMode_Color,
-        BlendMode_Luminosity,
-        BlendMode_Overlay,
-        BlendMode_BlendModeCount
-    };
+	enum BlendMode {
+		BlendMode_Translucent,
+		BlendMode_Additive,
+		BlendMode_Modulate,
+		BlendMode_Modulate2,
+		BlendMode_Over,
+		BlendMode_Normal,
+		BlendMode_Dissolve,
+		BlendMode_Darken,
+		BlendMode_ColorBurn,
+		BlendMode_LinearBurn,
+		BlendMode_DarkerColor,
+		BlendMode_Lighten,
+		BlendMode_Screen,
+		BlendMode_ColorDodge,
+		BlendMode_LinearDodge,
+		BlendMode_LighterColor,
+		BlendMode_SoftLight,
+		BlendMode_HardLight,
+		BlendMode_VividLight,
+		BlendMode_LinearLight,
+		BlendMode_PinLight,
+		BlendMode_HardMix,
+		BlendMode_Difference,
+		BlendMode_Exclusion,
+		BlendMode_Subtract,
+		BlendMode_Divide,
+		BlendMode_Hue,
+		BlendMode_Saturation,
+		BlendMode_Color,
+		BlendMode_Luminosity,
+		BlendMode_Overlay,
+		BlendMode_BlendModeCount
+	};
 
-    const Texture* getTexture(int index=0) const
-    {
+	const Texture *getTexture(int index = 0) const {
 		return textures[index];
-
-    }
+	}
 	int textureCount() const {
 		return static_cast<int>(textures.size());
 	}
-    BlendMode GetBlendMode() const
-    {
-        return blendMode;
-    }
-    float Alpha()
-    {
-        return alpha;
-    }
+	BlendMode GetBlendMode() const {
+		return blendMode;
+	}
+	float Alpha() {
+		return alpha;
+	}
+
 private:
-	std::vector<const Texture*> textures;
-    BlendMode blendMode;
-    float alpha;
+	std::vector<const Texture *> textures;
+	BlendMode blendMode;
+	float alpha;
 };
 
-typedef std::fbx_unordered_map<std::string, const Texture*> TextureMap;
-typedef std::fbx_unordered_map<std::string, const LayeredTexture*> LayeredTextureMap;
-
+typedef std::fbx_unordered_map<std::string, const Texture *> TextureMap;
+typedef std::fbx_unordered_map<std::string, const LayeredTexture *> LayeredTextureMap;
 
 /** DOM class for generic FBX videos */
 class Video : public Object {
 public:
-    Video(uint64_t id, const Element& element, const Document& doc, const std::string& name);
+	Video(uint64_t id, const Element &element, const Document &doc, const std::string &name);
 
-    virtual ~Video();
+	virtual ~Video();
 
-    const std::string& Type() const {
-        return type;
-    }
+	const std::string &Type() const {
+		return type;
+	}
 
-    const std::string& FileName() const {
-        return fileName;
-    }
+	const std::string &FileName() const {
+		return fileName;
+	}
 
-    const std::string& RelativeFilename() const {
-        return relativeFileName;
-    }
+	const std::string &RelativeFilename() const {
+		return relativeFileName;
+	}
 
-    const PropertyTable& Props() const {
-        ai_assert(props.get());
-        return *props.get();
-    }
+	const PropertyTable &Props() const {
+		ai_assert(props.get());
+		return *props.get();
+	}
 
-    const uint8_t* Content() const {
-        ai_assert(content);
-        return content;
-    }
+	const uint8_t *Content() const {
+		ai_assert(content);
+		return content;
+	}
 
-    uint64_t ContentLength() const {
-        return contentLength;
-    }
+	uint64_t ContentLength() const {
+		return contentLength;
+	}
 
-    uint8_t* RelinquishContent() {
-        uint8_t* ptr = content;
-        content = 0;
-        return ptr;
-    }
+	uint8_t *RelinquishContent() {
+		uint8_t *ptr = content;
+		content = 0;
+		return ptr;
+	}
 
-    bool operator==(const Video& other) const
-    {
-        return (
-               type == other.type
-            && relativeFileName == other.relativeFileName
-            && fileName == other.fileName
-        );
-    }
+	bool operator==(const Video &other) const {
+		return (
+				type == other.type && relativeFileName == other.relativeFileName && fileName == other.fileName);
+	}
 
-    bool operator<(const Video& other) const
-    {
-        return std::tie(type, relativeFileName, fileName) < std::tie(other.type, other.relativeFileName, other.fileName);
-    }
+	bool operator<(const Video &other) const {
+		return std::tie(type, relativeFileName, fileName) < std::tie(other.type, other.relativeFileName, other.fileName);
+	}
 
 private:
-    std::string type;
-    std::string relativeFileName;
-    std::string fileName;
-    std::shared_ptr<const PropertyTable> props;
+	std::string type;
+	std::string relativeFileName;
+	std::string fileName;
+	std::shared_ptr<const PropertyTable> props;
 
-    uint64_t contentLength;
-    uint8_t* content;
+	uint64_t contentLength;
+	uint8_t *content;
 };
 
 /** DOM class for generic FBX materials */
 class Material : public Object {
 public:
-    Material(uint64_t id, const Element& element, const Document& doc, const std::string& name);
+	Material(uint64_t id, const Element &element, const Document &doc, const std::string &name);
 
-    virtual ~Material();
+	virtual ~Material();
 
-    const std::string& GetShadingModel() const {
-        return shading;
-    }
+	const std::string &GetShadingModel() const {
+		return shading;
+	}
 
-    bool IsMultilayer() const {
-        return multilayer;
-    }
+	bool IsMultilayer() const {
+		return multilayer;
+	}
 
-    const PropertyTable& Props() const {
-        ai_assert(props.get());
-        return *props.get();
-    }
+	const PropertyTable &Props() const {
+		ai_assert(props.get());
+		return *props.get();
+	}
 
-    const TextureMap& Textures() const {
-        return textures;
-    }
+	const TextureMap &Textures() const {
+		return textures;
+	}
 
-    const LayeredTextureMap& LayeredTextures() const {
-        return layeredTextures;
-    }
+	const LayeredTextureMap &LayeredTextures() const {
+		return layeredTextures;
+	}
 
 private:
-    std::string shading;
-    bool multilayer;
-    std::shared_ptr<const PropertyTable> props;
+	std::string shading;
+	bool multilayer;
+	std::shared_ptr<const PropertyTable> props;
 
-    TextureMap textures;
-    LayeredTextureMap layeredTextures;
+	TextureMap textures;
+	LayeredTextureMap layeredTextures;
 };
 
 typedef std::vector<int64_t> KeyTimeList;
@@ -704,314 +699,309 @@ typedef std::vector<float> KeyValueList;
 /** Represents a FBX animation curve (i.e. a 1-dimensional set of keyframes and values therefor) */
 class AnimationCurve : public Object {
 public:
-    AnimationCurve(uint64_t id, const Element& element, const std::string& name, const Document& doc);
-    virtual ~AnimationCurve();
+	AnimationCurve(uint64_t id, const Element &element, const std::string &name, const Document &doc);
+	virtual ~AnimationCurve();
 
-    /** get list of keyframe positions (time).
+	/** get list of keyframe positions (time).
      *  Invariant: |GetKeys()| > 0 */
-    const KeyTimeList& GetKeys() const {
-        return keys;
-    }
+	const KeyTimeList &GetKeys() const {
+		return keys;
+	}
 
-    /** get list of keyframe values.
+	/** get list of keyframe values.
       * Invariant: |GetKeys()| == |GetValues()| && |GetKeys()| > 0*/
-    const KeyValueList& GetValues() const {
-        return values;
-    }
+	const KeyValueList &GetValues() const {
+		return values;
+	}
 
-    const std::vector<float>& GetAttributes() const {
-        return attributes;
-    }
+	const std::vector<float> &GetAttributes() const {
+		return attributes;
+	}
 
-    const std::vector<unsigned int>& GetFlags() const {
-        return flags;
-    }
+	const std::vector<unsigned int> &GetFlags() const {
+		return flags;
+	}
 
 private:
-    KeyTimeList keys;
-    KeyValueList values;
-    std::vector<float> attributes;
-    std::vector<unsigned int> flags;
+	KeyTimeList keys;
+	KeyValueList values;
+	std::vector<float> attributes;
+	std::vector<unsigned int> flags;
 };
 
 // property-name -> animation curve
-typedef std::map<std::string, const AnimationCurve*> AnimationCurveMap;
+typedef std::map<std::string, const AnimationCurve *> AnimationCurveMap;
 
 /** Represents a FBX animation curve (i.e. a mapping from single animation curves to nodes) */
 class AnimationCurveNode : public Object {
 public:
-    /* the optional white list specifies a list of property names for which the caller
+	/* the optional white list specifies a list of property names for which the caller
     wants animations for. If the curve node does not match one of these, std::range_error
     will be thrown. */
-    AnimationCurveNode(uint64_t id, const Element& element, const std::string& name, const Document& doc,
-        const char* const * target_prop_whitelist = NULL, size_t whitelist_size = 0);
+	AnimationCurveNode(uint64_t id, const Element &element, const std::string &name, const Document &doc,
+			const char *const *target_prop_whitelist = NULL, size_t whitelist_size = 0);
 
-    virtual ~AnimationCurveNode();
+	virtual ~AnimationCurveNode();
 
-    const PropertyTable& Props() const {
-        ai_assert(props.get());
-        return *props.get();
-    }
+	const PropertyTable &Props() const {
+		ai_assert(props.get());
+		return *props.get();
+	}
 
+	const AnimationCurveMap &Curves() const;
 
-    const AnimationCurveMap& Curves() const;
-
-    /** Object the curve is assigned to, this can be NULL if the
+	/** Object the curve is assigned to, this can be NULL if the
      *  target object has no DOM representation or could not
      *  be read for other reasons.*/
-    const Object* Target() const {
-        return target;
-    }
+	const Object *Target() const {
+		return target;
+	}
 
-    const Model* TargetAsModel() const {
-        return dynamic_cast<const Model*>(target);
-    }
+	const Model *TargetAsModel() const {
+		return dynamic_cast<const Model *>(target);
+	}
 
-    const NodeAttribute* TargetAsNodeAttribute() const {
-        return dynamic_cast<const NodeAttribute*>(target);
-    }
+	const NodeAttribute *TargetAsNodeAttribute() const {
+		return dynamic_cast<const NodeAttribute *>(target);
+	}
 
-    /** Property of Target() that is being animated*/
-    const std::string& TargetProperty() const {
-        return prop;
-    }
+	/** Property of Target() that is being animated*/
+	const std::string &TargetProperty() const {
+		return prop;
+	}
 
 private:
-    const Object* target;
-    std::shared_ptr<const PropertyTable> props;
-    mutable AnimationCurveMap curves;
+	const Object *target;
+	std::shared_ptr<const PropertyTable> props;
+	mutable AnimationCurveMap curves;
 
-    std::string prop;
-    const Document& doc;
+	std::string prop;
+	const Document &doc;
 };
 
-typedef std::vector<const AnimationCurveNode*> AnimationCurveNodeList;
+typedef std::vector<const AnimationCurveNode *> AnimationCurveNodeList;
 
 /** Represents a FBX animation layer (i.e. a list of node animations) */
 class AnimationLayer : public Object {
 public:
-    AnimationLayer(uint64_t id, const Element& element, const std::string& name, const Document& doc);
-    virtual ~AnimationLayer();
+	AnimationLayer(uint64_t id, const Element &element, const std::string &name, const Document &doc);
+	virtual ~AnimationLayer();
 
-    const PropertyTable& Props() const {
-        ai_assert(props.get());
-        return *props.get();
-    }
+	const PropertyTable &Props() const {
+		ai_assert(props.get());
+		return *props.get();
+	}
 
-    /* the optional white list specifies a list of property names for which the caller
+	/* the optional white list specifies a list of property names for which the caller
     wants animations for. Curves not matching this list will not be added to the
     animation layer. */
-    AnimationCurveNodeList Nodes(const char* const * target_prop_whitelist = nullptr, size_t whitelist_size = 0) const;
+	AnimationCurveNodeList Nodes(const char *const *target_prop_whitelist = nullptr, size_t whitelist_size = 0) const;
 
 private:
-    std::shared_ptr<const PropertyTable> props;
-    const Document& doc;
+	std::shared_ptr<const PropertyTable> props;
+	const Document &doc;
 };
 
-typedef std::vector<const AnimationLayer*> AnimationLayerList;
+typedef std::vector<const AnimationLayer *> AnimationLayerList;
 
 /** Represents a FBX animation stack (i.e. a list of animation layers) */
 class AnimationStack : public Object {
 public:
-    AnimationStack(uint64_t id, const Element& element, const std::string& name, const Document& doc);
-    virtual ~AnimationStack();
+	AnimationStack(uint64_t id, const Element &element, const std::string &name, const Document &doc);
+	virtual ~AnimationStack();
 
-    fbx_simple_property(LocalStart, int64_t, 0L)
-    fbx_simple_property(LocalStop, int64_t, 0L)
-    fbx_simple_property(ReferenceStart, int64_t, 0L)
-    fbx_simple_property(ReferenceStop, int64_t, 0L)
+	fbx_simple_property(LocalStart, int64_t, 0L)
+			fbx_simple_property(LocalStop, int64_t, 0L)
+					fbx_simple_property(ReferenceStart, int64_t, 0L)
+							fbx_simple_property(ReferenceStop, int64_t, 0L)
 
-    const PropertyTable& Props() const {
-        ai_assert(props.get());
-        return *props.get();
-    }
+									const PropertyTable &Props() const {
+		ai_assert(props.get());
+		return *props.get();
+	}
 
-    const AnimationLayerList& Layers() const {
-        return layers;
-    }
+	const AnimationLayerList &Layers() const {
+		return layers;
+	}
 
 private:
-    std::shared_ptr<const PropertyTable> props;
-    AnimationLayerList layers;
+	std::shared_ptr<const PropertyTable> props;
+	AnimationLayerList layers;
 };
-
 
 /** DOM class for deformers */
 class Deformer : public Object {
 public:
-    Deformer(uint64_t id, const Element& element, const Document& doc, const std::string& name);
-    virtual ~Deformer();
+	Deformer(uint64_t id, const Element &element, const Document &doc, const std::string &name);
+	virtual ~Deformer();
 
-    const PropertyTable& Props() const {
-        ai_assert(props.get());
-        return *props.get();
-    }
+	const PropertyTable &Props() const {
+		ai_assert(props.get());
+		return *props.get();
+	}
 
 private:
-    std::shared_ptr<const PropertyTable> props;
+	std::shared_ptr<const PropertyTable> props;
 };
 
 typedef std::vector<float> WeightArray;
 typedef std::vector<unsigned int> WeightIndexArray;
 
-
 /** DOM class for BlendShapeChannel deformers */
 class BlendShapeChannel : public Deformer {
 public:
-    BlendShapeChannel(uint64_t id, const Element& element, const Document& doc, const std::string& name);
+	BlendShapeChannel(uint64_t id, const Element &element, const Document &doc, const std::string &name);
 
-    virtual ~BlendShapeChannel();
+	virtual ~BlendShapeChannel();
 
-    float DeformPercent() const {
-        return percent;
-    }
+	float DeformPercent() const {
+		return percent;
+	}
 
-    const WeightArray& GetFullWeights() const {
-        return fullWeights;
-    }
+	const WeightArray &GetFullWeights() const {
+		return fullWeights;
+	}
 
-    const std::vector<const ShapeGeometry*>& GetShapeGeometries() const {
-        return shapeGeometries;
-    }
+	const std::vector<const ShapeGeometry *> &GetShapeGeometries() const {
+		return shapeGeometries;
+	}
 
 private:
-    float percent;
-    WeightArray fullWeights;
-    std::vector<const ShapeGeometry*> shapeGeometries;
+	float percent;
+	WeightArray fullWeights;
+	std::vector<const ShapeGeometry *> shapeGeometries;
 };
 
 /** DOM class for BlendShape deformers */
 class BlendShape : public Deformer {
 public:
-    BlendShape(uint64_t id, const Element& element, const Document& doc, const std::string& name);
+	BlendShape(uint64_t id, const Element &element, const Document &doc, const std::string &name);
 
-    virtual ~BlendShape();
+	virtual ~BlendShape();
 
-    const std::vector<const BlendShapeChannel*>& BlendShapeChannels() const {
-        return blendShapeChannels;
-    }
+	const std::vector<const BlendShapeChannel *> &BlendShapeChannels() const {
+		return blendShapeChannels;
+	}
 
 private:
-    std::vector<const BlendShapeChannel*> blendShapeChannels;
+	std::vector<const BlendShapeChannel *> blendShapeChannels;
 };
 
 /** DOM class for skin deformer clusters (aka sub-deformers) */
 class Cluster : public Deformer {
 public:
-    Cluster(uint64_t id, const Element& element, const Document& doc, const std::string& name);
+	Cluster(uint64_t id, const Element &element, const Document &doc, const std::string &name);
 
-    virtual ~Cluster();
+	virtual ~Cluster();
 
-    /** get the list of deformer weights associated with this cluster.
+	/** get the list of deformer weights associated with this cluster.
      *  Use #GetIndices() to get the associated vertices. Both arrays
      *  have the same size (and may also be empty). */
-    const WeightArray& GetWeights() const {
-        return weights;
-    }
+	const WeightArray &GetWeights() const {
+		return weights;
+	}
 
-    /** get indices into the vertex data of the geometry associated
+	/** get indices into the vertex data of the geometry associated
      *  with this cluster. Use #GetWeights() to get the associated weights.
      *  Both arrays have the same size (and may also be empty). */
-    const WeightIndexArray& GetIndices() const {
-        return indices;
-    }
+	const WeightIndexArray &GetIndices() const {
+		return indices;
+	}
 
-    /** */
-    const aiMatrix4x4& Transform() const {
-        return transform;
-    }
+	/** */
+	const aiMatrix4x4 &Transform() const {
+		return transform;
+	}
 
-    const aiMatrix4x4& TransformLink() const {
-        return transformLink;
-    }
+	const aiMatrix4x4 &TransformLink() const {
+		return transformLink;
+	}
 
-    const Model* TargetNode() const {
-        return node;
-    }
+	const Model *TargetNode() const {
+		return node;
+	}
 
 private:
-    WeightArray weights;
-    WeightIndexArray indices;
+	WeightArray weights;
+	WeightIndexArray indices;
 
-    aiMatrix4x4 transform;
-    aiMatrix4x4 transformLink;
+	aiMatrix4x4 transform;
+	aiMatrix4x4 transformLink;
 
-    const Model* node;
+	const Model *node;
 };
 
 /** DOM class for skin deformers */
 class Skin : public Deformer {
 public:
-    Skin(uint64_t id, const Element& element, const Document& doc, const std::string& name);
+	Skin(uint64_t id, const Element &element, const Document &doc, const std::string &name);
 
-    virtual ~Skin();
+	virtual ~Skin();
 
-    float DeformAccuracy() const {
-        return accuracy;
-    }
+	float DeformAccuracy() const {
+		return accuracy;
+	}
 
-    const std::vector<const Cluster*>& Clusters() const {
-        return clusters;
-    }
+	const std::vector<const Cluster *> &Clusters() const {
+		return clusters;
+	}
 
 private:
-    float accuracy;
-    std::vector<const Cluster*> clusters;
+	float accuracy;
+	std::vector<const Cluster *> clusters;
 };
 
 /** Represents a link between two FBX objects. */
 class Connection {
 public:
-    Connection(uint64_t insertionOrder,  uint64_t src, uint64_t dest, const std::string& prop, const Document& doc);
+	Connection(uint64_t insertionOrder, uint64_t src, uint64_t dest, const std::string &prop, const Document &doc);
 
-    ~Connection();
+	~Connection();
 
-    // note: a connection ensures that the source and dest objects exist, but
-    // not that they have DOM representations, so the return value of one of
-    // these functions can still be NULL.
-    const Object* SourceObject() const;
-    const Object* DestinationObject() const;
+	// note: a connection ensures that the source and dest objects exist, but
+	// not that they have DOM representations, so the return value of one of
+	// these functions can still be NULL.
+	const Object *SourceObject() const;
+	const Object *DestinationObject() const;
 
-    // these, however, are always guaranteed to be valid
-    LazyObject& LazySourceObject() const;
-    LazyObject& LazyDestinationObject() const;
+	// these, however, are always guaranteed to be valid
+	LazyObject &LazySourceObject() const;
+	LazyObject &LazyDestinationObject() const;
 
-
-    /** return the name of the property the connection is attached to.
+	/** return the name of the property the connection is attached to.
       * this is an empty string for object to object (OO) connections. */
-    const std::string& PropertyName() const {
-        return prop;
-    }
+	const std::string &PropertyName() const {
+		return prop;
+	}
 
-    uint64_t InsertionOrder() const {
-        return insertionOrder;
-    }
+	uint64_t InsertionOrder() const {
+		return insertionOrder;
+	}
 
-    int CompareTo(const Connection* c) const {
-        ai_assert( nullptr != c );
+	int CompareTo(const Connection *c) const {
+		ai_assert(nullptr != c);
 
-        // note: can't subtract because this would overflow uint64_t
-        if(InsertionOrder() > c->InsertionOrder()) {
-            return 1;
-        }
-        else if(InsertionOrder() < c->InsertionOrder()) {
-            return -1;
-        }
-        return 0;
-    }
+		// note: can't subtract because this would overflow uint64_t
+		if (InsertionOrder() > c->InsertionOrder()) {
+			return 1;
+		} else if (InsertionOrder() < c->InsertionOrder()) {
+			return -1;
+		}
+		return 0;
+	}
 
-    bool Compare(const Connection* c) const {
-        ai_assert( nullptr != c );
+	bool Compare(const Connection *c) const {
+		ai_assert(nullptr != c);
 
-        return InsertionOrder() < c->InsertionOrder();
-    }
+		return InsertionOrder() < c->InsertionOrder();
+	}
 
 public:
-    uint64_t insertionOrder;
-    const std::string prop;
+	uint64_t insertionOrder;
+	const std::string prop;
 
-    uint64_t src, dest;
-    const Document& doc;
+	uint64_t src, dest;
+	const Document &doc;
 };
 
 // XXX again, unique_ptr would be useful. shared_ptr is too
@@ -1019,197 +1009,193 @@ public:
 // during their entire lifetime (Document). FBX files have
 // up to many thousands of objects (most of which we never use),
 // so the memory overhead for them should be kept at a minimum.
-typedef std::fbx_unordered_map<uint64_t, LazyObject*> ObjectMap;
+typedef std::fbx_unordered_map<uint64_t, LazyObject *> ObjectMap;
 typedef std::fbx_unordered_map<std::string, std::shared_ptr<const PropertyTable> > PropertyTemplateMap;
 
-typedef std::fbx_unordered_multimap<uint64_t, const Connection*> ConnectionMap;
+typedef std::fbx_unordered_multimap<uint64_t, const Connection *> ConnectionMap;
 
 /** DOM class for global document settings, a single instance per document can
  *  be accessed via Document.Globals(). */
 class FileGlobalSettings {
 public:
-    FileGlobalSettings(const Document& doc, std::shared_ptr<const PropertyTable> props);
+	FileGlobalSettings(const Document &doc, std::shared_ptr<const PropertyTable> props);
 
-    ~FileGlobalSettings();
+	~FileGlobalSettings();
 
-    const PropertyTable& Props() const {
-        ai_assert(props.get());
-        return *props.get();
-    }
+	const PropertyTable &Props() const {
+		ai_assert(props.get());
+		return *props.get();
+	}
 
-    const Document& GetDocument() const {
-        return doc;
-    }
+	const Document &GetDocument() const {
+		return doc;
+	}
 
-    fbx_simple_property(UpAxis, int, 1)
-    fbx_simple_property(UpAxisSign, int, 1)
-    fbx_simple_property(FrontAxis, int, 2)
-    fbx_simple_property(FrontAxisSign, int, 1)
-    fbx_simple_property(CoordAxis, int, 0)
-    fbx_simple_property(CoordAxisSign, int, 1)
-    fbx_simple_property(OriginalUpAxis, int, 0)
-    fbx_simple_property(OriginalUpAxisSign, int, 1)
-    fbx_simple_property(UnitScaleFactor, float, 1)
-    fbx_simple_property(OriginalUnitScaleFactor, float, 1)
-    fbx_simple_property(AmbientColor, aiVector3D, aiVector3D(0,0,0))
-    fbx_simple_property(DefaultCamera, std::string, "")
+	fbx_simple_property(UpAxis, int, 1);
+	fbx_simple_property(UpAxisSign, int, 1);
+	fbx_simple_property(FrontAxis, int, 2);
+	fbx_simple_property(FrontAxisSign, int, 1);
+	fbx_simple_property(CoordAxis, int, 0);
+	fbx_simple_property(CoordAxisSign, int, 1);
+	fbx_simple_property(OriginalUpAxis, int, 0);
+	fbx_simple_property(OriginalUpAxisSign, int, 1);
+	fbx_simple_property(UnitScaleFactor, float, 1);
+	fbx_simple_property(OriginalUnitScaleFactor, float, 1);
+	fbx_simple_property(AmbientColor, aiVector3D, aiVector3D(0, 0, 0));
+	fbx_simple_property(DefaultCamera, std::string, "");
 
+	enum FrameRate {
+		FrameRate_DEFAULT = 0,
+		FrameRate_120 = 1,
+		FrameRate_100 = 2,
+		FrameRate_60 = 3,
+		FrameRate_50 = 4,
+		FrameRate_48 = 5,
+		FrameRate_30 = 6,
+		FrameRate_30_DROP = 7,
+		FrameRate_NTSC_DROP_FRAME = 8,
+		FrameRate_NTSC_FULL_FRAME = 9,
+		FrameRate_PAL = 10,
+		FrameRate_CINEMA = 11,
+		FrameRate_1000 = 12,
+		FrameRate_CINEMA_ND = 13,
+		FrameRate_CUSTOM = 14,
 
-    enum FrameRate {
-        FrameRate_DEFAULT = 0,
-        FrameRate_120 = 1,
-        FrameRate_100 = 2,
-        FrameRate_60 = 3,
-        FrameRate_50 = 4,
-        FrameRate_48 = 5,
-        FrameRate_30 = 6,
-        FrameRate_30_DROP = 7,
-        FrameRate_NTSC_DROP_FRAME = 8,
-        FrameRate_NTSC_FULL_FRAME = 9,
-        FrameRate_PAL = 10,
-        FrameRate_CINEMA = 11,
-        FrameRate_1000 = 12,
-        FrameRate_CINEMA_ND = 13,
-        FrameRate_CUSTOM = 14,
+		FrameRate_MAX // end-of-enum sentinel
+	};
 
-        FrameRate_MAX// end-of-enum sentinel
-    };
-
-    fbx_simple_enum_property(TimeMode, FrameRate, FrameRate_DEFAULT)
-    fbx_simple_property(TimeSpanStart, uint64_t, 0L)
-    fbx_simple_property(TimeSpanStop, uint64_t, 0L)
-    fbx_simple_property(CustomFrameRate, float, -1.0f)
+	fbx_simple_enum_property(TimeMode, FrameRate, FrameRate_DEFAULT);
+	fbx_simple_property(TimeSpanStart, uint64_t, 0L);
+	fbx_simple_property(TimeSpanStop, uint64_t, 0L);
+	fbx_simple_property(CustomFrameRate, float, -1.0f);
 
 private:
-    std::shared_ptr<const PropertyTable> props;
-    const Document& doc;
+	std::shared_ptr<const PropertyTable> props;
+	const Document &doc;
 };
 
 /** DOM root for a FBX file */
 class Document {
 public:
-    Document(const Parser& parser, const ImportSettings& settings);
+	Document(const Parser &parser, const ImportSettings &settings);
 
-    ~Document();
+	~Document();
 
-    LazyObject* GetObject(uint64_t id) const;
+	LazyObject *GetObject(uint64_t id) const;
 
-    bool IsBinary() const {
-        return parser.IsBinary();
-    }
+	bool IsBinary() const {
+		return parser.IsBinary();
+	}
 
-    unsigned int FBXVersion() const {
-        return fbxVersion;
-    }
+	unsigned int FBXVersion() const {
+		return fbxVersion;
+	}
 
-    const std::string& Creator() const {
-        return creator;
-    }
+	const std::string &Creator() const {
+		return creator;
+	}
 
-    // elements (in this order): Year, Month, Day, Hour, Second, Millisecond
-    const unsigned int* CreationTimeStamp() const {
-        return creationTimeStamp;
-    }
+	// elements (in this order): Year, Month, Day, Hour, Second, Millisecond
+	const unsigned int *CreationTimeStamp() const {
+		return creationTimeStamp;
+	}
 
-    const FileGlobalSettings& GlobalSettings() const {
-        ai_assert(globals.get());
-        return *globals.get();
-    }
+	const FileGlobalSettings &GlobalSettings() const {
+		ai_assert(globals.get());
+		return *globals.get();
+	}
 
-    const PropertyTemplateMap& Templates() const {
-        return templates;
-    }
+	const PropertyTemplateMap &Templates() const {
+		return templates;
+	}
 
-    const ObjectMap& Objects() const {
-        return objects;
-    }
+	const ObjectMap &Objects() const {
+		return objects;
+	}
 
-    const ImportSettings& Settings() const {
-        return settings;
-    }
+	const ImportSettings &Settings() const {
+		return settings;
+	}
 
-    const ConnectionMap& ConnectionsBySource() const {
-        return src_connections;
-    }
+	const ConnectionMap &ConnectionsBySource() const {
+		return src_connections;
+	}
 
-    const ConnectionMap& ConnectionsByDestination() const {
-        return dest_connections;
-    }
+	const ConnectionMap &ConnectionsByDestination() const {
+		return dest_connections;
+	}
 
-    // note: the implicit rule in all DOM classes is to always resolve
-    // from destination to source (since the FBX object hierarchy is,
-    // with very few exceptions, a DAG, this avoids cycles). In all
-    // cases that may involve back-facing edges in the object graph,
-    // use LazyObject::IsBeingConstructed() to check.
+	// note: the implicit rule in all DOM classes is to always resolve
+	// from destination to source (since the FBX object hierarchy is,
+	// with very few exceptions, a DAG, this avoids cycles). In all
+	// cases that may involve back-facing edges in the object graph,
+	// use LazyObject::IsBeingConstructed() to check.
 
-    std::vector<const Connection*> GetConnectionsBySourceSequenced(uint64_t source) const;
-    std::vector<const Connection*> GetConnectionsByDestinationSequenced(uint64_t dest) const;
+	std::vector<const Connection *> GetConnectionsBySourceSequenced(uint64_t source) const;
+	std::vector<const Connection *> GetConnectionsByDestinationSequenced(uint64_t dest) const;
 
-    std::vector<const Connection*> GetConnectionsBySourceSequenced(uint64_t source, const char* classname) const;
-    std::vector<const Connection*> GetConnectionsByDestinationSequenced(uint64_t dest, const char* classname) const;
+	std::vector<const Connection *> GetConnectionsBySourceSequenced(uint64_t source, const char *classname) const;
+	std::vector<const Connection *> GetConnectionsByDestinationSequenced(uint64_t dest, const char *classname) const;
 
-    std::vector<const Connection*> GetConnectionsBySourceSequenced(uint64_t source,
-        const char* const* classnames, size_t count) const;
-    std::vector<const Connection*> GetConnectionsByDestinationSequenced(uint64_t dest,
-        const char* const* classnames,
-        size_t count) const;
+	std::vector<const Connection *> GetConnectionsBySourceSequenced(uint64_t source,
+			const char *const *classnames, size_t count) const;
+	std::vector<const Connection *> GetConnectionsByDestinationSequenced(uint64_t dest,
+			const char *const *classnames,
+			size_t count) const;
 
-    const std::vector<const AnimationStack*>& AnimationStacks() const;
-
-private:
-    std::vector<const Connection*> GetConnectionsSequenced(uint64_t id, const ConnectionMap&) const;
-    std::vector<const Connection*> GetConnectionsSequenced(uint64_t id, bool is_src,
-        const ConnectionMap&,
-        const char* const* classnames,
-        size_t count) const;
-    void ReadHeader();
-    void ReadObjects();
-    void ReadPropertyTemplates();
-    void ReadConnections();
-    void ReadGlobalSettings();
+	const std::vector<const AnimationStack *> &AnimationStacks() const;
 
 private:
-    const ImportSettings& settings;
+	std::vector<const Connection *> GetConnectionsSequenced(uint64_t id, const ConnectionMap &) const;
+	std::vector<const Connection *> GetConnectionsSequenced(uint64_t id, bool is_src,
+			const ConnectionMap &,
+			const char *const *classnames,
+			size_t count) const;
+	void ReadHeader();
+	void ReadObjects();
+	void ReadPropertyTemplates();
+	void ReadConnections();
+	void ReadGlobalSettings();
 
-    ObjectMap objects;
-    const Parser& parser;
+private:
+	const ImportSettings &settings;
 
-    PropertyTemplateMap templates;
-    ConnectionMap src_connections;
-    ConnectionMap dest_connections;
+	ObjectMap objects;
+	const Parser &parser;
 
-    unsigned int fbxVersion;
-    std::string creator;
-    unsigned int creationTimeStamp[7];
+	PropertyTemplateMap templates;
+	ConnectionMap src_connections;
+	ConnectionMap dest_connections;
 
-    std::vector<uint64_t> animationStacks;
-    mutable std::vector<const AnimationStack*> animationStacksResolved;
+	unsigned int fbxVersion;
+	std::string creator;
+	unsigned int creationTimeStamp[7];
 
-    std::unique_ptr<FileGlobalSettings> globals;
+	std::vector<uint64_t> animationStacks;
+	mutable std::vector<const AnimationStack *> animationStacksResolved;
+
+	std::unique_ptr<FileGlobalSettings> globals;
 };
 
 } // Namespace FBX
 } // Namespace Assimp
 
-namespace std
-{
-    template <>
-    struct hash<const Assimp::FBX::Video>
-    {
-        std::size_t operator()(const Assimp::FBX::Video& video) const
-        {
-            using std::size_t;
-            using std::hash;
-            using std::string;
+namespace std {
+template <>
+struct hash<const Assimp::FBX::Video> {
+	std::size_t operator()(const Assimp::FBX::Video &video) const {
+		using std::hash;
+		using std::size_t;
+		using std::string;
 
-            size_t res = 17;
-            res = res * 31 + hash<string>()(video.Name());
-            res = res * 31 + hash<string>()(video.RelativeFilename());
-            res = res * 31 + hash<string>()(video.Type());
+		size_t res = 17;
+		res = res * 31 + hash<string>()(video.Name());
+		res = res * 31 + hash<string>()(video.RelativeFilename());
+		res = res * 31 + hash<string>()(video.Type());
 
-            return res;
-        }
-    };
-}
+		return res;
+	}
+};
+} // namespace std
 
 #endif // INCLUDED_AI_FBX_DOCUMENT_H

--- a/code/FBX/FBXNodeAttribute.cpp
+++ b/code/FBX/FBXNodeAttribute.cpp
@@ -50,6 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "FBXDocument.h"
 #include "FBXImporter.h"
 #include "FBXDocumentUtil.h"
+#include <iostream>
 
 namespace Assimp {
 namespace FBX {
@@ -154,7 +155,24 @@ Null::~Null()
 LimbNode::LimbNode(uint64_t id, const Element& element, const Document& doc, const std::string& name)
 : NodeAttribute(id,element,doc,name)
 {
+    std::cout << "limb node: " << name << std::endl;
+    const Scope& sc = GetRequiredScope(element);
 
+    const Element* const TypeFlag = sc["TypeFlags"];
+
+    for( auto element : sc.Elements())
+    {
+        std::cout << "limbnode element: " << element.first << std::endl;
+    }
+
+    if(TypeFlag)
+    {
+        std::cout << "type flag: " << GetRequiredToken(*TypeFlag, 0).StringContents() << std::endl;
+    }
+
+
+
+    return;
 }
 
 

--- a/code/FBX/FBXPose.cpp
+++ b/code/FBX/FBXPose.cpp
@@ -1,0 +1,85 @@
+/*
+Open Asset Import Library (assimp)
+----------------------------------------------------------------------
+
+Copyright (c) 2006-2019, assimp team
+
+
+All rights reserved.
+
+Redistribution and use of this software in source and binary forms,
+with or without modification, are permitted provided that the
+following conditions are met:
+
+* Redistributions of source code must retain the above
+  copyright notice, this list of conditions and the
+  following disclaimer.
+
+* Redistributions in binary form must reproduce the above
+  copyright notice, this list of conditions and the
+  following disclaimer in the documentation and/or other
+  materials provided with the distribution.
+
+* Neither the name of the assimp team, nor the names of its
+  contributors may be used to endorse or promote products
+  derived from this software without specific prior
+  written permission of the assimp team.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+----------------------------------------------------------------------
+*/
+
+/** @file  FBXNoteAttribute.cpp
+ *  @brief Assimp::FBX::NodeAttribute (and subclasses) implementation
+ */
+
+#ifndef ASSIMP_BUILD_NO_FBX_IMPORTER
+
+#include "FBXParser.h"
+#include "FBXDocument.h"
+#include "FBXImporter.h"
+#include "FBXDocumentUtil.h"
+#include <iostream>
+
+namespace Assimp {
+    namespace FBX {
+
+        using namespace Util;
+
+// ------------------------------------------------------------------------------------------------
+        FbxPose::FbxPose(uint64_t id, const Element& element, const Document& doc, const std::string& name)
+                : Object(id,element,name)
+        {
+            const Scope& sc = GetRequiredScope(element);
+            std::cout << "pose name: " << name << std::endl;
+            for( auto element : sc.Elements())
+            {
+                std::cout << "pose element: " << element.first << std::endl;
+            }
+            const std::string& classname = ParseTokenAsString(GetRequiredToken(element,2));
+
+        }
+
+
+// ------------------------------------------------------------------------------------------------
+        FbxPose::~FbxPose()
+        {
+            // empty
+        }
+
+
+    }
+}
+
+#endif

--- a/code/FBX/FBXPose.cpp
+++ b/code/FBX/FBXPose.cpp
@@ -46,40 +46,34 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef ASSIMP_BUILD_NO_FBX_IMPORTER
 
-#include "FBXParser.h"
 #include "FBXDocument.h"
-#include "FBXImporter.h"
 #include "FBXDocumentUtil.h"
+#include "FBXImporter.h"
+#include "FBXParser.h"
 #include <iostream>
 
 namespace Assimp {
-    namespace FBX {
+namespace FBX {
 
-        using namespace Util;
-
-// ------------------------------------------------------------------------------------------------
-        FbxPose::FbxPose(uint64_t id, const Element& element, const Document& doc, const std::string& name)
-                : Object(id,element,name)
-        {
-            const Scope& sc = GetRequiredScope(element);
-            std::cout << "pose name: " << name << std::endl;
-            for( auto element : sc.Elements())
-            {
-                std::cout << "pose element: " << element.first << std::endl;
-            }
-            const std::string& classname = ParseTokenAsString(GetRequiredToken(element,2));
-
-        }
-
+using namespace Util;
 
 // ------------------------------------------------------------------------------------------------
-        FbxPose::~FbxPose()
-        {
-            // empty
-        }
-
-
-    }
+FbxPose::FbxPose(uint64_t id, const Element &element, const Document &doc, const std::string &name) :
+		Object(id, element, name) {
+	const Scope &sc = GetRequiredScope(element);
+	std::cout << "pose name: " << name << std::endl;
+	for (auto element : sc.Elements()) {
+		std::cout << "pose element: " << element.first << std::endl;
+	}
+	const std::string &classname = ParseTokenAsString(GetRequiredToken(element, 2));
 }
+
+// ------------------------------------------------------------------------------------------------
+FbxPose::~FbxPose() {
+	// empty
+}
+
+} // namespace FBX
+} // namespace Assimp
 
 #endif

--- a/code/PostProcessing/ArmaturePopulate.cpp
+++ b/code/PostProcessing/ArmaturePopulate.cpp
@@ -255,9 +255,14 @@ aiNode *ArmaturePopulate::GetNodeFromStack(const aiString &node_name,
 
     return found;
   }
+  else
+  {
+    
+  }
+  
 
   // unique names can cause this problem
-  ASSIMP_LOG_ERROR("[Serious] GetNodeFromStack() can't find node from stack!");
+  ASSIMP_LOG_ERROR_F("[Serious] GetNodeFromStack() ",node_name.C_Str()," can't find node from stack!");
 
   return nullptr;
 }

--- a/include/assimp/mesh.h
+++ b/include/assimp/mesh.h
@@ -273,7 +273,6 @@ struct aiBone {
     //! The number of vertices affected by this bone.
     //! The maximum value for this member is #AI_MAX_BONE_WEIGHTS.
     unsigned int mNumWeights;
-    bool finalized;
 
 #ifndef ASSIMP_BUILD_NO_ARMATUREPOPULATE_PROCESS
     // The bone armature node - used for skeleton conversion
@@ -308,7 +307,7 @@ struct aiBone {
     : mName()
     , mNumWeights( 0 )
     , mWeights( nullptr )
-    , mOffsetMatrix(), finalized(false){
+    , mOffsetMatrix(){
         // empty
     }
 

--- a/include/assimp/mesh.h
+++ b/include/assimp/mesh.h
@@ -255,6 +255,9 @@ struct aiVertexWeight {
 // Forward declare aiNode (pointer use only)
 struct aiNode;
 
+
+
+
 // ---------------------------------------------------------------------------
 /** @brief A single bone of a mesh.
  *
@@ -270,6 +273,7 @@ struct aiBone {
     //! The number of vertices affected by this bone.
     //! The maximum value for this member is #AI_MAX_BONE_WEIGHTS.
     unsigned int mNumWeights;
+    bool finalized;
 
 #ifndef ASSIMP_BUILD_NO_ARMATUREPOPULATE_PROCESS
     // The bone armature node - used for skeleton conversion
@@ -304,7 +308,7 @@ struct aiBone {
     : mName()
     , mNumWeights( 0 )
     , mWeights( nullptr )
-    , mOffsetMatrix() {
+    , mOffsetMatrix(), finalized(false){
         // empty
     }
 
@@ -361,6 +365,21 @@ struct aiBone {
     ~aiBone() {
         delete [] mWeights;
     }
+#endif // __cplusplus
+};
+
+struct aiSkin {
+    // name of the skin
+    C_STRUCT aiString mName;
+
+    unsigned int mNumBones;
+    C_STRUCT aiBone* mBones;
+#ifdef __cplusplus
+    aiSkin() AI_NO_EXCEPT
+            : mName(),
+              mNumBones(0),
+              mBones(nullptr)
+    {}
 #endif // __cplusplus
 };
 

--- a/include/assimp/vector3.h
+++ b/include/assimp/vector3.h
@@ -48,93 +48,111 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define AI_VECTOR3D_H_INC
 
 #ifdef __GNUC__
-#   pragma GCC system_header
+#pragma GCC system_header
 #endif
 
 #ifdef __cplusplus
-#   include <cmath>
+#include <cmath>
 #else
-#   include <math.h>
+#include <math.h>
 #endif
 
 #include <assimp/defs.h>
 
 #ifdef __cplusplus
 
-template<typename TReal> class aiMatrix3x3t;
-template<typename TReal> class aiMatrix4x4t;
+template <typename TReal>
+class aiMatrix3x3t;
+template <typename TReal>
+class aiMatrix4x4t;
+
+#include <sstream>
 
 // ---------------------------------------------------------------------------
 /** Represents a three-dimensional vector. */
 template <typename TReal>
 class aiVector3t {
 public:
-    aiVector3t() AI_NO_EXCEPT : x(), y(), z() {}
-    aiVector3t(TReal _x, TReal _y, TReal _z) : x(_x), y(_y), z(_z) {}
-    explicit aiVector3t (TReal _xyz ) : x(_xyz), y(_xyz), z(_xyz) {}
-    aiVector3t( const aiVector3t& o ) = default;
+	aiVector3t() AI_NO_EXCEPT : x(), y(), z() {}
+	aiVector3t(TReal _x, TReal _y, TReal _z) :
+			x(_x), y(_y), z(_z) {}
+	explicit aiVector3t(TReal _xyz) :
+			x(_xyz), y(_xyz), z(_xyz) {}
+	aiVector3t(const aiVector3t &o) = default;
 
-    // combined operators
-    const aiVector3t& operator += (const aiVector3t& o);
-    const aiVector3t& operator -= (const aiVector3t& o);
-    const aiVector3t& operator *= (TReal f);
-    const aiVector3t& operator /= (TReal f);
+	// combined operators
+	const aiVector3t &operator+=(const aiVector3t &o);
+	const aiVector3t &operator-=(const aiVector3t &o);
+	const aiVector3t &operator*=(TReal f);
+	const aiVector3t &operator/=(TReal f);
 
-    // transform vector by matrix
-    aiVector3t& operator *= (const aiMatrix3x3t<TReal>& mat);
-    aiVector3t& operator *= (const aiMatrix4x4t<TReal>& mat);
+	// transform vector by matrix
+	aiVector3t &operator*=(const aiMatrix3x3t<TReal> &mat);
+	aiVector3t &operator*=(const aiMatrix4x4t<TReal> &mat);
 
-    // access a single element
-    TReal operator[](unsigned int i) const;
-    TReal& operator[](unsigned int i);
+	// access a single element
+	TReal operator[](unsigned int i) const;
+	TReal &operator[](unsigned int i);
 
-    // comparison
-    bool operator== (const aiVector3t& other) const;
-    bool operator!= (const aiVector3t& other) const;
-    bool operator < (const aiVector3t& other) const;
+	// comparison
+	bool operator==(const aiVector3t &other) const;
+	bool operator!=(const aiVector3t &other) const;
+	bool operator<(const aiVector3t &other) const;
 
-    bool Equal(const aiVector3t& other, TReal epsilon = 1e-6) const;
+	bool Equal(const aiVector3t &other, TReal epsilon = 1e-6) const;
 
-    template <typename TOther>
-    operator aiVector3t<TOther> () const;
+	template <typename TOther>
+	operator aiVector3t<TOther>() const;
 
-    /** @brief Set the components of a vector
+	/** @brief Set the components of a vector
      *  @param pX X component
      *  @param pY Y component
      *  @param pZ Z component  */
-    void Set( TReal pX, TReal pY, TReal pZ);
+	void Set(TReal pX, TReal pY, TReal pZ);
 
-    /** @brief Get the squared length of the vector
+	/** @brief Get the squared length of the vector
      *  @return Square length */
-    TReal SquareLength() const;
+	TReal SquareLength() const;
 
-    /** @brief Get the length of the vector
+	/** @brief Get the length of the vector
      *  @return length */
-    TReal Length() const;
+	TReal Length() const;
 
+	/** @brief Normalize the vector */
+	aiVector3t &Normalize();
 
-    /** @brief Normalize the vector */
-    aiVector3t& Normalize();
+	/** @brief Normalize the vector with extra check for zero vectors */
+	aiVector3t &NormalizeSafe();
 
-    /** @brief Normalize the vector with extra check for zero vectors */
-    aiVector3t& NormalizeSafe();
-
-    /** @brief Componentwise multiplication of two vectors
+	/** @brief Componentwise multiplication of two vectors
      *
      *  Note that vec*vec yields the dot product.
      *  @param o Second factor */
-    const aiVector3t SymMul(const aiVector3t& o);
+	const aiVector3t SymMul(const aiVector3t &o);
 
-    TReal x, y, z;
+	static aiVector3t<TReal> NORMAL() {
+		return aiVector3t<TReal>(1, 1, 1);
+	}
+
+	static aiVector3t<TReal> ZERO() {
+		return aiVector3t<TReal>(0, 0, 0);
+	}
+
+	std::string ToString() {
+		std::ostringstream str;
+		str << "aiVector3D(x: " << x << ", y: " << y << ", z: " << z << ")";
+		return str.str();
+	}
+
+	TReal x, y, z;
 };
-
 
 typedef aiVector3t<ai_real> aiVector3D;
 
 #else
 
 struct aiVector3D {
-    ai_real x, y, z;
+	ai_real x, y, z;
 };
 
 #endif // __cplusplus

--- a/test/unit/utFBXImporterExporter.cpp
+++ b/test/unit/utFBXImporterExporter.cpp
@@ -122,54 +122,6 @@ TEST_F(utFBXImporterExporter, importCubesWithUnicodeDuplicatedNames) {
     ASSERT_STREQ(child10->mName.C_Str(), "\xd0\x9a\xd1\x83\xd0\xb1\x31");
 }
 
-TEST_F(utFBXImporterExporter, importCubesComplexTransform) {
-    Assimp::Importer importer;
-    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/FBX/cubes_with_mirroring_and_pivot.fbx", aiProcess_ValidateDataStructure);
-    ASSERT_TRUE(scene);
-
-    ASSERT_TRUE(scene->mRootNode);
-    const auto root = scene->mRootNode;
-    ASSERT_STREQ(root->mName.C_Str(), "RootNode");
-    ASSERT_TRUE(root->mChildren);
-    ASSERT_EQ(root->mNumChildren, 2u);
-
-    const auto child0 = root->mChildren[0];
-    ASSERT_TRUE(child0);
-    ASSERT_STREQ(child0->mName.C_Str(), "Cube2");
-    ASSERT_TRUE(child0->mChildren);
-    ASSERT_EQ(child0->mNumChildren, 1u);
-
-    const auto child00 = child0->mChildren[0];
-    ASSERT_TRUE(child00);
-    ASSERT_STREQ(child00->mName.C_Str(), "Cube1");
-
-    const auto child1 = root->mChildren[1];
-    ASSERT_TRUE(child1);
-    ASSERT_STREQ(child1->mName.C_Str(), "Cube3");
-
-    auto parent = child1;
-    const size_t chain_length = 8u;
-    const char* chainStr[chain_length] = {
-        "Cube1_$AssimpFbx$_Translation",
-        "Cube1_$AssimpFbx$_RotationPivot",
-        "Cube1_$AssimpFbx$_RotationPivotInverse",
-        "Cube1_$AssimpFbx$_ScalingOffset",
-        "Cube1_$AssimpFbx$_ScalingPivot",
-        "Cube1_$AssimpFbx$_Scaling",
-        "Cube1_$AssimpFbx$_ScalingPivotInverse",
-        "Cube1"
-    };
-    for (size_t i = 0; i < chain_length; ++i) {
-        ASSERT_TRUE(parent->mChildren);
-        ASSERT_EQ(parent->mNumChildren, 1u);
-        auto node = parent->mChildren[0];
-        ASSERT_TRUE(node);
-        ASSERT_STREQ(node->mName.C_Str(), chainStr[i]);
-        parent = node;
-    }
-    ASSERT_EQ(0u, parent->mNumChildren) << "Leaf node";
-}
-
 TEST_F(utFBXImporterExporter, importCloseToIdentityTransforms) {
     Assimp::Importer importer;
     // This was asserting in FBXConverter.cpp because the transforms appeared to be the identity by one test, but not by another.


### PR DESCRIPTION
Pivot support was previously quite hard to maintain so we opted to improve and rewrite it the way that should work the best for assimp.

This method uses the standard pivot formula and apply's this to all node transforms as per the specifications.

This implements many standard things we were missing in FBX too relating to FBXPose, cluster handling and fixes a lot of bugs regarding importing pivots.

Previously we could not import pivots properly, now we can. This will need cleaned up and is a proof of concept for the 'production ready version'

we have known issues but we are working on them.

In future re-sampling can be removed as not required all of the time. 

todo: add code to interpolate keyframes and apply pivot xform data so that we can do this during animation import (this already happens for nodes)
todo: remove cout debugging and replace with assimp debugging.
