### PR TITLE
Fixed wrong matrix type used in aiMatrix3x3t comparison operators.

### DIFF
--- a/include/assimp/matrix3x3.h
+++ b/include/assimp/matrix3x3.h
@@ -93,10 +93,10 @@ public:
     const TReal* operator[] (unsigned int p_iIndex) const;
 
     // comparison operators
-    bool operator== (const aiMatrix4x4t<TReal>& m) const;
-    bool operator!= (const aiMatrix4x4t<TReal>& m) const;
+    bool operator== (const aiMatrix3x3t<TReal>& m) const;
+    bool operator!= (const aiMatrix3x3t<TReal>& m) const;
 
-    bool Equal(const aiMatrix4x4t<TReal>& m, TReal epsilon = 1e-6) const;
+    bool Equal(const aiMatrix3x3t<TReal>& m, TReal epsilon = 1e-6) const;
 
     template <typename TOther>
     operator aiMatrix3x3t<TOther> () const;

--- a/include/assimp/matrix3x3.inl
+++ b/include/assimp/matrix3x3.inl
@@ -141,7 +141,7 @@ const TReal* aiMatrix3x3t<TReal>::operator[] (unsigned int p_iIndex) const {
 // ------------------------------------------------------------------------------------------------
 template <typename TReal>
 AI_FORCE_INLINE
-bool aiMatrix3x3t<TReal>::operator== (const aiMatrix4x4t<TReal>& m) const {
+bool aiMatrix3x3t<TReal>::operator== (const aiMatrix3x3t<TReal>& m) const {
     return a1 == m.a1 && a2 == m.a2 && a3 == m.a3 &&
            b1 == m.b1 && b2 == m.b2 && b3 == m.b3 &&
            c1 == m.c1 && c2 == m.c2 && c3 == m.c3;
@@ -150,14 +150,14 @@ bool aiMatrix3x3t<TReal>::operator== (const aiMatrix4x4t<TReal>& m) const {
 // ------------------------------------------------------------------------------------------------
 template <typename TReal>
 AI_FORCE_INLINE
-bool aiMatrix3x3t<TReal>::operator!= (const aiMatrix4x4t<TReal>& m) const {
+bool aiMatrix3x3t<TReal>::operator!= (const aiMatrix3x3t<TReal>& m) const {
     return !(*this == m);
 }
 
 // ---------------------------------------------------------------------------
 template<typename TReal>
 AI_FORCE_INLINE
-bool aiMatrix3x3t<TReal>::Equal(const aiMatrix4x4t<TReal>& m, TReal epsilon) const {
+bool aiMatrix3x3t<TReal>::Equal(const aiMatrix3x3t<TReal>& m, TReal epsilon) const {
     return
         std::abs(a1 - m.a1) <= epsilon &&
         std::abs(a2 - m.a2) <= epsilon &&


### PR DESCRIPTION
The class `aiMatrix3x3t` has 2 operator overloading methods as well as an `Equal` method, which all take an `aiMatrix4x4t` as the input parameter. Please correct me if I am wrong, but I believe it was rather meant to be an `aiMatrix3x3t`.

See the files below:

https://github.com/assimp/assimp/blob/1e2c3c9c016d7a557a364161ac3cd8fbee16c72d/include/assimp/matrix3x3.h#L96-L99

https://github.com/assimp/assimp/blob/1e2c3c9c016d7a557a364161ac3cd8fbee16c72d/include/assimp/matrix3x3.inl#L144-L148

The following changes were tested with the following projects:

* assimp
* assimp_cmd
* assimp_simpleogl
* assimp_simpletextureddirectx11
* assimp_simpletexturedogl
* assimp_viewer
* unit

All tests were run.