### PR TITLE
Fix fbx rotation ;

### DIFF
--- a/code/AssetLib/FBX/FBXConverter.cpp
+++ b/code/AssetLib/FBX/FBXConverter.cpp
@@ -3315,6 +3315,7 @@ void FBXConverter::InterpolateKeys(aiQuatKey *valOut, const KeyTimeList &keys, c
         // http://www.3dkingdoms.com/weekly/weekly.php?a=36
         if (quat.x * lastq.x + quat.y * lastq.y + quat.z * lastq.z + quat.w * lastq.w < 0) {
             quat.Conjugate();
+            quat.w = -quat.w;
         }
         lastq = quat;
 


### PR DESCRIPTION
Hello,

I am working on the [Radium-Engine libraries](https://github.com/STORM-IRIT/Radium-Engine) and we are using AssImp as a file loader for more than 3 years now.
We recently ran into an issue with FBX files loading regarding the rotation interpolation for animations.
This comes from a recent cleaning update of AssImp, i.e. merge of PR #3086 where some code has been cleaned a bit too much in file `code/FBX/FBXConverter.cpp` at line 3317:
```
            quat.x = -quat.x;
            quat.y = -quat.y;
            quat.z = -quat.z;
            quat.w = -quat.w;
```
became:
```
            quat.Conjugate();
```
thus missing the `w` component.

Thanks for considering this PR