### PR TITLE
Enable gcc on Linux on CI, fix warnings

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -8,13 +8,13 @@ on:
 
 jobs:
   job:
-    name: ${{ matrix.os }}-build-and-test
+    name: ${{ matrix.os }}-${{ matrix.cxx }}-build-and-test
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        # For Windows msvc, for Linux and macOS let's use the clang compiler
+        # For Windows msvc, for Linux and macOS let's use the clang compiler, use gcc for Linux.
         include:
           - os: windows-latest
             cxx: cl.exe
@@ -22,6 +22,9 @@ jobs:
           - os: ubuntu-latest
             cxx: clang++
             cc: clang
+          - os: ubuntu-latest
+            cxx: g++
+            cc: gcc
           - os: macos-latest
             cxx: clang++
             cc: clang

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -13,21 +13,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        name: [ubuntu-gcc, macos-clang, windows-msvc, ubuntu-clang]
         # For Windows msvc, for Linux and macOS let's use the clang compiler, use gcc for Linux.
         include:
-          - os: windows-latest
+          - name: windows-msvc
+            os: windows-latest
             cxx: cl.exe
             cc: cl.exe
-          - os: ubuntu-latest
+          - name: ubuntu-clang
+            os: ubuntu-latest
             cxx: clang++
             cc: clang
-          - os: ubuntu-latest
+          - name: macos-clang
+            os: macos-latest
+            cxx: clang++
+            cc: clang
+          - name: ubuntu-gcc
+            os: ubuntu-latest
             cxx: g++
             cc: gcc
-          - os: macos-latest
-            cxx: clang++
-            cc: clang
 
     steps:
     - uses: actions/checkout@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -239,22 +239,14 @@ IF( UNIX )
   INCLUDE(GNUInstallDirs)
 ENDIF()
 
-# enable warnings as errors ########################################
-IF (MSVC)
-  ADD_COMPILE_OPTIONS(/WX)
-ELSE()
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror")
-  SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")
-ENDIF()
-
 # Grouped compiler settings ########################################
 IF ((CMAKE_C_COMPILER_ID MATCHES "GNU") AND NOT CMAKE_COMPILER_IS_MINGW)
   IF(NOT ASSIMP_HUNTER_ENABLED)
-    SET(CMAKE_CXX_FLAGS "-fPIC -std=c++0x ${CMAKE_CXX_FLAGS}")
-    SET(CMAKE_C_FLAGS "-fPIC ${CMAKE_C_FLAGS}")
+    SET(CMAKE_CXX_STANDARD 11)
+    SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
   ENDIF()
   # hide all not-exported symbols
-  SET(CMAKE_CXX_FLAGS "-g -fvisibility=hidden -fno-strict-aliasing -Wall ${CMAKE_CXX_FLAGS}")
+  SET(CMAKE_CXX_FLAGS "-fvisibility=hidden -fno-strict-aliasing -Wall ${CMAKE_CXX_FLAGS}")
   SET(CMAKE_C_FLAGS "-fno-strict-aliasing ${CMAKE_C_FLAGS}")
   SET(LIBSTDC++_LIBRARIES -lstdc++)
 ELSEIF(MSVC)

