### PR TITLE
Add support for gltf extension KHR_materials_sheen

### DIFF
--- a/code/AssetLib/glTF2/glTF2Asset.h
+++ b/code/AssetLib/glTF2/glTF2Asset.h
@@ -46,6 +46,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *   KHR_materials_pbrSpecularGlossiness full
  *   KHR_materials_unlit full
  *   KHR_lights_punctual full
+ *   KHR_materials_sheen full
  */
 #ifndef GLTF2ASSET_H_INC
 #define GLTF2ASSET_H_INC
@@ -677,6 +678,7 @@ const vec4 defaultBaseColor = { 1, 1, 1, 1 };
 const vec3 defaultEmissiveFactor = { 0, 0, 0 };
 const vec4 defaultDiffuseFactor = { 1, 1, 1, 1 };
 const vec3 defaultSpecularFactor = { 1, 1, 1 };
+const vec3 defaultSheenFactor = { 0, 0, 0 };
 
 struct TextureInfo {
     Ref<Texture> texture;
@@ -718,6 +720,16 @@ struct PbrSpecularGlossiness {
     void SetDefaults();
 };
 
+struct MaterialSheen {
+    vec3 sheenColorFactor;
+    float sheenRoughnessFactor;
+    TextureInfo sheenColorTexture;
+    TextureInfo sheenRoughnessTexture;
+
+    MaterialSheen() { SetDefaults(); }
+    void SetDefaults();
+};
+
 //! The material appearance of a primitive.
 struct Material : public Object {
     //PBR metallic roughness properties
@@ -734,6 +746,9 @@ struct Material : public Object {
 
     //extension: KHR_materials_pbrSpecularGlossiness
     Nullable<PbrSpecularGlossiness> pbrSpecularGlossiness;
+
+    //extension: KHR_materials_sheen
+    Nullable<MaterialSheen> materialSheen;
 
     //extension: KHR_materials_unlit
     bool unlit;
@@ -1053,6 +1068,7 @@ public:
         bool KHR_materials_unlit;
         bool KHR_lights_punctual;
         bool KHR_texture_transform;
+        bool KHR_materials_sheen;
     } extensionsUsed;
 
     //! Keeps info about the required extensions

--- a/code/AssetLib/glTF2/glTF2Asset.inl
+++ b/code/AssetLib/glTF2/glTF2Asset.inl
@@ -1042,6 +1042,19 @@ inline void Material::Read(Value &material, Asset &r) {
         if (r.extensionsUsed.KHR_texture_transform) {
         }
 
+        if (r.extensionsUsed.KHR_materials_sheen) {
+            if (Value *curMaterialSheen = FindObject(*extensions, "KHR_materials_sheen")) {
+                MaterialSheen sheen;
+
+                ReadMember(*curMaterialSheen, "sheenColorFactor", sheen.sheenColorFactor);
+                ReadTextureProperty(r, *curMaterialSheen, "sheenColorTexture", sheen.sheenColorTexture);
+                ReadMember(*curMaterialSheen, "sheenRoughnessFactor", sheen.sheenRoughnessFactor);
+                ReadTextureProperty(r, *curMaterialSheen, "sheenRoughnessTexture", sheen.sheenRoughnessTexture);
+
+                this->materialSheen = Nullable<MaterialSheen>(sheen);
+            }
+        }
+
         unlit = nullptr != FindObject(*extensions, "KHR_materials_unlit");
     }
 }
@@ -1079,6 +1092,12 @@ inline void PbrSpecularGlossiness::SetDefaults() {
     SetVector(diffuseFactor, defaultDiffuseFactor);
     SetVector(specularFactor, defaultSpecularFactor);
     glossinessFactor = 1.0;
+}
+
+inline void MaterialSheen::SetDefaults() {
+    //KHR_materials_sheen properties
+    SetVector(sheenColorFactor, defaultSheenFactor);
+    sheenRoughnessFactor = 0.f;
 }
 
 namespace {
@@ -1731,6 +1750,7 @@ inline void Asset::ReadExtensionsUsed(Document &doc) {
     CHECK_EXT(KHR_materials_unlit);
     CHECK_EXT(KHR_lights_punctual);
     CHECK_EXT(KHR_texture_transform);
+    CHECK_EXT(KHR_materials_sheen);
 
 #undef CHECK_EXT
 }

--- a/code/AssetLib/glTF2/glTF2AssetWriter.h
+++ b/code/AssetLib/glTF2/glTF2AssetWriter.h
@@ -46,6 +46,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * glTF Extensions Support:
  *   KHR_materials_pbrSpecularGlossiness: full
  *   KHR_materials_unlit: full
+ *   KHR_materials_sheen: full
  */
 #ifndef GLTF2ASSETWRITER_H_INC
 #define GLTF2ASSETWRITER_H_INC

--- a/code/AssetLib/glTF2/glTF2AssetWriter.inl
+++ b/code/AssetLib/glTF2/glTF2AssetWriter.inl
@@ -417,6 +417,25 @@ namespace glTF2 {
           exts.AddMember("KHR_materials_unlit", unlit, w.mAl);
         }
 
+        if (m.materialSheen.isPresent) {
+            Value materialSheen(rapidjson::Type::kObjectType);
+
+            MaterialSheen &sheen = m.materialSheen.value;
+
+            WriteVec(materialSheen, sheen.sheenColorFactor, "sheenColorFactor", defaultSheenFactor, w.mAl);
+
+            if (sheen.sheenRoughnessFactor != 0.f) {
+                WriteFloat(materialSheen, sheen.sheenRoughnessFactor, "sheenRoughnessFactor", w.mAl);
+            }
+
+            WriteTex(materialSheen, sheen.sheenColorTexture, "sheenColorTexture", w.mAl);
+            WriteTex(materialSheen, sheen.sheenRoughnessTexture, "sheenRoughnessTexture", w.mAl);
+
+            if (!materialSheen.ObjectEmpty()) {
+                exts.AddMember("KHR_materials_sheen", materialSheen, w.mAl);
+            }
+        }
+
         if (!exts.ObjectEmpty()) {
             obj.AddMember("extensions", exts, w.mAl);
         }
@@ -807,6 +826,10 @@ namespace glTF2 {
 
             if (this->mAsset.extensionsUsed.KHR_materials_unlit) {
               exts.PushBack(StringRef("KHR_materials_unlit"), mAl);
+            }
+
+            if (this->mAsset.extensionsUsed.KHR_materials_sheen) {
+                exts.PushBack(StringRef("KHR_materials_sheen"), mAl);
             }
         }
 

--- a/code/AssetLib/glTF2/glTF2Exporter.cpp
+++ b/code/AssetLib/glTF2/glTF2Exporter.cpp
@@ -714,6 +714,22 @@ void glTF2Exporter::ExportMaterials()
             mAsset->extensionsUsed.KHR_materials_unlit = true;
             m->unlit = true;
         }
+
+        bool hasMaterialSheen = false;
+        mat->Get(AI_MATKEY_GLTF_MATERIAL_SHEEN, hasMaterialSheen);
+
+        if (hasMaterialSheen) {
+            mAsset->extensionsUsed.KHR_materials_sheen = true;
+
+            MaterialSheen sheen;
+
+            GetMatColor(mat, sheen.sheenColorFactor, AI_MATKEY_GLTF_MATERIAL_SHEEN_COLOR_FACTOR);
+            mat->Get(AI_MATKEY_GLTF_MATERIAL_SHEEN_ROUGHNESS_FACTOR, sheen.sheenRoughnessFactor);
+            GetMatTex(mat, sheen.sheenColorTexture, AI_MATKEY_GLTF_MATERIAL_SHEEN_COLOR_TEXTURE);
+            GetMatTex(mat, sheen.sheenRoughnessTexture, AI_MATKEY_GLTF_MATERIAL_SHEEN_ROUGHNESS_TEXTURE);
+
+            m->materialSheen = Nullable<MaterialSheen>(sheen);
+        }
     }
 }
 

