### PR TITLE
Fix for issue #3445

### DIFF
--- a/code/AssetLib/XGL/XGLLoader.cpp
+++ b/code/AssetLib/XGL/XGLLoader.cpp
@@ -598,7 +598,7 @@ bool XGLImporter::ReadMesh(XmlNode &node, TempScope &scope) {
 	}
 
 	// finally extract output meshes and add them to the scope
-	typedef std::pair<unsigned int, TempMaterialMesh> pairt;
+	typedef std::pair<const unsigned int, TempMaterialMesh> pairt;
 	for (const pairt &p : bymat) {
 		aiMesh *const m = ToOutputMesh(p.second);
 		scope.meshes_linear.push_back(m);


### PR DESCRIPTION
Add const to avoid creating a temporary copy.

This should fix the cmake compilation error on XGLLoader.cpp shown in bug #3445

The fix is similar to commit bbe6f7f213b5e2ee689146df5c068dc1a55ea919