### PR TITLE
Fix for build break due to warnings-as-errors.

### DIFF
--- a/code/AssetLib/M3D/M3DWrapper.cpp
+++ b/code/AssetLib/M3D/M3DWrapper.cpp
@@ -133,6 +133,9 @@ unsigned char *M3DWrapper::Save(int quality, int flags, unsigned int &size) {
     saved_output_ = m3d_save(m3d_, quality, flags, &size);
     return saved_output_;
 #else
+    (void)quality;
+    (void)flags;
+    (void)size;
     return nullptr;
 #endif
 }


### PR DESCRIPTION
Happens when not building M3D exporter - unused argument warnings.