### PR TITLE
Fixed variable in loop - HL1MDLLoader.cpp

### DIFF
--- a/code/AssetLib/MDL/HalfLife/HL1MDLLoader.cpp
+++ b/code/AssetLib/MDL/HalfLife/HL1MDLLoader.cpp
@@ -829,7 +829,7 @@ void HL1MDLLoader::read_meshes() {
                         }
                     } else {
                         for (int faceIdx = 0; faceIdx < num_faces; ++faceIdx) {
-                            if (i & 1) {
+                            if (faceIdx & 1) {
                                 // Preserve winding order.
                                 mesh_faces.push_back(HL1MeshFace{
                                         tricmds[faceIdx + 1],


### PR DESCRIPTION
Commit 7e5a0acc48efc54d7aa7900c36cd63db1fbeec9b made changes to HL1MDLLoader.cpp - Several variables have been renamed. A loop variable `i` was renamed to `faceIdx`, but one reference was left unchanged. This would break polygon winding order. Please see line 832 below.

https://github.com/assimp/assimp/blob/4ff5a06ef441e1df782906878d0dbf96251206d3/code/AssetLib/MDL/HalfLife/HL1MDLLoader.cpp#L831-L845
