### PR TITLE
Removed unused header file in SimpleTexturedOpenGL sample.

### DIFF
--- a/samples/SimpleTexturedOpenGL/CMakeLists.txt
+++ b/samples/SimpleTexturedOpenGL/CMakeLists.txt
@@ -30,7 +30,6 @@ LINK_DIRECTORIES(
 )
 
 ADD_EXECUTABLE( assimp_simpletexturedogl WIN32
-  SimpleTexturedOpenGL/include/boost_includes.h
   SimpleTexturedOpenGL/src/model_loading.cpp
   ${SAMPLES_SHARED_CODE_DIR}/UTFConverter.cpp
   ${SAMPLES_SHARED_CODE_DIR}/UTFConverter.h

--- a/samples/SimpleTexturedOpenGL/SimpleTexturedOpenGL/include/boost_includes.h
+++ b/samples/SimpleTexturedOpenGL/SimpleTexturedOpenGL/include/boost_includes.h
@@ -1,1 +1,0 @@
-#include <boost/lexical_cast.hpp>


### PR DESCRIPTION
It appears the file `SimpleTexturedOpenGL/include/boost_includes.h` is unused in the
sample and is not referenced anywhere else in the code.