### PR TITLE
Removed name of unreferenced local variable in catch block

### DIFF
--- a/code/FBX/FBXConverter.cpp
+++ b/code/FBX/FBXConverter.cpp
@@ -1564,7 +1564,7 @@ namespace Assimp {
 
                 bone_map.clear();
             }
-            catch (std::exception&e) {
+            catch (std::exception&) {
                 std::for_each(bones.begin(), bones.end(), Util::delete_fun<aiBone>());
                 throw;
             }


### PR DESCRIPTION
Fixes MSVC++ warning C4101: 'e': unreferenced local variable