### PR TITLE
Fixed /W4 compile warnings in sample SimpleTexturedOpenGL.

### DIFF
--- a/contrib/stb_image/stb_image.h
+++ b/contrib/stb_image/stb_image.h
@@ -6336,7 +6336,7 @@ static stbi_uc *stbi__process_gif_raster(stbi__context *s, stbi__gif *g)
 
 // this function is designed to support animated gifs, although stb_image doesn't support it
 // two back is the image from two frames ago, used for a very specific disposal format
-static stbi_uc *stbi__gif_load_next(stbi__context *s, stbi__gif *g, int *comp, int req_comp, stbi_uc *two_back)
+static stbi_uc *stbi__gif_load_next(stbi__context *s, stbi__gif *g, int *comp, int /*req_comp*/, stbi_uc *two_back)
 {
    int dispose; 
    int first_frame; 
@@ -6560,7 +6560,7 @@ static void *stbi__load_gif_main(stbi__context *s, int **delays, int *x, int *y,
    }
 }
 
-static void *stbi__gif_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
+static void *stbi__gif_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info * /*ri*/)
 {
    stbi_uc *u = 0;
    stbi__gif g;

--- a/contrib/stb_image/stb_image.h
+++ b/contrib/stb_image/stb_image.h
@@ -6336,7 +6336,7 @@ static stbi_uc *stbi__process_gif_raster(stbi__context *s, stbi__gif *g)
 
 // this function is designed to support animated gifs, although stb_image doesn't support it
 // two back is the image from two frames ago, used for a very specific disposal format
-static stbi_uc *stbi__gif_load_next(stbi__context *s, stbi__gif *g, int *comp, int /*req_comp*/, stbi_uc *two_back)
+static stbi_uc *stbi__gif_load_next(stbi__context *s, stbi__gif *g, int *comp, int req_comp, stbi_uc *two_back)
 {
    int dispose; 
    int first_frame; 
@@ -6560,7 +6560,7 @@ static void *stbi__load_gif_main(stbi__context *s, int **delays, int *x, int *y,
    }
 }
 
-static void *stbi__gif_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info * /*ri*/)
+static void *stbi__gif_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
 {
    stbi_uc *u = 0;
    stbi__gif g;

--- a/samples/SimpleTexturedOpenGL/SimpleTexturedOpenGL/src/model_loading.cpp
+++ b/samples/SimpleTexturedOpenGL/SimpleTexturedOpenGL/src/model_loading.cpp
@@ -18,8 +18,10 @@
 #include <GL/gl.h>
 #include <GL/glu.h>
 
+#pragma warning(disable: 4100) // Disable warning 'unreferenced formal parameter'
 #define STB_IMAGE_IMPLEMENTATION
 #include "contrib/stb_image/stb_image.h"
+#pragma warning(default: 4100) // Enable warning 'unreferenced formal parameter'
 
 #include <fstream>
 


### PR DESCRIPTION
[Link to issue](https://github.com/assimp/assimp/issues/3123).

The following changes fix compile warnings for sample project SimpleTexturedOpenGL.

All tests were run.