### PR TITLE
Fixed /W4 compile warnings in sample SimpleTexturedDirectx11.

### DIFF
--- a/samples/SimpleTexturedDirectx11/SimpleTexturedDirectx11/Mesh.h
+++ b/samples/SimpleTexturedDirectx11/SimpleTexturedDirectx11/Mesh.h
@@ -31,40 +31,40 @@ struct Texture {
 
 class Mesh {
 public:
-    std::vector<VERTEX> vertices;
-    std::vector<UINT> indices;
-    std::vector<Texture> textures;
-    ID3D11Device *dev;
+    std::vector<VERTEX> vertices_;
+    std::vector<UINT> indices_;
+    std::vector<Texture> textures_;
+    ID3D11Device *dev_;
 
     Mesh(ID3D11Device *dev, const std::vector<VERTEX>& vertices, const std::vector<UINT>& indices, const std::vector<Texture>& textures) :
-            vertices(vertices),
-            indices(indices),
-            textures(textures),
-            dev(dev),
-            VertexBuffer(nullptr),
-            IndexBuffer(nullptr) {
-        this->setupMesh(this->dev);
+            vertices_(vertices),
+            indices_(indices),
+            textures_(textures),
+            dev_(dev),
+            VertexBuffer_(nullptr),
+            IndexBuffer_(nullptr) {
+        this->setupMesh(this->dev_);
     }
 
     void Draw(ID3D11DeviceContext *devcon) {
         UINT stride = sizeof(VERTEX);
         UINT offset = 0;
 
-        devcon->IASetVertexBuffers(0, 1, &VertexBuffer, &stride, &offset);
-        devcon->IASetIndexBuffer(IndexBuffer, DXGI_FORMAT_R32_UINT, 0);
+        devcon->IASetVertexBuffers(0, 1, &VertexBuffer_, &stride, &offset);
+        devcon->IASetIndexBuffer(IndexBuffer_, DXGI_FORMAT_R32_UINT, 0);
 
-        devcon->PSSetShaderResources(0, 1, &textures[0].texture);
+        devcon->PSSetShaderResources(0, 1, &textures_[0].texture);
 
-        devcon->DrawIndexed(static_cast<UINT>(indices.size()), 0, 0);
+        devcon->DrawIndexed(static_cast<UINT>(indices_.size()), 0, 0);
     }
 
     void Close() {
-        SafeRelease(VertexBuffer);
-        SafeRelease(IndexBuffer);
+        SafeRelease(VertexBuffer_);
+        SafeRelease(IndexBuffer_);
     }
 private:
     // Render data
-    ID3D11Buffer *VertexBuffer, *IndexBuffer;
+    ID3D11Buffer *VertexBuffer_, *IndexBuffer_;
 
     // Functions
     // Initializes all the buffer objects/arrays
@@ -73,15 +73,15 @@ private:
 
         D3D11_BUFFER_DESC vbd;
         vbd.Usage = D3D11_USAGE_IMMUTABLE;
-        vbd.ByteWidth = static_cast<UINT>(sizeof(VERTEX) * vertices.size());
+        vbd.ByteWidth = static_cast<UINT>(sizeof(VERTEX) * vertices_.size());
         vbd.BindFlags = D3D11_BIND_VERTEX_BUFFER;
         vbd.CPUAccessFlags = 0;
         vbd.MiscFlags = 0;
 
         D3D11_SUBRESOURCE_DATA initData;
-        initData.pSysMem = &vertices[0];
+        initData.pSysMem = &vertices_[0];
 
-        hr = dev->CreateBuffer(&vbd, &initData, &VertexBuffer);
+        hr = dev->CreateBuffer(&vbd, &initData, &VertexBuffer_);
         if (FAILED(hr)) {
             Close();
             throw std::runtime_error("Failed to create vertex buffer.");
@@ -89,14 +89,14 @@ private:
 
         D3D11_BUFFER_DESC ibd;
         ibd.Usage = D3D11_USAGE_IMMUTABLE;
-        ibd.ByteWidth = static_cast<UINT>(sizeof(UINT) * indices.size());
+        ibd.ByteWidth = static_cast<UINT>(sizeof(UINT) * indices_.size());
         ibd.BindFlags = D3D11_BIND_INDEX_BUFFER;
         ibd.CPUAccessFlags = 0;
         ibd.MiscFlags = 0;
 
-        initData.pSysMem = &indices[0];
+        initData.pSysMem = &indices_[0];
 
-        hr = dev->CreateBuffer(&ibd, &initData, &IndexBuffer);
+        hr = dev->CreateBuffer(&ibd, &initData, &IndexBuffer_);
         if (FAILED(hr)) {
             Close();
             throw std::runtime_error("Failed to create index buffer.");

--- a/samples/SimpleTexturedDirectx11/SimpleTexturedDirectx11/ModelLoader.cpp
+++ b/samples/SimpleTexturedDirectx11/SimpleTexturedDirectx11/ModelLoader.cpp
@@ -37,7 +37,7 @@ bool ModelLoader::Load(HWND hwnd, ID3D11Device * dev, ID3D11DeviceContext * devc
 }
 
 void ModelLoader::Draw(ID3D11DeviceContext * devcon) {
-	for (int i = 0; i < meshes_.size(); ++i ) {
+	for (size_t i = 0; i < meshes_.size(); ++i ) {
 		meshes_[i].Draw(devcon);
 	}
 }
@@ -132,7 +132,7 @@ void ModelLoader::Close() {
 	for (auto& t : textures_loaded_)
 		t.Release();
 
-	for (int i = 0; i < meshes_.size(); i++) {
+	for (size_t i = 0; i < meshes_.size(); i++) {
 		meshes_[i].Close();
 	}
 }

--- a/samples/SimpleTexturedDirectx11/SimpleTexturedDirectx11/ModelLoader.cpp
+++ b/samples/SimpleTexturedDirectx11/SimpleTexturedDirectx11/ModelLoader.cpp
@@ -1,12 +1,12 @@
 #include "ModelLoader.h"
 
 ModelLoader::ModelLoader() : 
-        dev(nullptr),
-        devcon(nullptr),
-        meshes(),
-        directory(),
-        textures_loaded(),
-        hwnd(nullptr) {
+        dev_(nullptr),
+        devcon_(nullptr),
+        meshes_(),
+        directory_(),
+        textures_loaded_(),
+        hwnd_(nullptr) {
     // empty
 }
 
@@ -25,11 +25,11 @@ bool ModelLoader::Load(HWND hwnd, ID3D11Device * dev, ID3D11DeviceContext * devc
 	if (pScene == NULL)
 		return false;
 
-	this->directory = filename.substr(0, filename.find_last_of("/\\"));
+	this->directory_ = filename.substr(0, filename.find_last_of("/\\"));
 
-	this->dev = dev;
-	this->devcon = devcon;
-	this->hwnd = hwnd;
+	this->dev_ = dev;
+	this->devcon_ = devcon;
+	this->hwnd_ = hwnd;
 
 	processNode(pScene->mRootNode, pScene);
 
@@ -37,8 +37,8 @@ bool ModelLoader::Load(HWND hwnd, ID3D11Device * dev, ID3D11DeviceContext * devc
 }
 
 void ModelLoader::Draw(ID3D11DeviceContext * devcon) {
-	for (int i = 0; i < meshes.size(); ++i ) {
-		meshes[i].Draw(devcon);
+	for (int i = 0; i < meshes_.size(); ++i ) {
+		meshes_[i].Draw(devcon);
 	}
 }
 
@@ -88,7 +88,7 @@ Mesh ModelLoader::processMesh(aiMesh * mesh, const aiScene * scene) {
 		textures.insert(textures.end(), diffuseMaps.begin(), diffuseMaps.end());
 	}
 
-	return Mesh(dev, vertices, indices, textures);
+	return Mesh(dev_, vertices, indices, textures);
 }
 
 std::vector<Texture> ModelLoader::loadMaterialTextures(aiMaterial * mat, aiTextureType type, std::string typeName, const aiScene * scene) {
@@ -98,9 +98,9 @@ std::vector<Texture> ModelLoader::loadMaterialTextures(aiMaterial * mat, aiTextu
 		mat->GetTexture(type, i, &str);
 		// Check if texture was loaded before and if so, continue to next iteration: skip loading a new texture
 		bool skip = false;
-		for (UINT j = 0; j < textures_loaded.size(); j++) {
-			if (std::strcmp(textures_loaded[j].path.c_str(), str.C_Str()) == 0) {
-				textures.push_back(textures_loaded[j]);
+		for (UINT j = 0; j < textures_loaded_.size(); j++) {
+			if (std::strcmp(textures_loaded_[j].path.c_str(), str.C_Str()) == 0) {
+				textures.push_back(textures_loaded_[j]);
 				skip = true; // A texture with the same filepath has already been loaded, continue to next one. (optimization)
 				break;
 			}
@@ -113,34 +113,34 @@ std::vector<Texture> ModelLoader::loadMaterialTextures(aiMaterial * mat, aiTextu
 				texture.texture = getTextureFromModel(scene, textureindex);
 			} else {
 				std::string filename = std::string(str.C_Str());
-				filename = directory + '/' + filename;
+				filename = directory_ + '/' + filename;
 				std::wstring filenamews = std::wstring(filename.begin(), filename.end());
-				hr = CreateWICTextureFromFile(dev, devcon, filenamews.c_str(), nullptr, &texture.texture);
+				hr = CreateWICTextureFromFile(dev_, devcon_, filenamews.c_str(), nullptr, &texture.texture);
 				if (FAILED(hr))
-					MessageBox(hwnd, "Texture couldn't be loaded", "Error!", MB_ICONERROR | MB_OK);
+					MessageBox(hwnd_, "Texture couldn't be loaded", "Error!", MB_ICONERROR | MB_OK);
 			}
 			texture.type = typeName;
 			texture.path = str.C_Str();
 			textures.push_back(texture);
-			this->textures_loaded.push_back(texture);  // Store it as texture loaded for entire model, to ensure we won't unnecesery load duplicate textures.
+			this->textures_loaded_.push_back(texture);  // Store it as texture loaded for entire model, to ensure we won't unnecesery load duplicate textures.
 		}
 	}
 	return textures;
 }
 
 void ModelLoader::Close() {
-	for (auto& t : textures_loaded)
+	for (auto& t : textures_loaded_)
 		t.Release();
 
-	for (int i = 0; i < meshes.size(); i++) {
-		meshes[i].Close();
+	for (int i = 0; i < meshes_.size(); i++) {
+		meshes_[i].Close();
 	}
 }
 
 void ModelLoader::processNode(aiNode * node, const aiScene * scene) {
 	for (UINT i = 0; i < node->mNumMeshes; i++) {
 		aiMesh* mesh = scene->mMeshes[node->mMeshes[i]];
-		meshes.push_back(this->processMesh(mesh, scene));
+		meshes_.push_back(this->processMesh(mesh, scene));
 	}
 
 	for (UINT i = 0; i < node->mNumChildren; i++) {
@@ -179,9 +179,9 @@ ID3D11ShaderResourceView * ModelLoader::getTextureFromModel(const aiScene * scen
 
 	int* size = reinterpret_cast<int*>(&scene->mTextures[textureindex]->mWidth);
 
-	hr = CreateWICTextureFromMemory(dev, devcon, reinterpret_cast<unsigned char*>(scene->mTextures[textureindex]->pcData), *size, nullptr, &texture);
+	hr = CreateWICTextureFromMemory(dev_, devcon_, reinterpret_cast<unsigned char*>(scene->mTextures[textureindex]->pcData), *size, nullptr, &texture);
 	if (FAILED(hr))
-		MessageBox(hwnd, "Texture couldn't be created from memory!", "Error!", MB_ICONERROR | MB_OK);
+		MessageBox(hwnd_, "Texture couldn't be created from memory!", "Error!", MB_ICONERROR | MB_OK);
 
 	return texture;
 }

--- a/samples/SimpleTexturedDirectx11/SimpleTexturedDirectx11/ModelLoader.h
+++ b/samples/SimpleTexturedDirectx11/SimpleTexturedDirectx11/ModelLoader.h
@@ -25,12 +25,12 @@ public:
 
 	void Close();
 private:
-	ID3D11Device *dev;
-	ID3D11DeviceContext *devcon;
-	std::vector<Mesh> meshes;
-	std::string directory;
-	std::vector<Texture> textures_loaded;
-	HWND hwnd;
+	ID3D11Device *dev_;
+	ID3D11DeviceContext *devcon_;
+	std::vector<Mesh> meshes_;
+	std::string directory_;
+	std::vector<Texture> textures_loaded_;
+	HWND hwnd_;
 
 	void processNode(aiNode* node, const aiScene* scene);
 	Mesh processMesh(aiMesh* mesh, const aiScene* scene);

--- a/samples/SimpleTexturedDirectx11/SimpleTexturedDirectx11/main.cpp
+++ b/samples/SimpleTexturedDirectx11/SimpleTexturedDirectx11/main.cpp
@@ -56,7 +56,7 @@ const char g_szClassName[] = "directxWindowClass";
 static std::string g_ModelPath;
 
 UINT width, height;
-HWND hwnd = nullptr;
+HWND g_hwnd = nullptr;
 
 // ------------------------------------------------------------
 //                        DirectX Variables
@@ -120,8 +120,8 @@ LRESULT CALLBACK WndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 	return 0;
 }
 
-int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
-	LPWSTR lpCmdLine, int nCmdShow)
+int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE /*hPrevInstance*/,
+	LPWSTR /*lpCmdLine*/, int nCmdShow)
 {
 	int argc;
 	LPWSTR* argv = CommandLineToArgvW(GetCommandLineW(), &argc);
@@ -182,7 +182,7 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 	RECT wr = { 0,0, SCREEN_WIDTH, SCREEN_HEIGHT };
 	AdjustWindowRect(&wr, WS_OVERLAPPEDWINDOW, FALSE);
 
-	hwnd = CreateWindowEx(
+	g_hwnd = CreateWindowEx(
 		WS_EX_CLIENTEDGE,
 		g_szClassName,
 		" Simple Textured Directx11 Sample ",
@@ -191,21 +191,21 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 		NULL, NULL, hInstance, NULL
 	);
 
-	if (hwnd == NULL)
+	if (g_hwnd == NULL)
 	{
 		MessageBox(NULL, "Window Creation Failed!", "Error!",
 			MB_ICONEXCLAMATION | MB_OK);
 		return 0;
 	}
 
-	ShowWindow(hwnd, nCmdShow);
-	UpdateWindow(hwnd);
+	ShowWindow(g_hwnd, nCmdShow);
+	UpdateWindow(g_hwnd);
 
 	width = wr.right - wr.left;
 	height = wr.bottom - wr.top;
 
 	try {
-		InitD3D(hInstance, hwnd);
+		InitD3D(hInstance, g_hwnd);
 
 		while (true)
 		{
@@ -225,17 +225,17 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance,
 		CleanD3D();
 		return static_cast<int>(msg.wParam);
 	} catch (const std::exception& e) {
-		MessageBox(hwnd, e.what(), TEXT("Error!"), MB_ICONERROR | MB_OK);
+		MessageBox(g_hwnd, e.what(), TEXT("Error!"), MB_ICONERROR | MB_OK);
 		CleanD3D();
 		return EXIT_FAILURE;
 	} catch (...) {
-		MessageBox(hwnd, TEXT("Caught an unknown exception."), TEXT("Error!"), MB_ICONERROR | MB_OK);
+		MessageBox(g_hwnd, TEXT("Caught an unknown exception."), TEXT("Error!"), MB_ICONERROR | MB_OK);
 		CleanD3D();
 		return EXIT_FAILURE;
 	}
 }
 
-void InitD3D(HINSTANCE hinstance, HWND hWnd)
+void InitD3D(HINSTANCE /*hinstance*/, HWND hWnd)
 {
 	HRESULT hr;
 
@@ -362,7 +362,7 @@ void InitD3D(HINSTANCE hinstance, HWND hWnd)
 	}
 
 	// Note this tutorial doesn't handle full-screen swapchains so we block the ALT+ENTER shortcut
-	dxgiFactory->MakeWindowAssociation(hwnd, DXGI_MWA_NO_ALT_ENTER);
+	dxgiFactory->MakeWindowAssociation(g_hwnd, DXGI_MWA_NO_ALT_ENTER);
 
 	dxgiFactory->Release();
 
@@ -564,7 +564,7 @@ void InitGraphics()
 	m_View = XMMatrixLookAtLH(Eye, At, Up);
 
 	ourModel = new ModelLoader;
-	if (!ourModel->Load(hwnd, dev, devcon, g_ModelPath))
+	if (!ourModel->Load(g_hwnd, dev, devcon, g_ModelPath))
 		Throwanerror("Model couldn't be loaded");
 }
 


### PR DESCRIPTION
[Link to issue](https://github.com/assimp/assimp/issues/3123).

The following changes fix compile warnings for sample project SimpleTexturedDirectx11.

All tests were run.

A few notes about the changes:

- Several class member variables have been renamed to reduce the risk of running into name conflicts in the future.