### PR TITLE
Use the translation matrix in gltf2 cameras for aiCamera.mPosition

### DIFF
--- a/code/glTF2/glTF2Importer.cpp
+++ b/code/glTF2/glTF2Importer.cpp
@@ -925,6 +925,11 @@ aiNode *ImportNode(aiScene *pScene, glTF2::Asset &r, std::vector<unsigned int> &
 
 	if (node.camera) {
 		pScene->mCameras[node.camera.GetIndex()]->mName = ainode->mName;
+		if (node.translation.isPresent) {
+			aiVector3D trans;
+			CopyValue(node.translation.value, trans);
+			pScene->mCameras[node.camera.GetIndex()]->mPosition = trans;
+		}
 	}
 
 	if (node.light) {


### PR DESCRIPTION
In gltf2, camera positions are specified in nodes by transforms, whilst other data such as projection and perspective are stored in the camera part itself. This sets the `aiCamera.mPosition` to be the translation specified in the camera's node, if any. An example of a file which might do this can be seen [here](https://github.com/KhronosGroup/glTF-Sample-Models/blob/master/2.0/Cameras/glTF/Cameras.gltf)