### PR TITLE
Hotfix for Hunter builds

### DIFF
--- a/cmake/assimp-hunter-config.cmake.in
+++ b/cmake/assimp-hunter-config.cmake.in
@@ -8,6 +8,7 @@ find_package(openddlparser CONFIG REQUIRED)
 find_package(poly2tri CONFIG REQUIRED)
 find_package(polyclipping CONFIG REQUIRED)
 find_package(zip CONFIG REQUIRED)
+find_package(pugixml CONFIG REQUIRED)
 
 include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
 check_required_components("@PROJECT_NAME@")


### PR DESCRIPTION
I tried to add the newest Assimp to Hunter but tests failed: https://github.com/cpp-pm/hunter/pull/288

I realize that is because I forgot to update the generated config with `pugixml`. That is fixed in this PR.