### PR TITLE
Fix possible null pointer exception on scene metadata when exporting a glTF2 file

### DIFF
--- a/code/glTF2/glTF2Exporter.cpp
+++ b/code/glTF2/glTF2Exporter.cpp
@@ -1000,7 +1000,7 @@ void glTF2Exporter::ExportMetadata()
 
     // Copyright
 	aiString copyright_str;
-	if (mScene->mMetaData->Get(AI_METADATA_SOURCE_COPYRIGHT, copyright_str)) {
+	if (mScene->mMetaData != nullptr && mScene->mMetaData->Get(AI_METADATA_SOURCE_COPYRIGHT, copyright_str)) {
         asset.copyright = copyright_str.C_Str();
 	}
 }


### PR DESCRIPTION
Hello,

The glTF2 exporter crashes if the scene has no metadata (since commit 986b6780 on 9th december). I have just added a check to avoid that.

Loïc