### PR TITLE
Fixed a crash of the Gltf 2 exporter in the case of an animation without scale animation key.

### DIFF
--- a/code/AssetLib/glTF2/glTF2Exporter.cpp
+++ b/code/AssetLib/glTF2/glTF2Exporter.cpp
@@ -1338,38 +1338,36 @@ void glTF2Exporter::ExportAnimations()
         if (anim->mName.length > 0) {
             nameAnim = anim->mName.C_Str();
         }
+        Ref<Animation> animRef = mAsset->animations.Create(nameAnim);
 
         for (unsigned int channelIndex = 0; channelIndex < anim->mNumChannels; ++channelIndex) {
             const aiNodeAnim* nodeChannel = anim->mChannels[channelIndex];
 
-            // It appears that assimp stores this type of animation as multiple animations.
-            // where each aiNodeAnim in mChannels animates a specific node.
             std::string name = nameAnim + "_" + to_string(channelIndex);
             name = mAsset->FindUniqueID(name, "animation");
-            Ref<Animation> animRef = mAsset->animations.Create(name);
 
             Ref<Node> animNode = mAsset->nodes.Get(nodeChannel->mNodeName.C_Str());
 
             if (nodeChannel->mNumPositionKeys > 0)
             {
-				Animation::Sampler translationSampler;
-				ExtractTranslationSampler(*mAsset, name, bufferRef, nodeChannel, ticksPerSecond, translationSampler);
-				AddSampler(animRef, animNode, translationSampler, AnimationPath_TRANSLATION);
-			}
+                Animation::Sampler translationSampler;
+                ExtractTranslationSampler(*mAsset, name, bufferRef, nodeChannel, ticksPerSecond, translationSampler);
+                AddSampler(animRef, animNode, translationSampler, AnimationPath_TRANSLATION);
+            }
 
             if (nodeChannel->mNumRotationKeys > 0)
             {
-				Animation::Sampler rotationSampler;
-				ExtractRotationSampler(*mAsset, name, bufferRef, nodeChannel, ticksPerSecond, rotationSampler);
-				AddSampler(animRef, animNode, rotationSampler, AnimationPath_ROTATION);
-			}
+                Animation::Sampler rotationSampler;
+                ExtractRotationSampler(*mAsset, name, bufferRef, nodeChannel, ticksPerSecond, rotationSampler);
+                AddSampler(animRef, animNode, rotationSampler, AnimationPath_ROTATION);
+            }
 
             if (nodeChannel->mNumScalingKeys > 0)
             {
-				Animation::Sampler scaleSampler;
-				ExtractScaleSampler(*mAsset, name, bufferRef, nodeChannel, ticksPerSecond, scaleSampler);
-				AddSampler(animRef, animNode, scaleSampler, AnimationPath_SCALE);
-			}
+                Animation::Sampler scaleSampler;
+                ExtractScaleSampler(*mAsset, name, bufferRef, nodeChannel, ticksPerSecond, scaleSampler);
+                AddSampler(animRef, animNode, scaleSampler, AnimationPath_SCALE);
+            }
         }
 
         // Assimp documentation staes this is not used (not implemented)

--- a/code/AssetLib/glTF2/glTF2Exporter.cpp
+++ b/code/AssetLib/glTF2/glTF2Exporter.cpp
@@ -1258,9 +1258,6 @@ inline Ref<Accessor> GetSamplerInputRef(Asset& asset, std::string& animId, Ref<B
 inline void ExtractTranslationSampler(Asset& asset, std::string& animId, Ref<Buffer>& buffer, const aiNodeAnim* nodeChannel, float ticksPerSecond, Animation::Sampler& sampler)
 {
     const unsigned int numKeyframes = nodeChannel->mNumPositionKeys;
-    if (numKeyframes == 0) {
-        return;
-    }
 
     std::vector<float> times(numKeyframes);
     std::vector<float> values(numKeyframes * 3);
@@ -1281,9 +1278,6 @@ inline void ExtractTranslationSampler(Asset& asset, std::string& animId, Ref<Buf
 inline void ExtractScaleSampler(Asset& asset, std::string& animId, Ref<Buffer>& buffer, const aiNodeAnim* nodeChannel, float ticksPerSecond, Animation::Sampler& sampler)
 {
     const unsigned int numKeyframes = nodeChannel->mNumScalingKeys;
-    if (numKeyframes == 0) {
-        return;
-    }
 
     std::vector<float> times(numKeyframes);
     std::vector<float> values(numKeyframes * 3);
@@ -1304,9 +1298,6 @@ inline void ExtractScaleSampler(Asset& asset, std::string& animId, Ref<Buffer>& 
 inline void ExtractRotationSampler(Asset& asset, std::string& animId, Ref<Buffer>& buffer, const aiNodeAnim* nodeChannel, float ticksPerSecond, Animation::Sampler& sampler)
 {
     const unsigned int numKeyframes = nodeChannel->mNumRotationKeys;
-    if (numKeyframes == 0) {
-        return;
-    }
 
     std::vector<float> times(numKeyframes);
     std::vector<float> values(numKeyframes * 4);
@@ -1359,17 +1350,26 @@ void glTF2Exporter::ExportAnimations()
 
             Ref<Node> animNode = mAsset->nodes.Get(nodeChannel->mNodeName.C_Str());
 
-            Animation::Sampler translationSampler;
-            ExtractTranslationSampler(*mAsset, name, bufferRef, nodeChannel, ticksPerSecond, translationSampler);
-            AddSampler(animRef, animNode, translationSampler, AnimationPath_TRANSLATION);
+            if (nodeChannel->mNumPositionKeys > 0)
+            {
+				Animation::Sampler translationSampler;
+				ExtractTranslationSampler(*mAsset, name, bufferRef, nodeChannel, ticksPerSecond, translationSampler);
+				AddSampler(animRef, animNode, translationSampler, AnimationPath_TRANSLATION);
+			}
 
-            Animation::Sampler rotationSampler;
-            ExtractRotationSampler(*mAsset, name, bufferRef, nodeChannel, ticksPerSecond, rotationSampler);
-            AddSampler(animRef, animNode, rotationSampler, AnimationPath_ROTATION);
+            if (nodeChannel->mNumRotationKeys > 0)
+            {
+				Animation::Sampler rotationSampler;
+				ExtractRotationSampler(*mAsset, name, bufferRef, nodeChannel, ticksPerSecond, rotationSampler);
+				AddSampler(animRef, animNode, rotationSampler, AnimationPath_ROTATION);
+			}
 
-            Animation::Sampler scaleSampler;
-            ExtractScaleSampler(*mAsset, name, bufferRef, nodeChannel, ticksPerSecond, scaleSampler);
-            AddSampler(animRef, animNode, scaleSampler, AnimationPath_SCALE);
+            if (nodeChannel->mNumScalingKeys > 0)
+            {
+				Animation::Sampler scaleSampler;
+				ExtractScaleSampler(*mAsset, name, bufferRef, nodeChannel, ticksPerSecond, scaleSampler);
+				AddSampler(animRef, animNode, scaleSampler, AnimationPath_SCALE);
+			}
         }
 
         // Assimp documentation staes this is not used (not implemented)


### PR DESCRIPTION
In the GLTF 2 exporter, when we build the animation samplers, we check that the animation channel has at least one key, otherwise no need to add it.
The problem is that in this case, we don't initialize the sampler but we add them anyway which causes a crash at the time of writing.
The solution is simply not to add the animation channel in this case.