--- a/code/ASE/ASEParser.cpp
+++ b/code/ASE/ASEParser.cpp
@@ -142,11 +142,11 @@ void Parser::LogWarning(const char* szWarn)
 {
     ai_assert(NULL != szWarn);
 
-    char szTemp[1024];
+    char szTemp[2048];
 #if _MSC_VER >= 1400
     sprintf_s(szTemp, "Line %u: %s",iLineNumber,szWarn);
 #else
-    ai_snprintf(szTemp,1024,"Line %u: %s",iLineNumber,szWarn);
+    ai_snprintf(szTemp,sizeof(szTemp),"Line %u: %s",iLineNumber,szWarn);
 #endif
 
     // output the warning to the logger ...

--- a/code/Blender/BlenderBMesh.cpp
+++ b/code/Blender/BlenderBMesh.cpp
@@ -42,7 +42,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *  @brief Conversion of Blender's new BMesh stuff
  */
 
-
 #ifndef ASSIMP_BUILD_NO_BLEND_IMPORTER
 
 #include "BlenderDNA.h"

--- a/code/Blender/BlenderBMesh.cpp
+++ b/code/Blender/BlenderBMesh.cpp
@@ -181,6 +181,7 @@ void BlenderBMeshConverter::AddFace( int v1, int v2, int v3, int v4 )
     face.v2 = v2;
     face.v3 = v3;
     face.v4 = v4;
+    face.flag = 0;
     // TODO - Work out how materials work
     face.mat_nr = 0;
     triMesh->mface.push_back( face );

--- a/code/CApi/AssimpCExport.cpp
+++ b/code/CApi/AssimpCExport.cpp
@@ -73,11 +73,11 @@ ASSIMP_API const aiExportFormatDesc* aiGetExportFormatDescription( size_t index)
 
     aiExportFormatDesc *desc = new aiExportFormatDesc;
     desc->description = new char[ strlen( orig->description ) + 1 ]();
-    ::strncpy( (char*) desc->description, orig->description, strlen( orig->description ) );
+    ::memcpy( (char*) desc->description, orig->description, strlen( orig->description ) );
     desc->fileExtension = new char[ strlen( orig->fileExtension ) + 1 ]();
-    ::strncpy( ( char* ) desc->fileExtension, orig->fileExtension, strlen( orig->fileExtension ) );
+    ::memcpy( ( char* ) desc->fileExtension, orig->fileExtension, strlen( orig->fileExtension ) );
     desc->id = new char[ strlen( orig->id ) + 1 ]();
-    ::strncpy( ( char* ) desc->id, orig->id, strlen( orig->id ) );
+    ::memcpy( ( char* ) desc->id, orig->id, strlen( orig->id ) );
 
     return desc;
 }

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -1134,6 +1134,13 @@ ENDIF ()
 ADD_LIBRARY( assimp ${assimp_src} )
 ADD_LIBRARY(assimp::assimp ALIAS assimp)
 
