### PR TITLE
Fix to read orthographic camera data

### DIFF
--- a/code/glTF2/glTF2Asset.inl
+++ b/code/glTF2/glTF2Asset.inl
@@ -1087,10 +1087,10 @@ inline void Camera::Read(Value& obj, Asset& /*r*/)
         cameraProperties.perspective.znear       = MemberOrDefault(*it, "znear", 0.01f);
     }
     else {
-        cameraProperties.ortographic.xmag  = MemberOrDefault(obj, "xmag", 1.f);
-        cameraProperties.ortographic.ymag  = MemberOrDefault(obj, "ymag", 1.f);
-        cameraProperties.ortographic.zfar  = MemberOrDefault(obj, "zfar", 100.f);
-        cameraProperties.ortographic.znear = MemberOrDefault(obj, "znear", 0.01f);
+        cameraProperties.ortographic.xmag  = MemberOrDefault(*it, "xmag", 1.f);
+        cameraProperties.ortographic.ymag  = MemberOrDefault(*it, "ymag", 1.f);
+        cameraProperties.ortographic.zfar  = MemberOrDefault(*it, "zfar", 100.f);
+        cameraProperties.ortographic.znear = MemberOrDefault(*it, "znear", 0.01f);
     }
 }
 

--- a/code/glTF2/glTF2Importer.cpp
+++ b/code/glTF2/glTF2Importer.cpp
@@ -715,6 +715,7 @@ void glTF2Importer::ImportCameras(glTF2::Asset &r) {
 			aicam->mClipPlaneFar = cam.cameraProperties.ortographic.zfar;
 			aicam->mClipPlaneNear = cam.cameraProperties.ortographic.znear;
 			aicam->mHorizontalFOV = 0.0;
+			aicam->mOrthographicWidth = cam.cameraProperties.ortographic.xmag;
 			aicam->mAspect = 1.0f;
 			if (0.f != cam.cameraProperties.ortographic.ymag) {
 				aicam->mAspect = cam.cameraProperties.ortographic.xmag / cam.cameraProperties.ortographic.ymag;

--- a/include/assimp/camera.h
+++ b/include/assimp/camera.h
@@ -171,15 +171,26 @@ struct aiCamera
      */
     float mAspect;
 
+    /** Half horizontal orthographic width, in scene units.
+     *
+     *  The orthographic width specifies the half width of the
+     *  orthographic view box. If non-zero the camera is
+     *  orthographic and the mAspect should define to the
+     *  ratio between the orthographic width and height
+     *  and mHorizontalFOV should be set to 0.
+     *  The default value is 0 (not orthographic).
+     */
+	float mOrthographicWidth;
 #ifdef __cplusplus
 
     aiCamera() AI_NO_EXCEPT
-        : mUp               (0.f,1.f,0.f)
-        , mLookAt           (0.f,0.f,1.f)
-        , mHorizontalFOV    (0.25f * (float)AI_MATH_PI)
-        , mClipPlaneNear    (0.1f)
-        , mClipPlaneFar     (1000.f)
-        , mAspect           (0.f)
+        : mUp                (0.f,1.f,0.f)
+        , mLookAt            (0.f,0.f,1.f)
+        , mHorizontalFOV     (0.25f * (float)AI_MATH_PI)
+        , mClipPlaneNear     (0.1f)
+        , mClipPlaneFar      (1000.f)
+        , mAspect            (0.f)
+	    , mOrthographicWidth (0.f)
     {}
 
     /** @brief Get a *right-handed* camera matrix from me

--- a/include/assimp/camera.h
+++ b/include/assimp/camera.h
@@ -180,7 +180,7 @@ struct aiCamera
      *  and mHorizontalFOV should be set to 0.
      *  The default value is 0 (not orthographic).
      */
-	float mOrthographicWidth;
+    float mOrthographicWidth;
 #ifdef __cplusplus
 
     aiCamera() AI_NO_EXCEPT
@@ -190,7 +190,7 @@ struct aiCamera
         , mClipPlaneNear     (0.1f)
         , mClipPlaneFar      (1000.f)
         , mAspect            (0.f)
-	    , mOrthographicWidth (0.f)
+        , mOrthographicWidth (0.f)
     {}
 
     /** @brief Get a *right-handed* camera matrix from me


### PR DESCRIPTION
Merge to fix missing orthographic camera data in glTF2. Fixes #3028.