### PR TITLE
FBX Version/Size Check

### DIFF
--- a/code/AssetLib/FBX/FBXBinaryTokenizer.cpp
+++ b/code/AssetLib/FBX/FBXBinaryTokenizer.cpp
@@ -468,7 +468,7 @@ void TokenizeBinary(TokenList& output_tokens, const char* input, size_t length)
     catch (const DeadlyImportError& e)
     {
         if ((sizeof(size_t) > 4) && !is64bits && (length > std::numeric_limits<std::uint32_t>::max())) {
-            throw DeadlyImportError("The FBX is invalid. This may be because the content is too big for this older version (" + to_string(version) + ") of the FBX format. (" + e.what() + ")");
+            throw DeadlyImportError("The FBX file is invalid. This may be because the content is too big for this older version (" + to_string(version) + ") of the FBX format. (" + e.what() + ")");
         }
         throw;
     }

--- a/code/AssetLib/FBX/FBXBinaryTokenizer.cpp
+++ b/code/AssetLib/FBX/FBXBinaryTokenizer.cpp
@@ -54,6 +54,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/Exceptional.h>
 #include <assimp/ByteSwapper.h>
 #include <assimp/DefaultLogger.hpp>
+#include <assimp/StringUtils.h>
 
 namespace Assimp {
 namespace FBX {
@@ -456,10 +457,20 @@ void TokenizeBinary(TokenList& output_tokens, const char* input, size_t length)
 	ASSIMP_LOG_DEBUG_F("FBX version: ", version);
 	const bool is64bits = version >= 7500;
     const char *end = input + length;
-    while (cursor < end ) {
-		if (!ReadScope(output_tokens, input, cursor, input + length, is64bits)) {
-            break;
+    try
+    {
+        while (cursor < end ) {
+		    if (!ReadScope(output_tokens, input, cursor, input + length, is64bits)) {
+                break;
+            }
         }
+    }
+    catch (const DeadlyImportError& e)
+    {
+        if ((sizeof(size_t) > 4) && !is64bits && (length > std::numeric_limits<std::uint32_t>::max())) {
+            throw DeadlyImportError("The FBX is invalid. This may be because the content is too big for this older version (" + to_string(version) + ") of the FBX format. (" + e.what() + ")");
+        }
+        throw;
     }
 }
 

--- a/code/AssetLib/FBX/FBXBinaryTokenizer.cpp
+++ b/code/AssetLib/FBX/FBXBinaryTokenizer.cpp
@@ -467,7 +467,7 @@ void TokenizeBinary(TokenList& output_tokens, const char* input, size_t length)
     }
     catch (const DeadlyImportError& e)
     {
-        if ((sizeof(size_t) > 4) && !is64bits && (length > std::numeric_limits<std::uint32_t>::max())) {
+        if (!is64bits && (length > std::numeric_limits<std::uint32_t>::max())) {
             throw DeadlyImportError("The FBX file is invalid. This may be because the content is too big for this older version (" + to_string(version) + ") of the FBX format. (" + e.what() + ")");
         }
         throw;


### PR DESCRIPTION
If you export a really big model as FBX from 3ds Max (and possibly other tools) and you have the export version set to FBX2013, then you will generate a corrupt FBX file, without the modeller giving you any warning. We seen a few people hit this. Assimp currently gives quite a technical error (FBX Tokenisation error) in these circumstances, but it is convenient to explain to users the cause, since they can fix it themselves by adjusting the export version.

This change augments the error message to read as follows:
* The FBX file is invalid. This may be because the content is too big for this older version (7300) of the FBX format. (FBX-Tokenize (offset 0xf20311a7) block offset is out of range)

Btw, the underlying issue happens is because the older, 32-bit format cannot describe large offsets.

