### PR TITLE
NFF importer double precision support

### DIFF
--- a/code/AssetLib/NFF/NFFLoader.cpp
+++ b/code/AssetLib/NFF/NFFLoader.cpp
@@ -96,7 +96,7 @@ const aiImporterDesc *NFFImporter::GetInfo() const {
 // ------------------------------------------------------------------------------------------------
 #define AI_NFF_PARSE_FLOAT(f) \
     SkipSpaces(&sz);          \
-    if (!::IsLineEnd(*sz)) sz = fast_atoreal_move<float>(sz, (float &)f);
+    if (!::IsLineEnd(*sz)) sz = fast_atoreal_move<ai_real>(sz, (ai_real &)f);
 
 // ------------------------------------------------------------------------------------------------
 #define AI_NFF_PARSE_TRIPLE(v) \
@@ -233,7 +233,7 @@ void NFFImporter::InternReadFile(const std::string &pFile,
 
     // camera parameters
     aiVector3D camPos, camUp(0.f, 1.f, 0.f), camLookAt(0.f, 0.f, 1.f);
-    float angle = 45.f;
+    ai_real angle = 45.f;
     aiVector2D resolution;
 
     bool hasCam = false;
@@ -262,7 +262,7 @@ void NFFImporter::InternReadFile(const std::string &pFile,
 
     // check whether this is the NFF2 file format
     if (TokenMatch(buffer, "nff", 3)) {
-        const float qnan = get_qnan();
+        const ai_real qnan = get_qnan();
         const aiColor4D cQNAN = aiColor4D(qnan, 0.f, 0.f, 1.f);
         const aiVector3D vQNAN = aiVector3D(qnan, 0.f, 0.f);
 
@@ -706,7 +706,7 @@ void NFFImporter::InternReadFile(const std::string &pFile,
             }
             // 'f' - shading information block
             else if (TokenMatch(sz, "f", 1)) {
-                float d;
+                ai_real d;
 
                 // read the RGB colors
                 AI_NFF_PARSE_TRIPLE(s.color);
@@ -856,7 +856,7 @@ void NFFImporter::InternReadFile(const std::string &pFile,
 
                 // read the two center points and the respective radii
                 aiVector3D center1, center2;
-                float radius1 = 0.f, radius2 = 0.f;
+                ai_real radius1 = 0.f, radius2 = 0.f;
                 AI_NFF_PARSE_TRIPLE(center1);
                 AI_NFF_PARSE_FLOAT(radius1);
 
@@ -874,7 +874,7 @@ void NFFImporter::InternReadFile(const std::string &pFile,
                 curMesh.dir = center2 - center1;
                 curMesh.center = center1 + curMesh.dir / (ai_real)2.0;
 
-                float f;
+                ai_real f;
                 if ((f = curMesh.dir.Length()) < 10e-3f) {
                     ASSIMP_LOG_ERROR("NFF: Cone height is close to zero");
                     continue;

--- a/code/AssetLib/NFF/NFFLoader.h
+++ b/code/AssetLib/NFF/NFFLoader.h
@@ -113,14 +113,14 @@ private:
         {}
 
         aiColor3D color,diffuse,specular,ambient,emissive;
-        float refracti;
+        ai_real refracti;
 
         std::string texFile;
 
         // For NFF2
         bool twoSided;
         bool shaded;
-        float opacity, shininess;
+        ai_real opacity, shininess;
 
         std::string name;
 
@@ -155,7 +155,7 @@ private:
         {}
 
         aiVector3D position;
-        float intensity;
+        ai_real intensity;
         aiColor3D color;
     };
 


### PR DESCRIPTION
The NFF importer parses values to floats, which aren't correctly written to doubles inside an `aiVector3D` when compiling with **ASSIMP_DOUBLE_PRECISION=ON**.

There is no 'normal' float to double conversion possible since the double (`f` in the line below, which lives in an `aiVector3D`) is incorrectly referenced as a float. Because of this incorrect reference, the parsed float is written to the double _as if the double was a float_, causing corrupt values.
https://github.com/assimp/assimp/blob/9fc00cbf74abcdae4fb5fdd8b64b5c58f8fce368/code/AssetLib/NFF/NFFLoader.cpp#L99

The issue is fixed by changing the parsed value from float to ai_real, which matches the ai_real inside the `aiVector3D`.