### PR TITLE
Added missing functionalities to C API.

### DIFF
--- a/code/Common/Assimp.cpp
+++ b/code/Common/Assimp.cpp
@@ -693,3 +693,598 @@ ASSIMP_API C_STRUCT const aiImporterDesc* aiGetImporterDesc( const char *extensi
 }
 
 // ------------------------------------------------------------------------------------------------
+ASSIMP_API int aiVector2AreEqual(
+    const C_STRUCT aiVector2D* a,
+    const C_STRUCT aiVector2D* b) {
+    ai_assert(NULL != a);
+    ai_assert(NULL != b);
+    return *a == *b;
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API int aiVector2AreEqualEpsilon(
+    const C_STRUCT aiVector2D* a,
+    const C_STRUCT aiVector2D* b,
+    const float epsilon) {
+    ai_assert(NULL != a);
+    ai_assert(NULL != b);
+    return a->Equal(*b, epsilon);
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiVector2Add(
+    C_STRUCT aiVector2D* dst,
+    const C_STRUCT aiVector2D* src) {
+    ai_assert(NULL != dst);
+    ai_assert(NULL != src);
+    *dst = *dst + *src;
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiVector2Subtract(
+    C_STRUCT aiVector2D* dst,
+    const C_STRUCT aiVector2D* src) {
+    ai_assert(NULL != dst);
+    ai_assert(NULL != src);
+    *dst = *dst - *src;
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiVector2Scale(
+    C_STRUCT aiVector2D* dst,
+    const float s) {
+    ai_assert(NULL != dst);
+    *dst *= s;
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiVector2SymMul(
+    C_STRUCT aiVector2D* dst,
+    const C_STRUCT aiVector2D* other) {
+    ai_assert(NULL != dst);
+    ai_assert(NULL != other);
+    *dst = dst->SymMul(*other);
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiVector2DivideByScalar(
+    C_STRUCT aiVector2D* dst,
+    const float s) {
+    ai_assert(NULL != dst);
+    *dst /= s;
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiVector2DivideByVector(
+    C_STRUCT aiVector2D* dst,
+    C_STRUCT aiVector2D* v) {
+    ai_assert(NULL != dst);
+    ai_assert(NULL != v);
+    *dst = *dst / *v;
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API float aiVector2Length(
+    const C_STRUCT aiVector2D* v) {
+    ai_assert(NULL != v);
+    return v->Length();
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API float aiVector2SquareLength(
+    const C_STRUCT aiVector2D* v) {
+    ai_assert(NULL != v);
+    return v->SquareLength();
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiVector2Negate(
+    C_STRUCT aiVector2D* dst) {
+    ai_assert(NULL != dst);
+    *dst = -(*dst);
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API float aiVector2DotProduct(
+    const C_STRUCT aiVector2D* a,
+    const C_STRUCT aiVector2D* b) {
+    ai_assert(NULL != a);
+    ai_assert(NULL != b);
+    return (*a) * (*b);
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiVector2Normalize(
+    C_STRUCT aiVector2D* v) {
+    ai_assert(NULL != v);
+    v->Normalize();
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API int aiVector3AreEqual(
+    const C_STRUCT aiVector3D* a,
+    const C_STRUCT aiVector3D* b) {
+    ai_assert(NULL != a);
+    ai_assert(NULL != b);
+    return *a == *b;
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API int aiVector3AreEqualEpsilon(
+    const C_STRUCT aiVector3D* a,
+    const C_STRUCT aiVector3D* b,
+    const float epsilon) {
+    ai_assert(NULL != a);
+    ai_assert(NULL != b);
+    return a->Equal(*b, epsilon);
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API int aiVector3LessThan(
+    const C_STRUCT aiVector3D* a,
+    const C_STRUCT aiVector3D* b) {
+    ai_assert(NULL != a);
+    ai_assert(NULL != b);
+    return *a < *b;
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiVector3Add(
+    C_STRUCT aiVector3D* dst,
+    const C_STRUCT aiVector3D* src) {
+    ai_assert(NULL != dst);
+    ai_assert(NULL != src);
+    *dst = *dst + *src;
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiVector3Subtract(
+    C_STRUCT aiVector3D* dst,
+    const C_STRUCT aiVector3D* src) {
+    ai_assert(NULL != dst);
+    ai_assert(NULL != src);
+    *dst = *dst - *src;
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiVector3Scale(
+    C_STRUCT aiVector3D* dst,
+    const float s) {
+    ai_assert(NULL != dst);
+    *dst *= s;
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiVector3SymMul(
+    C_STRUCT aiVector3D* dst,
+    const C_STRUCT aiVector3D* other) {
+    ai_assert(NULL != dst);
+    ai_assert(NULL != other);
+    *dst = dst->SymMul(*other);
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiVector3DivideByScalar(
+    C_STRUCT aiVector3D* dst, const float s) {
+    ai_assert(NULL != dst);
+    *dst /= s;
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiVector3DivideByVector(
+    C_STRUCT aiVector3D* dst,
+    C_STRUCT aiVector3D* v) {
+    ai_assert(NULL != dst);
+    ai_assert(NULL != v);
+    *dst = *dst / *v;
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API float aiVector3Length(
+    const C_STRUCT aiVector3D* v) {
+    ai_assert(NULL != v);
+    return v->Length();
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API float aiVector3SquareLength(
+    const C_STRUCT aiVector3D* v) {
+    ai_assert(NULL != v);
+    return v->SquareLength();
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiVector3Negate(
+    C_STRUCT aiVector3D* dst) {
+    ai_assert(NULL != dst);
+    *dst = -(*dst);
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API float aiVector3DotProduct(
+    const C_STRUCT aiVector3D* a,
+    const C_STRUCT aiVector3D* b) {
+    ai_assert(NULL != a);
+    ai_assert(NULL != b);
+    return (*a) * (*b);
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiVector3CrossProduct(
+    C_STRUCT aiVector3D* dst,
+    const C_STRUCT aiVector3D* a,
+    const C_STRUCT aiVector3D* b) {
+    ai_assert(NULL != dst);
+    ai_assert(NULL != a);
+    ai_assert(NULL != b);
+    *dst = *a ^ *b;
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiVector3Normalize(
+    C_STRUCT aiVector3D* v) {
+    ai_assert(NULL != v);
+    v->Normalize();
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiVector3NormalizeSafe(
+    C_STRUCT aiVector3D* v) {
+    ai_assert(NULL != v);
+    v->NormalizeSafe();
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiVector3RotateByQuaternion(
+    C_STRUCT aiVector3D* v,
+    const C_STRUCT aiQuaternion* q) {
+    ai_assert(NULL != v);
+    ai_assert(NULL != q);
+    *v = q->Rotate(*v);
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiMatrix3FromMatrix4(
+    C_STRUCT aiMatrix3x3* dst,
+    const C_STRUCT aiMatrix4x4* mat) {
+    ai_assert(NULL != dst);
+    ai_assert(NULL != mat);
+    *dst = aiMatrix3x3(*mat);
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiMatrix3FromQuaternion(
+    C_STRUCT aiMatrix3x3* mat,
+    const C_STRUCT aiQuaternion* q) {
+    ai_assert(NULL != mat);
+    ai_assert(NULL != q);
+    *mat = q->GetMatrix();
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API int aiMatrix3AreEqual(
+    const C_STRUCT aiMatrix3x3* a,
+    const C_STRUCT aiMatrix3x3* b) {
+    ai_assert(NULL != a);
+    ai_assert(NULL != b);
+    return *a == *b;
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API int aiMatrix3AreEqualEpsilon(
+    const C_STRUCT aiMatrix3x3* a,
+    const C_STRUCT aiMatrix3x3* b,
+    const float epsilon) {
+    ai_assert(NULL != a);
+    ai_assert(NULL != b);
+    return a->Equal(*b, epsilon);
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiMatrix3Inverse(C_STRUCT aiMatrix3x3* mat) {
+    ai_assert(NULL != mat);
+    mat->Inverse();
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API float aiMatrix3Determinant(const C_STRUCT aiMatrix3x3* mat) {
+    ai_assert(NULL != mat);
+    return mat->Determinant();
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiMatrix3RotationZ(
+    C_STRUCT aiMatrix3x3* mat,
+    const float angle) {
+    ai_assert(NULL != mat);
+    aiMatrix3x3::RotationZ(angle, *mat);
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiMatrix3FromRotationAroundAxis(
+    C_STRUCT aiMatrix3x3* mat,
+    const C_STRUCT aiVector3D* axis,
+    const float angle) {
+    ai_assert(NULL != mat);
+    ai_assert(NULL != axis);
+    aiMatrix3x3::Rotation(angle, *axis, *mat);
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiMatrix3Translation(
+    C_STRUCT aiMatrix3x3* mat,
+    const C_STRUCT aiVector2D* translation) {
+    ai_assert(NULL != mat);
+    ai_assert(NULL != translation);
+    aiMatrix3x3::Translation(*translation, *mat);
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiMatrix3FromTo(
+    C_STRUCT aiMatrix3x3* mat,
+    const C_STRUCT aiVector3D* from,
+    const C_STRUCT aiVector3D* to) {
+    ai_assert(NULL != mat);
+    ai_assert(NULL != from);
+    ai_assert(NULL != to);
+    aiMatrix3x3::FromToMatrix(*from, *to, *mat);
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiMatrix4FromMatrix3(
+    C_STRUCT aiMatrix4x4* dst,
+    const C_STRUCT aiMatrix3x3* mat) {
+    ai_assert(NULL != dst);
+    ai_assert(NULL != mat);
+    *dst = aiMatrix4x4(*mat);
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiMatrix4FromScalingQuaternionPosition(
+    C_STRUCT aiMatrix4x4* mat,
+    const C_STRUCT aiVector3D* scaling,
+    const C_STRUCT aiQuaternion* rotation,
+    const C_STRUCT aiVector3D* position) {
+    ai_assert(NULL != mat);
+    ai_assert(NULL != scaling);
+    ai_assert(NULL != rotation);
+    ai_assert(NULL != position);
+    *mat = aiMatrix4x4(*scaling, *rotation, *position);
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiMatrix4Add(
+    C_STRUCT aiMatrix4x4* dst,
+    const C_STRUCT aiMatrix4x4* src) {
+    ai_assert(NULL != dst);
+    ai_assert(NULL != src);
+    *dst = *dst + *src;
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API int aiMatrix4AreEqual(
+    const C_STRUCT aiMatrix4x4* a,
+    const C_STRUCT aiMatrix4x4* b) {
+    ai_assert(NULL != a);
+    ai_assert(NULL != b);
+    return *a == *b;
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API int aiMatrix4AreEqualEpsilon(
+    const C_STRUCT aiMatrix4x4* a,
+    const C_STRUCT aiMatrix4x4* b,
+    const float epsilon) {
+    ai_assert(NULL != a);
+    ai_assert(NULL != b);
+    return a->Equal(*b, epsilon);
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiMatrix4Inverse(C_STRUCT aiMatrix4x4* mat) {
+    ai_assert(NULL != mat);
+    mat->Inverse();
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API float aiMatrix4Determinant(const C_STRUCT aiMatrix4x4* mat) {
+    ai_assert(NULL != mat);
+    return mat->Determinant();
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API int aiMatrix4IsIdentity(const C_STRUCT aiMatrix4x4* mat) {
+    ai_assert(NULL != mat);
+    return mat->IsIdentity();
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiMatrix4DecomposeIntoScalingEulerAnglesPosition(
+    const C_STRUCT aiMatrix4x4* mat,
+    C_STRUCT aiVector3D* scaling,
+    C_STRUCT aiVector3D* rotation,
+    C_STRUCT aiVector3D* position) {
+    ai_assert(NULL != mat);
+    ai_assert(NULL != scaling);
+    ai_assert(NULL != rotation);
+    ai_assert(NULL != position);
+    mat->Decompose(*scaling, *rotation, *position);
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiMatrix4DecomposeIntoScalingAxisAnglePosition(
+    const C_STRUCT aiMatrix4x4* mat,
+    C_STRUCT aiVector3D* scaling,
+    C_STRUCT aiVector3D* axis,
+    float* angle,
+    C_STRUCT aiVector3D* position) {
+    ai_assert(NULL != mat);
+    ai_assert(NULL != scaling);
+    ai_assert(NULL != axis);
+    ai_assert(NULL != angle);
+    ai_assert(NULL != position);
+    mat->Decompose(*scaling, *axis, *angle, *position);
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiMatrix4DecomposeNoScaling(
+    const C_STRUCT aiMatrix4x4* mat,
+    C_STRUCT aiQuaternion* rotation,
+    C_STRUCT aiVector3D* position) {
+    ai_assert(NULL != mat);
+    ai_assert(NULL != rotation);
+    ai_assert(NULL != position);
+    mat->DecomposeNoScaling(*rotation, *position);
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiMatrix4FromEulerAngles(
+    C_STRUCT aiMatrix4x4* mat,
+    float x, float y, float z) {
+    ai_assert(NULL != mat);
+    mat->FromEulerAnglesXYZ(x, y, z);
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiMatrix4RotationX(
+    C_STRUCT aiMatrix4x4* mat,
+    const float angle) {
+    ai_assert(NULL != mat);
+    aiMatrix4x4::RotationX(angle, *mat);
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiMatrix4RotationY(
+    C_STRUCT aiMatrix4x4* mat,
+    const float angle) {
+    ai_assert(NULL != mat);
+    aiMatrix4x4::RotationY(angle, *mat);
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiMatrix4RotationZ(
+    C_STRUCT aiMatrix4x4* mat,
+    const float angle) {
+    ai_assert(NULL != mat);
+    aiMatrix4x4::RotationZ(angle, *mat);
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiMatrix4FromRotationAroundAxis(
+    C_STRUCT aiMatrix4x4* mat,
+    const C_STRUCT aiVector3D* axis,
+    const float angle) {
+    ai_assert(NULL != mat);
+    ai_assert(NULL != axis);
+    aiMatrix4x4::Rotation(angle, *axis, *mat);
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiMatrix4Translation(
+    C_STRUCT aiMatrix4x4* mat,
+    const C_STRUCT aiVector3D* translation) {
+    ai_assert(NULL != mat);
+    ai_assert(NULL != translation);
+    aiMatrix4x4::Translation(*translation, *mat);
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiMatrix4Scaling(
+    C_STRUCT aiMatrix4x4* mat,
+    const C_STRUCT aiVector3D* scaling) {
+    ai_assert(NULL != mat);
+    ai_assert(NULL != scaling);
+    aiMatrix4x4::Scaling(*scaling, *mat);
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiMatrix4FromTo(
+    C_STRUCT aiMatrix4x4* mat,
+    const C_STRUCT aiVector3D* from,
+    const C_STRUCT aiVector3D* to) {
+    ai_assert(NULL != mat);
+    ai_assert(NULL != from);
+    ai_assert(NULL != to);
+    aiMatrix4x4::FromToMatrix(*from, *to, *mat);
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiQuaternionFromEulerAngles(
+    C_STRUCT aiQuaternion* q,
+    float x, float y, float z) {
+    ai_assert(NULL != q);
+    *q = aiQuaternion(x, y, z);
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiQuaternionFromAxisAngle(
+    C_STRUCT aiQuaternion* q,
+    const C_STRUCT aiVector3D* axis,
+    const float angle) {
+    ai_assert(NULL != q);
+    ai_assert(NULL != axis);
+    *q = aiQuaternion(*axis, angle);
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiQuaternionFromNormalizedQuaternion(
+    C_STRUCT aiQuaternion* q,
+    const C_STRUCT aiVector3D* normalized) {
+    ai_assert(NULL != q);
+    ai_assert(NULL != normalized);
+    *q = aiQuaternion(*normalized);
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API int aiQuaternionAreEqual(
+    const C_STRUCT aiQuaternion* a,
+    const C_STRUCT aiQuaternion* b) {
+    ai_assert(NULL != a);
+    ai_assert(NULL != b);
+    return *a == *b;
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API int aiQuaternionAreEqualEpsilon(
+    const C_STRUCT aiQuaternion* a,
+    const C_STRUCT aiQuaternion* b,
+    const float epsilon) {
+    ai_assert(NULL != a);
+    ai_assert(NULL != b);
+    return a->Equal(*b, epsilon);
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiQuaternionNormalize(
+    C_STRUCT aiQuaternion* q) {
+    ai_assert(NULL != q);
+    q->Normalize();
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiQuaternionConjugate(
+    C_STRUCT aiQuaternion* q) {
+    ai_assert(NULL != q);
+    q->Conjugate();
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiQuaternionMultiply(
+    C_STRUCT aiQuaternion* dst,
+    const C_STRUCT aiQuaternion* q) {
+    ai_assert(NULL != dst);
+    ai_assert(NULL != q);
+    *dst = (*dst) * (*q);
+}
+
+// ------------------------------------------------------------------------------------------------
+ASSIMP_API void aiQuaternionInterpolate(
+    C_STRUCT aiQuaternion* dst,
+    const C_STRUCT aiQuaternion* start,
+    const C_STRUCT aiQuaternion* end,
+    const float factor) {
+    ai_assert(NULL != dst);
+    ai_assert(NULL != start);
+    ai_assert(NULL != end);
+    aiQuaternion::Interpolate(*dst, *start, *end, factor);
+}

--- a/include/assimp/cimport.h
+++ b/include/assimp/cimport.h
@@ -562,6 +562,675 @@ ASSIMP_API size_t aiGetImportFormatCount(void);
  * @return A description of that specific import format. NULL if pIndex is out of range.
  */
 ASSIMP_API const C_STRUCT aiImporterDesc* aiGetImportFormatDescription( size_t pIndex);
+
+// --------------------------------------------------------------------------------
+/** Check if 2D vectors are equal.
+ *  @param a First vector to compare
+ *  @param b Second vector to compare
+ *  @return 1 if the vectors are equal
+ *  @return 0 if the vectors are not equal
+ */
+ASSIMP_API int aiVector2AreEqual(
+    const C_STRUCT aiVector2D* a,
+    const C_STRUCT aiVector2D* b);
+
+// --------------------------------------------------------------------------------
+/** Check if 2D vectors are equal using epsilon.
+ *  @param a First vector to compare
+ *  @param b Second vector to compare
+ *  @param epsilon Epsilon
+ *  @return 1 if the vectors are equal
+ *  @return 0 if the vectors are not equal
+ */
+ASSIMP_API int aiVector2AreEqualEpsilon(
+    const C_STRUCT aiVector2D* a,
+    const C_STRUCT aiVector2D* b,
+    const float epsilon);
+
+// --------------------------------------------------------------------------------
+/** Add 2D vectors.
+ *  @param dst First addend, receives result.
+ *  @param src Vector to be added to 'dst'.
+ */
+ASSIMP_API void aiVector2Add(
+    C_STRUCT aiVector2D* dst,
+    const C_STRUCT aiVector2D* src);
+
+// --------------------------------------------------------------------------------
+/** Subtract 2D vectors.
+ *  @param dst Minuend, receives result.
+ *  @param src Vector to be subtracted from 'dst'.
+ */
+ASSIMP_API void aiVector2Subtract(
+    C_STRUCT aiVector2D* dst,
+    const C_STRUCT aiVector2D* src);
+
+// --------------------------------------------------------------------------------
+/** Multiply a 2D vector by a scalar.
+ *  @param dst Vector to be scaled by \p s
+ *  @param s Scale factor
+ */
+ASSIMP_API void aiVector2Scale(
+    C_STRUCT aiVector2D* dst,
+    const float s);
+
+// --------------------------------------------------------------------------------
+/** Multiply each component of a 2D vector with
+ *  the components of another vector.
+ *  @param dst First vector, receives result
+ *  @param other Second vector
+ */
+ASSIMP_API void aiVector2SymMul(
+    C_STRUCT aiVector2D* dst,
+    const C_STRUCT aiVector2D* other);
+
+// --------------------------------------------------------------------------------
+/** Divide a 2D vector by a scalar.
+ *  @param dst Vector to be divided by \p s
+ *  @param s Scalar divisor
+ */
+ASSIMP_API void aiVector2DivideByScalar(
+    C_STRUCT aiVector2D* dst,
+    const float s);
+
+// --------------------------------------------------------------------------------
+/** Divide each component of a 2D vector by
+ *  the components of another vector.
+ *  @param dst Vector as the dividend
+ *  @param v Vector as the divisor
+ */
+ASSIMP_API void aiVector2DivideByVector(
+    C_STRUCT aiVector2D* dst,
+    C_STRUCT aiVector2D* v);
+
+// --------------------------------------------------------------------------------
+/** Get the length of a 2D vector.
+ *  @return v Vector to evaluate
+ */
+ASSIMP_API float aiVector2Length(
+    const C_STRUCT aiVector2D* v);
+
+// --------------------------------------------------------------------------------
+/** Get the squared length of a 2D vector.
+ *  @return v Vector to evaluate
+ */
+ASSIMP_API float aiVector2SquareLength(
+    const C_STRUCT aiVector2D* v);
+
+// --------------------------------------------------------------------------------
+/** Negate a 2D vector.
+ *  @param dst Vector to be negated
+ */
+ASSIMP_API void aiVector2Negate(
+    C_STRUCT aiVector2D* dst);
+
+// --------------------------------------------------------------------------------
+/** Get the dot product of 2D vectors.
+ *  @param a First vector
+ *  @param b Second vector
+ *  @return The dot product of vectors
+ */
+ASSIMP_API float aiVector2DotProduct(
+    const C_STRUCT aiVector2D* a,
+    const C_STRUCT aiVector2D* b);
+
+// --------------------------------------------------------------------------------
+/** Normalize a 2D vector.
+ *  @param v Vector to normalize
+ */
+ASSIMP_API void aiVector2Normalize(
+    C_STRUCT aiVector2D* v);
+
+// --------------------------------------------------------------------------------
+/** Check if 3D vectors are equal.
+ *  @param a First vector to compare
+ *  @param b Second vector to compare
+ *  @return 1 if the vectors are equal
+ *  @return 0 if the vectors are not equal
+ */
+ASSIMP_API int aiVector3AreEqual(
+    const C_STRUCT aiVector3D* a,
+    const C_STRUCT aiVector3D* b);
+
+// --------------------------------------------------------------------------------
+/** Check if 3D vectors are equal using epsilon.
+ *  @param a First vector to compare
+ *  @param b Second vector to compare
+ *  @param epsilon Epsilon
+ *  @return 1 if the vectors are equal
+ *  @return 0 if the vectors are not equal
+ */
+ASSIMP_API int aiVector3AreEqualEpsilon(
+    const C_STRUCT aiVector3D* a,
+    const C_STRUCT aiVector3D* b,
+    const float epsilon);
+
+// --------------------------------------------------------------------------------
+/** Check if vector \p a is less than vector \p b.
+ *  @param a First vector to compare
+ *  @param b Second vector to compare
+ *  @param epsilon Epsilon
+ *  @return 1 if \p a is less than \p b
+ *  @return 0 if \p a is equal or greater than \p b
+ */
+ASSIMP_API int aiVector3LessThan(
+    const C_STRUCT aiVector3D* a,
+    const C_STRUCT aiVector3D* b);
+
+// --------------------------------------------------------------------------------
+/** Add 3D vectors.
+ *  @param dst First addend, receives result.
+ *  @param src Vector to be added to 'dst'.
+ */
+ASSIMP_API void aiVector3Add(
+    C_STRUCT aiVector3D* dst,
+    const C_STRUCT aiVector3D* src);
+
+// --------------------------------------------------------------------------------
+/** Subtract 3D vectors.
+ *  @param dst Minuend, receives result.
+ *  @param src Vector to be subtracted from 'dst'.
+ */
+ASSIMP_API void aiVector3Subtract(
+    C_STRUCT aiVector3D* dst,
+    const C_STRUCT aiVector3D* src);
+
+// --------------------------------------------------------------------------------
+/** Multiply a 3D vector by a scalar.
+ *  @param dst Vector to be scaled by \p s
+ *  @param s Scale factor
+ */
+ASSIMP_API void aiVector3Scale(
+    C_STRUCT aiVector3D* dst,
+    const float s);
+
+// --------------------------------------------------------------------------------
+/** Multiply each component of a 3D vector with
+ *  the components of another vector.
+ *  @param dst First vector, receives result
+ *  @param other Second vector
+ */
+ASSIMP_API void aiVector3SymMul(
+    C_STRUCT aiVector3D* dst,
+    const C_STRUCT aiVector3D* other);
+
+// --------------------------------------------------------------------------------
+/** Divide a 3D vector by a scalar.
+ *  @param dst Vector to be divided by \p s
+ *  @param s Scalar divisor
+ */
+ASSIMP_API void aiVector3DivideByScalar(
+    C_STRUCT aiVector3D* dst,
+    const float s);
+
+// --------------------------------------------------------------------------------
+/** Divide each component of a 3D vector by
+ *  the components of another vector.
+ *  @param dst Vector as the dividend
+ *  @param v Vector as the divisor
+ */
+ASSIMP_API void aiVector3DivideByVector(
+    C_STRUCT aiVector3D* dst,
+    C_STRUCT aiVector3D* v);
+
+// --------------------------------------------------------------------------------
+/** Get the length of a 3D vector.
+ *  @return v Vector to evaluate
+ */
+ASSIMP_API float aiVector3Length(
+    const C_STRUCT aiVector3D* v);
+
+// --------------------------------------------------------------------------------
+/** Get the squared length of a 3D vector.
+ *  @return v Vector to evaluate
+ */
+ASSIMP_API float aiVector3SquareLength(
+    const C_STRUCT aiVector3D* v);
+
+// --------------------------------------------------------------------------------
+/** Negate a 3D vector.
+ *  @param dst Vector to be negated
+ */
+ASSIMP_API void aiVector3Negate(
+    C_STRUCT aiVector3D* dst);
+
+// --------------------------------------------------------------------------------
+/** Get the dot product of 3D vectors.
+ *  @param a First vector
+ *  @param b Second vector
+ *  @return The dot product of vectors
+ */
+ASSIMP_API float aiVector3DotProduct(
+    const C_STRUCT aiVector3D* a,
+    const C_STRUCT aiVector3D* b);
+
+// --------------------------------------------------------------------------------
+/** Get cross product of 3D vectors.
+ *  @param dst Vector to receive the result.
+ *  @param a First vector
+ *  @param b Second vector
+ *  @return The dot product of vectors
+ */
+ASSIMP_API void aiVector3CrossProduct(
+    C_STRUCT aiVector3D* dst,
+    const C_STRUCT aiVector3D* a,
+    const C_STRUCT aiVector3D* b);
+
+// --------------------------------------------------------------------------------
+/** Normalize a 3D vector.
+ *  @param v Vector to normalize
+ */
+ASSIMP_API void aiVector3Normalize(
+    C_STRUCT aiVector3D* v);
+
+// --------------------------------------------------------------------------------
+/** Check for division by zero and normalize a 3D vector.
+ *  @param v Vector to normalize
+ */
+ASSIMP_API void aiVector3NormalizeSafe(
+    C_STRUCT aiVector3D* v);
+
+// --------------------------------------------------------------------------------
+/** Rotate a 3D vector by a quaternion.
+ *  @param v The vector to rotate by \p q
+ *  @param q Quaternion to use to rotate \p v
+ */
+ASSIMP_API void aiVector3RotateByQuaternion(
+    C_STRUCT aiVector3D* v,
+    const C_STRUCT aiQuaternion* q);
+
+// --------------------------------------------------------------------------------
+/** Construct a 3x3 matrix from a 4x4 matrix.
+ *  @param dst Receives the output matrix
+ *  @param mat The 4x4 matrix to use
+ */
+ASSIMP_API void aiMatrix3FromMatrix4(
+    C_STRUCT aiMatrix3x3* dst,
+    const C_STRUCT aiMatrix4x4* mat);
+
+// --------------------------------------------------------------------------------
+/** Construct a 3x3 matrix from a quaternion.
+ *  @param mat Receives the output matrix
+ *  @param q The quaternion matrix to use
+ */
+ASSIMP_API void aiMatrix3FromQuaternion(
+    C_STRUCT aiMatrix3x3* mat,
+    const C_STRUCT aiQuaternion* q);
+
+// --------------------------------------------------------------------------------
+/** Check if 3x3 matrices are equal.
+ *  @param a First matrix to compare
+ *  @param b Second matrix to compare
+ *  @return 1 if the matrices are equal
+ *  @return 0 if the matrices are not equal
+ */
+ASSIMP_API int aiMatrix3AreEqual(
+    const C_STRUCT aiMatrix3x3* a,
+    const C_STRUCT aiMatrix3x3* b);
+
+// --------------------------------------------------------------------------------
+/** Check if 3x3 matrices are equal.
+ *  @param a First matrix to compare
+ *  @param b Second matrix to compare
+ *  @param epsilon Epsilon
+ *  @return 1 if the matrices are equal
+ *  @return 0 if the matrices are not equal
+ */
+ASSIMP_API int aiMatrix3AreEqualEpsilon(
+    const C_STRUCT aiMatrix3x3* a,
+    const C_STRUCT aiMatrix3x3* b,
+    const float epsilon);
+
+// --------------------------------------------------------------------------------
+/** Invert a 3x3 matrix.
+ *  @param mat Matrix to invert
+ */
+ASSIMP_API void aiMatrix3Inverse(
+    C_STRUCT aiMatrix3x3* mat);
+
+// --------------------------------------------------------------------------------
+/** Get the determinant of a 3x3 matrix.
+ *  @param mat Matrix to get the determinant from
+ */
+ASSIMP_API float aiMatrix3Determinant(
+    const C_STRUCT aiMatrix3x3* mat);
+
+// --------------------------------------------------------------------------------
+/** Get a 3x3 rotation matrix around the Z axis.
+ *  @param mat Receives the output matrix 
+ *  @param angle Rotation angle, in radians
+ */
+ASSIMP_API void aiMatrix3RotationZ(
+    C_STRUCT aiMatrix3x3* mat,
+    const float angle);
+
+// --------------------------------------------------------------------------------
+/** Returns a 3x3 rotation matrix for a rotation around an arbitrary axis.
+ *  @param mat Receives the output matrix 
+ *  @param axis Rotation axis, should be a normalized vector
+ *  @param angle Rotation angle, in radians
+ */
+ASSIMP_API void aiMatrix3FromRotationAroundAxis(
+    C_STRUCT aiMatrix3x3* mat,
+    const C_STRUCT aiVector3D* axis,
+    const float angle);
+
+// --------------------------------------------------------------------------------
+/** Get a 3x3 translation matrix.
+ *  @param mat Receives the output matrix 
+ *  @param translation The translation vector
+ */
+ASSIMP_API void aiMatrix3Translation(
+    C_STRUCT aiMatrix3x3* mat,
+    const C_STRUCT aiVector2D* translation);
+
+// --------------------------------------------------------------------------------
+/** Create a 3x3 matrix that rotates one vector to another vector.
+ *  @param mat Receives the output matrix 
+ *  @param from Vector to rotate from
+ *  @param to Vector to rotate to
+ */
+ASSIMP_API void aiMatrix3FromTo(
+    C_STRUCT aiMatrix3x3* mat,
+    const C_STRUCT aiVector3D* from,
+    const C_STRUCT aiVector3D* to);
+
+// --------------------------------------------------------------------------------
+/** Construct a 4x4 matrix from a 3x3 matrix.
+ *  @param dst Receives the output matrix
+ *  @param mat The 3x3 matrix to use
+ */
+ASSIMP_API void aiMatrix4FromMatrix3(
+    C_STRUCT aiMatrix4x4* dst,
+    const C_STRUCT aiMatrix3x3* mat);
+
+// --------------------------------------------------------------------------------
+/** Construct a 4x4 matrix from scaling, rotation and position.
+ *  @param mat Receives the output matrix.
+ *  @param scaling The scaling for the x,y,z axes
+ *  @param rotation The rotation as a hamilton quaternion
+ *  @param position The position for the x,y,z axes
+ */
+ASSIMP_API void aiMatrix4FromScalingQuaternionPosition(
+    C_STRUCT aiMatrix4x4* mat,
+    const C_STRUCT aiVector3D* scaling,
+    const C_STRUCT aiQuaternion* rotation,
+    const C_STRUCT aiVector3D* position);
+
+// --------------------------------------------------------------------------------
+/** Add 4x4 matrices.
+ *  @param dst First addend, receives result.
+ *  @param src Matrix to be added to 'dst'.
+ */
+ASSIMP_API void aiMatrix4Add(
+    C_STRUCT aiMatrix4x4* dst,
+    const C_STRUCT aiMatrix4x4* src);
+
+// --------------------------------------------------------------------------------
+/** Check if 4x4 matrices are equal.
+ *  @param a First matrix to compare
+ *  @param b Second matrix to compare
+ *  @return 1 if the matrices are equal
+ *  @return 0 if the matrices are not equal
+ */
+ASSIMP_API int aiMatrix4AreEqual(
+    const C_STRUCT aiMatrix4x4* a,
+    const C_STRUCT aiMatrix4x4* b);
+
+// --------------------------------------------------------------------------------
+/** Check if 4x4 matrices are equal.
+ *  @param a First matrix to compare
+ *  @param b Second matrix to compare
+ *  @param epsilon Epsilon
+ *  @return 1 if the matrices are equal
+ *  @return 0 if the matrices are not equal
+ */
+ASSIMP_API int aiMatrix4AreEqualEpsilon(
+    const C_STRUCT aiMatrix4x4* a,
+    const C_STRUCT aiMatrix4x4* b,
+    const float epsilon);
+
+// --------------------------------------------------------------------------------
+/** Invert a 4x4 matrix.
+ *  @param result Matrix to invert
+ */
+ASSIMP_API void aiMatrix4Inverse(
+    C_STRUCT aiMatrix4x4* mat);
+
+// --------------------------------------------------------------------------------
+/** Get the determinant of a 4x4 matrix.
+ *  @param mat Matrix to get the determinant from
+ *  @return The determinant of the matrix
+ */
+ASSIMP_API float aiMatrix4Determinant(
+    const C_STRUCT aiMatrix4x4* mat);
+
+// --------------------------------------------------------------------------------
+/** Returns true of the matrix is the identity matrix.
+ *  @param mat Matrix to get the determinant from
+ *  @return 1 if \p mat is an identity matrix.
+ *  @return 0 if \p mat is not an identity matrix.
+ */
+ASSIMP_API int aiMatrix4IsIdentity(
+    const C_STRUCT aiMatrix4x4* mat);
+
+// --------------------------------------------------------------------------------
+/** Decompose a transformation matrix into its scaling,
+ *  rotational as euler angles, and translational components.
+ *
+ * @param mat Matrix to decompose
+ * @param scaling Receives the output scaling for the x,y,z axes
+ * @param rotation Receives the output rotation as a Euler angles
+ * @param position Receives the output position for the x,y,z axes
+ */
+ASSIMP_API void aiMatrix4DecomposeIntoScalingEulerAnglesPosition(
+    const C_STRUCT aiMatrix4x4* mat,
+    C_STRUCT aiVector3D* scaling,
+    C_STRUCT aiVector3D* rotation,
+    C_STRUCT aiVector3D* position);
+
+// --------------------------------------------------------------------------------
+/** Decompose a transformation matrix into its scaling,
+ *  rotational split into an axis and rotational angle,
+ *  and it's translational components.
+ *
+ * @param mat Matrix to decompose
+ * @param rotation Receives the rotational component
+ * @param axis Receives the output rotation axis
+ * @param angle Receives the output rotation angle
+ * @param position Receives the output position for the x,y,z axes.
+ */
+ASSIMP_API void aiMatrix4DecomposeIntoScalingAxisAnglePosition(
+    const C_STRUCT aiMatrix4x4* mat,
+    C_STRUCT aiVector3D* scaling,
+    C_STRUCT aiVector3D* axis,
+    float* angle,
+    C_STRUCT aiVector3D* position);
+
+// --------------------------------------------------------------------------------
+/** Decompose a transformation matrix into its rotational and
+ *  translational components.
+ *
+ * @param mat Matrix to decompose
+ * @param rotation Receives the rotational component
+ * @param position Receives the translational component.
+ */
+ASSIMP_API void aiMatrix4DecomposeNoScaling(
+    const C_STRUCT aiMatrix4x4* mat,
+    C_STRUCT aiQuaternion* rotation,
+    C_STRUCT aiVector3D* position);
+
+// --------------------------------------------------------------------------------
+/** Creates a 4x4 matrix from a set of euler angles.
+ *  @param mat Receives the output matrix 
+ *  @param x Rotation angle for the x-axis, in radians
+ *  @param y Rotation angle for the y-axis, in radians
+ *  @param z Rotation angle for the z-axis, in radians
+ */
+ASSIMP_API void aiMatrix4FromEulerAngles(
+    C_STRUCT aiMatrix4x4* mat,
+    float x, float y, float z);
+
+// --------------------------------------------------------------------------------
+/** Get a 4x4 rotation matrix around the X axis.
+ *  @param mat Receives the output matrix
+ *  @param angle Rotation angle, in radians
+ */
+ASSIMP_API void aiMatrix4RotationX(
+    C_STRUCT aiMatrix4x4* mat,
+    const float angle);
+
+// --------------------------------------------------------------------------------
+/** Get a 4x4 rotation matrix around the Y axis.
+ *  @param mat Receives the output matrix
+ *  @param angle Rotation angle, in radians
+ */
+ASSIMP_API void aiMatrix4RotationY(
+    C_STRUCT aiMatrix4x4* mat,
+    const float angle);
+
+// --------------------------------------------------------------------------------
+/** Get a 4x4 rotation matrix around the Z axis.
+ *  @param mat Receives the output matrix
+ *  @param angle Rotation angle, in radians
+ */
+ASSIMP_API void aiMatrix4RotationZ(
+    C_STRUCT aiMatrix4x4* mat,
+    const float angle);
+
+// --------------------------------------------------------------------------------
+/** Returns a 4x4 rotation matrix for a rotation around an arbitrary axis.
+ *  @param mat Receives the output matrix
+ *  @param axis Rotation axis, should be a normalized vector
+ *  @param angle Rotation angle, in radians
+ */
+ASSIMP_API void aiMatrix4FromRotationAroundAxis(
+    C_STRUCT aiMatrix4x4* mat,
+    const C_STRUCT aiVector3D* axis,
+    const float angle);
+
+// --------------------------------------------------------------------------------
+/** Get a 4x4 translation matrix.
+ *  @param mat Receives the output matrix
+ *  @param translation The translation vector
+ */
+ASSIMP_API void aiMatrix4Translation(
+    C_STRUCT aiMatrix4x4* mat,
+    const C_STRUCT aiVector3D* translation);
+
+// --------------------------------------------------------------------------------
+/** Get a 4x4 scaling matrix.
+ *  @param mat Receives the output matrix
+ *  @param scaling The scaling vector
+ */
+ASSIMP_API void aiMatrix4Scaling(
+    C_STRUCT aiMatrix4x4* mat,
+    const C_STRUCT aiVector3D* scaling);
+
+// --------------------------------------------------------------------------------
+/** Create a 4x4 matrix that rotates one vector to another vector.
+ *  @param mat Receives the output matrix
+ *  @param from Vector to rotate from
+ *  @param to Vector to rotate to
+ */
+ASSIMP_API void aiMatrix4FromTo(
+    C_STRUCT aiMatrix4x4* mat,
+    const C_STRUCT aiVector3D* from,
+    const C_STRUCT aiVector3D* to);
+
+// --------------------------------------------------------------------------------
+/** Create a Quaternion from euler angles.
+ *  @param q Receives the output quaternion 
+ *  @param x Rotation angle for the x-axis, in radians
+ *  @param y Rotation angle for the y-axis, in radians
+ *  @param z Rotation angle for the z-axis, in radians
+ */
+ASSIMP_API void aiQuaternionFromEulerAngles(
+    C_STRUCT aiQuaternion* q,
+    float x, float y, float z);
+
+// --------------------------------------------------------------------------------
+/** Create a Quaternion from an axis angle pair.
+ *  @param q Receives the output quaternion
+ *  @param axis The orientation axis
+ *  @param angle The rotation angle, in radians
+ */
+ASSIMP_API void aiQuaternionFromAxisAngle(
+    C_STRUCT aiQuaternion* q,
+    const C_STRUCT aiVector3D* axis,
+    const float angle);
+
+// --------------------------------------------------------------------------------
+/** Create a Quaternion from a normalized quaternion stored
+ *  in a 3D vector.
+ *  @param q Receives the output quaternion
+ *  @param normalized The vector that stores the quaternion
+ */
+ASSIMP_API void aiQuaternionFromNormalizedQuaternion(
+    C_STRUCT aiQuaternion* q,
+    const C_STRUCT aiVector3D* normalized);
+
+// --------------------------------------------------------------------------------
+/** Check if quaternions are equal.
+ *  @param a First quaternion to compare
+ *  @param b Second quaternion to compare
+ *  @return 1 if the quaternions are equal
+ *  @return 0 if the quaternions are not equal
+ */
+ASSIMP_API int aiQuaternionAreEqual(
+    const C_STRUCT aiQuaternion* a,
+    const C_STRUCT aiQuaternion* b);
+
+// --------------------------------------------------------------------------------
+/** Check if quaternions are equal using epsilon.
+ *  @param a First quaternion to compare
+ *  @param b Second quaternion to compare
+ *  @param epsilon Epsilon
+ *  @return 1 if the quaternions are equal
+ *  @return 0 if the quaternions are not equal
+ */
+ASSIMP_API int aiQuaternionAreEqualEpsilon(
+    const C_STRUCT aiQuaternion* a,
+    const C_STRUCT aiQuaternion* b,
+    const float epsilon);
+
+// --------------------------------------------------------------------------------
+/** Normalize a quaternion.
+ *  @param q Quaternion to normalize
+ */
+ASSIMP_API void aiQuaternionNormalize(
+    C_STRUCT aiQuaternion* q);
+
+// --------------------------------------------------------------------------------
+/** Compute quaternion conjugate.
+ *  @param q Quaternion to compute conjugate,
+ *           receives the output quaternion
+ */
+ASSIMP_API void aiQuaternionConjugate(
+    C_STRUCT aiQuaternion* q);
+
+// --------------------------------------------------------------------------------
+/** Multiply quaternions.
+ *  @param dst First quaternion, receives the output quaternion
+ *  @param q Second quaternion
+ */
+ASSIMP_API void aiQuaternionMultiply(
+    C_STRUCT aiQuaternion* dst,
+    const C_STRUCT aiQuaternion* q);
+
+// --------------------------------------------------------------------------------
+/** Performs a spherical interpolation between two quaternions.
+ * @param dst Receives the quaternion resulting from the interpolation.
+ * @param start Quaternion when factor == 0
+ * @param end Quaternion when factor == 1
+ * @param factor Interpolation factor between 0 and 1
+ */
+ASSIMP_API void aiQuaternionInterpolate(
+    C_STRUCT aiQuaternion* dst,
+    const C_STRUCT aiQuaternion* start,
+    const C_STRUCT aiQuaternion* end,
+    const float factor);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/assimp/quaternion.h
+++ b/include/assimp/quaternion.h
@@ -99,7 +99,7 @@ public:
     aiQuaterniont& Conjugate ();
 
     /** Rotate a point by this quaternion */
-    aiVector3t<TReal> Rotate (const aiVector3t<TReal>& in);
+    aiVector3t<TReal> Rotate (const aiVector3t<TReal>& in) const;
 
     /** Multiply two quaternions */
     aiQuaterniont operator* (const aiQuaterniont& two) const;

--- a/include/assimp/quaternion.inl
+++ b/include/assimp/quaternion.inl
@@ -277,7 +277,7 @@ inline aiQuaterniont<TReal>& aiQuaterniont<TReal>::Conjugate ()
 
 // ---------------------------------------------------------------------------
 template<typename TReal>
-inline aiVector3t<TReal> aiQuaterniont<TReal>::Rotate (const aiVector3t<TReal>& v)
+inline aiVector3t<TReal> aiQuaterniont<TReal>::Rotate (const aiVector3t<TReal>& v) const
 {
     aiQuaterniont q2(0.f,v.x,v.y,v.z), q = *this, qinv = q;
     qinv.Conjugate();


### PR DESCRIPTION
[Link to issue](https://github.com/assimp/assimp/issues/3059).

I wrote several tests to ensure the API functions return the same result as the C++ methods. A new pull request containing the tests will be submitted after the current changes are merged.

The C API functions that have been added are the following:

2D vector functions:
- aiVector2AreEqual
- aiVector2AreEqualEpsilon
- aiVector2Add
- aiVector2Subtract
- aiVector2Scale
- aiVector2SymMul
- aiVector2DivideByScalar
- aiVector2DivideByVector
- aiVector2Length
- aiVector2SquareLength
- aiVector2Negate
- aiVector2DotProduct
- aiVector2Normalize

3D vector functions:
- aiVector3AreEqual
- aiVector3AreEqualEpsilon
- aiVector3LessThan
- aiVector3Add
- aiVector3Subtract
- aiVector3Scale
- aiVector3SymMul
- aiVector3DivideByScalar
- aiVector3DivideByVector
- aiVector3Length
- aiVector3SquareLength
- aiVector3Negate
- aiVector3DotProduct
- aiVector3CrossProduct
- aiVector3Normalize
- aiVector3NormalizeSafe
- aiVector3RotateByQuaternion

3x3 matrix functions:
- aiMatrix3FromMatrix4
- aiMatrix3FromQuaternion
- aiMatrix3AreEqual
- aiMatrix3AreEqualEpsilon
- aiMatrix3Inverse
- aiMatrix3Determinant
- aiMatrix3RotationZ
- aiMatrix3FromRotationAroundAxis
- aiMatrix3Translation
- aiMatrix3FromTo

4x4 matrix functions:
- aiMatrix4FromMatrix3
- aiMatrix4FromScalingQuaternionPosition
- aiMatrix4Add
- aiMatrix4AreEqual
- aiMatrix4AreEqualEpsilon
- aiMatrix4Inverse
- aiMatrix4Determinant
- aiMatrix4IsIdentity
- aiMatrix4DecomposeIntoScalingEulerAnglesPosition
- aiMatrix4DecomposeIntoScalingAxisAnglePosition
- aiMatrix4DecomposeNoScaling
- aiMatrix4FromEulerAngles
- aiMatrix4RotationX
- aiMatrix4RotationY
- aiMatrix4RotationZ
- aiMatrix4FromRotationAroundAxis
- aiMatrix4Translation
- aiMatrix4Scaling
- aiMatrix4FromTo

Quaternion:
- aiQuaternionFromEulerAngles
- aiQuaternionFromAxisAngle
- aiQuaternionFromNormalizedQuaternion
- aiQuaternionAreEqual
- aiQuaternionAreEqualEpsilon
- aiQuaternionNormalize
- aiQuaternionConjugate
- aiQuaternionMultiply
- aiQuaternionInterpolate

In addition, a const qualifier has been added to aiQuaterniont::Rotate to allow call to this method via a const aiQuaterniont pointer.