### PR TITLE
Only try to initialize members whose name starts with 'm' followed by an uppercase character

### DIFF
--- a/port/PyAssimp/pyassimp/core.py
+++ b/port/PyAssimp/pyassimp/core.py
@@ -138,7 +138,7 @@ def _init(self, target = None, parent = None):
             logger.debug(str(self) + ": Added array " + str(getattr(target, name)) +  " as self." + name.lower())
             continue
 
-        if m.startswith('m'):
+        if m.startswith('m') and len(m) > 1 and m[1].upper() == m[1]:
 
             if name == "parent":
                 setattr(target, name, parent)


### PR DESCRIPTION
This PR fixes an odd error I ran into. I attempted to load the
`african_head.obj` model from
[here](https://github.com/vahidk/tf.rasterizer/tree/a257e168033e34921bf2b184bf4ba5f5ef41296e/data/african_head)
using the following snippet:

```
git clone https://github.com/vahidk/tf.rasterizer
cd tf.rasterizer
python3 -c 'import pyassimp; mesh = pyassimp.load("data/african_head/african_head.obj")'
```

This resulted in an error with a strange backtrace:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/bb/ml/shawwn-gpt-2-watchdog/venv/lib/python3.7/site-packages/pyassimp/core.py", line 324, in load
    scene = _init(model.contents)
  File "/Users/bb/ml/shawwn-gpt-2-watchdog/venv/lib/python3.7/site-packages/pyassimp/core.py", line 219, in _init
    call_init(obj, target)
  File "/Users/bb/ml/shawwn-gpt-2-watchdog/venv/lib/python3.7/site-packages/pyassimp/core.py", line 84, in call_init
    _init(obj,parent=caller)
  File "/Users/bb/ml/shawwn-gpt-2-watchdog/venv/lib/python3.7/site-packages/pyassimp/core.py", line 215, in _init
    setattr(target, name, obj)
AttributeError: 'bytes' object has no attribute 'aketrans'
```

After debugging it, I believe the problem is that the object has a
member function `self.maketrans()`, and pyassimp incorrectly believes
it is a C-style struct member (e.g. `self.mFoo` or `self.mBar`).

This PR ensures that only attributes of the form `mFoo`, `mBar`, etc
are scanned. Specifically, it checks that the member variable name
meets the following conditions:

1. The name starts with `m`
2. The name is longer than 1 character
3. The second character is uppercase

This seems to fix the problem.