### PR TITLE
Keep post-processor intentions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -71,7 +71,7 @@ IncludeCategories:
     Priority:        3
 # IncludeIsMainRegex: '(Test)?$'
 IndentCaseLabels: true
-# IndentPPDirectives: None
+IndentPPDirectives: AfterHash
 IndentWidth:     4
 # IndentWrappedFunctionNames: false
 # JavaScriptQuotes: Leave


### PR DESCRIPTION
-  Update clang.format to keep formatting of hashes in include file to optimize readabilaty.