### PR TITLE
Fix an unreferenced formal parameter warning on MSVC when no exporter…

### DIFF
--- a/code/Common/Exporter.cpp
+++ b/code/Common/Exporter.cpp
@@ -140,6 +140,8 @@ void ExportAssimp2Json(const char* , IOSystem*, const aiScene* , const Assimp::E
 #endif
 
 static void setupExporterArray(std::vector<Exporter::ExportFormatEntry> &exporters) {
+	(void)exporters;
+
 #ifndef ASSIMP_BUILD_NO_COLLADA_EXPORTER
 	exporters.push_back(Exporter::ExportFormatEntry("collada", "COLLADA - Digital Asset Exchange Schema", "dae", &ExportSceneCollada));
 #endif


### PR DESCRIPTION
… is built

Reproducible on: Microsoft Visual Studio 2019: Version 16.7.2
When following CMake option is used: `ASSIMP_BUILD_ALL_EXPORTERS_BY_DEFAULT=OFF`.

The warning is treated as an error:

```
1>Exporter.cpp
1>assimp\code\Common\Exporter.cpp(142,74): error C2220: the following warning is treated as an error
1>assimp\code\Common\Exporter.cpp(142,74): warning C4100: 'exporters': unreferenced formal parameter
1>Done building project "assimp.vcxproj" -- FAILED.
```