### PR TITLE
Add all shipped .blend files to unit tests

### DIFF
--- a/test/unit/utBlenderImportExport.cpp
+++ b/test/unit/utBlenderImportExport.cpp
@@ -60,3 +60,175 @@ public:
 TEST_F( utBlenderImporterExporter, importBlenFromFileTest ) {
     EXPECT_TRUE( importerTest() );
 }
+
+
+TEST( utBlenderImporter, import4cubes ) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/BLEND/4Cubes4Mats_248.blend", aiProcess_ValidateDataStructure);
+    // FIXME: this is probably not right, loading this should succeed
+    ASSERT_EQ(nullptr, scene);
+}
+
+
+TEST( utBlenderImporter, import269_regress1 ) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/BLEND/blender_269_regress1.blend", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+}
+
+
+TEST( utBlenderImporter, importBlenderDefault248 ) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/BLEND/BlenderDefault_248.blend", aiProcess_ValidateDataStructure);
+    // FIXME: this is probably not right, loading this should succeed
+    ASSERT_EQ(nullptr, scene);
+}
+
+
+TEST( utBlenderImporter, importBlenderDefault250 ) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/BLEND/BlenderDefault_250.blend", aiProcess_ValidateDataStructure);
+    // FIXME: this is probably not right, loading this should succeed
+    ASSERT_EQ(nullptr, scene);
+}
+
+
+TEST( utBlenderImporter, importBlenderDefault250Compressed ) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/BLEND/BlenderDefault_250_Compressed.blend", aiProcess_ValidateDataStructure);
+    // FIXME: this is probably not right, loading this should succeed
+    ASSERT_EQ(nullptr, scene);
+}
+
+
+TEST( utBlenderImporter, importBlenderDefault262 ) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/BLEND/BlenderDefault_262.blend", aiProcess_ValidateDataStructure);
+    // FIXME: this is probably not right, loading this should succeed
+    ASSERT_EQ(nullptr, scene);
+}
+
+
+TEST( utBlenderImporter, importBlenderDefault269 ) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/BLEND/BlenderDefault_269.blend", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+}
+
+
+TEST( utBlenderImporter, importBlenderDefault271 ) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/BLEND/BlenderDefault_271.blend", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+}
+
+
+TEST( utBlenderImporter, importCubeHierarchy_248 ) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/BLEND/CubeHierarchy_248.blend", aiProcess_ValidateDataStructure);
+    // FIXME: this is probably not right, loading this should succeed
+    ASSERT_EQ(nullptr, scene);
+}
+
+
+TEST( utBlenderImporter, importHuman ) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/BLEND/HUMAN.blend", aiProcess_ValidateDataStructure);
+    // FIXME: this is probably not right, loading this should succeed
+    ASSERT_EQ(nullptr, scene);
+}
+
+
+TEST( utBlenderImporter, importMirroredCube_252 ) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/BLEND/MirroredCube_252.blend", aiProcess_ValidateDataStructure);
+    // FIXME: this is probably not right, loading this should succeed
+    ASSERT_EQ(nullptr, scene);
+}
+
+
+TEST( utBlenderImporter, importNoisyTexturedCube_VoronoiGlob_248 ) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/BLEND/NoisyTexturedCube_VoronoiGlob_248.blend", aiProcess_ValidateDataStructure);
+    // FIXME: this is probably not right, loading this should succeed
+    ASSERT_EQ(nullptr, scene);
+}
+
+
+TEST( utBlenderImporter, importSmoothVsSolidCube_248 ) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/BLEND/SmoothVsSolidCube_248.blend", aiProcess_ValidateDataStructure);
+    // FIXME: this is probably not right, loading this should succeed
+    ASSERT_EQ(nullptr, scene);
+}
+
+
+TEST( utBlenderImporter, importSuzanne_248 ) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/BLEND/Suzanne_248.blend", aiProcess_ValidateDataStructure);
+    // FIXME: this is probably not right, loading this should succeed
+    ASSERT_EQ(nullptr, scene);
+}
+
+
+TEST( utBlenderImporter, importSuzanneSubdiv_252 ) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/BLEND/SuzanneSubdiv_252.blend", aiProcess_ValidateDataStructure);
+    // FIXME: this is probably not right, loading this should succeed
+    ASSERT_EQ(nullptr, scene);
+}
+
+
+TEST( utBlenderImporter, importTexturedCube_ImageGlob_248 ) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/BLEND/TexturedCube_ImageGlob_248.blend", aiProcess_ValidateDataStructure);
+    // FIXME: this is probably not right, loading this should succeed
+    ASSERT_EQ(nullptr, scene);
+}
+
+
+TEST( utBlenderImporter, importTexturedPlane_ImageUv_248 ) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/BLEND/TexturedPlane_ImageUv_248.blend", aiProcess_ValidateDataStructure);
+    // FIXME: this is probably not right, loading this should succeed
+    ASSERT_EQ(nullptr, scene);
+}
+
+
+TEST( utBlenderImporter, importTexturedPlane_ImageUvPacked_248 ) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/BLEND/TexturedPlane_ImageUvPacked_248.blend", aiProcess_ValidateDataStructure);
+    // FIXME: this is probably not right, loading this should succeed
+    ASSERT_EQ(nullptr, scene);
+}
+
+
+TEST( utBlenderImporter, importTorusLightsCams_250_compressed ) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/BLEND/TorusLightsCams_250_compressed.blend", aiProcess_ValidateDataStructure);
+    // FIXME: this is probably not right, loading this should succeed
+    ASSERT_EQ(nullptr, scene);
+}
+
+
+TEST( utBlenderImporter, import_yxa_1 ) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/BLEND/yxa_1.blend", aiProcess_ValidateDataStructure);
+    // FIXME: this is probably not right, loading this should succeed
+    ASSERT_EQ(nullptr, scene);
+}
+
+
+TEST( utBlenderImporter, importBob ) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_NONBSD_DIR "/BLEND/Bob.blend", aiProcess_ValidateDataStructure);
+    // FIXME: this is probably not right, loading this should succeed
+    ASSERT_EQ(nullptr, scene);
+}
+
+
+TEST( utBlenderImporter, importFleurOptonl ) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_NONBSD_DIR "/BLEND/fleurOptonl.blend", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+}


### PR DESCRIPTION
Many of these currently fail and at least some of them appear to be unchanged from when they were added to the repository. I tried some of them in Blender 2.80 with mixed results. `Bob.blend` crashes blender whereas `TorusLightsCams_250_compressed.blend` loads successfullly in Blender but not in assimp. I have no idea what's going on here and have just codified the current behavior as expected. At least now we'll notice if their status changes.