### PR TITLE
Fix Bad Ownership Acquisition

### DIFF
--- a/code/AssetLib/FBX/FBXImporter.cpp
+++ b/code/AssetLib/FBX/FBXImporter.cpp
@@ -159,6 +159,8 @@ void FBXImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
 	contents[contents.size() - 1] = 0;
 	const char *const begin = &*contents.begin();
 
+	pIOHandler->Close(stream);
+
 	// broadphase tokenizing pass in which we identify the core
 	// syntax elements of FBX (brackets, commas, key:value mappings)
 	TokenList tokens;

--- a/code/AssetLib/FBX/FBXImporter.cpp
+++ b/code/AssetLib/FBX/FBXImporter.cpp
@@ -141,8 +141,8 @@ void FBXImporter::SetupProperties(const Importer *pImp) {
 // ------------------------------------------------------------------------------------------------
 // Imports the given file into the given scene structure.
 void FBXImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSystem *pIOHandler) {
-	IOStream* stream = pIOHandler->Open(pFile, "rb");
-	if (!stream) {
+	IOStream* pStream = pIOHandler->Open(pFile, "rb");
+	if (!pStream) {
 		ThrowException("Could not open file for reading");
 	}
 
@@ -154,12 +154,12 @@ void FBXImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
 	// streaming for its output data structures so the net win with
 	// streaming input data would be very low.
 	std::vector<char> contents;
-	contents.resize(stream->FileSize() + 1);
-	stream->Read(&*contents.begin(), 1, contents.size() - 1);
+	contents.resize(pStream->FileSize() + 1);
+	pStream->Read(&*contents.begin(), 1, contents.size() - 1);
 	contents[contents.size() - 1] = 0;
 	const char *const begin = &*contents.begin();
 
-	pIOHandler->Close(stream);
+	pIOHandler->Close(pStream);
 
 	// broadphase tokenizing pass in which we identify the core
 	// syntax elements of FBX (brackets, commas, key:value mappings)

--- a/code/AssetLib/FBX/FBXImporter.cpp
+++ b/code/AssetLib/FBX/FBXImporter.cpp
@@ -141,7 +141,7 @@ void FBXImporter::SetupProperties(const Importer *pImp) {
 // ------------------------------------------------------------------------------------------------
 // Imports the given file into the given scene structure.
 void FBXImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSystem *pIOHandler) {
-	std::unique_ptr<IOStream> stream(pIOHandler->Open(pFile, "rb"));
+	IOStream* stream = pIOHandler->Open(pFile, "rb");
 	if (!stream) {
 		ThrowException("Could not open file for reading");
 	}

--- a/code/AssetLib/Obj/ObjFileImporter.cpp
+++ b/code/AssetLib/Obj/ObjFileImporter.cpp
@@ -107,8 +107,8 @@ const aiImporterDesc *ObjFileImporter::GetInfo() const {
 void ObjFileImporter::InternReadFile(const std::string &file, aiScene *pScene, IOSystem *pIOHandler) {
     // Read file into memory
     static const std::string mode = "rb";
-    std::unique_ptr<IOStream> fileStream(pIOHandler->Open(file, mode));
-    if (!fileStream.get()) {
+    IOStream *fileStream = pIOHandler->Open(file, mode);
+    if (!fileStream) {
         throw DeadlyImportError("Failed to open file " + file + ".");
     }
 
@@ -119,10 +119,10 @@ void ObjFileImporter::InternReadFile(const std::string &file, aiScene *pScene, I
     }
 
     IOStreamBuffer<char> streamedBuffer;
-    streamedBuffer.open(fileStream.get());
+    streamedBuffer.open(fileStream);
 
     // Allocate buffer and read file into it
-    //TextFileToBuffer( fileStream.get(),m_Buffer);
+    //TextFileToBuffer( fileStream,m_Buffer);
 
     // Get the model name
     std::string modelName, folderName;
@@ -144,6 +144,8 @@ void ObjFileImporter::InternReadFile(const std::string &file, aiScene *pScene, I
     CreateDataFromImport(parser.GetModel(), pScene);
 
     streamedBuffer.close();
+
+    pIOHandler->Close(fileStream);
 
     // Clean up allocated storage for the next import
     m_Buffer.clear();

--- a/code/AssetLib/Obj/ObjFileImporter.cpp
+++ b/code/AssetLib/Obj/ObjFileImporter.cpp
@@ -107,22 +107,22 @@ const aiImporterDesc *ObjFileImporter::GetInfo() const {
 void ObjFileImporter::InternReadFile(const std::string &file, aiScene *pScene, IOSystem *pIOHandler) {
     // Read file into memory
     static const std::string mode = "rb";
-    IOStream *fileStream = pIOHandler->Open(file, mode);
-    if (!fileStream) {
+    IOStream *pFileStream = pIOHandler->Open(file, mode);
+    if (!pFileStream) {
         throw DeadlyImportError("Failed to open file " + file + ".");
     }
 
     // Get the file-size and validate it, throwing an exception when fails
-    size_t fileSize = fileStream->FileSize();
+    size_t fileSize = pFileStream->FileSize();
     if (fileSize < ObjMinSize) {
         throw DeadlyImportError("OBJ-file is too small.");
     }
 
     IOStreamBuffer<char> streamedBuffer;
-    streamedBuffer.open(fileStream);
+    streamedBuffer.open(pFileStream);
 
     // Allocate buffer and read file into it
-    //TextFileToBuffer( fileStream,m_Buffer);
+    //TextFileToBuffer( pFileStream,m_Buffer);
 
     // Get the model name
     std::string modelName, folderName;
@@ -145,7 +145,7 @@ void ObjFileImporter::InternReadFile(const std::string &file, aiScene *pScene, I
 
     streamedBuffer.close();
 
-    pIOHandler->Close(fileStream);
+    pIOHandler->Close(pFileStream);
 
     // Clean up allocated storage for the next import
     m_Buffer.clear();


### PR DESCRIPTION
This fixes a crash when using a custom IOSystem/IOStream implementation. `IOSystem::Open` is supposed to return an `IOStream` implementation, but the memory management is ambiguous. In some places within the loader code, here for example:
```c++
    IOStream * fileIO = pimpl->mIOHandler->Open( pFile );
    uint32_t fileSize = 0;
    if (fileIO)
    {
        fileSize = static_cast<uint32_t>(fileIO->FileSize());
        pimpl->mIOHandler->Close( fileIO );
    }
```
The `IOStream` pointer is acquired, closed, and never touched again. We get the pointer by calling `IOSystem::Open`, and then release it by calling `Close`. Later, in the .fbx and .obj loaders, I found this:
```c++
    std::unique_ptr<IOStream> fileStream(pIOHandler->Open(file, mode));
```
When this goes out of scope, it calls `delete`. This works perfectly fine for a `DefaultIOStream` because `IOSystem::Close` simply calls `delete` on the stream it's given. Does that mean that `Close` is expected or required to call `delete`? Why is this a pure virtual for `IOSystem` if that's the case? The pattern needs to be consistent. Either `~IOStream()` should be expected to close the stream, or else we must close the stream exclusively through `IOSystem::Close`. Either way, a `unique_ptr` acquiring the stream within a method far downstream from the object's instantiation is undesirable because ownership is quickly confused.

This is also a potential memory leak -- if we don't require that `IOSystem::Close` delete the stream passed to it, the stream will never get deleted, for example in Importer.cpp (the first posted code example). The `IOSystem` is requested to `Close` it, but without a guarantee that this method will delete it, there is a memory leak with no safeguards. If `Close` is required to free the memory, `Open` must be required to allocate memory, a seemingly arbitrary requirement. Better would be to rely on `Close` and `Open` to allow the `IOSystem` to manage any memory it needs however it wants.

In my case, the crash was caused by a double delete -- the `unique_ptr` in the .fbx and .obj loader deletes my memory, and then my `IOSystem` closes and deletes any streams it still records as open when it destructs.

This fix simply replaces the `unique_ptr`s with raw pointers when the streams are acquired. This reflects the fact that the importer does not acquire the `IOStream` when the file is read. Corresponding calls to `Close` are added. This prevents my double-delete situation and clears up potential memory leaks. Let me know if you have suggestions!