### PR TITLE
Fixed TextureTypeToString defined multiple times.

### DIFF
--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -198,6 +198,7 @@ SET( Common_SRCS
   Common/CreateAnimMesh.cpp
   Common/simd.h
   Common/simd.cpp
+  Common/material.cpp
 )
 SOURCE_GROUP(Common FILES ${Common_SRCS})
 

--- a/code/Common/material.cpp
+++ b/code/Common/material.cpp
@@ -1,0 +1,97 @@
+/*
+Open Asset Import Library (assimp)
+----------------------------------------------------------------------
+
+Copyright (c) 2006-2020, assimp team
+
+
+All rights reserved.
+
+Redistribution and use of this software in source and binary forms,
+with or without modification, are permitted provided that the
+following conditions are met:
+
+* Redistributions of source code must retain the above
+  copyright notice, this list of conditions and the
+  following disclaimer.
+
+* Redistributions in binary form must reproduce the above
+  copyright notice, this list of conditions and the
+  following disclaimer in the documentation and/or other
+  materials provided with the distribution.
+
+* Neither the name of the assimp team, nor the names of its
+  contributors may be used to endorse or promote products
+  derived from this software without specific prior
+  written permission of the assimp team.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+----------------------------------------------------------------------
+*/
+
+/// @file material.cpp
+/** Implement common material related functions. */
+
+#include <assimp/ai_assert.h>
+#include <assimp/material.h>
+
+// -------------------------------------------------------------------------------
+const char* TextureTypeToString(aiTextureType in)
+{
+    switch (in)
+    {
+    case aiTextureType_NONE:
+        return "n/a";
+    case aiTextureType_DIFFUSE:
+        return "Diffuse";
+    case aiTextureType_SPECULAR:
+        return "Specular";
+    case aiTextureType_AMBIENT:
+        return "Ambient";
+    case aiTextureType_EMISSIVE:
+        return "Emissive";
+    case aiTextureType_OPACITY:
+        return "Opacity";
+    case aiTextureType_NORMALS:
+        return "Normals";
+    case aiTextureType_HEIGHT:
+        return "Height";
+    case aiTextureType_SHININESS:
+        return "Shininess";
+    case aiTextureType_DISPLACEMENT:
+        return "Displacement";
+    case aiTextureType_LIGHTMAP:
+        return "Lightmap";
+    case aiTextureType_REFLECTION:
+        return "Reflection";
+    case aiTextureType_BASE_COLOR:
+        return "BaseColor";
+    case aiTextureType_NORMAL_CAMERA:
+        return "NormalCamera";
+    case aiTextureType_EMISSION_COLOR:
+        return "EmissionColor";
+    case aiTextureType_METALNESS:
+        return "Metalness";
+    case aiTextureType_DIFFUSE_ROUGHNESS:
+        return "DiffuseRoughness";
+    case aiTextureType_AMBIENT_OCCLUSION:
+        return "AmbientOcclusion";
+    case aiTextureType_UNKNOWN:
+        return "Unknown";
+    default:
+        break;
+    }
+    ai_assert(false);
+    return "BUG";
+}

--- a/code/PostProcessing/ProcessHelper.cpp
+++ b/code/PostProcessing/ProcessHelper.cpp
@@ -230,46 +230,6 @@ VertexWeightTable* ComputeVertexBoneWeightTable(const aiMesh* pMesh)
     return avPerVertexWeights;
 }
 
