### PR TITLE
Fixed /W4 compile warnings in sample SimpleOpenGL.

### DIFF
--- a/samples/SimpleOpenGL/Sample_SimpleOpenGL.c
+++ b/samples/SimpleOpenGL/Sample_SimpleOpenGL.c
@@ -245,7 +245,7 @@ void do_motion (void)
 	static int frames = 0;
 
 	int time = glutGet(GLUT_ELAPSED_TIME);
-	angle += (time-prev_time)*0.01;
+	angle += (time-prev_time)*0.01f;
 	prev_time = time;
 
 	frames += 1;


### PR DESCRIPTION
[Link to issue](https://github.com/assimp/assimp/issues/3123).

The following changes fix compile warnings for sample project SimpleOpenGL.

All tests were run.