### PR TITLE
Fixed /W4 compile warnings in Assimp viewer.

### DIFF
--- a/tools/assimp_view/Display.cpp
+++ b/tools/assimp_view/Display.cpp
@@ -275,7 +275,7 @@ int CDisplay::ReplaceCurrentTexture(const char* szPath)
     IDirect3DTexture9* piTexture = NULL;
     aiString szString;
     strcpy(szString.data,szPath);
-    szString.length = strlen(szPath);
+    szString.length = static_cast<ai_uint32>(strlen(szPath));
     CMaterialManager::Instance().LoadTexture(&piTexture,&szString);
 
     if (!piTexture) {
@@ -388,8 +388,8 @@ int CDisplay::AddTextureToDisplayList(unsigned int iType,
     {
         if ('*' == *szPath->data)
         {
-            int iIndex = atoi(szPath->data+1);
-            ai_snprintf(chTempEmb,256,"Embedded #%i",iIndex);
+            int iIndex2 = atoi(szPath->data+1);
+            ai_snprintf(chTempEmb,256,"Embedded #%i",iIndex2);
             sz = chTempEmb;
         }
         else
@@ -1308,7 +1308,7 @@ int CALLBACK TreeViewCompareFunc(LPARAM lParam1, LPARAM lParam2, LPARAM lParamSo
     return 0;
 }
 //-------------------------------------------------------------------------------
-int CDisplay::HandleTreeViewPopup2(WPARAM wParam,LPARAM lParam)
+int CDisplay::HandleTreeViewPopup2(WPARAM wParam,LPARAM /*lParam*/)
 {
     char szFileName[MAX_PATH];
     DWORD dwTemp = MAX_PATH;
@@ -1795,11 +1795,11 @@ int CDisplay::RenderFullScene()
         g_piDevice->SetVertexDeclaration( gDefaultVertexDecl);
         // this is very similar to the code in SetupMaterial()
         ID3DXEffect* piEnd = g_piNormalsEffect;
-        aiMatrix4x4 pcProj = m * mViewProjection;
+        aiMatrix4x4 pcProj2 = m * mViewProjection;
 
         D3DXVECTOR4 vVector(1.f,0.f,0.f,1.f);
         piEnd->SetVector("OUTPUT_COLOR",&vVector);
-        piEnd->SetMatrix("WorldViewProjection", (const D3DXMATRIX*)&pcProj);
+        piEnd->SetMatrix("WorldViewProjection", (const D3DXMATRIX*)&pcProj2);
 
         UINT dwPasses = 0;
         piEnd->Begin(&dwPasses,0);

--- a/tools/assimp_view/LogWindow.cpp
+++ b/tools/assimp_view/LogWindow.cpp
@@ -70,7 +70,7 @@ static const char* AI_VIEW_RTF_LOG_HEADER =
 // Message procedure for the log window
 //-------------------------------------------------------------------------------
 INT_PTR CALLBACK LogDialogProc(HWND hwndDlg,UINT uMsg,
-    WPARAM wParam,LPARAM lParam)
+    WPARAM /*wParam*/,LPARAM lParam)
     {
     (void)lParam;
     switch (uMsg)

--- a/tools/assimp_view/Material.cpp
+++ b/tools/assimp_view/Material.cpp
@@ -287,7 +287,7 @@ bool CMaterialManager::TryLongerPath(char* szTemp,aiString* p_szString)
                             size_t iLen2 = iLen+1;
                             iLen2 = iLen2 > MAXLEN ? MAXLEN : iLen2;
                             memcpy(p_szString->data,szTempB,iLen2);
-                            p_szString->length = iLen;
+                            p_szString->length = static_cast<ai_uint32>(iLen);
                             return true;
                         }
                     }
@@ -301,7 +301,7 @@ bool CMaterialManager::TryLongerPath(char* szTemp,aiString* p_szString)
                         size_t iLen2 = iLen+1;
                         iLen2 = iLen2 > MAXLEN ? MAXLEN : iLen2;
                         memcpy(p_szString->data,szTempB,iLen2);
-                        p_szString->length = iLen;
+                        p_szString->length = static_cast<ai_uint32>(iLen);
                         return true;
                     }
                 }
@@ -389,10 +389,10 @@ int CMaterialManager::FindValidPath(aiString* p_szString)
                     if( !q ) q=strrchr( tmp2,'\\' );
                     if( q ){
                         strcpy( q+1,p+1 );
-                        if((pFile=fopen( tmp2,"r" ))){
+                        if((pFile=fopen( tmp2,"r" )) != nullptr){
                             fclose( pFile );
                             strcpy(p_szString->data,tmp2);
-                            p_szString->length = strlen(tmp2);
+                            p_szString->length = static_cast<ai_uint32>(strlen(tmp2));
                             return 1;
                         }
                     }
@@ -407,7 +407,7 @@ int CMaterialManager::FindValidPath(aiString* p_szString)
         size_t iLen2 = iLen+1;
         iLen2 = iLen2 > MAXLEN ? MAXLEN : iLen2;
         memcpy(p_szString->data,szTemp,iLen2);
-        p_szString->length = iLen;
+        p_szString->length = static_cast<ai_uint32>(iLen);
 
     }
     return 1;
