### PR TITLE
Fbx exception safety

### DIFF
--- a/code/AssetLib/FBX/FBXConverter.cpp
+++ b/code/AssetLib/FBX/FBXConverter.cpp
@@ -318,7 +318,7 @@ void FBXConverter::ConvertNodes(uint64_t id, aiNode *parent, aiNode *root_node) 
         parent->mChildren = new aiNode *[nodes.size()]();
         parent->mNumChildren = static_cast<unsigned int>(nodes.size());
 
-        for (int i = 0; i < nodes.size(); ++i)
+        for (unsigned int i = 0; i < nodes.size(); ++i)
         {
             parent->mChildren[i] = nodes[i].mOwnership.release();
         }

--- a/code/AssetLib/FBX/FBXConverter.h
+++ b/code/AssetLib/FBX/FBXConverter.h
@@ -171,9 +171,10 @@ private:
 
     // ------------------------------------------------------------------------------------------------
     /**
-    *  note: memory for output_nodes will be managed by the caller
+    *  note: memory for output_nodes is managed by the caller, via the PotentialNode struct.
     */
-    bool GenerateTransformationNodeChain(const Model& model, const std::string& name, std::vector<aiNode*>& output_nodes, std::vector<aiNode*>& post_output_nodes);
+    struct PotentialNode;
+    bool GenerateTransformationNodeChain(const Model& model, const std::string& name, std::vector<PotentialNode>& output_nodes, std::vector<PotentialNode>& post_output_nodes);
 
     // ------------------------------------------------------------------------------------------------
     void SetupNodeMetadata(const Model& model, aiNode& nd);


### PR DESCRIPTION
An exception in the FBXConvertor can lead to a crash when deleting the node chains. 

The crash occurs because assimp tries to destroy a vector of objects where there is already an ownership relationship between them, leading to double deletes.

I've adjusted the code so the node chains carry an object which may or may not own its node. The diff looks messy, but the changes are pretty minor.