### PR TITLE
fix invalid pointer for bone animation

### DIFF
--- a/code/Common/Importer.cpp
+++ b/code/Common/Importer.cpp
@@ -1174,7 +1174,7 @@ void Importer::GetMemoryRequirements(aiMemoryInfo& in) const {
 
         // add all bone anims
         for (unsigned int a = 0; a < pc->mNumChannels; ++a) {
-            const aiNodeAnim* pc2 = pc->mChannels[i];
+            const aiNodeAnim* pc2 = pc->mChannels[a];
             in.animations += sizeof(aiNodeAnim);
             in.animations += pc2->mNumPositionKeys * sizeof(aiVectorKey);
             in.animations += pc2->mNumScalingKeys * sizeof(aiVectorKey);


### PR DESCRIPTION
Fix invalid pointer for bone animation. 

How to reproduce:

1. Download following glTF file [RiggedFigure.out.glb](https://github.com/infosia/themachinery-issues/blob/master/0002/RiggedFigure.out.glb)
2. Check if glTF file is valid (i.e. Open it with Windows 3D Viewer)
3. Load the glTF file in assimp
4. assimp crashes because of bad pointer

Expected: assimp should not crash.
