### PR TITLE
Fixed a bunch of clang warnings

### DIFF
--- a/code/COB/COBLoader.cpp
+++ b/code/COB/COBLoader.cpp
@@ -250,7 +250,7 @@ aiNode* COBImporter::BuildNodes(const Node& root,const Scene& scin,aiScene* fill
         const Mesh& ndmesh = (const Mesh&)(root);
         if (ndmesh.vertex_positions.size() && ndmesh.texture_coords.size()) {
 
-            typedef std::pair<unsigned int,Mesh::FaceRefList> Entry;
+            typedef std::pair<const unsigned int,Mesh::FaceRefList> Entry;
             for(const Entry& reflist : ndmesh.temp_map) {
                 {   // create mesh
                     size_t n = 0;

--- a/code/Importer/IFC/IFCCurve.cpp
+++ b/code/Importer/IFC/IFCCurve.cpp
@@ -323,7 +323,7 @@ public:
         // oh well.
         bool have_param = false, have_point = false;
         IfcVector3 point;
-        for(const Entry sel :entity.Trim1) {
+        for(const Entry& sel :entity.Trim1) {
             if (const ::Assimp::STEP::EXPRESS::REAL* const r = sel->ToPtr<::Assimp::STEP::EXPRESS::REAL>()) {
                 range.first = *r;
                 have_param = true;
@@ -340,7 +340,7 @@ public:
             }
         }
         have_param = false, have_point = false;
-        for(const Entry sel :entity.Trim2) {
+        for(const Entry& sel :entity.Trim2) {
             if (const ::Assimp::STEP::EXPRESS::REAL* const r = sel->ToPtr<::Assimp::STEP::EXPRESS::REAL>()) {
                 range.second = *r;
                 have_param = true;

--- a/code/MDL/MDLLoader.cpp
+++ b/code/MDL/MDLLoader.cpp
@@ -1421,7 +1421,7 @@ void MDLImporter::InternReadFile_3DGS_MDL7( )
         avOutList[i].reserve(3);
 
     // buffer to held the names of all groups in the file
-	const size_t buffersize( AI_MDL7_MAX_GROUPNAMESIZE*pcHeader->groups_num );
+    const size_t buffersize(AI_MDL7_MAX_GROUPNAMESIZE*pcHeader->groups_num);
 	char* aszGroupNameBuffer = new char[ buffersize ];
 
     // read all groups

--- a/code/MDL/MDLLoader.cpp
+++ b/code/MDL/MDLLoader.cpp
@@ -1422,10 +1422,10 @@ void MDLImporter::InternReadFile_3DGS_MDL7( )
 
     // buffer to held the names of all groups in the file
     const size_t buffersize(AI_MDL7_MAX_GROUPNAMESIZE*pcHeader->groups_num);
-	char* aszGroupNameBuffer = new char[ buffersize ];
+    char* aszGroupNameBuffer = new char[ buffersize ];
 
     // read all groups
-    for (unsigned int iGroup = 0; iGroup < (unsigned int)pcHeader->groups_num;++iGroup) {
+    for (unsigned int iGroup = 0; iGroup < (unsigned int)pcHeader->groups_num; ++iGroup) {
         MDL::IntGroupInfo_MDL7 groupInfo((BE_NCONST MDL::Group_MDL7*)szCurrent,iGroup);
         szCurrent = (const unsigned char*)(groupInfo.pcGroup+1);
 

--- a/code/XGL/XGLLoader.cpp
+++ b/code/XGL/XGLLoader.cpp
@@ -685,7 +685,7 @@ bool XGLImporter::ReadMesh(TempScope& scope)
     }
 
     // finally extract output meshes and add them to the scope
-    typedef std::pair<unsigned int, TempMaterialMesh> pairt;
+    typedef std::pair<const unsigned int, TempMaterialMesh> pairt;
     for(const pairt& p : bymat) {
         aiMesh* const m  = ToOutputMesh(p.second);
         scope.meshes_linear.push_back(m);


### PR DESCRIPTION
1. Fix misleading indentation warnings.
2. Fix creating a temporary const copy when iterating over a map (thanks to range analysis warnings)
3. Fix creating a copy when iterating over a range without reference qualifier (also thanks to range analysis warnings)

Closes #2975 