### PR TITLE
Removed unneeded SceneDiffer.h includes.

### DIFF
--- a/test/unit/ImportExport/utCOBImportExport.cpp
+++ b/test/unit/ImportExport/utCOBImportExport.cpp
@@ -39,7 +39,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ---------------------------------------------------------------------------
 */
 
-#include "SceneDiffer.h"
 #include "UnitTestPCH.h"
 
 #include <assimp/postprocess.h>

--- a/test/unit/ImportExport/utOFFImportExport.cpp
+++ b/test/unit/ImportExport/utOFFImportExport.cpp
@@ -40,7 +40,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "AbstractImportExportBase.h"
-#include "SceneDiffer.h"
 #include "UnitTestPCH.h"
 #include <assimp/postprocess.h>
 #include <assimp/scene.h>

--- a/test/unit/ImportExport/utOgreImportExport.cpp
+++ b/test/unit/ImportExport/utOgreImportExport.cpp
@@ -40,7 +40,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "AbstractImportExportBase.h"
-#include "SceneDiffer.h"
 #include "UnitTestPCH.h"
 
 #include <assimp/postprocess.h>

--- a/test/unit/ImportExport/utQ3BSPFileImportExport.cpp
+++ b/test/unit/ImportExport/utQ3BSPFileImportExport.cpp
@@ -40,7 +40,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "AbstractImportExportBase.h"
-#include "SceneDiffer.h"
 #include "UnitTestPCH.h"
 
 #include <assimp/postprocess.h>

--- a/test/unit/ut3DSImportExport.cpp
+++ b/test/unit/ut3DSImportExport.cpp
@@ -40,7 +40,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "AbstractImportExportBase.h"
-#include "SceneDiffer.h"
 #include "UnitTestPCH.h"
 
 #include <assimp/postprocess.h>

--- a/test/unit/utAMFImportExport.cpp
+++ b/test/unit/utAMFImportExport.cpp
@@ -40,7 +40,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "AbstractImportExportBase.h"
-#include "SceneDiffer.h"
 #include "UnitTestPCH.h"
 
 #include <assimp/postprocess.h>

--- a/test/unit/utASEImportExport.cpp
+++ b/test/unit/utASEImportExport.cpp
@@ -40,7 +40,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "AbstractImportExportBase.h"
-#include "SceneDiffer.h"
 #include "UnitTestPCH.h"
 
 #include <assimp/postprocess.h>

--- a/test/unit/utArmaturePopulate.cpp
+++ b/test/unit/utArmaturePopulate.cpp
@@ -42,7 +42,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "UnitTestPCH.h"
 
 #include "AbstractImportExportBase.h"
-#include "SceneDiffer.h"
 
 #include <assimp/material.h>
 #include <assimp/postprocess.h>

--- a/test/unit/utAssbinImportExport.cpp
+++ b/test/unit/utAssbinImportExport.cpp
@@ -39,7 +39,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ---------------------------------------------------------------------------
 */
 #include "AbstractImportExportBase.h"
-#include "SceneDiffer.h"
 #include "UnitTestPCH.h"
 #include <assimp/postprocess.h>
 #include <assimp/Exporter.hpp>

--- a/test/unit/utB3DImportExport.cpp
+++ b/test/unit/utB3DImportExport.cpp
@@ -40,7 +40,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "AbstractImportExportBase.h"
-#include "SceneDiffer.h"
 #include "UnitTestPCH.h"
 
 #include <assimp/postprocess.h>

--- a/test/unit/utDXFImporterExporter.cpp
+++ b/test/unit/utDXFImporterExporter.cpp
@@ -40,7 +40,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "AbstractImportExportBase.h"
-#include "SceneDiffer.h"
 #include "UnitTestPCH.h"
 
 #include <assimp/postprocess.h>

--- a/test/unit/utFBXImporterExporter.cpp
+++ b/test/unit/utFBXImporterExporter.cpp
@@ -40,7 +40,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "AbstractImportExportBase.h"
-#include "SceneDiffer.h"
 #include "UnitTestPCH.h"
 
 #include <assimp/commonMetaData.h>

--- a/test/unit/utM3DImportExport.cpp
+++ b/test/unit/utM3DImportExport.cpp
@@ -41,7 +41,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "AbstractImportExportBase.h"
-#include "SceneDiffer.h"
 #include "UnitTestPCH.h"
 
 #include <assimp/postprocess.h>

--- a/test/unit/utPMXImporter.cpp
+++ b/test/unit/utPMXImporter.cpp
@@ -40,7 +40,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "UnitTestPCH.h"
-#include "SceneDiffer.h"
 #include "AbstractImportExportBase.h"
 #include "MMD/MMDImporter.h"
 

--- a/test/unit/utSTLImportExport.cpp
+++ b/test/unit/utSTLImportExport.cpp
@@ -40,7 +40,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "AbstractImportExportBase.h"
-#include "SceneDiffer.h"
 #include "UnitTestPCH.h"
 
 #include <assimp/postprocess.h>

--- a/test/unit/utX3DImportExport.cpp
+++ b/test/unit/utX3DImportExport.cpp
@@ -40,7 +40,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "AbstractImportExportBase.h"
-#include "SceneDiffer.h"
 #include "UnitTestPCH.h"
 
 #include <assimp/postprocess.h>

--- a/test/unit/utXImporterExporter.cpp
+++ b/test/unit/utXImporterExporter.cpp
@@ -40,7 +40,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include "AbstractImportExportBase.h"
-#include "SceneDiffer.h"
 #include "UnitTestPCH.h"
 
 #include <assimp/postprocess.h>


### PR DESCRIPTION
The header [SceneDiffer.h](https://github.com/assimp/assimp/blob/master/test/unit/SceneDiffer.h) is included in several unit test files, but these tests do not make use of the **SceneDiffer** class.