### PR TITLE
Fix for issue# 3206: GLTF2 blendshape import missing shapes https://github.com/assimp/assimp/issues/3206

### DIFF
--- a/code/AssetLib/glTF2/glTF2Asset.inl
+++ b/code/AssetLib/glTF2/glTF2Asset.inl
@@ -1002,7 +1002,7 @@ inline void Mesh::Read(Value &pJSON_Object, Asset &pAsset_Root) {
                         // Valid attribute semantics include POSITION, NORMAL, TANGENT
                         int undPos = 0;
                         Mesh::AccessorList *vec = 0;
-                        if (GetAttribTargetVector(prim, i, attr, vec, undPos)) {
+                        if (GetAttribTargetVector(prim, j, attr, vec, undPos)) {
                             size_t idx = (attr[undPos] == '_') ? atoi(attr + undPos + 1) : 0;
                             if ((*vec).size() <= idx) {
                                 (*vec).resize(idx + 1);


### PR DESCRIPTION
This is to fix gltf2 import bug: blendshapes (morph targets) are missing. 
It seems an index i (refers to primitive) is wrongly used as target index. Thus one primitive eventually only has one target.
This pr just change the target index to the right one.