### PR TITLE
Prevent crash with malformed texture reference

### DIFF
--- a/code/AssetLib/FBX/FBXConverter.cpp
+++ b/code/AssetLib/FBX/FBXConverter.cpp
@@ -3481,10 +3481,11 @@ void FBXConverter::ConvertOrphanedEmbeddedTextures() {
                 const char *obtype = key.begin();
                 const size_t length = static_cast<size_t>(key.end() - key.begin());
                 if (strncmp(obtype, "Texture", length) == 0) {
-                    const Texture *texture = static_cast<const Texture *>(object->Get());
-                    if (texture->Media() && texture->Media()->ContentLength() > 0) {
-                        realTexture = texture;
-                    }
+                    if (const Texture *texture = static_cast<const Texture *>(object->Get())) {
+                        if (texture->Media() && texture->Media()->ContentLength() > 0) {
+                            realTexture = texture;
+                        }
+                    }    
                 }
             } catch (...) {
                 // do nothing


### PR DESCRIPTION
If you are loading in non-strict mode and the texture reference in the input FBX is malformed (for example, if the RelativeFilename is not a string) then the returned texture value is null. 

This change just prevents the value being dereferenced if the value is null.