### PR TITLE
glTF2: fix "file size doesn't match" issue when importing GLB in Blender (issue #3176 export glb error)

### DIFF
--- a/code/glTF2/glTF2AssetWriter.inl
+++ b/code/glTF2/glTF2AssetWriter.inl
@@ -672,10 +672,13 @@ namespace glTF2 {
         // Binary chunk
         //
 
+        int GLB_Chunk_count = 1;
         uint32_t binaryChunkLength = 0;
         if (bodyBuffer->byteLength > 0) {
             binaryChunkLength = (bodyBuffer->byteLength + 3) & ~3; // Round up to next multiple of 4
-            auto paddingLength = binaryChunkLength - bodyBuffer->byteLength;
+            
+            auto curPaddingLength = binaryChunkLength - bodyBuffer->byteLength;
+            ++GLB_Chunk_count;
 
             GLB_Chunk binaryChunk;
             binaryChunk.chunkLength = binaryChunkLength;
@@ -690,7 +693,7 @@ namespace glTF2 {
             if (outfile->Write(bodyBuffer->GetPointer(), 1, bodyBuffer->byteLength) != bodyBuffer->byteLength) {
                 throw DeadlyExportError("Failed to write body data!");
             }
-            if (paddingLength && outfile->Write(&padding, 1, paddingLength) != paddingLength) {
+            if (curPaddingLength && outfile->Write(&padding, 1, paddingLength) != paddingLength) {
                 throw DeadlyExportError("Failed to write body data padding!");
             }
         }
@@ -705,7 +708,7 @@ namespace glTF2 {
         header.version = 2;
         AI_SWAP4(header.version);
 
-        header.length = uint32_t(sizeof(GLB_Header) + 2 * sizeof(GLB_Chunk) + jsonChunkLength + binaryChunkLength);
+        header.length = uint32_t(sizeof(GLB_Header) + GLB_Chunk_count * sizeof(GLB_Chunk) + jsonChunkLength + binaryChunkLength);
         AI_SWAP4(header.length);
 
         outfile->Seek(0, aiOrigin_SET);


### PR DESCRIPTION
Hello,

I tested the copycd's correction proposed in issue #3176 and it fixes the GLB export problem which begins to appear between early March and now. The problem was a wrong calculation of chunk size which causes several applications to not be able to import GLB files created by Assimp (Blender displays a "file size doesn't match" error and Paint3D also couldn't open such GLB files).

Many thanks to copycd !

Regards,
Loïc

