### PR TITLE
Fix double free caused in FindInvalidDataProcess

### DIFF
--- a/code/PostProcessing/FindInvalidDataProcess.cpp
+++ b/code/PostProcessing/FindInvalidDataProcess.cpp
@@ -124,7 +124,7 @@ void FindInvalidDataProcess::Execute(aiScene *pScene) {
         if (2 == result) {
             // remove this mesh
             delete pScene->mMeshes[a];
-            AI_DEBUG_INVALIDATE_PTR(pScene->mMeshes[a]);
+            pScene->mMeshes[a] = NULL;
 
             meshMapping[a] = UINT_MAX;
             continue;


### PR DESCRIPTION
In debug builds, there's no issues, but in release, an invalid mesh that
is deleted in FindInvalidDataProcess will be double free'd when the
parent scene is destroyed.