### PR TITLE
fixes #2421

### DIFF
--- a/code/Irr/IRRLoader.cpp
+++ b/code/Irr/IRRLoader.cpp
@@ -629,7 +629,7 @@ void SetupMapping (aiMaterial* mat, aiTextureMapping mode, const aiVector3D& axi
                 p.push_back(m);
             }
         }
-        else if (! ::strcmp( prop->mKey.data, "$tex.uvwsrc"))   {
+        else if (! ::strcmp( prop->mKey.data, _AI_MATKEY_UVWSRC_BASE))   {
             delete mat->mProperties[i];
         }
         else p.push_back(prop);

--- a/code/PostProcessing/TextureTransform.cpp
+++ b/code/PostProcessing/TextureTransform.cpp
@@ -253,7 +253,7 @@ void TextureTransformStep::Execute( aiScene* pScene)
                         continue;
                     }
 
-                    if ( !::strcmp( prop2->mKey.data, "$tex.uvwsrc")) {
+                    if ( !::strcmp( prop2->mKey.data, _AI_MATKEY_UVWSRC_BASE)) {
                         info.uvIndex = *((int*)prop2->mData);
 
                         // Store a direct pointer for later use

--- a/code/PostProcessing/ValidateDataStructure.cpp
+++ b/code/PostProcessing/ValidateDataStructure.cpp
@@ -639,7 +639,7 @@ void ValidateDSProcess::SearchForInvalidTextures(const aiMaterial* pMaterial,
             }
 			//mappings[prop->mIndex] = ((aiUVTransform*)prop->mData);
         }
-        else if (!::strcmp(prop->mKey.data,"$tex.uvwsrc")) {
+        else if (!::strcmp(prop->mKey.data,_AI_MATKEY_UVWSRC_BASE)) {
             if (aiPTI_Integer != prop->mType || sizeof(int) > prop->mDataLength)
             {
                 ReportError("Material property %s%i is expected to be an integer (size is %i)",

--- a/include/assimp/material.h
+++ b/include/assimp/material.h
@@ -949,7 +949,7 @@ extern "C" {
 // Pure key names for all texture-related properties
 //! @cond MATS_DOC_FULL
 #define _AI_MATKEY_TEXTURE_BASE         "$tex.file"
-#define _AI_MATKEY_UVWSRC_BASE          "$tex.uvwsrc"
+#define _AI_MATKEY_UVWSRC_BASE          "$tex.file.texCoord"
 #define _AI_MATKEY_TEXOP_BASE           "$tex.op"
 #define _AI_MATKEY_MAPPING_BASE         "$tex.mapping"
 #define _AI_MATKEY_TEXBLEND_BASE        "$tex.blend"

--- a/port/AssimpDelphi/aiMaterial.pas
+++ b/port/AssimpDelphi/aiMaterial.pas
@@ -136,7 +136,7 @@ const AI_MATKEY_COLOR_REFLECTIVE = '$clr.reflective';
 const AI_MATKEY_GLOBAL_BACKGROUND_IMAGE = '?bg.global';
 
 const _AI_MATKEY_TEXTURE_BASE = '$tex.file';
-const _AI_MATKEY_UVWSRC_BASE = '$tex.uvwsrc';
+const _AI_MATKEY_UVWSRC_BASE = '$tex.file.texCoord';
 const _AI_MATKEY_TEXOP_BASE = '$tex.op';
 const _AI_MATKEY_MAPPING_BASE = '$tex.mapping';
 const _AI_MATKEY_TEXBLEND_BASE = '$tex.blend';


### PR DESCRIPTION
so `SetMaterialTextureProperty` in glTF2Importer.cpp does this:
```
        mat->AddProperty(&uri, AI_MATKEY_TEXTURE(texType, texSlot));
        mat->AddProperty(&prop.texCoord, 1, AI_MATKEY_GLTF_TEXTURE_TEXCOORD(texType, texSlot));
```
where `AI_MATKEY_GLTF_TEXTURE_TEXCOORD` is defined in pbrmaterial.h as:
```
#define _AI_MATKEY_GLTF_TEXTURE_TEXCOORD_BASE "$tex.file.texCoord"
...
#define AI_MATKEY_GLTF_TEXTURE_TEXCOORD(type, N) _AI_MATKEY_GLTF_TEXTURE_TEXCOORD_BASE, type, N
```
meanwhile glTF2Exporter.cpp does this:
```
    std::string textureKey = std::string(_AI_MATKEY_TEXTURE_BASE) + "." + propName;

    mat->Get(textureKey.c_str(), tt, slot, prop);
```
where `_AI_MATKEY_TEXTURE_BASE` is defined in material.h as
```
#define _AI_MATKEY_TEXTURE_BASE         "$tex.file"
```
so the above evaluates to `$tex.file.texCoord` string.

Meanwhile `_AI_MATKEY_UVWSRC_BASE` is defined in the same material.h as
```
#define _AI_MATKEY_UVWSRC_BASE          "$tex.uvwsrc"
```

The most obvious way to fix this would be therefor:
```
#define _AI_MATKEY_UVWSRC_BASE          "$tex.file.texCoord"
```

This breaks a couple of places where the old value is used explicitly, I think. I tred to find them, but see for yourself.