--- a/code/AssetLib/glTF2/glTF2Importer.cpp
+++ b/code/AssetLib/glTF2/glTF2Importer.cpp
@@ -280,6 +280,16 @@ static aiMaterial *ImportMaterial(std::vector<int> &embeddedTexIdxs, Asset &r, M
     if (mat.unlit) {
         aimat->AddProperty(&mat.unlit, 1, AI_MATKEY_GLTF_UNLIT);
     }
+    //KHR_materials_sheen
+    if (mat.materialSheen.isPresent) {
+        MaterialSheen &sheen = mat.materialSheen.value;
+
+        aimat->AddProperty(&mat.materialSheen.isPresent, 1, AI_MATKEY_GLTF_MATERIALSHEEN);
+        SetMaterialColorProperty(r, sheen.sheenColorFactor, aimat, AI_MATKEY_GLTF_MATERIALSHEEN_COLOR_FACTOR);
+        aimat->AddProperty(&sheen.sheenRoughnessFactor, 1, AI_MATKEY_GLTF_MATERIALSHEEN_ROUGHNESS_FACTOR);
+        SetMaterialTextureProperty(embeddedTexIdxs, r, sheen.sheenColorTexture, aimat, AI_MATKEY_GLTF_MATERIALSHEEN_COLOR_TEXTURE);
+        SetMaterialTextureProperty(embeddedTexIdxs, r, sheen.sheenRoughnessTexture, aimat, AI_MATKEY_GLTF_MATERIALSHEEN_ROUGHNESS_TEXTURE);
+    }
 
     return aimat;
 }