@@ -627,7 +627,7 @@ void CMaterialManager::HMtoNMIfNecessary(
     {
         union
         {
-            struct {unsigned char b,g,r,a;};
+            struct {unsigned char b,g,r,a;} _data;
             char _array[4];
         };
     };
@@ -646,7 +646,7 @@ void CMaterialManager::HMtoNMIfNecessary(
     {
         for (unsigned int x = 0; x <  sDesc.Width;++x)
         {
-            if (pcPointer->b != pcPointer->r || pcPointer->b != pcPointer->g)
+            if (pcPointer->_data.b != pcPointer->_data.r || pcPointer->_data.b != pcPointer->_data.g)
             {
                 bIsEqual = false;
                 break;
@@ -705,9 +705,9 @@ void CMaterialManager::HMtoNMIfNecessary(
                     aiColor3D clrColorLine;
                     for (unsigned int x = 0; x <  sDesc.Width;++x)
                     {
-                        clrColorLine.r += pcPointer->r;
-                        clrColorLine.g += pcPointer->g;
-                        clrColorLine.b += pcPointer->b;
+                        clrColorLine.r += pcPointer->_data.r;
+                        clrColorLine.g += pcPointer->_data.g;
+                        clrColorLine.b += pcPointer->_data.b;
                         pcPointer++;
                     }
                     clrColor.r += clrColorLine.r /= (float)sDesc.Width;
@@ -739,17 +739,17 @@ void CMaterialManager::HMtoNMIfNecessary(
     // need to convert it NOW
     if (bMustConvert)
     {
-        D3DSURFACE_DESC sDesc;
-        piTexture->GetLevelDesc(0, &sDesc);
+        D3DSURFACE_DESC sDesc2;
+        piTexture->GetLevelDesc(0, &sDesc2);
 
         IDirect3DTexture9* piTempTexture;
         if(FAILED(g_piDevice->CreateTexture(
-            sDesc.Width,
-            sDesc.Height,
+            sDesc2.Width,
+            sDesc2.Height,
             piTexture->GetLevelCount(),
-            sDesc.Usage,
-            sDesc.Format,
-            sDesc.Pool, &piTempTexture, NULL)))
+            sDesc2.Usage,
+            sDesc2.Format,
+            sDesc2.Pool, &piTempTexture, NULL)))
         {
             CLogDisplay::Instance().AddEntry(
                 "[ERROR] Unable to create normal map texture",

--- a/tools/assimp_view/Material.cpp
+++ b/tools/assimp_view/Material.cpp
@@ -627,7 +627,7 @@ void CMaterialManager::HMtoNMIfNecessary(
     {
         union
         {
-            struct {unsigned char b,g,r,a;} _data;
+            struct {unsigned char b,g,r,a;} data;
             char _array[4];
         };
     };
@@ -646,7 +646,7 @@ void CMaterialManager::HMtoNMIfNecessary(
     {
         for (unsigned int x = 0; x <  sDesc.Width;++x)
         {
-            if (pcPointer->_data.b != pcPointer->_data.r || pcPointer->_data.b != pcPointer->_data.g)
+            if (pcPointer->data.b != pcPointer->data.r || pcPointer->data.b != pcPointer->data.g)
             {
                 bIsEqual = false;
                 break;
@@ -705,9 +705,9 @@ void CMaterialManager::HMtoNMIfNecessary(
                     aiColor3D clrColorLine;
                     for (unsigned int x = 0; x <  sDesc.Width;++x)
                     {
-                        clrColorLine.r += pcPointer->_data.r;
-                        clrColorLine.g += pcPointer->_data.g;
-                        clrColorLine.b += pcPointer->_data.b;
+                        clrColorLine.r += pcPointer->data.r;
+                        clrColorLine.g += pcPointer->data.g;
+                        clrColorLine.b += pcPointer->data.b;
                         pcPointer++;
                     }
                     clrColor.r += clrColorLine.r /= (float)sDesc.Width;

--- a/tools/assimp_view/MessageProc.cpp
+++ b/tools/assimp_view/MessageProc.cpp
@@ -107,7 +107,7 @@ void MakeFileAssociations() {
         RegCreateKeyEx(HKEY_CURRENT_USER,buf,0,NULL,0,KEY_ALL_ACCESS, NULL, &hRegistry,NULL);
         RegSetValueEx(hRegistry,"",0,REG_SZ,(const BYTE*)"ASSIMPVIEW_CLASS",(DWORD)strlen("ASSIMPVIEW_CLASS")+1);
         RegCloseKey(hRegistry);
-    } while ((sz = strtok(NULL,";")));
+    } while ((sz = strtok(NULL,";")) != nullptr);
 
     RegCreateKeyEx(HKEY_CURRENT_USER,"Software\\Classes\\ASSIMPVIEW_CLASS",0,NULL,0,KEY_ALL_ACCESS, NULL, &hRegistry,NULL);
     RegCloseKey(hRegistry);

--- a/tools/assimp_view/MessageProc.cpp
+++ b/tools/assimp_view/MessageProc.cpp
@@ -107,7 +107,7 @@ void MakeFileAssociations() {
         RegCreateKeyEx(HKEY_CURRENT_USER,buf,0,NULL,0,KEY_ALL_ACCESS, NULL, &hRegistry,NULL);
         RegSetValueEx(hRegistry,"",0,REG_SZ,(const BYTE*)"ASSIMPVIEW_CLASS",(DWORD)strlen("ASSIMPVIEW_CLASS")+1);
         RegCloseKey(hRegistry);
-    } while ((sz = strtok(NULL,";")) != nullptr);
+    } while ((sz = strtok(nullptr,";")) != nullptr);
 
     RegCreateKeyEx(HKEY_CURRENT_USER,"Software\\Classes\\ASSIMPVIEW_CLASS",0,NULL,0,KEY_ALL_ACCESS, NULL, &hRegistry,NULL);
     RegCloseKey(hRegistry);

--- a/tools/assimp_view/assimp_view.cpp
+++ b/tools/assimp_view/assimp_view.cpp
@@ -505,7 +505,7 @@ int CreateAssetData()
         if (g_pcAsset->apcMeshes[i]->piOpacityTexture || 1.0f != g_pcAsset->apcMeshes[i]->fOpacity)
             dwUsage |= D3DUSAGE_DYNAMIC;
 
-        unsigned int nidx;
+        unsigned int nidx = 0;
         switch (mesh->mPrimitiveTypes) {
             case aiPrimitiveType_POINT:
                 nidx = 1;
@@ -639,7 +639,7 @@ int CreateAssetData()
                 ai_assert( weightsPerVertex[x].size() <= 4);
                 for( unsigned int a = 0; a < weightsPerVertex[x].size(); a++)
                 {
-                    boneIndices[a] = weightsPerVertex[x][a].mVertexId;
+                    boneIndices[a] = static_cast<unsigned char>(weightsPerVertex[x][a].mVertexId);
                     boneWeights[a] = (unsigned char) (weightsPerVertex[x][a].mWeight * 255.0f);
                 }
 
@@ -802,10 +802,10 @@ int ShutdownD3D(void)
 
 template<class TComPtr>
 inline 
-void SafeRelease(TComPtr *ptr) {
-    if (nullptr != g_piPassThroughEffect) {
-        g_piPassThroughEffect->Release();
-        g_piPassThroughEffect = nullptr;
+void SafeRelease(TComPtr *&ptr) {
+    if (nullptr != ptr) {
+        ptr->Release();
+        ptr = nullptr;
     }
 }
 


### PR DESCRIPTION
[Link to issue](https://github.com/assimp/assimp/issues/3123).

The following changes fix compile warnings for project Assimp viewer.

These changes have been tested in 32 bit and 64 bit builds, and compared against a build from master. Both appear to show similar results.

The following models were used for testing:

- test/models/OBJ/spider.obj
- test/models-nonbsd/MD5/Bob.md5mesh

The following functionalities were tested:

**Menu / Toolbar**

[Viewer]

*Note: Import settings were left to default.*

- Open asset
- Close asset
- Reload
- Reset view
- Memory consumption
- Clear history
- Save Screenshot

[Tools]
- Log window
- Clear log
- Original normals
- Hard normals
- Smooth normals
- Flip normals
- Stereo view

[Background]
- Set color
- Load texture
- Clear background

**Control panel**

[Display]

- Multisampling
- Wireframe
- No materials
- Display normals
- Low quality
- No specular
- Show skeleton
- Auto rotate
- Zoom/Rotate
- Rotate lights
- Two lights
- Backface culling
- No transparency

[Statistics]

- Vertices
- Nodes
- Shaders
- Load Time (arbitrary)
- Faces
- Materials
- Meshes
- FPS (arbitrary)

[Colors]
- Primary
- Secondary
- Ambient
- Colors reset button

Each animation has been verified in each model, including default bind pose.

All tests were run.

Additional information about the changes:

- SColor anonymous struct was given the name `_data` to prevent compiler warning:
`warning C4201: nonstandard extension used: nameless struct/union`

- The function [SafeRelease](https://github.com/assimp/assimp/blob/085212e58ab0cf6dc96256e1577e9e31d0a8f3e2/tools/assimp_view/assimp_view.cpp#L805-L810) was always releasing `g_piPassThroughEffect` instead of
`ptr`. This has been changed to `ptr`. In addition, the function attempts to set `ptr` to null, but it cannot be changed because `ptr` is neither passed as a double pointer or by reference. Therefore, a reference operator **&** has been added.