-
-// -------------------------------------------------------------------------------
-const char* TextureTypeToString(aiTextureType in)
-{
-    switch (in)
-    {
-    case aiTextureType_NONE:
-        return "n/a";
-    case aiTextureType_DIFFUSE:
-        return "Diffuse";
-    case aiTextureType_SPECULAR:
-        return "Specular";
-    case aiTextureType_AMBIENT:
-        return "Ambient";
-    case aiTextureType_EMISSIVE:
-        return "Emissive";
-    case aiTextureType_OPACITY:
-        return "Opacity";
-    case aiTextureType_NORMALS:
-        return "Normals";
-    case aiTextureType_HEIGHT:
-        return "Height";
-    case aiTextureType_SHININESS:
-        return "Shininess";
-    case aiTextureType_DISPLACEMENT:
-        return "Displacement";
-    case aiTextureType_LIGHTMAP:
-        return "Lightmap";
-    case aiTextureType_REFLECTION:
-        return "Reflection";
-    case aiTextureType_UNKNOWN:
-        return "Unknown";
-    default:
-        break;
-    }
-
-    ai_assert(false);
-    return  "BUG";
-}
-
 // -------------------------------------------------------------------------------
 const char* MappingTypeToString(aiTextureMapping in)
 {

--- a/code/PostProcessing/ProcessHelper.h
+++ b/code/PostProcessing/ProcessHelper.h
@@ -316,12 +316,6 @@ typedef std::vector <PerVertexWeight> VertexWeightTable;
 // Compute a per-vertex bone weight table
 VertexWeightTable* ComputeVertexBoneWeightTable(const aiMesh* pMesh);
 
-
-// -------------------------------------------------------------------------------
-// Get a string for a given aiTextureType
-const char* TextureTypeToString(aiTextureType in);
-
-
 // -------------------------------------------------------------------------------
 // Get a string for a given aiTextureMapping
 const char* MappingTypeToString(aiTextureMapping in);

--- a/include/assimp/material.h
+++ b/include/assimp/material.h
@@ -312,6 +312,10 @@ enum aiTextureType
 
 #define AI_TEXTURE_TYPE_MAX  aiTextureType_UNKNOWN
 
+// -------------------------------------------------------------------------------
+// Get a string for a given aiTextureType
+ASSIMP_API const char* TextureTypeToString(enum aiTextureType in);
+
 // ---------------------------------------------------------------------------
 /** @brief Defines all shading models supported by the library
  *

--- a/tools/assimp_cmd/Info.cpp
+++ b/tools/assimp_cmd/Info.cpp
@@ -444,6 +444,12 @@ int Assimp_Info (const char* const* params, unsigned int num) {
 			aiTextureType_DISPLACEMENT,
 			aiTextureType_LIGHTMAP,
 			aiTextureType_REFLECTION,
+			aiTextureType_BASE_COLOR,
+			aiTextureType_NORMAL_CAMERA,
+			aiTextureType_EMISSION_COLOR,
+			aiTextureType_METALNESS,
+			aiTextureType_DIFFUSE_ROUGHNESS,
+			aiTextureType_AMBIENT_OCCLUSION,
 			aiTextureType_UNKNOWN
 		};
 		for(unsigned int type = 0; type < sizeof(types)/sizeof(types[0]); ++type) {

--- a/tools/assimp_cmd/WriteDump.cpp
+++ b/tools/assimp_cmd/WriteDump.cpp
@@ -69,44 +69,6 @@ const char* AICMD_MSG_DUMP_HELP =
 FILE* out = NULL;
 bool shortened = false;
 
-// -------------------------------------------------------------------------------
-const char* TextureTypeToString(aiTextureType in)
-{
-	switch (in)
-	{
-	case aiTextureType_NONE:
-		return "n/a";
-	case aiTextureType_DIFFUSE:
-		return "Diffuse";
-	case aiTextureType_SPECULAR:
-		return "Specular";
-	case aiTextureType_AMBIENT:
-		return "Ambient";
-	case aiTextureType_EMISSIVE:
-		return "Emissive";
-	case aiTextureType_OPACITY:
-		return "Opacity";
-	case aiTextureType_NORMALS:
-		return "Normals";
-	case aiTextureType_HEIGHT:
-		return "Height";
-	case aiTextureType_SHININESS:
-		return "Shininess";
-	case aiTextureType_DISPLACEMENT:
-		return "Displacement";
-	case aiTextureType_LIGHTMAP:
-		return "Lightmap";
-	case aiTextureType_REFLECTION:
-		return "Reflection";
-	case aiTextureType_UNKNOWN:
-		return "Unknown";
-	default:
-		break;
-	}
-	ai_assert(false); 
-	return  "BUG";    
-}
-
 // -----------------------------------------------------------------------------------
 int Assimp_Dump (const char* const* params, unsigned int num)
 {


### PR DESCRIPTION
[Link to issue](https://github.com/assimp/assimp/issues/2964).

- Moved TextureTypeToString to it's own file.
- Added new file to CMakeLists.txt.
- Added 6 missing values in TextureTypeToString.
- Added 6 missing aiTextureType enum values in assimp_cmd/Info.cpp.