### PR TITLE
Re-throw exception

### DIFF
--- a/code/FBX/FBXConverter.cpp
+++ b/code/FBX/FBXConverter.cpp
@@ -1566,7 +1566,7 @@ namespace Assimp {
             }
             catch (std::exception&e) {
                 std::for_each(bones.begin(), bones.end(), Util::delete_fun<aiBone>());
-                throw;
+                throw e;
             }
 
             if (bones.empty()) {


### PR DESCRIPTION
Fixes MSVC++ warning C4101: 'e': unreferenced local variable