### PR TITLE
Pyassimp - contextmanager for load function

### DIFF
--- a/port/PyAssimp/README.md
+++ b/port/PyAssimp/README.md
@@ -42,17 +42,14 @@ substituted by assertions ...):
 
 ```python
 
-from pyassimp import *
-scene = load('hello.3ds')
+from pyassimp import load
+with load('hello.3ds') as scene:
 
-assert len(scene.meshes)
-mesh = scene.meshes[0]
+  assert len(scene.meshes)
+  mesh = scene.meshes[0]
 
-assert len(mesh.vertices)
-print(mesh.vertices[0])
-
-# don't forget this one, or you will leak!
-release(scene)
+  assert len(mesh.vertices)
+  print(mesh.vertices[0])
 
 ```
 
@@ -61,13 +58,11 @@ scene:
 
 ```python
 
-from pyassimp import *
-scene = load('hello.3ds')
+from pyassimp import load
+with load('hello.3ds') as scene:
 
-for c in scene.rootnode.children:
-    print(str(c))
-
-release(scene)
+  for c in scene.rootnode.children:
+      print(str(c))
 
 ```
 

--- a/port/PyAssimp/README.rst
+++ b/port/PyAssimp/README.rst
@@ -49,30 +49,27 @@ substituted by assertions ...):
 .. code:: python
 
 
-    from pyassimp import *
-    scene = load('hello.3ds')
+    from pyassimp import load
+    with load('hello.3ds') as scene:
 
-    assert len(scene.meshes)
-    mesh = scene.meshes[0]
+        assert len(scene.meshes)
+        mesh = scene.meshes[0]
 
-    assert len(mesh.vertices)
-    print(mesh.vertices[0])
+        assert len(mesh.vertices)
+        print(mesh.vertices[0])
 
-    # don't forget this one, or you will leak!
-    release(scene)
 
 Another example to list the 'top nodes' in a scene:
 
 .. code:: python
 
 
-    from pyassimp import *
-    scene = load('hello.3ds')
+    from pyassimp import load
+    with load('hello.3ds') as scene:
 
-    for c in scene.rootnode.children:
-        print(str(c))
+        for c in scene.rootnode.children:
+            print(str(c))
 
-    release(scene)
 
 INSTALL
 -------

--- a/port/PyAssimp/pyassimp/core.py
+++ b/port/PyAssimp/pyassimp/core.py
@@ -14,10 +14,13 @@ if sys.version_info >= (3,0):
     xrange = range
 
 
-try: import numpy
-except ImportError: numpy = None
+try: 
+    import numpy
+except ImportError: 
+    numpy = None
 import logging
 import ctypes
+from contextlib import contextmanager
 logger = logging.getLogger("pyassimp")
 # attach default null handler to logger so it doesn't complain
 # even if you don't attach another handler to logger
@@ -272,6 +275,13 @@ def recur_pythonize(node, scene):
     for c in node.children:
         recur_pythonize(c, scene)
 
+def release(scene):
+    '''
+    Release resources of a loaded scene.
+    '''
+    _assimp_lib.release(ctypes.pointer(scene))
+
+@contextmanager
 def load(filename,
          file_type  = None,
          processing = postprocess.aiProcess_Triangulate):
@@ -319,7 +329,10 @@ def load(filename,
         raise AssimpError('Could not import file!')
     scene = _init(model.contents)
     recur_pythonize(scene.rootnode, scene)
-    return scene
+    try:
+        yield scene
+    finally:
+        release(scene)
 
 def export(scene,
            filename,
@@ -372,9 +385,6 @@ def export_blob(scene,
     if exportBlobPtr == 0:
         raise AssimpError('Could not export scene to blob!')
     return exportBlobPtr
-
-def release(scene):
-    _assimp_lib.release(ctypes.pointer(scene))
 
 def _finalize_texture(tex, target):
     setattr(target, "achformathint", tex.achFormatHint)


### PR DESCRIPTION
Thought it was more elegant to implement the load function with a contextmanager so that you can use it like "with open('/file.txt') as f: ..." and don't have to remember releasing it.

I also updated the examples in the README.md/README.rst.