### PR TITLE
Simplification: textures_converted keys can just be pointers

### DIFF
--- a/code/AssetLib/FBX/FBXConverter.cpp
+++ b/code/AssetLib/FBX/FBXConverter.cpp
@@ -1715,14 +1715,14 @@ aiString FBXConverter::GetTexturePath(const Texture *tex) {
         bool textureReady = false; //tells if our texture is ready (if it was loaded or if it was found)
         unsigned int index=0;
 
-        VideoMap::const_iterator it = textures_converted.find(*media);
+        VideoMap::const_iterator it = textures_converted.find(media);
         if (it != textures_converted.end()) {
             index = (*it).second;
             textureReady = true;
         } else {
             if (media->ContentLength() > 0) {
                 index = ConvertVideo(*media);
-                textures_converted[*media] = index;
+                textures_converted[media] = index;
                 textureReady = true;
             }
         }
@@ -2221,12 +2221,12 @@ void FBXConverter::SetShadingPropertiesRaw(aiMaterial *out_mat, const PropertyTa
             if (media != nullptr && media->ContentLength() > 0) {
                 unsigned int index;
 
-                VideoMap::const_iterator videoIt = textures_converted.find(*media);
+                VideoMap::const_iterator videoIt = textures_converted.find(media);
                 if (videoIt != textures_converted.end()) {
                     index = videoIt->second;
                 } else {
                     index = ConvertVideo(*media);
-                    textures_converted[*media] = index;
+                    textures_converted[media] = index;
                 }
 
                 // setup texture reference string (copied from ColladaLoader::FindFilenameForEffectTexture)
@@ -3493,7 +3493,7 @@ void FBXConverter::ConvertOrphanedEmbeddedTextures() {
             if (realTexture) {
                 const Video *media = realTexture->Media();
                 unsigned int index = ConvertVideo(*media);
-                textures_converted[*media] = index;
+                textures_converted[media] = index;
             }
         }
     }

--- a/code/AssetLib/FBX/FBXConverter.h
+++ b/code/AssetLib/FBX/FBXConverter.h
@@ -428,7 +428,7 @@ private:
     using MaterialMap = std::fbx_unordered_map<const Material*, unsigned int>;
     MaterialMap materials_converted;
 
-    using VideoMap = std::fbx_unordered_map<const Video, unsigned int>;
+    using VideoMap = std::fbx_unordered_map<const Video*, unsigned int>;
     VideoMap textures_converted;
 
     using MeshMap = std::fbx_unordered_map<const Geometry*, std::vector<unsigned int> >;

--- a/code/AssetLib/FBX/FBXDocument.h
+++ b/code/AssetLib/FBX/FBXDocument.h
@@ -638,15 +638,6 @@ public:
         return ptr;
     }
 
-    bool operator==(const Video& other) const
-    {
-        return (
-               type == other.type
-            && relativeFileName == other.relativeFileName
-            && fileName == other.fileName
-        );
-    }
-
     bool operator<(const Video& other) const
     {
         return std::tie(type, relativeFileName, fileName) < std::tie(other.type, other.relativeFileName, other.fileName);
@@ -1191,26 +1182,5 @@ private:
 
 } // Namespace FBX
 } // Namespace Assimp
-
-namespace std
-{
-    template <>
-    struct hash<const Assimp::FBX::Video>
-    {
-        std::size_t operator()(const Assimp::FBX::Video& video) const
-        {
-            using std::size_t;
-            using std::hash;
-            using std::string;
-
-            size_t res = 17;
-            res = res * 31 + hash<string>()(video.Name());
-            res = res * 31 + hash<string>()(video.RelativeFilename());
-            res = res * 31 + hash<string>()(video.Type());
-
-            return res;
-        }
-    };
-}
 
 #endif // INCLUDED_AI_FBX_DOCUMENT_H

--- a/code/AssetLib/FBX/FBXDocument.h
+++ b/code/AssetLib/FBX/FBXDocument.h
@@ -638,11 +638,6 @@ public:
         return ptr;
     }
 
-    bool operator<(const Video& other) const
-    {
-        return std::tie(type, relativeFileName, fileName) < std::tie(other.type, other.relativeFileName, other.fileName);
-    }
-
 private:
     std::string type;
     std::string relativeFileName;


### PR DESCRIPTION
In #2741, the keys of the textures_converted map were switched to Video objects rather than pointers. I don't think that's necessary:
* The video object are owned by the document
* In all the code I've looked at, the video objects are always const, so the keys always continue to match the objects they were copied from. 

All unit tests, including the one provided with that PR, still pass when pointers are used. (And the tests we use internally also pass.)

I thought I needed this PR for another change, but that is no longer true. However, I'll leave it here as an optional simplification.