### PR TITLE
Fixed mValues allocated twice in SceneCombiner.cpp.

### DIFF
--- a/code/Common/SceneCombiner.cpp
+++ b/code/Common/SceneCombiner.cpp
@@ -1312,7 +1312,6 @@ void SceneCombiner::Copy(aiMetadata** _dest, const aiMetadata* src) {
     aiMetadata* dest = *_dest = aiMetadata::Alloc( src->mNumProperties );
     std::copy(src->mKeys, src->mKeys + src->mNumProperties, dest->mKeys);
 
-    dest->mValues = new aiMetadataEntry[src->mNumProperties];
     for (unsigned int i = 0; i < src->mNumProperties; ++i) {
         aiMetadataEntry& in = src->mValues[i];
         aiMetadataEntry& out = dest->mValues[i];


### PR DESCRIPTION
`dest` is allocated from `aiMetadata::Alloc`, which returns an `aiMetadata` instance will all members allocated, including `dest->mValues`. See the following code below.

https://github.com/assimp/assimp/blob/78b074ac5aa3ff3573675d49d154b358ba8e9700/code/Common/SceneCombiner.cpp#L1312-L1315

`dest->mValues` is allocated again, which makes it lose track of the previously allocated memory and results in a memory leak.

