### PR TITLE
Check invalid vertex id for bone weight

### DIFF
--- a/code/PostProcessing/LimitBoneWeightsProcess.cpp
+++ b/code/PostProcessing/LimitBoneWeightsProcess.cpp
@@ -114,6 +114,10 @@ void LimitBoneWeightsProcess::ProcessMesh(aiMesh* pMesh)
         for (unsigned int w = 0; w < bone->mNumWeights; ++w)
         {
             const aiVertexWeight& vw = bone->mWeights[w];
+
+            if (vertexWeights.size() <= vw.mVertexId)
+                continue;
+
             vertexWeights[vw.mVertexId].push_back(Weight(b, vw.mWeight));
             maxVertexWeights = std::max(maxVertexWeights, vertexWeights[vw.mVertexId].size());
         }


### PR DESCRIPTION
assimp should not error out even when asset has invalid vertex id for bone weight.  Just ignoring it seems fine.

How to reproduce:

1. Download following glTF file [crash.glb](https://github.com/infosia/themachinery-issues/blob/master/0001/crash.glb)
2. Check if glTF file is valid (i.e. Open it with Windows 3D Viewer)
3. Load the glTF file in assimp
4. assimp errors out because of std::vector out of range.

Expected: assimp should not error out even when asset has invalid vertex id. Just ignoring it seems fine.
