### PR TITLE
Fix PlyExporter to support faces with 0 vertices

### DIFF
--- a/code/Ply/PlyExporter.cpp
+++ b/code/Ply/PlyExporter.cpp
@@ -373,10 +373,11 @@ void PlyExporter::WriteMeshIndices(const aiMesh* m, unsigned int offset)
 {
     for (unsigned int i = 0; i < m->mNumFaces; ++i) {
         const aiFace& f = m->mFaces[i];
-        mOutput << f.mNumIndices << " ";
+        mOutput << f.mNumIndices;
         for(unsigned int c = 0; c < f.mNumIndices; ++c) {
-            mOutput << (f.mIndices[c] + offset) << (c == f.mNumIndices-1 ? endl : " ");
+            mOutput << " " << (f.mIndices[c] + offset);
         }
+        mOutput << endl;
     }
 }
 


### PR DESCRIPTION
The Ply format standard doesn't preclude Ply files from containing faces with 0 vertices. In the current existing code, faces with 0 vertices are being written incorrectly because the for loop would never write the endline character if the number of indices was 0. 
This change fixes that behavior by writing a space character before each index and then adding the endline character outside of the loop.