--- a/code/AssetLib/glTF2/glTF2Importer.cpp
+++ b/code/AssetLib/glTF2/glTF2Importer.cpp
@@ -284,11 +284,11 @@ static aiMaterial *ImportMaterial(std::vector<int> &embeddedTexIdxs, Asset &r, M
     if (mat.materialSheen.isPresent) {
         MaterialSheen &sheen = mat.materialSheen.value;
 
-        aimat->AddProperty(&mat.materialSheen.isPresent, 1, AI_MATKEY_GLTF_MATERIALSHEEN);
-        SetMaterialColorProperty(r, sheen.sheenColorFactor, aimat, AI_MATKEY_GLTF_MATERIALSHEEN_COLOR_FACTOR);
-        aimat->AddProperty(&sheen.sheenRoughnessFactor, 1, AI_MATKEY_GLTF_MATERIALSHEEN_ROUGHNESS_FACTOR);
-        SetMaterialTextureProperty(embeddedTexIdxs, r, sheen.sheenColorTexture, aimat, AI_MATKEY_GLTF_MATERIALSHEEN_COLOR_TEXTURE);
-        SetMaterialTextureProperty(embeddedTexIdxs, r, sheen.sheenRoughnessTexture, aimat, AI_MATKEY_GLTF_MATERIALSHEEN_ROUGHNESS_TEXTURE);
+        aimat->AddProperty(&mat.materialSheen.isPresent, 1, AI_MATKEY_GLTF_MATERIAL_SHEEN);
+        SetMaterialColorProperty(r, sheen.sheenColorFactor, aimat, AI_MATKEY_GLTF_MATERIAL_SHEEN_COLOR_FACTOR);
+        aimat->AddProperty(&sheen.sheenRoughnessFactor, 1, AI_MATKEY_GLTF_MATERIAL_SHEEN_ROUGHNESS_FACTOR);
+        SetMaterialTextureProperty(embeddedTexIdxs, r, sheen.sheenColorTexture, aimat, AI_MATKEY_GLTF_MATERIAL_SHEEN_COLOR_TEXTURE);
+        SetMaterialTextureProperty(embeddedTexIdxs, r, sheen.sheenRoughnessTexture, aimat, AI_MATKEY_GLTF_MATERIAL_SHEEN_ROUGHNESS_TEXTURE);
     }
 
     return aimat;

--- a/include/assimp/pbrmaterial.h
+++ b/include/assimp/pbrmaterial.h
@@ -60,11 +60,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define AI_MATKEY_GLTF_PBRSPECULARGLOSSINESS "$mat.gltf.pbrSpecularGlossiness", 0, 0
 #define AI_MATKEY_GLTF_PBRSPECULARGLOSSINESS_GLOSSINESS_FACTOR "$mat.gltf.pbrMetallicRoughness.glossinessFactor", 0, 0
 #define AI_MATKEY_GLTF_UNLIT "$mat.gltf.unlit", 0, 0
-#define AI_MATKEY_GLTF_MATERIALSHEEN "$mat.gltf.materialSheen", 0, 0
-#define AI_MATKEY_GLTF_MATERIALSHEEN_COLOR_FACTOR "$mat.gltf.materialSheen.sheenColorFactor", 0, 0
-#define AI_MATKEY_GLTF_MATERIALSHEEN_ROUGHNESS_FACTOR "$mat.gltf.materialSheen.sheenRoughnessFactor", 0, 0
-#define AI_MATKEY_GLTF_MATERIALSHEEN_COLOR_TEXTURE aiTextureType_UNKNOWN, 1
-#define AI_MATKEY_GLTF_MATERIALSHEEN_ROUGHNESS_TEXTURE aiTextureType_UNKNOWN, 2
+#define AI_MATKEY_GLTF_MATERIAL_SHEEN "$mat.gltf.materialSheen", 0, 0
+#define AI_MATKEY_GLTF_MATERIAL_SHEEN_COLOR_FACTOR "$mat.gltf.materialSheen.sheenColorFactor", 0, 0
+#define AI_MATKEY_GLTF_MATERIAL_SHEEN_ROUGHNESS_FACTOR "$mat.gltf.materialSheen.sheenRoughnessFactor", 0, 0
+#define AI_MATKEY_GLTF_MATERIAL_SHEEN_COLOR_TEXTURE aiTextureType_UNKNOWN, 1
+#define AI_MATKEY_GLTF_MATERIAL_SHEEN_ROUGHNESS_TEXTURE aiTextureType_UNKNOWN, 2
 
 #define _AI_MATKEY_GLTF_TEXTURE_TEXCOORD_BASE "$tex.file.texCoord"
 #define _AI_MATKEY_GLTF_MAPPINGNAME_BASE "$tex.mappingname"

--- a/include/assimp/pbrmaterial.h
+++ b/include/assimp/pbrmaterial.h
@@ -60,6 +60,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define AI_MATKEY_GLTF_PBRSPECULARGLOSSINESS "$mat.gltf.pbrSpecularGlossiness", 0, 0
 #define AI_MATKEY_GLTF_PBRSPECULARGLOSSINESS_GLOSSINESS_FACTOR "$mat.gltf.pbrMetallicRoughness.glossinessFactor", 0, 0
 #define AI_MATKEY_GLTF_UNLIT "$mat.gltf.unlit", 0, 0
+#define AI_MATKEY_GLTF_MATERIALSHEEN "$mat.gltf.materialSheen", 0, 0
+#define AI_MATKEY_GLTF_MATERIALSHEEN_COLOR_FACTOR "$mat.gltf.materialSheen.sheenColorFactor", 0, 0
+#define AI_MATKEY_GLTF_MATERIALSHEEN_ROUGHNESS_FACTOR "$mat.gltf.materialSheen.sheenRoughnessFactor", 0, 0
+#define AI_MATKEY_GLTF_MATERIALSHEEN_COLOR_TEXTURE aiTextureType_UNKNOWN, 1
+#define AI_MATKEY_GLTF_MATERIALSHEEN_ROUGHNESS_TEXTURE aiTextureType_UNKNOWN, 2
 
 #define _AI_MATKEY_GLTF_TEXTURE_TEXCOORD_BASE "$tex.file.texCoord"
 #define _AI_MATKEY_GLTF_MAPPINGNAME_BASE "$tex.mappingname"


### PR DESCRIPTION
Add support for gltf2 extension KHR_materials_sheen (import/export): 
https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_materials_sheen