### PR TITLE
fix incorrect header path on framework build

### DIFF
--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -1232,7 +1232,7 @@ if (APPLE)
     # add ./Compiler/*.h to assimp.framework via copy command
     ADD_CUSTOM_COMMAND(TARGET assimp POST_BUILD
       COMMAND "${CMAKE_COMMAND}" -E copy_directory
-         "../${HEADER_PATH}/Compiler"
+         "${HEADER_PATH}/Compiler"
          assimp.framework/Headers/Compiler
       COMMENT "Copying public ./Compiler/ header files to framework bundle's Headers/Compiler/")
   ENDIF()


### PR DESCRIPTION
Without this patch building framework for macOS fails with the following error:
```
$ cmake CMakeLists.txt
$ make -j4
...
...
...
Copying OS X content bin/assimp.framework/Versions/C/Headers/config.h
[ 90%] Linking CXX shared library ../bin/assimp.framework/assimp
Copying public ./Compiler/ header files to framework bundle's Headers/Compiler/
Error copying directory from "../../include/assimp/Compiler" to "assimp.framework/Headers/Compiler".
make[2]: *** [code/CMakeFiles/assimp.dir/build.make:3316: bin/assimp.framework/Versions/C/assimp] Error 1
make[2]: *** Deleting file 'bin/assimp.framework/Versions/C/assimp'
make[1]: *** [CMakeFiles/Makefile2:208: code/CMakeFiles/assimp.dir/all] Error 2
make: *** [Makefile:150: all] Error 2
```

