### PR TITLE
Fix build when ASSIMP_DOUBLE_PRECISION is on.

### DIFF
--- a/code/Common/Assimp.cpp
+++ b/code/Common/Assimp.cpp
@@ -1079,7 +1079,7 @@ ASSIMP_API void aiMatrix4DecomposeIntoScalingAxisAnglePosition(
         const C_STRUCT aiMatrix4x4 *mat,
         C_STRUCT aiVector3D *scaling,
         C_STRUCT aiVector3D *axis,
-        float *angle,
+        ai_real *angle,
         C_STRUCT aiVector3D *position) {
     ai_assert(nullptr != mat);
     ai_assert(nullptr != scaling);

--- a/code/Common/SpatialSort.cpp
+++ b/code/Common/SpatialSort.cpp
@@ -214,7 +214,7 @@ BinFloat ToBinary(const ai_real &pValue) {
     const bool OneComplement = ((-42 == ~42) && (binValue & 0x80000000));
 
     if (DefaultValue)
-        return BinFloat(1 << (CHAR_BIT * sizeof(BinFloat) - 1)) - binValue;
+        return BinFloat(BinFloat(1) << (CHAR_BIT * sizeof(BinFloat) - 1)) - binValue;
     // One's complement?
     else if (OneComplement)
         return BinFloat(-0) - binValue;

--- a/code/PostProcessing/ProcessHelper.h
+++ b/code/PostProcessing/ProcessHelper.h
@@ -222,7 +222,7 @@ template <>
 struct MinMaxChooser<aiVertexWeight> {
     void operator()(aiVertexWeight &min, aiVertexWeight &max) {
         MinMaxChooser<unsigned int>()(min.mVertexId, max.mVertexId);
-        MinMaxChooser<float>()(min.mWeight, max.mWeight);
+        MinMaxChooser<ai_real>()(min.mWeight, max.mWeight);
     }
 };
 

--- a/include/assimp/cimport.h
+++ b/include/assimp/cimport.h
@@ -1044,7 +1044,7 @@ ASSIMP_API void aiMatrix4DecomposeIntoScalingAxisAnglePosition(
     const C_STRUCT aiMatrix4x4* mat,
     C_STRUCT aiVector3D* scaling,
     C_STRUCT aiVector3D* axis,
-    float* angle,
+    ai_real* angle,
     C_STRUCT aiVector3D* position);
 
 // --------------------------------------------------------------------------------

--- a/test/unit/AssimpAPITest_aiMatrix4x4.cpp
+++ b/test/unit/AssimpAPITest_aiMatrix4x4.cpp
@@ -176,7 +176,7 @@ TEST_F(AssimpAPITest_aiMatrix4x4, aiMatrix4DecomposeIntoScalingAxisAnglePosition
     aiVector3D scaling_c, scaling_cpp,
         axis_c, axis_cpp,
         position_c, position_cpp;
-    float angle_c, angle_cpp;
+    ai_real angle_c, angle_cpp;
 
     result_c = result_cpp = get_predetermined_transformation_matrix_for_decomposition();
     result_cpp.Decompose(scaling_cpp, axis_cpp, angle_cpp, position_cpp);


### PR DESCRIPTION
Tested:

```sh
$ cmake -DASSIMP_DOUBLE_PRECISION=1 -DASSIMP_BUILD_MDL_IMPORTER=0 ..; make
```

The MDL importer is disabled due to the fact that there is some float-only code in MDL. This also means bin/assimp and bin/unit would not link successfully with the above build flags.