+# enable warnings as errors ########################################
+IF (MSVC)
+  TARGET_COMPILE_OPTIONS(assimp PRIVATE /WX)
+ELSE()
+  TARGET_COMPILE_OPTIONS(assimp PRIVATE -Werror)
+ENDIF()
+
 TARGET_INCLUDE_DIRECTORIES ( assimp PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../include>

--- a/code/Common/SceneCombiner.cpp
+++ b/code/Common/SceneCombiner.cpp
@@ -979,7 +979,7 @@ void GetArrayCopy(Type*& dest, ai_uint num ) {
 
     dest = new Type[num];
     ::memcpy(dest, old, sizeof(Type) * num);
-}
+    }
 
 // ------------------------------------------------------------------------------------------------
 void SceneCombiner::CopySceneFlat(aiScene** _dest,const aiScene* src) {
@@ -1065,7 +1065,7 @@ void SceneCombiner::Copy( aiMesh** _dest, const aiMesh* src ) {
     aiMesh* dest = *_dest = new aiMesh();
 
     // get a flat copy
-    ::memcpy(dest,src,sizeof(aiMesh));
+    *dest = *src;
 
     // and reallocate all arrays
     GetArrayCopy( dest->mVertices,   dest->mNumVertices );
@@ -1104,7 +1104,7 @@ void SceneCombiner::Copy(aiAnimMesh** _dest, const aiAnimMesh* src) {
     aiAnimMesh* dest = *_dest = new aiAnimMesh();
 
     // get a flat copy
-    ::memcpy(dest, src, sizeof(aiAnimMesh));
+    *dest = *src;
 
     // and reallocate all arrays
     GetArrayCopy(dest->mVertices, dest->mNumVertices);
@@ -1161,7 +1161,7 @@ void SceneCombiner::Copy(aiTexture** _dest, const aiTexture* src) {
     aiTexture* dest = *_dest = new aiTexture();
 
     // get a flat copy
-    ::memcpy(dest,src,sizeof(aiTexture));
+    *dest = *src;
 
     // and reallocate all arrays. We must do it manually here
     const char* old = (const char*)dest->pcData;
@@ -1191,7 +1191,7 @@ void SceneCombiner::Copy( aiAnimation** _dest, const aiAnimation* src ) {
     aiAnimation* dest = *_dest = new aiAnimation();
 
     // get a flat copy
-    ::memcpy(dest,src,sizeof(aiAnimation));
+    *dest = *src;
 
     // and reallocate all arrays
     CopyPtrArray( dest->mChannels, src->mChannels, dest->mNumChannels );
@@ -1207,7 +1207,7 @@ void SceneCombiner::Copy(aiNodeAnim** _dest, const aiNodeAnim* src) {
     aiNodeAnim* dest = *_dest = new aiNodeAnim();
 
     // get a flat copy
-    ::memcpy(dest,src,sizeof(aiNodeAnim));
+    *dest = *src;
 
     // and reallocate all arrays
     GetArrayCopy( dest->mPositionKeys, dest->mNumPositionKeys );
@@ -1223,7 +1223,7 @@ void SceneCombiner::Copy(aiMeshMorphAnim** _dest, const aiMeshMorphAnim* src) {
     aiMeshMorphAnim* dest = *_dest = new aiMeshMorphAnim();
 
     // get a flat copy
-    ::memcpy(dest,src,sizeof(aiMeshMorphAnim));
+    *dest = *src;
 
     // and reallocate all arrays
     GetArrayCopy( dest->mKeys, dest->mNumKeys );
@@ -1244,7 +1244,7 @@ void SceneCombiner::Copy( aiCamera** _dest,const  aiCamera* src) {
     aiCamera* dest = *_dest = new aiCamera();
 
     // get a flat copy, that's already OK
-    ::memcpy(dest,src,sizeof(aiCamera));
+    *dest = *src;
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -1256,7 +1256,7 @@ void SceneCombiner::Copy(aiLight** _dest, const aiLight* src) {
     aiLight* dest = *_dest = new aiLight();
 
     // get a flat copy, that's already OK
-    ::memcpy(dest,src,sizeof(aiLight));
+    *dest = *src;
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -1268,7 +1268,7 @@ void SceneCombiner::Copy(aiBone** _dest, const aiBone* src) {
     aiBone* dest = *_dest = new aiBone();
 
     // get a flat copy
-    ::memcpy(dest,src,sizeof(aiBone));
+    *dest = *src;
 
     // and reallocate all arrays
     GetArrayCopy( dest->mWeights, dest->mNumWeights );
@@ -1282,7 +1282,7 @@ void SceneCombiner::Copy     (aiNode** _dest, const aiNode* src)
     aiNode* dest = *_dest = new aiNode();
 
     // get a flat copy
-    ::memcpy(dest,src,sizeof(aiNode));
+    *dest = *src;
 
     if (src->mMetaData) {
         Copy(&dest->mMetaData, src->mMetaData);

--- a/code/M3D/m3d.h
+++ b/code/M3D/m3d.h
@@ -1556,7 +1556,7 @@ static int _m3dstbi__create_png_image(_m3dstbi__png *a, unsigned char *image_dat
     return 1;
 }
 
-static int _m3dstbi__compute_transparency(_m3dstbi__png *z, unsigned char tc[3], int out_n) {
+static int _m3dstbi__compute_transparency(_m3dstbi__png *z, unsigned char* tc, int out_n) {
     _m3dstbi__context *s = z->s;
     _m3dstbi__uint32 i, pixel_count = s->img_x * s->img_y;
     unsigned char *p = z->out;
@@ -1639,7 +1639,7 @@ static int _m3dstbi__expand_png_palette(_m3dstbi__png *a, unsigned char *palette
 
 static int _m3dstbi__parse_png_file(_m3dstbi__png *z, int scan, int req_comp) {
     unsigned char palette[1024], pal_img_n = 0;
-    unsigned char has_trans = 0, tc[3];
+    unsigned char has_trans = 0, tc[3] = {};
     _m3dstbi__uint16 tc16[3];
     _m3dstbi__uint32 ioff = 0, idata_limit = 0, i, pal_len = 0;
     int first = 1, k, interlace = 0, color = 0;
@@ -4350,7 +4350,7 @@ unsigned char *m3d_save(m3d_t *model, int quality, int flags, unsigned int *size
     M3D_INDEX last, *vrtxidx = NULL, *mtrlidx = NULL, *tmapidx = NULL, *skinidx = NULL;
     uint32_t idx, numcmap = 0, *cmap = NULL, numvrtx = 0, maxvrtx = 0, numtmap = 0, maxtmap = 0, numproc = 0;
     uint32_t numskin = 0, maxskin = 0, numstr = 0, maxt = 0, maxbone = 0, numgrp = 0, maxgrp = 0, *grpidx = NULL;
-    uint8_t *opa;
+    uint8_t *opa = nullptr;
     m3dcd_t *cd;
     m3dc_t *cmd;
     m3dstr_t *str = NULL;

--- a/contrib/irrXML/irrString.h
+++ b/contrib/irrXML/irrString.h
@@ -635,9 +635,6 @@ private:
 		s32 amount = used < new_size ? used : new_size;
 		for (s32 i=0; i<amount; ++i)
 			array[i] = old_array[i];
-
-		if (allocated < used)
-			used = allocated;
 		
 		delete [] old_array;
 	}


### PR DESCRIPTION
- Enable building with `gcc` on Linux;
- Fix warning (mostly uninit'ed data);
- Remove some explicit flags specific for `gcc` with CMake "portable" ones;
- Use warning as error only on `assimp` target, not on 3rd party dependencies;