### PR TITLE
Improve ToBinary() for double precision.

### DIFF
--- a/code/Common/SpatialSort.cpp
+++ b/code/Common/SpatialSort.cpp
@@ -208,13 +208,14 @@ BinFloat ToBinary(const ai_real &pValue) {
     // floating-point numbers are of sign-magnitude format, so find out what signed number
     //  representation we must convert negative values to.
     // See http://en.wikipedia.org/wiki/Signed_number_representations.
+    const BinFloat mask = BinFloat(1) << (CHAR_BIT * sizeof(BinFloat) - 1);
 
     // Two's complement?
-    const bool DefaultValue = ((-42 == (~42 + 1)) && (binValue & 0x80000000));
-    const bool OneComplement = ((-42 == ~42) && (binValue & 0x80000000));
+    const bool DefaultValue = ((-42 == (~42 + 1)) && (binValue & mask));
+    const bool OneComplement = ((-42 == ~42) && (binValue & mask));
 
     if (DefaultValue)
-        return BinFloat(BinFloat(1) << (CHAR_BIT * sizeof(BinFloat) - 1)) - binValue;
+        return mask - binValue;
     // One's complement?
     else if (OneComplement)
         return BinFloat(-0) - binValue;


### PR DESCRIPTION
The constant 0x80000000 is specific to 32 bit types. Make the bit mask according to the size of types.