### PR TITLE
closes https://github.com/assimp/assimp/issues/2992: detect double support 

### DIFF
--- a/code/Common/Importer.cpp
+++ b/code/Common/Importer.cpp
@@ -515,46 +515,55 @@ void WriteLogOpening(const std::string& file) {
     // need to ask the authors of incoming bug reports for
     // the library version they're using - a log dump is
     // sufficient.
-    const unsigned int flags( aiGetCompileFlags() );
+    const unsigned int flags = aiGetCompileFlags();
     std::stringstream stream;
     stream << "Assimp " << aiGetVersionMajor() << "." << aiGetVersionMinor() << "." << aiGetVersionRevision() << " "
 #if defined(ASSIMP_BUILD_ARCHITECTURE)
-        << ASSIMP_BUILD_ARCHITECTURE
+           << ASSIMP_BUILD_ARCHITECTURE
 #elif defined(_M_IX86) || defined(__x86_32__) || defined(__i386__)
-        << "x86"
+           << "x86"
 #elif defined(_M_X64) || defined(__x86_64__)
-        << "amd64"
+           << "amd64"
 #elif defined(_M_IA64) || defined(__ia64__)
-        << "itanium"
+           << "itanium"
 #elif defined(__ppc__) || defined(__powerpc__)
-        << "ppc32"
+           << "ppc32"
 #elif defined(__powerpc64__)
-        << "ppc64"
+           << "ppc64"
 #elif defined(__arm__)
-        << "arm"
+           << "arm"
 #else
-        << "<unknown architecture>"
+           << "<unknown architecture>"
 #endif
-        << " "
+           << " "
 #if defined(ASSIMP_BUILD_COMPILER)
-        << ( ASSIMP_BUILD_COMPILER )
+           << (ASSIMP_BUILD_COMPILER)
 #elif defined(_MSC_VER)
-        << "msvc"
+           << "msvc"
 #elif defined(__GNUC__)
-        << "gcc"
+           << "gcc"
+#elif defined(__clang__)
+           << "clang"
+#elif defined(__EMSCRIPTEN__)
+           << "emscripten"
+#elif defined(__MINGW32__)
+           << "MinGW-w64 32bit"
+#elif defined(__MINGW64__)
+           << "MinGW-w64 64bit"
 #else
-        << "<unknown compiler>"
+           << "<unknown compiler>"
 #endif
 
 #ifdef ASSIMP_BUILD_DEBUG
-        << " debug"
+           << " debug"
 #endif
 
-        << (flags & ASSIMP_CFLAGS_NOBOOST ? " noboost" : "")
-        << (flags & ASSIMP_CFLAGS_SHARED  ? " shared" : "")
-        << (flags & ASSIMP_CFLAGS_SINGLETHREADED  ? " singlethreaded" : "");
+           << (flags & ASSIMP_CFLAGS_NOBOOST ? " noboost" : "")
+           << (flags & ASSIMP_CFLAGS_SHARED ? " shared" : "")
+           << (flags & ASSIMP_CFLAGS_SINGLETHREADED ? " singlethreaded" : "")
+           << (flags & ASSIMP_CFLAGS_DOUBLE_SUPPORT ? " double : " : "single : ");
 
-        ASSIMP_LOG_DEBUG(stream.str());
+    ASSIMP_LOG_DEBUG(stream.str());
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/code/Common/Version.cpp
+++ b/code/Common/Version.cpp
@@ -104,6 +104,9 @@ ASSIMP_API unsigned int aiGetCompileFlags() {
 #ifdef _STLPORT_VERSION
     flags |= ASSIMP_CFLAGS_STLPORT;
 #endif
+#ifdef ASSIMP_DOUBLE_PRECISION
+    flags |= ASSIMP_CFLAGS_DOUBLE_SUPPORT;
+#endif
 
     return flags;
 }
@@ -113,13 +116,29 @@ ASSIMP_API unsigned int aiGetVersionRevision() {
     return GitVersion;
 }
 
+// ------------------------------------------------------------------------------------------------
 ASSIMP_API const char *aiGetBranchName() {
     return GitBranch;
 }
 
 // ------------------------------------------------------------------------------------------------
 ASSIMP_API aiScene::aiScene() :
-        mFlags(0), mRootNode(nullptr), mNumMeshes(0), mMeshes(nullptr), mNumMaterials(0), mMaterials(nullptr), mNumAnimations(0), mAnimations(nullptr), mNumTextures(0), mTextures(nullptr), mNumLights(0), mLights(nullptr), mNumCameras(0), mCameras(nullptr), mMetaData(nullptr), mPrivate(new Assimp::ScenePrivateData()) {
+        mFlags(0),
+        mRootNode(nullptr),
+        mNumMeshes(0),
+        mMeshes(nullptr),
+        mNumMaterials(0),
+        mMaterials(nullptr),
+        mNumAnimations(0),
+        mAnimations(nullptr),
+        mNumTextures(0),
+        mTextures(nullptr),
+        mNumLights(0),
+        mLights(nullptr),
+        mNumCameras(0),
+        mCameras(nullptr),
+        mMetaData(nullptr),
+        mPrivate(new Assimp::ScenePrivateData()) {
     // empty
 }
 

--- a/include/assimp/version.h
+++ b/include/assimp/version.h
@@ -5,8 +5,6 @@ Open Asset Import Library (assimp)
 
 Copyright (c) 2006-2020, assimp team
 
-
-
 All rights reserved.
 
 Redistribution and use of this software in source and binary forms,
@@ -91,7 +89,7 @@ ASSIMP_API unsigned int aiGetVersionMajor (void);
 ASSIMP_API unsigned int aiGetVersionRevision (void);
 
 // ---------------------------------------------------------------------------
-/** @brief Returns the branchname of the Assimp runtime.
+/** @brief Returns the branch-name of the Assimp runtime.
  *  @return The current branch name.
  */
 ASSIMP_API const char *aiGetBranchName();
@@ -107,12 +105,14 @@ ASSIMP_API const char *aiGetBranchName();
 #define ASSIMP_CFLAGS_NOBOOST           0x8
 //! Assimp was compiled with ASSIMP_BUILD_SINGLETHREADED defined
 #define ASSIMP_CFLAGS_SINGLETHREADED    0x10
+//! Assimp was compiled with ASSIMP_BUILD_SINGLETHREADED defined
+#define ASSIMP_CFLAGS_DOUBLE_SUPPORT 0x20
 
 // ---------------------------------------------------------------------------
 /** @brief Returns assimp's compile flags
  *  @return Any bitwise combination of the ASSIMP_CFLAGS_xxx constants.
  */
-ASSIMP_API unsigned int aiGetCompileFlags (void);
+ASSIMP_API unsigned int aiGetCompileFlags(void);
 
 #ifdef __cplusplus
 } // end extern "C"


### PR DESCRIPTION
- add single or double precision 
- add missing compilers.