### PR TITLE
Gltf2 Export Target Names for Blendshapes

### DIFF
--- a/code/AssetLib/glTF2/glTF2AssetWriter.inl
+++ b/code/AssetLib/glTF2/glTF2AssetWriter.inl
@@ -468,6 +468,22 @@ namespace glTF2 {
         }
 
         obj.AddMember("primitives", primitives, w.mAl);
+        // targetNames
+        if (m.targetNames.size() > 0) {
+            Value extras;
+            extras.SetObject();
+            Value targetNames;
+            targetNames.SetArray();
+            targetNames.Reserve(unsigned(m.targetNames.size()), w.mAl);
+            for (unsigned int n = 0; n < m.targetNames.size(); ++n) {
+                std::string name = m.targetNames[n];
+                Value tname;
+                tname.SetString(name.c_str(), w.mAl);
+                targetNames.PushBack(tname, w.mAl);
+            }
+            extras.AddMember("targetNames", targetNames, w.mAl);
+            obj.AddMember("extras", extras, w.mAl);
+        }
     }
 
     inline void Write(Value& obj, Node& n, AssetWriter& w)

--- a/code/AssetLib/glTF2/glTF2Exporter.cpp
+++ b/code/AssetLib/glTF2/glTF2Exporter.cpp
@@ -824,9 +824,14 @@ void glTF2Exporter::ExportMeshes()
 
         /*************** Targets for blendshapes ****************/
         if (aim->mNumAnimMeshes > 0) {
+            bool bExportTargetNames = this->mProperties->HasPropertyBool("GLTF2_TARGETNAMES_EXP") &&
+                              this->mProperties->GetPropertyBool("GLTF2_TARGETNAMES_EXP");
+
             p.targets.resize(aim->mNumAnimMeshes);
             for (unsigned int am = 0; am < aim->mNumAnimMeshes; ++am) {
                 aiAnimMesh *pAnimMesh = aim->mAnimMeshes[am];
+                if (bExportTargetNames)
+                    m->targetNames.push_back(pAnimMesh->mName.data);
 
                 // position
                 if (pAnimMesh->HasPositions()) {


### PR DESCRIPTION
This pr exports blendshape names for gltf2 format. It follows the gltf2 specification:
The blendshape names are mesh.extras.targetNames. 
E.g.

{
      "meshes": [
        {
          "primitives": [
            {
              "attributes": {
                "POSITION": 0
              },
              "targets": [
                {
                  "POSITION": 1
                },
                {
                  "POSITION": 2
                }
              ],
              "extras": {
                "targetNames": [
                  "Happy",
                  "Sad"
                ]
              }
            }
          ]
        }
      ]
    }

It is tested and blendshape names show up in 3rd party gltf viewer.