### PR TITLE
Update minizip

### DIFF
--- a/code/AssetLib/3MF/D3MFExporter.cpp
+++ b/code/AssetLib/3MF/D3MFExporter.cpp
@@ -395,7 +395,8 @@ void D3MFExporter::addFileInZip(const std::string& entry, const std::string& exp
     nullptr, 0, // comment
     6); // similar to the previous ZIP_DEFAULT_COMPRESSION_LEVEL value
 
-    zipWriteInFileInZip(m_zipArchive, exportTxt.c_str(), exportTxt.size());
+    uint32_t contentLength = static_cast<uint32_t>(exportTxt.size());
+    zipWriteInFileInZip(m_zipArchive, exportTxt.c_str(), contentLength);
 
     zipCloseFileInZip(m_zipArchive);
 }

--- a/code/AssetLib/3MF/D3MFExporter.cpp
+++ b/code/AssetLib/3MF/D3MFExporter.cpp
@@ -109,7 +109,7 @@ bool D3MFExporter::validate() {
 bool D3MFExporter::exportArchive(const char *file) {
     bool ok(true);
 
-    m_zipArchive = zip_open(file, ZIP_DEFAULT_COMPRESSION_LEVEL, 'w');
+    m_zipArchive = (zip_t*)zipOpen(file, APPEND_STATUS_CREATE);
     if (nullptr == m_zipArchive) {
         return false;
     }
@@ -118,7 +118,7 @@ bool D3MFExporter::exportArchive(const char *file) {
     ok |= export3DModel();
     ok |= exportRelations();
 
-    zip_close(m_zipArchive);
+    zipClose(m_zipArchive, nullptr);
     m_zipArchive = nullptr;
 
     return ok;
@@ -362,12 +362,17 @@ void D3MFExporter::exportContentTyp(const std::string &filename) {
         throw DeadlyExportError("3MF-Export: Zip archive not valid, nullptr.");
     }
     const std::string entry = filename;
-    zip_entry_open(m_zipArchive, entry.c_str());
-
     const std::string &exportTxt(mContentOutput.str());
-    zip_entry_write(m_zipArchive, exportTxt.c_str(), exportTxt.size());
 
-    zip_entry_close(m_zipArchive);
+    zipOpenNewFileInZip(m_zipArchive, filename.c_str(), nullptr,
+    nullptr, 0, // extrafield local
+    nullptr, 0, // extrafield global
+    nullptr, 0, // comment
+    6); // similar to the previous ZIP_DEFAULT_COMPRESSION_LEVEL value
+
+    zipWriteInFileInZip(m_zipArchive, exportTxt.c_str(), exportTxt.size());
+
+    zipCloseFileInZip(m_zipArchive);
 }
 
 void D3MFExporter::writeModelToArchive(const std::string &folder, const std::string &modelName) {
@@ -375,12 +380,17 @@ void D3MFExporter::writeModelToArchive(const std::string &folder, const std::str
         throw DeadlyExportError("3MF-Export: Zip archive not valid, nullptr.");
     }
     const std::string entry = folder + "/" + modelName;
-    zip_entry_open(m_zipArchive, entry.c_str());
-
     const std::string &exportTxt(mModelOutput.str());
-    zip_entry_write(m_zipArchive, exportTxt.c_str(), exportTxt.size());
 
-    zip_entry_close(m_zipArchive);
+    zipOpenNewFileInZip(m_zipArchive, entry.c_str(), nullptr,
+    nullptr, 0, // extrafield local
+    nullptr, 0, // extrafield global
+    nullptr, 0, // comment
+    6); // similar to the previous ZIP_DEFAULT_COMPRESSION_LEVEL value
+
+    zipWriteInFileInZip(m_zipArchive, exportTxt.c_str(), exportTxt.size());
+
+    zipCloseFileInZip(m_zipArchive);
 }
 
 void D3MFExporter::writeRelInfoToFile(const std::string &folder, const std::string &relName) {
@@ -388,12 +398,17 @@ void D3MFExporter::writeRelInfoToFile(const std::string &folder, const std::stri
         throw DeadlyExportError("3MF-Export: Zip archive not valid, nullptr.");
     }
     const std::string entry = folder + "/" + relName;
-    zip_entry_open(m_zipArchive, entry.c_str());
-
     const std::string &exportTxt(mRelOutput.str());
-    zip_entry_write(m_zipArchive, exportTxt.c_str(), exportTxt.size());
 
-    zip_entry_close(m_zipArchive);
+    zipOpenNewFileInZip(m_zipArchive, entry.c_str(), nullptr,
+    nullptr, 0, // extrafield local
+    nullptr, 0, // extrafield global
+    nullptr, 0, // comment
+    6); // similar to the previous ZIP_DEFAULT_COMPRESSION_LEVEL value
+
+    zipWriteInFileInZip(m_zipArchive, exportTxt.c_str(), exportTxt.size());
+
+    zipCloseFileInZip(m_zipArchive);
 }
 
 } // Namespace D3MF

--- a/code/AssetLib/3MF/D3MFExporter.cpp
+++ b/code/AssetLib/3MF/D3MFExporter.cpp
@@ -364,15 +364,7 @@ void D3MFExporter::exportContentTyp(const std::string &filename) {
     const std::string entry = filename;
     const std::string &exportTxt(mContentOutput.str());
 
-    zipOpenNewFileInZip(m_zipArchive, filename.c_str(), nullptr,
-    nullptr, 0, // extrafield local
-    nullptr, 0, // extrafield global
-    nullptr, 0, // comment
-    6); // similar to the previous ZIP_DEFAULT_COMPRESSION_LEVEL value
-
-    zipWriteInFileInZip(m_zipArchive, exportTxt.c_str(), exportTxt.size());
-
-    zipCloseFileInZip(m_zipArchive);
+    addFileInZip(entry, exportTxt);
 }
 
 void D3MFExporter::writeModelToArchive(const std::string &folder, const std::string &modelName) {
@@ -382,15 +374,7 @@ void D3MFExporter::writeModelToArchive(const std::string &folder, const std::str
     const std::string entry = folder + "/" + modelName;
     const std::string &exportTxt(mModelOutput.str());
 
-    zipOpenNewFileInZip(m_zipArchive, entry.c_str(), nullptr,
-    nullptr, 0, // extrafield local
-    nullptr, 0, // extrafield global
-    nullptr, 0, // comment
-    6); // similar to the previous ZIP_DEFAULT_COMPRESSION_LEVEL value
-
-    zipWriteInFileInZip(m_zipArchive, exportTxt.c_str(), exportTxt.size());
-
-    zipCloseFileInZip(m_zipArchive);
+    addFileInZip(entry, exportTxt);
 }
 
 void D3MFExporter::writeRelInfoToFile(const std::string &folder, const std::string &relName) {
@@ -400,6 +384,11 @@ void D3MFExporter::writeRelInfoToFile(const std::string &folder, const std::stri
     const std::string entry = folder + "/" + relName;
     const std::string &exportTxt(mRelOutput.str());
 
+    addFileInZip(entry, exportTxt);
+}
+
+void D3MFExporter::addFileInZip(const std::string& entry, const std::string& exportTxt)
+{
     zipOpenNewFileInZip(m_zipArchive, entry.c_str(), nullptr,
     nullptr, 0, // extrafield local
     nullptr, 0, // extrafield global

--- a/code/AssetLib/3MF/D3MFExporter.h
+++ b/code/AssetLib/3MF/D3MFExporter.h
@@ -85,6 +85,7 @@ protected:
     void exportContentTyp( const std::string &filename );
     void writeModelToArchive( const std::string &folder, const std::string &modelName );
     void writeRelInfoToFile( const std::string &folder, const std::string &relName );
+    void addFileInZip( const std::string& entry, const std::string& exportTxt );
 
 private:
     std::string mArchiveName;

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -920,6 +920,7 @@ IF(ASSIMP_HUNTER_ENABLED)
   find_package(minizip CONFIG REQUIRED)
 ELSE()
   SET( unzip_SRCS
+    ../contrib/unzip/crypt.c
     ../contrib/unzip/crypt.h
     ../contrib/unzip/ioapi.c
     ../contrib/unzip/ioapi.h

--- a/contrib/unzip/crypt.c
+++ b/contrib/unzip/crypt.c
@@ -1,0 +1,146 @@
+/* crypt.c -- base code for traditional PKWARE encryption
+   Version 1.2.0, September 16th, 2017
+
+   Copyright (C) 2012-2017 Nathan Moinvaziri
+     https://github.com/nmoinvaz/minizip
+   Copyright (C) 1998-2005 Gilles Vollant
+     Modifications for Info-ZIP crypting
+     http://www.winimage.com/zLibDll/minizip.html
+   Copyright (C) 2003 Terry Thorsen
+
+   This code is a modified version of crypting code in Info-ZIP distribution
+
+   Copyright (C) 1990-2000 Info-ZIP.  All rights reserved.
+
+   This program is distributed under the terms of the same license as zlib.
+   See the accompanying LICENSE file for the full text of the license.
+
+   This encryption code is a direct transcription of the algorithm from
+   Roger Schlafly, described by Phil Katz in the file appnote.txt. This
+   file (appnote.txt) is distributed with the PKZIP program (even in the
+   version without encryption capabilities).
+
+   If you don't need crypting in your application, just define symbols
+   NOCRYPT and NOUNCRYPT.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <time.h>
+
+#ifdef _WIN32
+#  include <windows.h>
+#  include <wincrypt.h>
+#else
+#  include <sys/stat.h>
+#  include <fcntl.h>
+#  include <unistd.h>
+#endif
+
+#include "zlib.h"
+
+#include "crypt.h"
+
+/***************************************************************************/
+
+#define CRC32(c, b) ((*(pcrc_32_tab+(((uint32_t)(c) ^ (b)) & 0xff))) ^ ((c) >> 8))
+
+/***************************************************************************/
+
+uint8_t decrypt_byte(uint32_t *pkeys)
+{
+    unsigned temp;  /* POTENTIAL BUG:  temp*(temp^1) may overflow in an
+                     * unpredictable manner on 16-bit systems; not a problem
+                     * with any known compiler so far, though */
+
+    temp = ((uint32_t)(*(pkeys+2)) & 0xffff) | 2;
+    return (uint8_t)(((temp * (temp ^ 1)) >> 8) & 0xff);
+}
+
+uint8_t update_keys(uint32_t *pkeys, const z_crc_t *pcrc_32_tab, int32_t c)
+{
+    (*(pkeys+0)) = (uint32_t)CRC32((*(pkeys+0)), c);
+    (*(pkeys+1)) += (*(pkeys+0)) & 0xff;
+    (*(pkeys+1)) = (*(pkeys+1)) * 134775813L + 1;
+    {
+        register int32_t keyshift = (int32_t)((*(pkeys + 1)) >> 24);
+        (*(pkeys+2)) = (uint32_t)CRC32((*(pkeys+2)), keyshift);
+    }
+    return c;
+}
+
+void init_keys(const char *passwd, uint32_t *pkeys, const z_crc_t *pcrc_32_tab)
+{
+    *(pkeys+0) = 305419896L;
+    *(pkeys+1) = 591751049L;
+    *(pkeys+2) = 878082192L;
+    while (*passwd != 0)
+    {
+        update_keys(pkeys, pcrc_32_tab, *passwd);
+        passwd += 1;
+    }
+}
+
+/***************************************************************************/
+
+#ifndef NOCRYPT
+int cryptrand(unsigned char *buf, unsigned int len)
+{
+#ifdef _WIN32
+    HCRYPTPROV provider;
+    unsigned __int64 pentium_tsc[1];
+    int rlen = 0;
+    int result = 0;
+
+
+    if (CryptAcquireContext(&provider, NULL, NULL, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT | CRYPT_SILENT))
+    {
+        result = CryptGenRandom(provider, len, buf);
+        CryptReleaseContext(provider, 0);
+        if (result)
+            return len;
+    }
+
+    for (rlen = 0; rlen < (int)len; ++rlen)
+    {
+        if (rlen % 8 == 0)
+            QueryPerformanceCounter((LARGE_INTEGER *)pentium_tsc);
+        buf[rlen] = ((unsigned char*)pentium_tsc)[rlen % 8];
+    }
+
+    return rlen;
+#else
+    arc4random_buf(buf, len);
+    return len;
+#endif
+}
+
+int crypthead(const char *passwd, uint8_t *buf, int buf_size, uint32_t *pkeys,
+              const z_crc_t *pcrc_32_tab, uint8_t verify1, uint8_t verify2)
+{
+    uint8_t n = 0;                      /* index in random header */
+    uint8_t header[RAND_HEAD_LEN-2];    /* random header */
+    uint16_t t = 0;                     /* temporary */
+
+    if (buf_size < RAND_HEAD_LEN)
+        return 0;
+
+    init_keys(passwd, pkeys, pcrc_32_tab);
+
+    /* First generate RAND_HEAD_LEN-2 random bytes. */
+    cryptrand(header, RAND_HEAD_LEN-2);
+
+    /* Encrypt random header (last two bytes is high word of crc) */
+    init_keys(passwd, pkeys, pcrc_32_tab);
+
+    for (n = 0; n < RAND_HEAD_LEN-2; n++)
+        buf[n] = (uint8_t)zencode(pkeys, pcrc_32_tab, header[n], t);
+
+    buf[n++] = (uint8_t)zencode(pkeys, pcrc_32_tab, verify1, t);
+    buf[n++] = (uint8_t)zencode(pkeys, pcrc_32_tab, verify2, t);
+    return n;
+}
+#endif
+
+/***************************************************************************/

--- a/contrib/unzip/crypt.c
+++ b/contrib/unzip/crypt.c
@@ -42,6 +42,9 @@
 
 #include "crypt.h"
 
+// these warnings are considered as errors on VS
+#pragma warning(disable : 4244) 
+
 /***************************************************************************/
 
 #define CRC32(c, b) ((*(pcrc_32_tab+(((uint32_t)(c) ^ (b)) & 0xff))) ^ ((c) >> 8))

--- a/contrib/unzip/crypt.h
+++ b/contrib/unzip/crypt.h
@@ -1,133 +1,66 @@
-/* crypt.h -- base code for crypt/uncrypt ZIPfile
+/* crypt.h -- base code for traditional PKWARE encryption
+   Version 1.2.0, September 16th, 2017
 
-
-   Version 1.01e, February 12th, 2005
-
+   Copyright (C) 2012-2017 Nathan Moinvaziri
+     https://github.com/nmoinvaz/minizip
    Copyright (C) 1998-2005 Gilles Vollant
+     Modifications for Info-ZIP crypting
+     http://www.winimage.com/zLibDll/minizip.html
+   Copyright (C) 2003 Terry Thorsen
 
-   This code is a modified version of crypting code in Infozip distribution
+   This code is a modified version of crypting code in Info-ZIP distribution
 
-   The encryption/decryption parts of this source code (as opposed to the
-   non-echoing password parts) were originally written in Europe.  The
-   whole source package can be freely distributed, including from the USA.
-   (Prior to January 2000, re-export from the US was a violation of US law.)
+   Copyright (C) 1990-2000 Info-ZIP.  All rights reserved.
 
-   This encryption code is a direct transcription of the algorithm from
-   Roger Schlafly, described by Phil Katz in the file appnote.txt.  This
-   file (appnote.txt) is distributed with the PKZIP program (even in the
-   version without encryption capabilities).
-
-   If you don't need crypting in your application, just define symbols
-   NOCRYPT and NOUNCRYPT.
-
-   This code support the "Traditional PKWARE Encryption".
-
-   The new AES encryption added on Zip format by Winzip (see the page
-   http://www.winzip.com/aes_info.htm ) and PKWare PKZip 5.x Strong
-   Encryption is not supported.
+   This program is distributed under the terms of the same license as zlib.
+   See the accompanying LICENSE file for the full text of the license.
 */
 
-#define CRC32(c, b) ((*(pcrc_32_tab+(((int)(c) ^ (b)) & 0xff))) ^ ((c) >> 8))
+#ifndef _MINICRYPT_H
+#define _MINICRYPT_H
 
-/***********************************************************************
- * Return the next byte in the pseudo-random sequence
- */
-static int decrypt_byte(unsigned long* pkeys, const z_crc_t* t)
-{
-    unsigned temp;  /* POTENTIAL BUG:  temp*(temp^1) may overflow in an
-                     * unpredictable manner on 16-bit systems; not a problem
-                     * with any known compiler so far, though */
+#if ZLIB_VERNUM < 0x1270
+typedef unsigned long z_crc_t;
+#endif
 
-    temp = ((unsigned)(*(pkeys+2)) & 0xffff) | 2;
-    (void)t;
-    return (int)(((temp * (temp ^ 1)) >> 8) & 0xff);
-}
-
-/***********************************************************************
- * Update the encryption keys with the next byte of plain text
- */
-static int update_keys(unsigned long* pkeys,const z_crc_t* pcrc_32_tab,int c)
-{
-    (*(pkeys+0)) = CRC32((*(pkeys+0)), c);
-    (*(pkeys+1)) += (*(pkeys+0)) & 0xff;
-    (*(pkeys+1)) = (*(pkeys+1)) * 134775813L + 1;
-    {
-      register int keyshift = (int)((*(pkeys+1)) >> 24);
-      (*(pkeys+2)) = CRC32((*(pkeys+2)), keyshift);
-    }
-    return c;
-}
-
-
-/***********************************************************************
- * Initialize the encryption keys and the random header according to
- * the given password.
- */
-static void init_keys(const char* passwd,unsigned long* pkeys,const z_crc_t* pcrc_32_tab)
-{
-    *(pkeys+0) = 305419896L;
-    *(pkeys+1) = 591751049L;
-    *(pkeys+2) = 878082192L;
-    while (*passwd != '\0') {
-        update_keys(pkeys,pcrc_32_tab,(int)*passwd);
-        passwd++;
-    }
-}
-
-#define zdecode(pkeys,pcrc_32_tab,c) \
-    (update_keys(pkeys,pcrc_32_tab,c ^= decrypt_byte(pkeys,pcrc_32_tab)))
-
-#define zencode(pkeys,pcrc_32_tab,c,t) \
-    (t=decrypt_byte(pkeys,pcrc_32_tab), update_keys(pkeys,pcrc_32_tab,c), t^(c))
-
-#ifdef INCLUDECRYPTINGCODE_IFCRYPTALLOWED
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define RAND_HEAD_LEN  12
-   /* "last resort" source for second part of crypt seed pattern */
-#  ifndef ZCR_SEED2
-#    define ZCR_SEED2 3141592654UL     /* use PI as default pattern */
-#  endif
 
-static int crypthead(passwd, buf, bufSize, pkeys, pcrc_32_tab, crcForCrypting)
-    const char *passwd;         /* password string */
-    unsigned char *buf;         /* where to write header */
-    int bufSize;
-    unsigned long* pkeys;
-    const unsigned long* pcrc_32_tab;
-    unsigned long crcForCrypting;
-{
-    int n;                       /* index in random header */
-    int t;                       /* temporary */
-    int c;                       /* random byte */
-    unsigned char header[RAND_HEAD_LEN-2]; /* random header */
-    static unsigned calls = 0;   /* ensure different random header each time */
+/***************************************************************************/
 
-    if (bufSize<RAND_HEAD_LEN)
-      return 0;
+#define zdecode(pkeys,pcrc_32_tab,c) \
+    (update_keys(pkeys,pcrc_32_tab, c ^= decrypt_byte(pkeys)))
 
-    /* First generate RAND_HEAD_LEN-2 random bytes. We encrypt the
-     * output of rand() to get less predictability, since rand() is
-     * often poorly implemented.
-     */
-    if (++calls == 1)
-    {
-        srand((unsigned)(time(NULL) ^ ZCR_SEED2));
-    }
-    init_keys(passwd, pkeys, pcrc_32_tab);
-    for (n = 0; n < RAND_HEAD_LEN-2; n++)
-    {
-        c = (rand() >> 7) & 0xff;
-        header[n] = (unsigned char)zencode(pkeys, pcrc_32_tab, c, t);
-    }
-    /* Encrypt random header (last two bytes is high word of crc) */
-    init_keys(passwd, pkeys, pcrc_32_tab);
-    for (n = 0; n < RAND_HEAD_LEN-2; n++)
-    {
-        buf[n] = (unsigned char)zencode(pkeys, pcrc_32_tab, header[n], t);
-    }
-    buf[n++] = zencode(pkeys, pcrc_32_tab, (int)(crcForCrypting >> 16) & 0xff, t);
-    buf[n++] = zencode(pkeys, pcrc_32_tab, (int)(crcForCrypting >> 24) & 0xff, t);
-    return n;
+#define zencode(pkeys,pcrc_32_tab,c,t) \
+    (t = decrypt_byte(pkeys), update_keys(pkeys,pcrc_32_tab,c), t^(c))
+
+/***************************************************************************/
+
+/* Return the next byte in the pseudo-random sequence */
+uint8_t decrypt_byte(uint32_t *pkeys);
+
+/* Update the encryption keys with the next byte of plain text */
+uint8_t update_keys(uint32_t *pkeys, const z_crc_t *pcrc_32_tab, int32_t c);
+
+/* Initialize the encryption keys and the random header according to the given password. */
+void init_keys(const char *passwd, uint32_t *pkeys, const z_crc_t *pcrc_32_tab);
+
+#ifndef NOCRYPT
+/* Generate cryptographically secure random numbers */
+int cryptrand(unsigned char *buf, unsigned int len);
+
+/* Create encryption header */
+int crypthead(const char *passwd, uint8_t *buf, int buf_size, uint32_t *pkeys,
+    const z_crc_t *pcrc_32_tab, uint8_t verify1, uint8_t verify2);
+#endif
+
+/***************************************************************************/
+
+#ifdef __cplusplus
 }
+#endif
 
 #endif

--- a/contrib/unzip/ioapi.c
+++ b/contrib/unzip/ioapi.c
@@ -23,6 +23,9 @@
 
 #include "ioapi.h"
 
+// these warnings are considered as errors on VS
+#pragma warning(disable : 4100) 
+
 #if defined(_WIN32)
 #  define snprintf _snprintf
 #endif

--- a/contrib/unzip/ioapi.c
+++ b/contrib/unzip/ioapi.c
@@ -1,179 +1,335 @@
 /* ioapi.c -- IO base function header for compress/uncompress .zip
-   files using zlib + zip or unzip API
+   part of the MiniZip project
 
-   Version 1.01e, February 12th, 2005
+   Copyright (C) 2012-2017 Nathan Moinvaziri
+     https://github.com/nmoinvaz/minizip
+   Modifications for Zip64 support
+     Copyright (C) 2009-2010 Mathias Svensson
+     http://result42.com
+   Copyright (C) 1998-2010 Gilles Vollant
+     http://www.winimage.com/zLibDll/minizip.html
 
-   Copyright (C) 1998-2005 Gilles Vollant
+   This program is distributed under the terms of the same license as zlib.
+   See the accompanying LICENSE file for the full text of the license.
 */
 
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include "zlib.h"
+#if defined unix || defined __APPLE__
+#include <sys/types.h>
+#include <unistd.h>
+#endif
+
 #include "ioapi.h"
 
-#ifdef _WIN32
-#    pragma warning(push)
-#    pragma warning(disable : 4131 4100)
-#    ifdef __clang__
-#    pragma clang diagnostic push
-#    pragma clang diagnostic ignored "-Wunused-parameter"
-#    endif
-#endif // _WIN32
-
-/* I've found an old Unix (a SunOS 4.1.3_U1) without all SEEK_* defined.... */
-
-#ifndef SEEK_CUR
-#define SEEK_CUR    1
+#if defined(_WIN32)
+#  define snprintf _snprintf
 #endif
 
-#ifndef SEEK_END
-#define SEEK_END    2
-#endif
+voidpf call_zopen64(const zlib_filefunc64_32_def *pfilefunc, const void *filename, int mode)
+{
+    if (pfilefunc->zfile_func64.zopen64_file != NULL)
+        return (*(pfilefunc->zfile_func64.zopen64_file)) (pfilefunc->zfile_func64.opaque, filename, mode);
+    return (*(pfilefunc->zopen32_file))(pfilefunc->zfile_func64.opaque, (const char*)filename, mode);
+}
 
-#ifndef SEEK_SET
-#define SEEK_SET    0
-#endif
+voidpf call_zopendisk64(const zlib_filefunc64_32_def *pfilefunc, voidpf filestream, uint32_t number_disk, int mode)
+{
+    if (pfilefunc->zfile_func64.zopendisk64_file != NULL)
+        return (*(pfilefunc->zfile_func64.zopendisk64_file)) (pfilefunc->zfile_func64.opaque, filestream, number_disk, mode);
+    return (*(pfilefunc->zopendisk32_file))(pfilefunc->zfile_func64.opaque, filestream, number_disk, mode);
+}
 
-voidpf ZCALLBACK fopen_file_func OF((
-   voidpf opaque,
-   const char* filename,
-   int mode));
+long call_zseek64(const zlib_filefunc64_32_def *pfilefunc, voidpf filestream, uint64_t offset, int origin)
+{
+    uint32_t offset_truncated = 0;
+    if (pfilefunc->zfile_func64.zseek64_file != NULL)
+        return (*(pfilefunc->zfile_func64.zseek64_file)) (pfilefunc->zfile_func64.opaque,filestream,offset,origin);
+    offset_truncated = (uint32_t)offset;
+    if (offset_truncated != offset)
+        return -1;
+    return (*(pfilefunc->zseek32_file))(pfilefunc->zfile_func64.opaque,filestream, offset_truncated, origin);
+}
 
-uLong ZCALLBACK fread_file_func OF((
-   voidpf opaque,
-   voidpf stream,
-   void* buf,
-   uLong size));
+uint64_t call_ztell64(const zlib_filefunc64_32_def *pfilefunc, voidpf filestream)
+{
+    uint64_t position;
+    if (pfilefunc->zfile_func64.zseek64_file != NULL)
+        return (*(pfilefunc->zfile_func64.ztell64_file)) (pfilefunc->zfile_func64.opaque, filestream);
+    position = (*(pfilefunc->ztell32_file))(pfilefunc->zfile_func64.opaque, filestream);
+    if ((position) == UINT32_MAX)
+        return (uint64_t)-1;
+    return position;
+}
 
-uLong ZCALLBACK fwrite_file_func OF((
-   voidpf opaque,
-   voidpf stream,
-   const void* buf,
-   uLong size));
+void fill_zlib_filefunc64_32_def_from_filefunc32(zlib_filefunc64_32_def *p_filefunc64_32, const zlib_filefunc_def *p_filefunc32)
+{
+    p_filefunc64_32->zfile_func64.zopen64_file = NULL;
+    p_filefunc64_32->zfile_func64.zopendisk64_file = NULL;
+    p_filefunc64_32->zopen32_file = p_filefunc32->zopen_file;
+    p_filefunc64_32->zopendisk32_file = p_filefunc32->zopendisk_file;
+    p_filefunc64_32->zfile_func64.zerror_file = p_filefunc32->zerror_file;
+    p_filefunc64_32->zfile_func64.zread_file = p_filefunc32->zread_file;
+    p_filefunc64_32->zfile_func64.zwrite_file = p_filefunc32->zwrite_file;
+    p_filefunc64_32->zfile_func64.ztell64_file = NULL;
+    p_filefunc64_32->zfile_func64.zseek64_file = NULL;
+    p_filefunc64_32->zfile_func64.zclose_file = p_filefunc32->zclose_file;
+    p_filefunc64_32->zfile_func64.zerror_file = p_filefunc32->zerror_file;
+    p_filefunc64_32->zfile_func64.opaque = p_filefunc32->opaque;
+    p_filefunc64_32->zseek32_file = p_filefunc32->zseek_file;
+    p_filefunc64_32->ztell32_file = p_filefunc32->ztell_file;
+}
 
-long ZCALLBACK ftell_file_func OF((
-   voidpf opaque,
-   voidpf stream));
+static voidpf   ZCALLBACK fopen_file_func(ZIP_UNUSED voidpf opaque, const char *filename, int mode);
+static uint32_t ZCALLBACK fread_file_func(voidpf opaque, voidpf stream, void* buf, uint32_t size);
+static uint32_t ZCALLBACK fwrite_file_func(voidpf opaque, voidpf stream, const void *buf, uint32_t size);
+static uint64_t ZCALLBACK ftell64_file_func(voidpf opaque, voidpf stream);
+static long     ZCALLBACK fseek64_file_func(voidpf opaque, voidpf stream, uint64_t offset, int origin);
+static int      ZCALLBACK fclose_file_func(voidpf opaque, voidpf stream);
+static int      ZCALLBACK ferror_file_func(voidpf opaque, voidpf stream);
 
-long ZCALLBACK fseek_file_func OF((
-   voidpf opaque,
-   voidpf stream,
-   uLong offset,
-   int origin));
+typedef struct
+{
+    FILE *file;
+    int filenameLength;
+    void *filename;
+} FILE_IOPOSIX;
 
-int ZCALLBACK fclose_file_func OF((
-   voidpf opaque,
-   voidpf stream));
+static voidpf file_build_ioposix(FILE *file, const char *filename)
+{
+    FILE_IOPOSIX *ioposix = NULL;
+    if (file == NULL)
+        return NULL;
+    ioposix = (FILE_IOPOSIX*)malloc(sizeof(FILE_IOPOSIX));
+    ioposix->file = file;
+    ioposix->filenameLength = (int)strlen(filename) + 1;
+    ioposix->filename = (char*)malloc(ioposix->filenameLength * sizeof(char));
+    memcpy((char*)ioposix->filename, filename, ioposix->filenameLength);
+    return (voidpf)ioposix;
+}
 
-int ZCALLBACK ferror_file_func OF((
-   voidpf opaque,
-   voidpf stream));
-
-
-voidpf ZCALLBACK fopen_file_func (opaque, filename, mode)
-   voidpf opaque;
-   const char* filename;
-   int mode;
+static voidpf ZCALLBACK fopen_file_func(ZIP_UNUSED voidpf opaque, const char *filename, int mode)
 {
     FILE* file = NULL;
-    const char* mode_fopen = NULL;
-    if ((mode & ZLIB_FILEFUNC_MODE_READWRITEFILTER)==ZLIB_FILEFUNC_MODE_READ)
+    const char *mode_fopen = NULL;
+    if ((mode & ZLIB_FILEFUNC_MODE_READWRITEFILTER) == ZLIB_FILEFUNC_MODE_READ)
         mode_fopen = "rb";
-    else
-    if (mode & ZLIB_FILEFUNC_MODE_EXISTING)
+    else if (mode & ZLIB_FILEFUNC_MODE_EXISTING)
         mode_fopen = "r+b";
-    else
-    if (mode & ZLIB_FILEFUNC_MODE_CREATE)
+    else if (mode & ZLIB_FILEFUNC_MODE_CREATE)
         mode_fopen = "wb";
 
-    if ((filename!=NULL) && (mode_fopen != NULL))
+    if ((filename != NULL) && (mode_fopen != NULL))
+    {
         file = fopen(filename, mode_fopen);
+        return file_build_ioposix(file, filename);
+    }
     return file;
 }
 
-
-uLong ZCALLBACK fread_file_func (opaque, stream, buf, size)
-   voidpf opaque;
-   voidpf stream;
-   void* buf;
-   uLong size;
+static voidpf ZCALLBACK fopen64_file_func(ZIP_UNUSED voidpf opaque, const void *filename, int mode)
 {
-    uLong ret;
-    ret = (uLong)fread(buf, 1, (size_t)size, (FILE *)stream);
+    FILE* file = NULL;
+    const char *mode_fopen = NULL;
+    if ((mode & ZLIB_FILEFUNC_MODE_READWRITEFILTER) == ZLIB_FILEFUNC_MODE_READ)
+        mode_fopen = "rb";
+    else if (mode & ZLIB_FILEFUNC_MODE_EXISTING)
+        mode_fopen = "r+b";
+    else if (mode & ZLIB_FILEFUNC_MODE_CREATE)
+        mode_fopen = "wb";
+
+    if ((filename != NULL) && (mode_fopen != NULL))
+    {
+        file = fopen64((const char*)filename, mode_fopen);
+        return file_build_ioposix(file, (const char*)filename);
+    }
+    return file;
+}
+
+static voidpf ZCALLBACK fopendisk64_file_func(voidpf opaque, voidpf stream, uint32_t number_disk, int mode)
+{
+    FILE_IOPOSIX *ioposix = NULL;
+    char *diskFilename = NULL;
+    voidpf ret = NULL;
+    int i = 0;
+
+    if (stream == NULL)
+        return NULL;
+    ioposix = (FILE_IOPOSIX*)stream;
+    diskFilename = (char*)malloc(ioposix->filenameLength * sizeof(char));
+    strncpy(diskFilename, (const char*)ioposix->filename, ioposix->filenameLength);
+    for (i = ioposix->filenameLength - 1; i >= 0; i -= 1)
+    {
+        if (diskFilename[i] != '.')
+            continue;
+        snprintf(&diskFilename[i], ioposix->filenameLength - i, ".z%02u", number_disk + 1);
+        break;
+    }
+    if (i >= 0)
+        ret = fopen64_file_func(opaque, diskFilename, mode);
+    free(diskFilename);
     return ret;
 }
 
-
-uLong ZCALLBACK fwrite_file_func (opaque, stream, buf, size)
-   voidpf opaque;
-   voidpf stream;
-   const void* buf;
-   uLong size;
+static voidpf ZCALLBACK fopendisk_file_func(voidpf opaque, voidpf stream, uint32_t number_disk, int mode)
 {
-    uLong ret;
-    ret = (uLong)fwrite(buf, 1, (size_t)size, (FILE *)stream);
+    FILE_IOPOSIX *ioposix = NULL;
+    char *diskFilename = NULL;
+    voidpf ret = NULL;
+    int i = 0;
+
+    if (stream == NULL)
+        return NULL;
+    ioposix = (FILE_IOPOSIX*)stream;
+    diskFilename = (char*)malloc(ioposix->filenameLength * sizeof(char));
+    strncpy(diskFilename, (const char*)ioposix->filename, ioposix->filenameLength);
+    for (i = ioposix->filenameLength - 1; i >= 0; i -= 1)
+    {
+        if (diskFilename[i] != '.')
+            continue;
+        snprintf(&diskFilename[i], ioposix->filenameLength - i, ".z%02u", number_disk + 1);
+        break;
+    }
+    if (i >= 0)
+        ret = fopen_file_func(opaque, diskFilename, mode);
+    free(diskFilename);
     return ret;
 }
 
-long ZCALLBACK ftell_file_func (opaque, stream)
-   voidpf opaque;
-   voidpf stream;
+static uint32_t ZCALLBACK fread_file_func(ZIP_UNUSED voidpf opaque, voidpf stream, void* buf, uint32_t size)
 {
-    long ret;
-    ret = ftell((FILE *)stream);
+    FILE_IOPOSIX *ioposix = NULL;
+    uint32_t read = (uint32_t)-1;
+    if (stream == NULL)
+        return read;
+    ioposix = (FILE_IOPOSIX*)stream;
+    read = (uint32_t)fread(buf, 1, (size_t)size, ioposix->file);
+    return read;
+}
+
+static uint32_t ZCALLBACK fwrite_file_func(ZIP_UNUSED voidpf opaque, voidpf stream, const void *buf, uint32_t size)
+{
+    FILE_IOPOSIX *ioposix = NULL;
+    uint32_t written = (uint32_t)-1;
+    if (stream == NULL)
+        return written;
+    ioposix = (FILE_IOPOSIX*)stream;
+    written = (uint32_t)fwrite(buf, 1, (size_t)size, ioposix->file);
+    return written;
+}
+
+static long ZCALLBACK ftell_file_func(ZIP_UNUSED voidpf opaque, voidpf stream)
+{
+    FILE_IOPOSIX *ioposix = NULL;
+    long ret = -1;
+    if (stream == NULL)
+        return ret;
+    ioposix = (FILE_IOPOSIX*)stream;
+    ret = ftell(ioposix->file);
     return ret;
 }
 
-long ZCALLBACK fseek_file_func (opaque, stream, offset, origin)
-   voidpf opaque;
-   voidpf stream;
-   uLong offset;
-   int origin;
+static uint64_t ZCALLBACK ftell64_file_func(ZIP_UNUSED voidpf opaque, voidpf stream)
 {
-    int fseek_origin=0;
-    long ret;
+    FILE_IOPOSIX *ioposix = NULL;
+    uint64_t ret = (uint64_t)-1;
+    if (stream == NULL)
+        return ret;
+    ioposix = (FILE_IOPOSIX*)stream;
+    ret = ftello64(ioposix->file);
+    return ret;
+}
+
+static long ZCALLBACK fseek_file_func(ZIP_UNUSED voidpf opaque, voidpf stream, uint32_t offset, int origin)
+{
+    FILE_IOPOSIX *ioposix = NULL;
+    int fseek_origin = 0;
+    long ret = 0;
+
+    if (stream == NULL)
+        return -1;
+    ioposix = (FILE_IOPOSIX*)stream;
+
     switch (origin)
     {
-    case ZLIB_FILEFUNC_SEEK_CUR :
-        fseek_origin = SEEK_CUR;
-        break;
-    case ZLIB_FILEFUNC_SEEK_END :
-        fseek_origin = SEEK_END;
-        break;
-    case ZLIB_FILEFUNC_SEEK_SET :
-        fseek_origin = SEEK_SET;
-        break;
-    default: return -1;
+        case ZLIB_FILEFUNC_SEEK_CUR:
+            fseek_origin = SEEK_CUR;
+            break;
+        case ZLIB_FILEFUNC_SEEK_END:
+            fseek_origin = SEEK_END;
+            break;
+        case ZLIB_FILEFUNC_SEEK_SET:
+            fseek_origin = SEEK_SET;
+            break;
+        default:
+            return -1;
     }
-    ret = 0;
-    fseek((FILE *)stream, offset, fseek_origin);
+    if (fseek(ioposix->file, offset, fseek_origin) != 0)
+        ret = -1;
     return ret;
 }
 
-int ZCALLBACK fclose_file_func (opaque, stream)
-   voidpf opaque;
-   voidpf stream;
+static long ZCALLBACK fseek64_file_func(ZIP_UNUSED voidpf opaque, voidpf stream, uint64_t offset, int origin)
 {
-    int ret;
-    ret = fclose((FILE *)stream);
+    FILE_IOPOSIX *ioposix = NULL;
+    int fseek_origin = 0;
+    long ret = 0;
+
+    if (stream == NULL)
+        return -1;
+    ioposix = (FILE_IOPOSIX*)stream;
+
+    switch (origin)
+    {
+        case ZLIB_FILEFUNC_SEEK_CUR:
+            fseek_origin = SEEK_CUR;
+            break;
+        case ZLIB_FILEFUNC_SEEK_END:
+            fseek_origin = SEEK_END;
+            break;
+        case ZLIB_FILEFUNC_SEEK_SET:
+            fseek_origin = SEEK_SET;
+            break;
+        default:
+            return -1;
+    }
+
+    if (fseeko64(ioposix->file, offset, fseek_origin) != 0)
+        ret = -1;
+
     return ret;
 }
 
-int ZCALLBACK ferror_file_func (opaque, stream)
-   voidpf opaque;
-   voidpf stream;
+static int ZCALLBACK fclose_file_func(ZIP_UNUSED voidpf opaque, voidpf stream)
 {
-    int ret;
-    ret = ferror((FILE *)stream);
+    FILE_IOPOSIX *ioposix = NULL;
+    int ret = -1;
+    if (stream == NULL)
+        return ret;
+    ioposix = (FILE_IOPOSIX*)stream;
+    if (ioposix->filename != NULL)
+        free(ioposix->filename);
+    ret = fclose(ioposix->file);
+    free(ioposix);
     return ret;
 }
 
-void fill_fopen_filefunc (pzlib_filefunc_def)
-  zlib_filefunc_def* pzlib_filefunc_def;
+static int ZCALLBACK ferror_file_func(ZIP_UNUSED voidpf opaque, voidpf stream)
+{
+    FILE_IOPOSIX *ioposix = NULL;
+    int ret = -1;
+    if (stream == NULL)
+        return ret;
+    ioposix = (FILE_IOPOSIX*)stream;
+    ret = ferror(ioposix->file);
+    return ret;
+}
+
+void fill_fopen_filefunc(zlib_filefunc_def *pzlib_filefunc_def)
 {
     pzlib_filefunc_def->zopen_file = fopen_file_func;
+    pzlib_filefunc_def->zopendisk_file = fopendisk_file_func;
     pzlib_filefunc_def->zread_file = fread_file_func;
     pzlib_filefunc_def->zwrite_file = fwrite_file_func;
     pzlib_filefunc_def->ztell_file = ftell_file_func;
@@ -183,9 +339,15 @@ void fill_fopen_filefunc (pzlib_filefunc_def)
     pzlib_filefunc_def->opaque = NULL;
 }
 
-#ifdef _WIN32
-#    pragma warning(pop)
-#    ifdef __clang__
-#        pragma clang diagnostic pop
-#    endif
-#endif // _WIN32
+void fill_fopen64_filefunc(zlib_filefunc64_def *pzlib_filefunc_def)
+{
+    pzlib_filefunc_def->zopen64_file = fopen64_file_func;
+    pzlib_filefunc_def->zopendisk64_file = fopendisk64_file_func;
+    pzlib_filefunc_def->zread_file = fread_file_func;
+    pzlib_filefunc_def->zwrite_file = fwrite_file_func;
+    pzlib_filefunc_def->ztell64_file = ftell64_file_func;
+    pzlib_filefunc_def->zseek64_file = fseek64_file_func;
+    pzlib_filefunc_def->zclose_file = fclose_file_func;
+    pzlib_filefunc_def->zerror_file = ferror_file_func;
+    pzlib_filefunc_def->opaque = NULL;
+}

--- a/contrib/unzip/ioapi.h
+++ b/contrib/unzip/ioapi.h
@@ -1,75 +1,153 @@
 /* ioapi.h -- IO base function header for compress/uncompress .zip
-   files using zlib + zip or unzip API
+   part of the MiniZip project
 
-   Version 1.01e, February 12th, 2005
+   Copyright (C) 2012-2017 Nathan Moinvaziri
+     https://github.com/nmoinvaz/minizip
+   Copyright (C) 2009-2010 Mathias Svensson
+     Modifications for Zip64 support
+     http://result42.com
+   Copyright (C) 1998-2010 Gilles Vollant
+     http://www.winimage.com/zLibDll/minizip.html
 
-   Copyright (C) 1998-2005 Gilles Vollant
+   This program is distributed under the terms of the same license as zlib.
+   See the accompanying LICENSE file for the full text of the license.
 */
 
-#ifndef _ZLIBIOAPI_H
-#define _ZLIBIOAPI_H
+#ifndef _ZLIBIOAPI64_H
+#define _ZLIBIOAPI64_H
 
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
 
-#define ZLIB_FILEFUNC_SEEK_CUR (1)
-#define ZLIB_FILEFUNC_SEEK_END (2)
-#define ZLIB_FILEFUNC_SEEK_SET (0)
+#include "zlib.h"
 
-#define ZLIB_FILEFUNC_MODE_READ      (1)
-#define ZLIB_FILEFUNC_MODE_WRITE     (2)
-#define ZLIB_FILEFUNC_MODE_READWRITEFILTER (3)
-
-#define ZLIB_FILEFUNC_MODE_EXISTING (4)
-#define ZLIB_FILEFUNC_MODE_CREATE   (8)
-
-
-#ifndef ZCALLBACK
-
-#if (defined(_WIN32) || defined (WINDOWS) || defined (_WINDOWS)) && defined(CALLBACK) && defined (USEWINDOWS_CALLBACK)
-#define ZCALLBACK CALLBACK
+#ifdef __GNUC__
+#  define ZIP_UNUSED __attribute__((__unused__))
 #else
-#define ZCALLBACK
+#  define ZIP_UNUSED
 #endif
+
+#if defined(USE_FILE32API)
+#  define fopen64 fopen
+#  define ftello64 ftell
+#  define fseeko64 fseek
+#else
+#  if defined(_MSC_VER)
+#    define fopen64 fopen
+#    if (_MSC_VER >= 1400) && (!(defined(NO_MSCVER_FILE64_FUNC)))
+#      define ftello64 _ftelli64
+#      define fseeko64 _fseeki64
+#    else /* old MSC */
+#      define ftello64 ftell
+#      define fseeko64 fseek
+#    endif
+#  else
+#    define fopen64 fopen
+#    define ftello64 ftello
+#    define fseeko64 fseeko
+#  endif
 #endif
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-typedef voidpf (ZCALLBACK *open_file_func) OF((voidpf opaque, const char* filename, int mode));
-typedef uLong  (ZCALLBACK *read_file_func) OF((voidpf opaque, voidpf stream, void* buf, uLong size));
-typedef uLong  (ZCALLBACK *write_file_func) OF((voidpf opaque, voidpf stream, const void* buf, uLong size));
-typedef long   (ZCALLBACK *tell_file_func) OF((voidpf opaque, voidpf stream));
-typedef long   (ZCALLBACK *seek_file_func) OF((voidpf opaque, voidpf stream, uLong offset, int origin));
-typedef int    (ZCALLBACK *close_file_func) OF((voidpf opaque, voidpf stream));
-typedef int    (ZCALLBACK *testerror_file_func) OF((voidpf opaque, voidpf stream));
+#define ZLIB_FILEFUNC_SEEK_CUR (1)
+#define ZLIB_FILEFUNC_SEEK_END (2)
+#define ZLIB_FILEFUNC_SEEK_SET (0)
 
+#define ZLIB_FILEFUNC_MODE_READ             (1)
+#define ZLIB_FILEFUNC_MODE_WRITE            (2)
+#define ZLIB_FILEFUNC_MODE_READWRITEFILTER  (3)
+#define ZLIB_FILEFUNC_MODE_EXISTING         (4)
+#define ZLIB_FILEFUNC_MODE_CREATE           (8)
+
+#ifndef ZCALLBACK
+#  if (defined(WIN32) || defined(_WIN32) || defined (WINDOWS) || \
+       defined (_WINDOWS)) && defined(CALLBACK) && defined (USEWINDOWS_CALLBACK)
+#    define ZCALLBACK CALLBACK
+#  else
+#    define ZCALLBACK
+#  endif
+#endif
+
+typedef voidpf   (ZCALLBACK *open_file_func)     (voidpf opaque, const char *filename, int mode);
+typedef voidpf   (ZCALLBACK *opendisk_file_func) (voidpf opaque, voidpf stream, uint32_t number_disk, int mode);
+typedef uint32_t (ZCALLBACK *read_file_func)     (voidpf opaque, voidpf stream, void* buf, uint32_t size);
+typedef uint32_t (ZCALLBACK *write_file_func)    (voidpf opaque, voidpf stream, const void *buf, uint32_t size);
+typedef int      (ZCALLBACK *close_file_func)    (voidpf opaque, voidpf stream);
+typedef int      (ZCALLBACK *error_file_func)    (voidpf opaque, voidpf stream);
+
+typedef long     (ZCALLBACK *tell_file_func)     (voidpf opaque, voidpf stream);
+typedef long     (ZCALLBACK *seek_file_func)     (voidpf opaque, voidpf stream, uint32_t offset, int origin);
+
+/* here is the "old" 32 bits structure structure */
 typedef struct zlib_filefunc_def_s
 {
     open_file_func      zopen_file;
+    opendisk_file_func  zopendisk_file;
     read_file_func      zread_file;
     write_file_func     zwrite_file;
     tell_file_func      ztell_file;
     seek_file_func      zseek_file;
     close_file_func     zclose_file;
-    testerror_file_func zerror_file;
+    error_file_func     zerror_file;
     voidpf              opaque;
 } zlib_filefunc_def;
 
+typedef uint64_t (ZCALLBACK *tell64_file_func)    (voidpf opaque, voidpf stream);
+typedef long     (ZCALLBACK *seek64_file_func)    (voidpf opaque, voidpf stream, uint64_t offset, int origin);
+typedef voidpf   (ZCALLBACK *open64_file_func)    (voidpf opaque, const void *filename, int mode);
+typedef voidpf   (ZCALLBACK *opendisk64_file_func)(voidpf opaque, voidpf stream, uint32_t number_disk, int mode);
 
+typedef struct zlib_filefunc64_def_s
+{
+    open64_file_func     zopen64_file;
+    opendisk64_file_func zopendisk64_file;
+    read_file_func       zread_file;
+    write_file_func      zwrite_file;
+    tell64_file_func     ztell64_file;
+    seek64_file_func     zseek64_file;
+    close_file_func      zclose_file;
+    error_file_func      zerror_file;
+    voidpf               opaque;
+} zlib_filefunc64_def;
 
-void fill_fopen_filefunc OF((zlib_filefunc_def* pzlib_filefunc_def));
+void fill_fopen_filefunc(zlib_filefunc_def *pzlib_filefunc_def);
+void fill_fopen64_filefunc(zlib_filefunc64_def *pzlib_filefunc_def);
 
-#define ZREAD(filefunc,filestream,buf,size) ((*((filefunc).zread_file))((filefunc).opaque,filestream,buf,size))
-#define ZWRITE(filefunc,filestream,buf,size) ((*((filefunc).zwrite_file))((filefunc).opaque,filestream,buf,size))
-#define ZTELL(filefunc,filestream) ((*((filefunc).ztell_file))((filefunc).opaque,filestream))
-#define ZSEEK(filefunc,filestream,pos,mode) ((*((filefunc).zseek_file))((filefunc).opaque,filestream,pos,mode))
-#define ZCLOSE(filefunc,filestream) ((*((filefunc).zclose_file))((filefunc).opaque,filestream))
-#define ZERROR(filefunc,filestream) ((*((filefunc).zerror_file))((filefunc).opaque,filestream))
+/* now internal definition, only for zip.c and unzip.h */
+typedef struct zlib_filefunc64_32_def_s
+{
+    zlib_filefunc64_def zfile_func64;
+    open_file_func      zopen32_file;
+    opendisk_file_func  zopendisk32_file;
+    tell_file_func      ztell32_file;
+    seek_file_func      zseek32_file;
+} zlib_filefunc64_32_def;
 
+#define ZREAD64(filefunc,filestream,buf,size)       ((*((filefunc).zfile_func64.zread_file))        ((filefunc).zfile_func64.opaque,filestream,buf,size))
+#define ZWRITE64(filefunc,filestream,buf,size)      ((*((filefunc).zfile_func64.zwrite_file))       ((filefunc).zfile_func64.opaque,filestream,buf,size))
+/*#define ZTELL64(filefunc,filestream)                ((*((filefunc).ztell64_file))                   ((filefunc).opaque,filestream))*/
+/*#define ZSEEK64(filefunc,filestream,pos,mode)       ((*((filefunc).zseek64_file))                   ((filefunc).opaque,filestream,pos,mode))*/
+#define ZCLOSE64(filefunc,filestream)               ((*((filefunc).zfile_func64.zclose_file))       ((filefunc).zfile_func64.opaque,filestream))
+#define ZERROR64(filefunc,filestream)               ((*((filefunc).zfile_func64.zerror_file))       ((filefunc).zfile_func64.opaque,filestream))
+
+voidpf   call_zopen64(const zlib_filefunc64_32_def *pfilefunc,const void*filename, int mode);
+voidpf   call_zopendisk64(const zlib_filefunc64_32_def *pfilefunc, voidpf filestream, uint32_t number_disk, int mode);
+long     call_zseek64(const zlib_filefunc64_32_def *pfilefunc, voidpf filestream, uint64_t offset, int origin);
+uint64_t call_ztell64(const zlib_filefunc64_32_def *pfilefunc, voidpf filestream);
+
+void fill_zlib_filefunc64_32_def_from_filefunc32(zlib_filefunc64_32_def *p_filefunc64_32, const zlib_filefunc_def *p_filefunc32);
+
+#define ZOPEN64(filefunc,filename,mode)             (call_zopen64((&(filefunc)),(filename),(mode)))
+#define ZOPENDISK64(filefunc,filestream,diskn,mode) (call_zopendisk64((&(filefunc)),(filestream),(diskn),(mode)))
+#define ZTELL64(filefunc,filestream)                (call_ztell64((&(filefunc)),(filestream)))
+#define ZSEEK64(filefunc,filestream,pos,mode)       (call_zseek64((&(filefunc)),(filestream),(pos),(mode)))
 
 #ifdef __cplusplus
 }
 #endif
 
 #endif
-

--- a/contrib/unzip/unzip.c
+++ b/contrib/unzip/unzip.c
@@ -1,1061 +1,1028 @@
 /* unzip.c -- IO for uncompress .zip files using zlib
-   Version 1.01e, February 12th, 2005
+   Version 1.2.0, September 16th, 2017
+   part of the MiniZip project
 
-   Copyright (C) 1998-2005 Gilles Vollant
+   Copyright (C) 2010-2017 Nathan Moinvaziri
+     Modifications for AES, PKWARE disk spanning
+     https://github.com/nmoinvaz/minizip
+   Copyright (C) 2009-2010 Mathias Svensson
+     Modifications for Zip64 support on both zip and unzip
+     http://result42.com
+   Copyright (C) 2007-2008 Even Rouault
+     Modifications of Unzip for Zip64
+   Copyright (C) 1998-2010 Gilles Vollant
+     http://www.winimage.com/zLibDll/minizip.html
 
-   Read unzip.h for more info
+   This program is distributed under the terms of the same license as zlib.
+   See the accompanying LICENSE file for the full text of the license.
 */
-
-/* Decryption code comes from crypt.c by Info-ZIP but has been greatly reduced in terms of
-compatibility with older software. The following is from the original crypt.c. Code
-woven in by Terry Thorsen 1/2003.
-*/
-/*
-  Copyright (c) 1990-2000 Info-ZIP.  All rights reserved.
-
-  See the accompanying file LICENSE, version 2000-Apr-09 or later
-  (the contents of which are also included in zip.h) for terms of use.
-  If, for some reason, all these files are missing, the Info-ZIP license
-  also may be found at:  ftp://ftp.info-zip.org/pub/infozip/license.html
-*/
-/*
-  crypt.c (full version) by Info-ZIP.      Last revised:  [see crypt.h]
-
-  The encryption/decryption parts of this source code (as opposed to the
-  non-echoing password parts) were originally written in Europe.  The
-  whole source package can be freely distributed, including from the USA.
-  (Prior to January 2000, re-export from the US was a violation of US law.)
- */
-
-/*
-  This encryption code is a direct transcription of the algorithm from
-  Roger Schlafly, described by Phil Katz in the file appnote.txt.  This
-  file (appnote.txt) is distributed with the PKZIP program (even in the
-  version without encryption capabilities).
- */
-
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
+#include <limits.h>
+#include <errno.h>
+
 #include "zlib.h"
 #include "unzip.h"
 
-#if ZLIB_VERNUM < 0x1270
-typedef unsigned long z_crc_t;
+#ifdef HAVE_AES
+#  define AES_METHOD          (99)
+#  define AES_PWVERIFYSIZE    (2)
+#  define AES_MAXSALTLENGTH   (16)
+#  define AES_AUTHCODESIZE    (10)
+#  define AES_HEADERSIZE      (11)
+#  define AES_KEYSIZE(mode)   (64 + (mode * 64))
+
+#  include "aes/aes.h"
+#  include "aes/fileenc.h"
+#endif
+#ifdef HAVE_APPLE_COMPRESSION
+#  include <compression.h>
 #endif
 
-#ifdef STDC
-#  include <stddef.h>
-#  include <string.h>
-#  include <stdlib.h>
-#endif
-#ifdef NO_ERRNO_H
-    extern int errno;
-#else
-#   include <errno.h>
+#ifndef NOUNCRYPT
+#  include "crypt.h"
 #endif
 
+#define DISKHEADERMAGIC             (0x08074b50)
+#define LOCALHEADERMAGIC            (0x04034b50)
+#define CENTRALHEADERMAGIC          (0x02014b50)
+#define ENDHEADERMAGIC              (0x06054b50)
+#define ZIP64ENDHEADERMAGIC         (0x06064b50)
+#define ZIP64ENDLOCHEADERMAGIC      (0x07064b50)
 
-#ifndef local
-#  define local static
+#define SIZECENTRALDIRITEM          (0x2e)
+#define SIZECENTRALHEADERLOCATOR    (0x14)
+#define SIZEZIPLOCALHEADER          (0x1e)
+
+#ifndef BUFREADCOMMENT
+#  define BUFREADCOMMENT            (0x400)
 #endif
-/* compile with -Dlocal if your debugger can't find static symbols */
-
-
-#ifndef CASESENSITIVITYDEFAULT_NO
-#  if !defined(unix) && !defined(CASESENSITIVITYDEFAULT_YES)
-#    define CASESENSITIVITYDEFAULT_NO
-#  endif
-#endif
-
 
 #ifndef UNZ_BUFSIZE
-#define UNZ_BUFSIZE (16384)
+#  define UNZ_BUFSIZE               (UINT16_MAX)
 #endif
-
 #ifndef UNZ_MAXFILENAMEINZIP
-#define UNZ_MAXFILENAMEINZIP (256)
+#  define UNZ_MAXFILENAMEINZIP      (256)
 #endif
 
 #ifndef ALLOC
-# define ALLOC(size) (malloc(size))
+#  define ALLOC(size) (malloc(size))
 #endif
 #ifndef TRYFREE
-# define TRYFREE(p) {if (p) free(p);}
+#  define TRYFREE(p) {if (p) free(p);}
 #endif
 
-#define SIZECENTRALDIRITEM (0x2e)
-#define SIZEZIPLOCALHEADER (0x1e)
+const char unz_copyright[] = " unzip 1.2.0 Copyright 1998-2017 - https://github.com/nmoinvaz/minizip";
 
-
-#ifdef _WIN32
-#    pragma warning(push)
-#    pragma warning(disable : 4131 4244 4189 4245)
-#endif // _WIN32
-
-const char unz_copyright[] =
-   " unzip 1.01 Copyright 1998-2004 Gilles Vollant - http://www.winimage.com/zLibDll";
-
-/* unz_file_info_interntal contain internal info about a file in zipfile*/
-typedef struct unz_file_info_internal_s
+/* unz_file_info_internal contain internal info about a file in zipfile*/
+typedef struct unz_file_info64_internal_s
 {
-    uLong offset_curfile;/* relative offset of local header 4 bytes */
-} unz_file_info_internal;
+    uint64_t offset_curfile;            /* relative offset of local header 8 bytes */
+    uint64_t byte_before_the_zipfile;   /* byte before the zipfile, (>0 for sfx) */
+#ifdef HAVE_AES
+    uint8_t  aes_encryption_mode;
+    uint16_t aes_compression_method;
+    uint16_t aes_version;
+#endif
+} unz_file_info64_internal;
 
-
-/* file_in_zip_read_info_s contain internal information about a file in zipfile,
-    when reading and decompress it */
+/* file_in_zip_read_info_s contain internal information about a file in zipfile */
 typedef struct
 {
-    char  *read_buffer;         /* internal buffer for compressed data */
-    z_stream stream;            /* zLib stream structure for inflate */
+    uint8_t *read_buffer;               /* internal buffer for compressed data */
+    z_stream stream;                    /* zLib stream structure for inflate */
+#ifdef HAVE_BZIP2
+    bz_stream bstream;                  /* bzLib stream structure for bziped */
+#endif
+#ifdef HAVE_APPLE_COMPRESSION
+    compression_stream astream;         /* libcompression stream structure */
+#endif
+#ifdef HAVE_AES
+    fcrypt_ctx aes_ctx;
+#endif
+    uint64_t pos_in_zipfile;            /* position in byte on the zipfile, for fseek */
+    uint8_t  stream_initialised;        /* flag set if stream structure is initialised */
 
-    uLong pos_in_zipfile;       /* position in byte on the zipfile, for fseek*/
-    uLong stream_initialised;   /* flag set if stream structure is initialised*/
+    uint64_t offset_local_extrafield;   /* offset of the local extra field */
+    uint16_t size_local_extrafield;     /* size of the local extra field */
+    uint64_t pos_local_extrafield;      /* position in the local extra field in read */
+    uint64_t total_out_64;
 
-    uLong offset_local_extrafield;/* offset of the local extra field */
-    uInt  size_local_extrafield;/* size of the local extra field */
-    uLong pos_local_extrafield;   /* position in the local extra field in read*/
+    uint32_t crc32;                     /* crc32 of all data uncompressed */
+    uint32_t crc32_expected;            /* crc32 we must obtain after decompress all */
+    uint64_t rest_read_compressed;      /* number of byte to be decompressed */
+    uint64_t rest_read_uncompressed;    /* number of byte to be obtained after decomp */
 
-    uLong crc32;                /* crc32 of all data uncompressed */
-    uLong crc32_wait;           /* crc32 we must obtain after decompress all */
-    uLong rest_read_compressed; /* number of byte to be decompressed */
-    uLong rest_read_uncompressed;/*number of byte to be obtained after decomp*/
-    zlib_filefunc_def z_filefunc;
-    voidpf filestream;        /* io structore of the zipfile */
-    uLong compression_method;   /* compression method (0==store) */
-    uLong byte_before_the_zipfile;/* byte before the zipfile, (>0 for sfx)*/
-    int   raw;
-} file_in_zip_read_info_s;
+    zlib_filefunc64_32_def z_filefunc;
 
+    voidpf   filestream;                /* io structore of the zipfile */
+    uint16_t compression_method;        /* compression method (0==store) */
+    uint64_t byte_before_the_zipfile;   /* byte before the zipfile, (>0 for sfx) */
+    int      raw;
+} file_in_zip64_read_info_s;
 
-/* unz_s contain internal information about the zipfile
-*/
+/* unz64_s contain internal information about the zipfile */
 typedef struct
 {
-    zlib_filefunc_def z_filefunc;
-    voidpf filestream;        /* io structore of the zipfile */
-    unz_global_info gi;       /* public global information */
-    uLong byte_before_the_zipfile;/* byte before the zipfile, (>0 for sfx)*/
-    uLong num_file;             /* number of the current file in the zipfile*/
-    uLong pos_in_central_dir;   /* pos of the current file in the central dir*/
-    uLong current_file_ok;      /* flag about the usability of the current file*/
-    uLong central_pos;          /* position of the beginning of the central dir*/
+    zlib_filefunc64_32_def z_filefunc;
 
-    uLong size_central_dir;     /* size of the central directory  */
-    uLong offset_central_dir;   /* offset of start of central directory with
-                                   respect to the starting disk number */
+    voidpf filestream;                  /* io structure of the current zipfile */
+    voidpf filestream_with_CD;          /* io structure of the disk with the central directory */
 
-    unz_file_info cur_file_info; /* public info about the current file in zip*/
-    unz_file_info_internal cur_file_info_internal; /* private info about it*/
-    file_in_zip_read_info_s* pfile_in_zip_read; /* structure about the current
-                                        file if we are decompressing it */
-    int encrypted;
-#    ifndef NOUNCRYPT
-    unsigned long keys[3];     /* keys defining the pseudo-random sequence */
-    const z_crc_t* pcrc_32_tab;
-#    endif
-} unz_s;
+    unz_global_info64 gi;               /* public global information */
 
+    uint64_t byte_before_the_zipfile;   /* byte before the zipfile, (>0 for sfx) */
+    uint64_t num_file;                  /* number of the current file in the zipfile */
+    uint64_t pos_in_central_dir;        /* pos of the current file in the central dir */
+    uint64_t current_file_ok;           /* flag about the usability of the current file */
+    uint64_t central_pos;               /* position of the beginning of the central dir */
+    uint32_t number_disk;               /* number of the current disk, used for spanning ZIP */
+    uint64_t size_central_dir;          /* size of the central directory */
+    uint64_t offset_central_dir;        /* offset of start of central directory with
+                                           respect to the starting disk number */
 
+    unz_file_info64 cur_file_info;      /* public info about the current file in zip*/
+    unz_file_info64_internal cur_file_info_internal;
+                                        /* private info about it*/
+    file_in_zip64_read_info_s *pfile_in_zip_read;
+                                        /* structure about the current file if we are decompressing it */
+    int is_zip64;                       /* is the current file zip64 */
 #ifndef NOUNCRYPT
-#include "crypt.h"
+    uint32_t keys[3];                   /* keys defining the pseudo-random sequence */
+    const z_crc_t *pcrc_32_tab;
 #endif
+} unz64_internal;
 
-/* ===========================================================================
-     Read a byte from a gz_stream; update next_in and avail_in. Return EOF
-   for end of file.
-   IN assertion: the stream s has been sucessfully opened for reading.
-*/
-
-
-local int unzlocal_getByte OF((
-    const zlib_filefunc_def* pzlib_filefunc_def,
-    voidpf filestream,
-    int *pi));
-
-local int unzlocal_getByte(pzlib_filefunc_def,filestream,pi)
-    const zlib_filefunc_def* pzlib_filefunc_def;
-    voidpf filestream;
-    int *pi;
+/* Read a byte from a gz_stream; Return EOF for end of file. */
+static int unzReadUInt8(const zlib_filefunc64_32_def *pzlib_filefunc_def, voidpf filestream, uint8_t *value)
 {
-    unsigned char c;
-    int err = (int)ZREAD(*pzlib_filefunc_def,filestream,&c,1);
-    if (err==1)
+    uint8_t c = 0;
+    if (ZREAD64(*pzlib_filefunc_def, filestream, &c, 1) == 1)
     {
-        *pi = (int)c;
+        *value = (uint8_t)c;
         return UNZ_OK;
     }
-    else
-    {
-        if (ZERROR(*pzlib_filefunc_def,filestream))
-            return UNZ_ERRNO;
-        else
-            return UNZ_EOF;
-    }
+    *value = 0;
+    if (ZERROR64(*pzlib_filefunc_def, filestream))
+        return UNZ_ERRNO;
+    return UNZ_EOF;
 }
 
-
-/* ===========================================================================
-   Reads a long in LSB order from the given gz_stream. Sets
-*/
-local int unzlocal_getShort OF((
-    const zlib_filefunc_def* pzlib_filefunc_def,
-    voidpf filestream,
-    uLong *pX));
-
-local int unzlocal_getShort (pzlib_filefunc_def,filestream,pX)
-    const zlib_filefunc_def* pzlib_filefunc_def;
-    voidpf filestream;
-    uLong *pX;
+static int unzReadUInt16(const zlib_filefunc64_32_def *pzlib_filefunc_def, voidpf filestream, uint16_t *value)
 {
-    uLong x ;
-    int i = 0;
-    int err;
+    uint16_t x;
+    uint8_t c = 0;
+    int err = UNZ_OK;
 
-    err = unzlocal_getByte(pzlib_filefunc_def,filestream,&i);
-    x = (uLong)i;
+    err = unzReadUInt8(pzlib_filefunc_def, filestream, &c);
+    x = (uint16_t)c;
+    if (err == UNZ_OK)
+        err = unzReadUInt8(pzlib_filefunc_def, filestream, &c);
+    x |= ((uint16_t)c) << 8;
 
-    if (err==UNZ_OK)
-        err = unzlocal_getByte(pzlib_filefunc_def,filestream,&i);
-    x += ((uLong)i)<<8;
-
-    if (err==UNZ_OK)
-        *pX = x;
+    if (err == UNZ_OK)
+        *value = x;
     else
-        *pX = 0;
+        *value = 0;
     return err;
 }
 
-local int unzlocal_getLong OF((
-    const zlib_filefunc_def* pzlib_filefunc_def,
-    voidpf filestream,
-    uLong *pX));
-
-local int unzlocal_getLong (pzlib_filefunc_def,filestream,pX)
-    const zlib_filefunc_def* pzlib_filefunc_def;
-    voidpf filestream;
-    uLong *pX;
+static int unzReadUInt32(const zlib_filefunc64_32_def *pzlib_filefunc_def, voidpf filestream, uint32_t *value)
 {
-    uLong x ;
-    int i = 0;
-    int err;
+    uint32_t x = 0;
+    uint8_t c = 0;
+    int err = UNZ_OK;
 
-    err = unzlocal_getByte(pzlib_filefunc_def,filestream,&i);
-    x = (uLong)i;
+    err = unzReadUInt8(pzlib_filefunc_def, filestream, &c);
+    x = (uint32_t)c;
+    if (err == UNZ_OK)
+        err = unzReadUInt8(pzlib_filefunc_def, filestream, &c);
+    x |= ((uint32_t)c) << 8;
+    if (err == UNZ_OK)
+        err = unzReadUInt8(pzlib_filefunc_def, filestream, &c);
+    x |= ((uint32_t)c) << 16;
+    if (err == UNZ_OK)
+        err = unzReadUInt8(pzlib_filefunc_def, filestream, &c);
+    x += ((uint32_t)c) << 24;
 
-    if (err==UNZ_OK)
-        err = unzlocal_getByte(pzlib_filefunc_def,filestream,&i);
-    x += ((uLong)i)<<8;
-
-    if (err==UNZ_OK)
-        err = unzlocal_getByte(pzlib_filefunc_def,filestream,&i);
-    x += ((uLong)i)<<16;
-
-    if (err==UNZ_OK)
-        err = unzlocal_getByte(pzlib_filefunc_def,filestream,&i);
-    x += ((uLong)i)<<24;
-
-    if (err==UNZ_OK)
-        *pX = x;
+    if (err == UNZ_OK)
+        *value = x;
     else
-        *pX = 0;
+        *value = 0;
     return err;
 }
 
-
-/* My own strcmpi / strcasecmp */
-local int strcmpcasenosensitive_internal (fileName1,fileName2)
-    const char* fileName1;
-    const char* fileName2;
+static int unzReadUInt64(const zlib_filefunc64_32_def *pzlib_filefunc_def, voidpf filestream, uint64_t *value)
 {
-    for (;;)
-    {
-        char c1=*(fileName1++);
-        char c2=*(fileName2++);
-        if ((c1>='a') && (c1<='z'))
-            c1 -= 0x20;
-        if ((c2>='a') && (c2<='z'))
-            c2 -= 0x20;
-        if (c1=='\0')
-            return ((c2=='\0') ? 0 : -1);
-        if (c2=='\0')
-            return 1;
-        if (c1<c2)
-            return -1;
-        if (c1>c2)
-            return 1;
-    }
+    uint64_t x = 0;
+    uint8_t i = 0;
+    int err = UNZ_OK;
+
+    err = unzReadUInt8(pzlib_filefunc_def, filestream, &i);
+    x = (uint64_t)i;
+    if (err == UNZ_OK)
+        err = unzReadUInt8(pzlib_filefunc_def, filestream, &i);
+    x |= ((uint64_t)i) << 8;
+    if (err == UNZ_OK)
+        err = unzReadUInt8(pzlib_filefunc_def, filestream, &i);
+    x |= ((uint64_t)i) << 16;
+    if (err == UNZ_OK)
+        err = unzReadUInt8(pzlib_filefunc_def, filestream, &i);
+    x |= ((uint64_t)i) << 24;
+    if (err == UNZ_OK)
+        err = unzReadUInt8(pzlib_filefunc_def, filestream, &i);
+    x |= ((uint64_t)i) << 32;
+    if (err == UNZ_OK)
+        err = unzReadUInt8(pzlib_filefunc_def, filestream, &i);
+    x |= ((uint64_t)i) << 40;
+    if (err == UNZ_OK)
+        err = unzReadUInt8(pzlib_filefunc_def, filestream, &i);
+    x |= ((uint64_t)i) << 48;
+    if (err == UNZ_OK)
+        err = unzReadUInt8(pzlib_filefunc_def, filestream, &i);
+    x |= ((uint64_t)i) << 56;
+
+    if (err == UNZ_OK)
+        *value = x;
+    else
+        *value = 0;
+    return err;
 }
 
-
-#ifdef  CASESENSITIVITYDEFAULT_NO
-#define CASESENSITIVITYDEFAULTVALUE 2
-#else
-#define CASESENSITIVITYDEFAULTVALUE 1
-#endif
-
-#ifndef STRCMPCASENOSENTIVEFUNCTION
-#define STRCMPCASENOSENTIVEFUNCTION strcmpcasenosensitive_internal
-#endif
-
-/*
-   Compare two filename (fileName1,fileName2).
-   If iCaseSenisivity = 1, comparision is case sensitivity (like strcmp)
-   If iCaseSenisivity = 2, comparision is not case sensitivity (like strcmpi
-                                                                or strcasecmp)
-   If iCaseSenisivity = 0, case sensitivity is defaut of your operating system
-        (like 1 on Unix, 2 on Windows)
-
-*/
-extern int ZEXPORT unzStringFileNameCompare (fileName1,fileName2,iCaseSensitivity)
-    const char* fileName1;
-    const char* fileName2;
-    int iCaseSensitivity;
+/* Locate the Central directory of a zip file (at the end, just before the global comment) */
+static int unzSearchCentralDir(const zlib_filefunc64_32_def *pzlib_filefunc_def, uint64_t *pos_found, voidpf filestream)
 {
-    if (iCaseSensitivity==0)
-        iCaseSensitivity=CASESENSITIVITYDEFAULTVALUE;
+    uint8_t buf[BUFREADCOMMENT + 4];
+    uint64_t file_size = 0;
+    uint64_t back_read = 4;
+    uint64_t max_back = UINT16_MAX; /* maximum size of global comment */
+    uint32_t read_size = 0;
+    uint64_t read_pos = 0;
+    uint32_t i = 0;
+    *pos_found = 0;
 
-    if (iCaseSensitivity==1)
-        return strcmp(fileName1,fileName2);
+    if (ZSEEK64(*pzlib_filefunc_def, filestream, 0, ZLIB_FILEFUNC_SEEK_END) != 0)
+        return UNZ_ERRNO;
 
-    return STRCMPCASENOSENTIVEFUNCTION(fileName1,fileName2);
-}
+    file_size = ZTELL64(*pzlib_filefunc_def, filestream);
 
-#ifndef BUFREADCOMMENT
-#define BUFREADCOMMENT (0x400)
-#endif
+    if (max_back > file_size)
+        max_back = file_size;
 
-/*
-  Locate the Central directory of a zipfile (at the end, just before
-    the global comment)
-*/
-local uLong unzlocal_SearchCentralDir OF((
-    const zlib_filefunc_def* pzlib_filefunc_def,
-    voidpf filestream));
-
-local uLong unzlocal_SearchCentralDir(pzlib_filefunc_def,filestream)
-    const zlib_filefunc_def* pzlib_filefunc_def;
-    voidpf filestream;
-{
-    unsigned char* buf;
-    uLong uSizeFile;
-    uLong uBackRead;
-    uLong uMaxBack=0xffff; /* maximum size of global comment */
-    uLong uPosFound=0;
-
-    if (ZSEEK(*pzlib_filefunc_def,filestream,0,ZLIB_FILEFUNC_SEEK_END) != 0)
-        return 0;
-
-
-    uSizeFile = ZTELL(*pzlib_filefunc_def,filestream);
-
-    if (uMaxBack>uSizeFile)
-        uMaxBack = uSizeFile;
-
-    buf = (unsigned char*)ALLOC(BUFREADCOMMENT+4);
-    if (buf==NULL)
-        return 0;
-
-    uBackRead = 4;
-    while (uBackRead<uMaxBack)
+    while (back_read < max_back)
     {
-        uLong uReadSize,uReadPos ;
-        int i;
-        if (uBackRead+BUFREADCOMMENT>uMaxBack)
-            uBackRead = uMaxBack;
+        if (back_read + BUFREADCOMMENT > max_back)
+            back_read = max_back;
         else
-            uBackRead+=BUFREADCOMMENT;
-        uReadPos = uSizeFile-uBackRead ;
+            back_read += BUFREADCOMMENT;
 
-        uReadSize = ((BUFREADCOMMENT+4) < (uSizeFile-uReadPos)) ?
-                     (BUFREADCOMMENT+4) : (uSizeFile-uReadPos);
-        if (ZSEEK(*pzlib_filefunc_def,filestream,uReadPos,ZLIB_FILEFUNC_SEEK_SET)!=0)
+        read_pos = file_size - back_read;
+        read_size = ((BUFREADCOMMENT + 4) < (file_size - read_pos)) ?
+                     (BUFREADCOMMENT + 4) : (uint32_t)(file_size - read_pos);
+
+        if (ZSEEK64(*pzlib_filefunc_def, filestream, read_pos, ZLIB_FILEFUNC_SEEK_SET) != 0)
+            break;
+        if (ZREAD64(*pzlib_filefunc_def, filestream, buf, read_size) != read_size)
             break;
 
-        if (ZREAD(*pzlib_filefunc_def,filestream,buf,uReadSize)!=uReadSize)
-            break;
-
-        for (i=(int)uReadSize-3; (i--)>0;)
-            if (((*(buf+i))==0x50) && ((*(buf+i+1))==0x4b) &&
-                ((*(buf+i+2))==0x05) && ((*(buf+i+3))==0x06))
+        for (i = read_size - 3; (i--) > 0;)
+            if (((*(buf+i)) == (ENDHEADERMAGIC & 0xff)) &&
+                ((*(buf+i+1)) == (ENDHEADERMAGIC >> 8 & 0xff)) &&
+                ((*(buf+i+2)) == (ENDHEADERMAGIC >> 16 & 0xff)) &&
+                ((*(buf+i+3)) == (ENDHEADERMAGIC >> 24 & 0xff)))
             {
-                uPosFound = uReadPos+i;
-                break;
+                *pos_found = read_pos+i;
+                return UNZ_OK;
             }
-
-        if (uPosFound!=0)
-            break;
     }
-    TRYFREE(buf);
-    return uPosFound;
+
+    return UNZ_ERRNO;
 }
 
-/*
-  Open a Zip file. path contain the full pathname (by example,
-     on a Windows NT computer "c:\\test\\zlib114.zip" or on an Unix computer
-     "zlib/zlib114.zip".
-     If the zipfile cannot be opened (file doesn't exist or in not valid), the
-       return value is NULL.
-     Else, the return value is a unzFile Handle, usable with other function
-       of this unzip package.
-*/
-extern unzFile ZEXPORT unzOpen2 (path, pzlib_filefunc_def)
-    const char *path;
-    zlib_filefunc_def* pzlib_filefunc_def;
+/* Locate the Central directory 64 of a zipfile (at the end, just before the global comment) */
+static int unzSearchCentralDir64(const zlib_filefunc64_32_def *pzlib_filefunc_def, uint64_t *offset, voidpf filestream,
+    const uint64_t endcentraloffset)
 {
-    unz_s us;
-    unz_s *s;
-    uLong central_pos,uL;
+    uint32_t value32 = 0;
+    *offset = 0;
 
-    uLong number_disk;          /* number of the current dist, used for
-                                   spaning ZIP, unsupported, always 0*/
-    uLong number_disk_with_CD;  /* number the the disk with central dir, used
-                                   for spaning ZIP, unsupported, always 0*/
-    uLong number_entry_CD;      /* total number of entries in
-                                   the central dir
-                                   (same than number_entry on nospan) */
+    /* Zip64 end of central directory locator */
+    if (ZSEEK64(*pzlib_filefunc_def, filestream, endcentraloffset - SIZECENTRALHEADERLOCATOR, ZLIB_FILEFUNC_SEEK_SET) != 0)
+        return UNZ_ERRNO;
 
-    int err=UNZ_OK;
+    /* Read locator signature */
+    if (unzReadUInt32(pzlib_filefunc_def, filestream, &value32) != UNZ_OK)
+        return UNZ_ERRNO;
+    if (value32 != ZIP64ENDLOCHEADERMAGIC)
+        return UNZ_ERRNO;
+    /* Number of the disk with the start of the zip64 end of  central directory */
+    if (unzReadUInt32(pzlib_filefunc_def, filestream, &value32) != UNZ_OK)
+        return UNZ_ERRNO;
+    /* Relative offset of the zip64 end of central directory record */
+    if (unzReadUInt64(pzlib_filefunc_def, filestream, offset) != UNZ_OK)
+        return UNZ_ERRNO;
+    /* Total number of disks */
+    if (unzReadUInt32(pzlib_filefunc_def, filestream, &value32) != UNZ_OK)
+        return UNZ_ERRNO;
+    /* Goto end of central directory record */
+    if (ZSEEK64(*pzlib_filefunc_def, filestream, *offset, ZLIB_FILEFUNC_SEEK_SET) != 0)
+        return UNZ_ERRNO;
+     /* The signature */
+    if (unzReadUInt32(pzlib_filefunc_def, filestream, &value32) != UNZ_OK)
+        return UNZ_ERRNO;
+    if (value32 != ZIP64ENDHEADERMAGIC)
+        return UNZ_ERRNO;
 
-    if (unz_copyright[0]!=' ')
-        return NULL;
+    return UNZ_OK;
+}
 
-    if (pzlib_filefunc_def==NULL)
-        fill_fopen_filefunc(&us.z_filefunc);
+static unzFile unzOpenInternal(const void *path, zlib_filefunc64_32_def *pzlib_filefunc64_32_def)
+{
+    unz64_internal us;
+    unz64_internal *s = NULL;
+    uint64_t central_pos = 0;
+    uint64_t central_pos64 = 0;
+    uint64_t number_entry_CD = 0;
+    uint16_t value16 = 0;
+    uint32_t value32 = 0;
+    uint64_t value64 = 0;
+    voidpf filestream = NULL;
+    int err = UNZ_OK;
+
+    us.filestream = NULL;
+    us.filestream_with_CD = NULL;
+    us.z_filefunc.zseek32_file = NULL;
+    us.z_filefunc.ztell32_file = NULL;
+
+    if (pzlib_filefunc64_32_def == NULL)
+        fill_fopen64_filefunc(&us.z_filefunc.zfile_func64);
     else
-        us.z_filefunc = *pzlib_filefunc_def;
+        us.z_filefunc = *pzlib_filefunc64_32_def;
 
-    us.filestream= (*(us.z_filefunc.zopen_file))(us.z_filefunc.opaque,
-                                                 path,
-                                                 ZLIB_FILEFUNC_MODE_READ |
-                                                 ZLIB_FILEFUNC_MODE_EXISTING);
-    if (us.filestream==NULL)
+    us.filestream = ZOPEN64(us.z_filefunc, path, ZLIB_FILEFUNC_MODE_READ | ZLIB_FILEFUNC_MODE_EXISTING);
+
+    if (us.filestream == NULL)
         return NULL;
 
-    central_pos = unzlocal_SearchCentralDir(&us.z_filefunc,us.filestream);
-    if (central_pos==0)
-        err=UNZ_ERRNO;
+    us.filestream_with_CD = us.filestream;
+    us.is_zip64 = 0;
 
-    if (ZSEEK(us.z_filefunc, us.filestream,
-                                      central_pos,ZLIB_FILEFUNC_SEEK_SET)!=0)
-        err=UNZ_ERRNO;
-
-    /* the signature, already checked */
-    if (unzlocal_getLong(&us.z_filefunc, us.filestream,&uL)!=UNZ_OK)
-        err=UNZ_ERRNO;
-
-    /* number of this disk */
-    if (unzlocal_getShort(&us.z_filefunc, us.filestream,&number_disk)!=UNZ_OK)
-        err=UNZ_ERRNO;
-
-    /* number of the disk with the start of the central directory */
-    if (unzlocal_getShort(&us.z_filefunc, us.filestream,&number_disk_with_CD)!=UNZ_OK)
-        err=UNZ_ERRNO;
-
-    /* total number of entries in the central dir on this disk */
-    if (unzlocal_getShort(&us.z_filefunc, us.filestream,&us.gi.number_entry)!=UNZ_OK)
-        err=UNZ_ERRNO;
-
-    /* total number of entries in the central dir */
-    if (unzlocal_getShort(&us.z_filefunc, us.filestream,&number_entry_CD)!=UNZ_OK)
-        err=UNZ_ERRNO;
-
-    if ((number_entry_CD!=us.gi.number_entry) ||
-        (number_disk_with_CD!=0) ||
-        (number_disk!=0))
-        err=UNZ_BADZIPFILE;
-
-    /* size of the central directory */
-    if (unzlocal_getLong(&us.z_filefunc, us.filestream,&us.size_central_dir)!=UNZ_OK)
-        err=UNZ_ERRNO;
-
-    /* offset of start of central directory with respect to the
-          starting disk number */
-    if (unzlocal_getLong(&us.z_filefunc, us.filestream,&us.offset_central_dir)!=UNZ_OK)
-        err=UNZ_ERRNO;
-
-    /* zipfile comment length */
-    if (unzlocal_getShort(&us.z_filefunc, us.filestream,&us.gi.size_comment)!=UNZ_OK)
-        err=UNZ_ERRNO;
-
-    if ((central_pos<us.offset_central_dir+us.size_central_dir) &&
-        (err==UNZ_OK))
-        err=UNZ_BADZIPFILE;
-
-    if (err!=UNZ_OK)
+    /* Search for end of central directory header */
+    err = unzSearchCentralDir(&us.z_filefunc, &central_pos, us.filestream);
+    if (err == UNZ_OK)
     {
-        ZCLOSE(us.z_filefunc, us.filestream);
+        if (ZSEEK64(us.z_filefunc, us.filestream, central_pos, ZLIB_FILEFUNC_SEEK_SET) != 0)
+            err = UNZ_ERRNO;
+
+        /* The signature, already checked */
+        if (unzReadUInt32(&us.z_filefunc, us.filestream, &value32) != UNZ_OK)
+            err = UNZ_ERRNO;
+        /* Number of this disk */
+        if (unzReadUInt16(&us.z_filefunc, us.filestream, &value16) != UNZ_OK)
+            err = UNZ_ERRNO;
+        us.number_disk = value16;
+        /* Number of the disk with the start of the central directory */
+        if (unzReadUInt16(&us.z_filefunc, us.filestream, &value16) != UNZ_OK)
+            err = UNZ_ERRNO;
+        us.gi.number_disk_with_CD = value16;
+        /* Total number of entries in the central directory on this disk */
+        if (unzReadUInt16(&us.z_filefunc, us.filestream, &value16) != UNZ_OK)
+            err = UNZ_ERRNO;
+        us.gi.number_entry = value16;
+        /* Total number of entries in the central directory */
+        if (unzReadUInt16(&us.z_filefunc, us.filestream, &value16) != UNZ_OK)
+            err = UNZ_ERRNO;
+        number_entry_CD = value16;
+        if (number_entry_CD != us.gi.number_entry)
+            err = UNZ_BADZIPFILE;
+        /* Size of the central directory */
+        if (unzReadUInt32(&us.z_filefunc, us.filestream, &value32) != UNZ_OK)
+            err = UNZ_ERRNO;
+        us.size_central_dir = value32;
+        /* Offset of start of central directory with respect to the starting disk number */
+        if (unzReadUInt32(&us.z_filefunc, us.filestream, &value32) != UNZ_OK)
+            err = UNZ_ERRNO;
+        us.offset_central_dir = value32;
+        /* Zipfile comment length */
+        if (unzReadUInt16(&us.z_filefunc, us.filestream, &us.gi.size_comment) != UNZ_OK)
+            err = UNZ_ERRNO;
+
+        if (err == UNZ_OK)
+        {
+            /* Search for Zip64 end of central directory header */
+            int err64 = unzSearchCentralDir64(&us.z_filefunc, &central_pos64, us.filestream, central_pos);
+            if (err64 == UNZ_OK)
+            {
+                central_pos = central_pos64;
+                us.is_zip64 = 1;
+
+                if (ZSEEK64(us.z_filefunc, us.filestream, central_pos, ZLIB_FILEFUNC_SEEK_SET) != 0)
+                    err = UNZ_ERRNO;
+
+                /* the signature, already checked */
+                if (unzReadUInt32(&us.z_filefunc, us.filestream, &value32) != UNZ_OK)
+                    err = UNZ_ERRNO;
+                /* size of zip64 end of central directory record */
+                if (unzReadUInt64(&us.z_filefunc, us.filestream, &value64) != UNZ_OK)
+                    err = UNZ_ERRNO;
+                /* version made by */
+                if (unzReadUInt16(&us.z_filefunc, us.filestream, &value16) != UNZ_OK)
+                    err = UNZ_ERRNO;
+                /* version needed to extract */
+                if (unzReadUInt16(&us.z_filefunc, us.filestream, &value16) != UNZ_OK)
+                    err = UNZ_ERRNO;
+                /* number of this disk */
+                if (unzReadUInt32(&us.z_filefunc, us.filestream, &us.number_disk) != UNZ_OK)
+                    err = UNZ_ERRNO;
+                /* number of the disk with the start of the central directory */
+                if (unzReadUInt32(&us.z_filefunc, us.filestream, &us.gi.number_disk_with_CD) != UNZ_OK)
+                    err = UNZ_ERRNO;
+                /* total number of entries in the central directory on this disk */
+                if (unzReadUInt64(&us.z_filefunc, us.filestream, &us.gi.number_entry) != UNZ_OK)
+                    err = UNZ_ERRNO;
+                /* total number of entries in the central directory */
+                if (unzReadUInt64(&us.z_filefunc, us.filestream, &number_entry_CD) != UNZ_OK)
+                    err = UNZ_ERRNO;
+                if (number_entry_CD != us.gi.number_entry)
+                    err = UNZ_BADZIPFILE;
+                /* size of the central directory */
+                if (unzReadUInt64(&us.z_filefunc, us.filestream, &us.size_central_dir) != UNZ_OK)
+                    err = UNZ_ERRNO;
+                /* offset of start of central directory with respect to the starting disk number */
+                if (unzReadUInt64(&us.z_filefunc, us.filestream, &us.offset_central_dir) != UNZ_OK)
+                    err = UNZ_ERRNO;
+            }
+            else if ((us.gi.number_entry == UINT16_MAX) || (us.size_central_dir == UINT16_MAX) || (us.offset_central_dir == UINT32_MAX))
+                err = UNZ_BADZIPFILE;
+        }
+    }
+    else
+        err = UNZ_ERRNO;
+
+    if ((err == UNZ_OK) && (central_pos < us.offset_central_dir + us.size_central_dir))
+        err = UNZ_BADZIPFILE;
+
+    if (err != UNZ_OK)
+    {
+        ZCLOSE64(us.z_filefunc, us.filestream);
         return NULL;
     }
 
-    us.byte_before_the_zipfile = central_pos -
-                            (us.offset_central_dir+us.size_central_dir);
+    if (us.gi.number_disk_with_CD == 0)
+    {
+        /* If there is only one disk open another stream so we don't have to seek between the CD
+           and the file headers constantly */
+        filestream = ZOPEN64(us.z_filefunc, path, ZLIB_FILEFUNC_MODE_READ | ZLIB_FILEFUNC_MODE_EXISTING);
+        if (filestream != NULL)
+            us.filestream = filestream;
+    }
+
+    /* Hack for zip files that have no respect for zip64
+    if ((central_pos > 0xffffffff) && (us.offset_central_dir < 0xffffffff))
+        us.offset_central_dir = central_pos - us.size_central_dir;*/
+
+    us.byte_before_the_zipfile = central_pos - (us.offset_central_dir + us.size_central_dir);
     us.central_pos = central_pos;
     us.pfile_in_zip_read = NULL;
-    us.encrypted = 0;
 
-
-    s=(unz_s*)ALLOC(sizeof(unz_s));
-    *s=us;
-    unzGoToFirstFile((unzFile)s);
+    s = (unz64_internal*)ALLOC(sizeof(unz64_internal));
+    if (s != NULL)
+    {
+        *s = us;
+        unzGoToFirstFile((unzFile)s);
+    }
     return (unzFile)s;
 }
 
-
-extern unzFile ZEXPORT unzOpen (path)
-    const char *path;
+extern unzFile ZEXPORT unzOpen2(const char *path, zlib_filefunc_def *pzlib_filefunc32_def)
 {
-    return unzOpen2(path, NULL);
+    if (pzlib_filefunc32_def != NULL)
+    {
+        zlib_filefunc64_32_def zlib_filefunc64_32_def_fill;
+        fill_zlib_filefunc64_32_def_from_filefunc32(&zlib_filefunc64_32_def_fill, pzlib_filefunc32_def);
+        return unzOpenInternal(path, &zlib_filefunc64_32_def_fill);
+    }
+    return unzOpenInternal(path, NULL);
 }
 
-/*
-  Close a ZipFile opened with unzipOpen.
-  If there is files inside the .Zip opened with unzipOpenCurrentFile (see later),
-    these files MUST be closed with unzipCloseCurrentFile before call unzipClose.
-  return UNZ_OK if there is no problem. */
-extern int ZEXPORT unzClose (file)
-    unzFile file;
+extern unzFile ZEXPORT unzOpen2_64(const void *path, zlib_filefunc64_def *pzlib_filefunc_def)
 {
-    unz_s* s;
-    if (file==NULL)
-        return UNZ_PARAMERROR;
-    s=(unz_s*)file;
+    if (pzlib_filefunc_def != NULL)
+    {
+        zlib_filefunc64_32_def zlib_filefunc64_32_def_fill;
+        zlib_filefunc64_32_def_fill.zfile_func64 = *pzlib_filefunc_def;
+        zlib_filefunc64_32_def_fill.ztell32_file = NULL;
+        zlib_filefunc64_32_def_fill.zseek32_file = NULL;
+        return unzOpenInternal(path, &zlib_filefunc64_32_def_fill);
+    }
+    return unzOpenInternal(path, NULL);
+}
 
-    if (s->pfile_in_zip_read!=NULL)
+extern unzFile ZEXPORT unzOpen(const char *path)
+{
+    return unzOpenInternal(path, NULL);
+}
+
+extern unzFile ZEXPORT unzOpen64(const void *path)
+{
+    return unzOpenInternal(path, NULL);
+}
+
+extern int ZEXPORT unzClose(unzFile file)
+{
+    unz64_internal *s;
+    if (file == NULL)
+        return UNZ_PARAMERROR;
+    s = (unz64_internal*)file;
+
+    if (s->pfile_in_zip_read != NULL)
         unzCloseCurrentFile(file);
 
-    ZCLOSE(s->z_filefunc, s->filestream);
+    if ((s->filestream != NULL) && (s->filestream != s->filestream_with_CD))
+        ZCLOSE64(s->z_filefunc, s->filestream);
+    if (s->filestream_with_CD != NULL)
+        ZCLOSE64(s->z_filefunc, s->filestream_with_CD);
+
+    s->filestream = NULL;
+    s->filestream_with_CD = NULL;
     TRYFREE(s);
     return UNZ_OK;
 }
 
-
-/*
-  Write info about the ZipFile in the *pglobal_info structure.
-  No preparation of the structure is needed
-  return UNZ_OK if there is no problem. */
-extern int ZEXPORT unzGetGlobalInfo (file,pglobal_info)
-    unzFile file;
-    unz_global_info *pglobal_info;
+/* Goto to the next available disk for spanned archives */
+static int unzGoToNextDisk(unzFile file)
 {
-    unz_s* s;
-    if (file==NULL)
+    unz64_internal *s;
+    uint32_t number_disk_next = 0;
+
+    s = (unz64_internal*)file;
+    if (s == NULL)
         return UNZ_PARAMERROR;
-    s=(unz_s*)file;
-    *pglobal_info=s->gi;
-    return UNZ_OK;
-}
+    number_disk_next = s->number_disk;
 
-
-/*
-   Translate date/time from Dos format to tm_unz (readable more easilty)
-*/
-local void unzlocal_DosDateToTmuDate (ulDosDate, ptm)
-    uLong ulDosDate;
-    tm_unz* ptm;
-{
-    uLong uDate;
-    uDate = (uLong)(ulDosDate>>16);
-    ptm->tm_mday = (uInt)(uDate&0x1f) ;
-    ptm->tm_mon =  (uInt)((((uDate)&0x1E0)/0x20)-1) ;
-    ptm->tm_year = (uInt)(((uDate&0x0FE00)/0x0200)+1980) ;
-
-    ptm->tm_hour = (uInt) ((ulDosDate &0xF800)/0x800);
-    ptm->tm_min =  (uInt) ((ulDosDate&0x7E0)/0x20) ;
-    ptm->tm_sec =  (uInt) (2*(ulDosDate&0x1f)) ;
-}
-
-/*
-  Get Info about the current file in the zipfile, with internal only info
-*/
-local int unzlocal_GetCurrentFileInfoInternal OF((unzFile file,
-                                                  unz_file_info *pfile_info,
-                                                  unz_file_info_internal
-                                                  *pfile_info_internal,
-                                                  char *szFileName,
-                                                  uLong fileNameBufferSize,
-                                                  void *extraField,
-                                                  uLong extraFieldBufferSize,
-                                                  char *szComment,
-                                                  uLong commentBufferSize));
-
-local int unzlocal_GetCurrentFileInfoInternal (file,
-                                              pfile_info,
-                                              pfile_info_internal,
-                                              szFileName, fileNameBufferSize,
-                                              extraField, extraFieldBufferSize,
-                                              szComment,  commentBufferSize)
-    unzFile file;
-    unz_file_info *pfile_info;
-    unz_file_info_internal *pfile_info_internal;
-    char *szFileName;
-    uLong fileNameBufferSize;
-    void *extraField;
-    uLong extraFieldBufferSize;
-    char *szComment;
-    uLong commentBufferSize;
-{
-    unz_s* s;
-    unz_file_info file_info;
-    unz_file_info_internal file_info_internal;
-    int err=UNZ_OK;
-    uLong uMagic;
-    long lSeek=0;
-
-    if (file==NULL)
-        return UNZ_PARAMERROR;
-    s=(unz_s*)file;
-    if (ZSEEK(s->z_filefunc, s->filestream,
-              s->pos_in_central_dir+s->byte_before_the_zipfile,
-              ZLIB_FILEFUNC_SEEK_SET)!=0)
-        err=UNZ_ERRNO;
-
-
-    /* we check the magic */
-    if (err==UNZ_OK)
-    {
-        if (unzlocal_getLong(&s->z_filefunc, s->filestream,&uMagic) != UNZ_OK)
-        {
-            err=UNZ_ERRNO;
-        }
-        else if (uMagic!=0x02014b50)
-        {
-            err=UNZ_BADZIPFILE;
-        }
-    }
-
-    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&file_info.version) != UNZ_OK)
-        err=UNZ_ERRNO;
-
-    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&file_info.version_needed) != UNZ_OK)
-        err=UNZ_ERRNO;
-
-    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&file_info.flag) != UNZ_OK)
-        err=UNZ_ERRNO;
-
-    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&file_info.compression_method) != UNZ_OK)
-        err=UNZ_ERRNO;
-
-    if (unzlocal_getLong(&s->z_filefunc, s->filestream,&file_info.dosDate) != UNZ_OK)
-        err=UNZ_ERRNO;
-
-    unzlocal_DosDateToTmuDate(file_info.dosDate,&file_info.tmu_date);
-
-    if (unzlocal_getLong(&s->z_filefunc, s->filestream,&file_info.crc) != UNZ_OK)
-        err=UNZ_ERRNO;
-
-    if (unzlocal_getLong(&s->z_filefunc, s->filestream,&file_info.compressed_size) != UNZ_OK)
-        err=UNZ_ERRNO;
-
-    if (unzlocal_getLong(&s->z_filefunc, s->filestream,&file_info.uncompressed_size) != UNZ_OK)
-        err=UNZ_ERRNO;
-
-    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&file_info.size_filename) != UNZ_OK)
-        err=UNZ_ERRNO;
-
-    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&file_info.size_file_extra) != UNZ_OK)
-        err=UNZ_ERRNO;
-
-    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&file_info.size_file_comment) != UNZ_OK)
-        err=UNZ_ERRNO;
-
-    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&file_info.disk_num_start) != UNZ_OK)
-        err=UNZ_ERRNO;
-
-    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&file_info.internal_fa) != UNZ_OK)
-        err=UNZ_ERRNO;
-
-    if (unzlocal_getLong(&s->z_filefunc, s->filestream,&file_info.external_fa) != UNZ_OK)
-        err=UNZ_ERRNO;
-
-    if (unzlocal_getLong(&s->z_filefunc, s->filestream,&file_info_internal.offset_curfile) != UNZ_OK)
-        err=UNZ_ERRNO;
-
-    lSeek+=file_info.size_filename;
-    if ((err==UNZ_OK) && (szFileName!=NULL))
-    {
-        uLong uSizeRead ;
-        if (file_info.size_filename<fileNameBufferSize)
-        {
-            *(szFileName+file_info.size_filename)='\0';
-            uSizeRead = file_info.size_filename;
-        }
-        else
-            uSizeRead = fileNameBufferSize;
-
-        if ((file_info.size_filename>0) && (fileNameBufferSize>0))
-            if (ZREAD(s->z_filefunc, s->filestream,szFileName,uSizeRead)!=uSizeRead)
-                err=UNZ_ERRNO;
-        lSeek -= uSizeRead;
-    }
-
-
-    if ((err==UNZ_OK) && (extraField!=NULL))
-    {
-        uLong uSizeRead ;
-        if (file_info.size_file_extra<extraFieldBufferSize)
-            uSizeRead = file_info.size_file_extra;
-        else
-            uSizeRead = extraFieldBufferSize;
-
-        if (lSeek!=0)
-        {
-            if (ZSEEK(s->z_filefunc, s->filestream,lSeek,ZLIB_FILEFUNC_SEEK_CUR)==0)
-                lSeek=0;
-            else
-                err=UNZ_ERRNO;
-        }
-        if ((file_info.size_file_extra>0) && (extraFieldBufferSize>0))
-            if (ZREAD(s->z_filefunc, s->filestream,extraField,uSizeRead)!=uSizeRead)
-                err=UNZ_ERRNO;
-        lSeek += file_info.size_file_extra - uSizeRead;
-    }
+    if ((s->pfile_in_zip_read != NULL) && (s->pfile_in_zip_read->rest_read_uncompressed > 0))
+        /* We are currently reading a file and we need the next sequential disk */
+        number_disk_next += 1;
     else
-    {
-        lSeek+=file_info.size_file_extra;
-    }
+        /* Goto the disk for the current file */
+        number_disk_next = s->cur_file_info.disk_num_start;
 
-    if ((err==UNZ_OK) && (szComment!=NULL))
+    if (number_disk_next != s->number_disk)
     {
-        uLong uSizeRead ;
-        if (file_info.size_file_comment<commentBufferSize)
+        /* Switch disks */
+        if ((s->filestream != NULL) && (s->filestream != s->filestream_with_CD))
+            ZCLOSE64(s->z_filefunc, s->filestream);
+
+        if (number_disk_next == s->gi.number_disk_with_CD)
         {
-            *(szComment+file_info.size_file_comment)='\0';
-            uSizeRead = file_info.size_file_comment;
+            s->filestream = s->filestream_with_CD;
         }
         else
         {
-            uSizeRead = commentBufferSize;
+            s->filestream = ZOPENDISK64(s->z_filefunc, s->filestream_with_CD, number_disk_next,
+                ZLIB_FILEFUNC_MODE_READ | ZLIB_FILEFUNC_MODE_EXISTING);
         }
 
-        if (lSeek!=0)
-        {
-            if (ZSEEK(s->z_filefunc, s->filestream,lSeek,ZLIB_FILEFUNC_SEEK_CUR)!=0)
-                err=UNZ_ERRNO;
-        }
-        if ((file_info.size_file_comment>0) && (commentBufferSize>0))
-            if (ZREAD(s->z_filefunc, s->filestream,szComment,uSizeRead)!=uSizeRead)
-                err=UNZ_ERRNO;
+        if (s->filestream == NULL)
+            return UNZ_ERRNO;
+
+        s->number_disk = number_disk_next;
     }
-    else
-    {
-    }
-
-    if ((err==UNZ_OK) && (pfile_info!=NULL))
-        *pfile_info=file_info;
-
-    if ((err==UNZ_OK) && (pfile_info_internal!=NULL))
-        *pfile_info_internal=file_info_internal;
-
-    return err;
-}
-
-
-
-/*
-  Write info about the ZipFile in the *pglobal_info structure.
-  No preparation of the structure is needed
-  return UNZ_OK if there is no problem.
-*/
-extern int ZEXPORT unzGetCurrentFileInfo (file,
-                                          pfile_info,
-                                          szFileName, fileNameBufferSize,
-                                          extraField, extraFieldBufferSize,
-                                          szComment,  commentBufferSize)
-    unzFile file;
-    unz_file_info *pfile_info;
-    char *szFileName;
-    uLong fileNameBufferSize;
-    void *extraField;
-    uLong extraFieldBufferSize;
-    char *szComment;
-    uLong commentBufferSize;
-{
-    return unzlocal_GetCurrentFileInfoInternal(file,pfile_info,NULL,
-                                                szFileName,fileNameBufferSize,
-                                                extraField,extraFieldBufferSize,
-                                                szComment,commentBufferSize);
-}
-
-/*
-  Set the current file of the zipfile to the first file.
-  return UNZ_OK if there is no problem
-*/
-extern int ZEXPORT unzGoToFirstFile (file)
-    unzFile file;
-{
-    int err=UNZ_OK;
-    unz_s* s;
-    if (file==NULL)
-        return UNZ_PARAMERROR;
-    s=(unz_s*)file;
-    s->pos_in_central_dir=s->offset_central_dir;
-    s->num_file=0;
-    err=unzlocal_GetCurrentFileInfoInternal(file,&s->cur_file_info,
-                                             &s->cur_file_info_internal,
-                                             NULL,0,NULL,0,NULL,0);
-    s->current_file_ok = (err == UNZ_OK);
-    return err;
-}
-
-/*
-  Set the current file of the zipfile to the next file.
-  return UNZ_OK if there is no problem
-  return UNZ_END_OF_LIST_OF_FILE if the actual file was the latest.
-*/
-extern int ZEXPORT unzGoToNextFile (file)
-    unzFile file;
-{
-    unz_s* s;
-    int err;
-
-    if (file==NULL)
-        return UNZ_PARAMERROR;
-    s=(unz_s*)file;
-    if (!s->current_file_ok)
-        return UNZ_END_OF_LIST_OF_FILE;
-    if (s->gi.number_entry != 0xffff)    /* 2^16 files overflow hack */
-      if (s->num_file+1==s->gi.number_entry)
-        return UNZ_END_OF_LIST_OF_FILE;
-
-    s->pos_in_central_dir += SIZECENTRALDIRITEM + s->cur_file_info.size_filename +
-            s->cur_file_info.size_file_extra + s->cur_file_info.size_file_comment ;
-    s->num_file++;
-    err = unzlocal_GetCurrentFileInfoInternal(file,&s->cur_file_info,
-                                               &s->cur_file_info_internal,
-                                               NULL,0,NULL,0,NULL,0);
-    s->current_file_ok = (err == UNZ_OK);
-    return err;
-}
-
-
-/*
-  Try locate the file szFileName in the zipfile.
-  For the iCaseSensitivity signification, see unzipStringFileNameCompare
-
-  return value :
-  UNZ_OK if the file is found. It becomes the current file.
-  UNZ_END_OF_LIST_OF_FILE if the file is not found
-*/
-extern int ZEXPORT unzLocateFile (file, szFileName, iCaseSensitivity)
-    unzFile file;
-    const char *szFileName;
-    int iCaseSensitivity;
-{
-    unz_s* s;
-    int err;
-
-    /* We remember the 'current' position in the file so that we can jump
-     * back there if we fail.
-     */
-    unz_file_info cur_file_infoSaved;
-    unz_file_info_internal cur_file_info_internalSaved;
-    uLong num_fileSaved;
-    uLong pos_in_central_dirSaved;
-
-
-    if (file==NULL)
-        return UNZ_PARAMERROR;
-
-    if (strlen(szFileName)>=UNZ_MAXFILENAMEINZIP)
-        return UNZ_PARAMERROR;
-
-    s=(unz_s*)file;
-    if (!s->current_file_ok)
-        return UNZ_END_OF_LIST_OF_FILE;
-
-    /* Save the current state */
-    num_fileSaved = s->num_file;
-    pos_in_central_dirSaved = s->pos_in_central_dir;
-    cur_file_infoSaved = s->cur_file_info;
-    cur_file_info_internalSaved = s->cur_file_info_internal;
-
-    err = unzGoToFirstFile(file);
-
-    while (err == UNZ_OK)
-    {
-        char szCurrentFileName[UNZ_MAXFILENAMEINZIP+1];
-        err = unzGetCurrentFileInfo(file,NULL,
-                                    szCurrentFileName,sizeof(szCurrentFileName)-1,
-                                    NULL,0,NULL,0);
-        if (err == UNZ_OK)
-        {
-            if (unzStringFileNameCompare(szCurrentFileName,
-                                            szFileName,iCaseSensitivity)==0)
-                return UNZ_OK;
-            err = unzGoToNextFile(file);
-        }
-    }
-
-    /* We failed, so restore the state of the 'current file' to where we
-     * were.
-     */
-    s->num_file = num_fileSaved ;
-    s->pos_in_central_dir = pos_in_central_dirSaved ;
-    s->cur_file_info = cur_file_infoSaved;
-    s->cur_file_info_internal = cur_file_info_internalSaved;
-    return err;
-}
-
-
-/*
-///////////////////////////////////////////
-// Contributed by Ryan Haksi (mailto://cryogen@infoserve.net)
-// I need random access
-//
-// Further optimization could be realized by adding an ability
-// to cache the directory in memory. The goal being a single
-// comprehensive file read to put the file I need in a memory.
-*/
-
-/*
-typedef struct unz_file_pos_s
-{
-    uLong pos_in_zip_directory;   // offset in file
-    uLong num_of_file;            // # of file
-} unz_file_pos;
-*/
-
-extern int ZEXPORT unzGetFilePos(file, file_pos)
-    unzFile file;
-    unz_file_pos* file_pos;
-{
-    unz_s* s;
-
-    if (file==NULL || file_pos==NULL)
-        return UNZ_PARAMERROR;
-    s=(unz_s*)file;
-    if (!s->current_file_ok)
-        return UNZ_END_OF_LIST_OF_FILE;
-
-    file_pos->pos_in_zip_directory  = s->pos_in_central_dir;
-    file_pos->num_of_file           = s->num_file;
 
     return UNZ_OK;
 }
 
-extern int ZEXPORT unzGoToFilePos(file, file_pos)
-    unzFile file;
-    unz_file_pos* file_pos;
+extern int ZEXPORT unzGetGlobalInfo(unzFile file, unz_global_info* pglobal_info32)
 {
-    unz_s* s;
-    int err;
-
-    if (file==NULL || file_pos==NULL)
+    unz64_internal *s = NULL;
+    if (file == NULL)
         return UNZ_PARAMERROR;
-    s=(unz_s*)file;
+    s = (unz64_internal*)file;
 
-    /* jump to the right spot */
-    s->pos_in_central_dir = file_pos->pos_in_zip_directory;
-    s->num_file           = file_pos->num_of_file;
-
-    /* set the current file */
-    err = unzlocal_GetCurrentFileInfoInternal(file,&s->cur_file_info,
-                                               &s->cur_file_info_internal,
-                                               NULL,0,NULL,0,NULL,0);
-    /* return results */
-    s->current_file_ok = (err == UNZ_OK);
-    return err;
+    pglobal_info32->number_entry = (uint32_t)s->gi.number_entry;
+    pglobal_info32->size_comment = s->gi.size_comment;
+    pglobal_info32->number_disk_with_CD = s->gi.number_disk_with_CD;
+    return UNZ_OK;
 }
 
-/*
-// Unzip Helper Functions - should be here?
-///////////////////////////////////////////
-*/
-
-/*
-  Read the local header of the current zipfile
-  Check the coherency of the local header and info in the end of central
-        directory about this file
-  store in *piSizeVar the size of extra info in local header
-        (filename and size of extra field data)
-*/
-local int unzlocal_CheckCurrentFileCoherencyHeader (s,piSizeVar,
-                                                    poffset_local_extrafield,
-                                                    psize_local_extrafield)
-    unz_s* s;
-    uInt* piSizeVar;
-    uLong *poffset_local_extrafield;
-    uInt  *psize_local_extrafield;
+extern int ZEXPORT unzGetGlobalInfo64(unzFile file, unz_global_info64 *pglobal_info)
 {
-    uLong uMagic,uData,uFlags;
-    uLong size_filename;
-    uLong size_extra_field;
-    int err=UNZ_OK;
+    unz64_internal *s = NULL;
+    if (file == NULL)
+        return UNZ_PARAMERROR;
+    s = (unz64_internal*)file;
+    *pglobal_info = s->gi;
+    return UNZ_OK;
+}
 
-    *piSizeVar = 0;
-    *poffset_local_extrafield = 0;
-    *psize_local_extrafield = 0;
+extern int ZEXPORT unzGetGlobalComment(unzFile file, char *comment, uint16_t comment_size)
+{
+    unz64_internal *s = NULL;
+    uint16_t bytes_to_read = comment_size;
+    if (file == NULL)
+        return (int)UNZ_PARAMERROR;
+    s = (unz64_internal*)file;
 
-    if (ZSEEK(s->z_filefunc, s->filestream,s->cur_file_info_internal.offset_curfile +
-                                s->byte_before_the_zipfile,ZLIB_FILEFUNC_SEEK_SET)!=0)
+    if (bytes_to_read > s->gi.size_comment)
+        bytes_to_read = s->gi.size_comment;
+
+    if (ZSEEK64(s->z_filefunc, s->filestream_with_CD, s->central_pos + 22, ZLIB_FILEFUNC_SEEK_SET) != 0)
         return UNZ_ERRNO;
 
-
-    if (err==UNZ_OK)
+    if (bytes_to_read > 0)
     {
-        if (unzlocal_getLong(&s->z_filefunc, s->filestream,&uMagic) != UNZ_OK)
-            err=UNZ_ERRNO;
-        else if (uMagic!=0x04034b50)
-            err=UNZ_BADZIPFILE;
+        *comment = 0;
+        if (ZREAD64(s->z_filefunc, s->filestream_with_CD, comment, bytes_to_read) != bytes_to_read)
+            return UNZ_ERRNO;
     }
 
-    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&uData) != UNZ_OK)
-        err=UNZ_ERRNO;
-/*
-    else if ((err==UNZ_OK) && (uData!=s->cur_file_info.wVersion))
-        err=UNZ_BADZIPFILE;
-*/
-    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&uFlags) != UNZ_OK)
-        err=UNZ_ERRNO;
+    if ((comment != NULL) && (comment_size > s->gi.size_comment))
+        *(comment + s->gi.size_comment) = 0;
 
-    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&uData) != UNZ_OK)
-        err=UNZ_ERRNO;
-    else if ((err==UNZ_OK) && (uData!=s->cur_file_info.compression_method))
-        err=UNZ_BADZIPFILE;
+    return (int)bytes_to_read;
+}
 
-    if ((err==UNZ_OK) && (s->cur_file_info.compression_method!=0) &&
-                         (s->cur_file_info.compression_method!=Z_DEFLATED))
-        err=UNZ_BADZIPFILE;
+static int unzGetCurrentFileInfoField(unzFile file, uint32_t *seek, void *field, uint16_t field_size, uint16_t size_file_field, int null_terminated_field)
+{
+    unz64_internal *s = NULL;
+    uint32_t bytes_to_read = 0;
+    int err = UNZ_OK;
 
-    if (unzlocal_getLong(&s->z_filefunc, s->filestream,&uData) != UNZ_OK) /* date/time */
-        err=UNZ_ERRNO;
+    if (file == NULL)
+        return (int)UNZ_PARAMERROR;
+    s = (unz64_internal*)file;
 
-    if (unzlocal_getLong(&s->z_filefunc, s->filestream,&uData) != UNZ_OK) /* crc */
-        err=UNZ_ERRNO;
-    else if ((err==UNZ_OK) && (uData!=s->cur_file_info.crc) &&
-                              ((uFlags & 8)==0))
-        err=UNZ_BADZIPFILE;
+    /* Read field */
+    if (field != NULL)
+    {
+        if (size_file_field < field_size)
+        {
+            if (null_terminated_field)
+                *((char *)field+size_file_field) = 0;
 
-    if (unzlocal_getLong(&s->z_filefunc, s->filestream,&uData) != UNZ_OK) /* size compr */
-        err=UNZ_ERRNO;
-    else if ((err==UNZ_OK) && (uData!=s->cur_file_info.compressed_size) &&
-                              ((uFlags & 8)==0))
-        err=UNZ_BADZIPFILE;
+            bytes_to_read = size_file_field;
+        }
+        else
+            bytes_to_read = field_size;
+        
+        if (*seek != 0)
+        {
+            if (ZSEEK64(s->z_filefunc, s->filestream_with_CD, *seek, ZLIB_FILEFUNC_SEEK_CUR) == 0)
+                *seek = 0;
+            else
+                err = UNZ_ERRNO;
+        }
+        
+        if ((size_file_field > 0) && (field_size > 0))
+        {
+            if (ZREAD64(s->z_filefunc, s->filestream_with_CD, field, bytes_to_read) != bytes_to_read)
+                err = UNZ_ERRNO;
+        }
+        *seek += size_file_field - bytes_to_read;
+    }
+    else
+    {
+        *seek += size_file_field;
+    }
 
-    if (unzlocal_getLong(&s->z_filefunc, s->filestream,&uData) != UNZ_OK) /* size uncompr */
-        err=UNZ_ERRNO;
-    else if ((err==UNZ_OK) && (uData!=s->cur_file_info.uncompressed_size) &&
-                              ((uFlags & 8)==0))
-        err=UNZ_BADZIPFILE;
+    return err;
+}
 
+/* Get info about the current file in the zipfile, with internal only info */
+static int unzGetCurrentFileInfoInternal(unzFile file, unz_file_info64 *pfile_info,
+    unz_file_info64_internal *pfile_info_internal, char *filename, uint16_t filename_size, void *extrafield,
+    uint16_t extrafield_size, char *comment, uint16_t comment_size)
+{
+    unz64_internal *s = NULL;
+    unz_file_info64 file_info;
+    unz_file_info64_internal file_info_internal;
+    uint32_t magic = 0;
+    uint64_t current_pos = 0;
+    uint32_t seek = 0;
+    uint32_t extra_pos = 0;
+    uint16_t extra_header_id = 0;
+    uint16_t extra_data_size = 0;
+    uint16_t value16 = 0;
+    uint32_t value32 = 0;
+    uint64_t value64 = 0;
+    int err = UNZ_OK;
 
-    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&size_filename) != UNZ_OK)
-        err=UNZ_ERRNO;
-    else if ((err==UNZ_OK) && (size_filename!=s->cur_file_info.size_filename))
-        err=UNZ_BADZIPFILE;
+    if (file == NULL)
+        return UNZ_PARAMERROR;
+    s = (unz64_internal*)file;
 
-    *piSizeVar += (uInt)size_filename;
+    if (ZSEEK64(s->z_filefunc, s->filestream_with_CD,
+            s->pos_in_central_dir + s->byte_before_the_zipfile, ZLIB_FILEFUNC_SEEK_SET) != 0)
+        err = UNZ_ERRNO;
 
-    if (unzlocal_getShort(&s->z_filefunc, s->filestream,&size_extra_field) != UNZ_OK)
-        err=UNZ_ERRNO;
-    *poffset_local_extrafield= s->cur_file_info_internal.offset_curfile +
-                                    SIZEZIPLOCALHEADER + size_filename;
-    *psize_local_extrafield = (uInt)size_extra_field;
+    /* Check the magic */
+    if (err == UNZ_OK)
+    {
+        if (unzReadUInt32(&s->z_filefunc, s->filestream_with_CD, &magic) != UNZ_OK)
+            err = UNZ_ERRNO;
+        else if (magic != CENTRALHEADERMAGIC)
+            err = UNZ_BADZIPFILE;
+    }
 
-    *piSizeVar += (uInt)size_extra_field;
+    /* Read central directory header */
+    if (unzReadUInt16(&s->z_filefunc, s->filestream_with_CD, &file_info.version) != UNZ_OK)
+        err = UNZ_ERRNO;
+    if (unzReadUInt16(&s->z_filefunc, s->filestream_with_CD, &file_info.version_needed) != UNZ_OK)
+        err = UNZ_ERRNO;
+    if (unzReadUInt16(&s->z_filefunc, s->filestream_with_CD, &file_info.flag) != UNZ_OK)
+        err = UNZ_ERRNO;
+    if (unzReadUInt16(&s->z_filefunc, s->filestream_with_CD, &file_info.compression_method) != UNZ_OK)
+        err = UNZ_ERRNO;
+    if (unzReadUInt32(&s->z_filefunc, s->filestream_with_CD, &file_info.dos_date) != UNZ_OK)
+        err = UNZ_ERRNO;
+    if (unzReadUInt32(&s->z_filefunc, s->filestream_with_CD, &file_info.crc) != UNZ_OK)
+        err = UNZ_ERRNO;
+    if (unzReadUInt32(&s->z_filefunc, s->filestream_with_CD, &value32) != UNZ_OK)
+        err = UNZ_ERRNO;
+    file_info.compressed_size = value32;
+    if (unzReadUInt32(&s->z_filefunc, s->filestream_with_CD, &value32) != UNZ_OK)
+        err = UNZ_ERRNO;
+    file_info.uncompressed_size = value32;
+    if (unzReadUInt16(&s->z_filefunc, s->filestream_with_CD, &file_info.size_filename) != UNZ_OK)
+        err = UNZ_ERRNO;
+    if (unzReadUInt16(&s->z_filefunc, s->filestream_with_CD, &file_info.size_file_extra) != UNZ_OK)
+        err = UNZ_ERRNO;
+    if (unzReadUInt16(&s->z_filefunc, s->filestream_with_CD, &file_info.size_file_comment) != UNZ_OK)
+        err = UNZ_ERRNO;
+    if (unzReadUInt16(&s->z_filefunc, s->filestream_with_CD, &value16) != UNZ_OK)
+        err = UNZ_ERRNO;
+    file_info.disk_num_start = value16;
+    if (unzReadUInt16(&s->z_filefunc, s->filestream_with_CD, &file_info.internal_fa) != UNZ_OK)
+        err = UNZ_ERRNO;
+    if (unzReadUInt32(&s->z_filefunc, s->filestream_with_CD, &file_info.external_fa) != UNZ_OK)
+        err = UNZ_ERRNO;
+    /* Relative offset of local header */
+    if (unzReadUInt32(&s->z_filefunc, s->filestream_with_CD, &value32) != UNZ_OK)
+        err = UNZ_ERRNO;
+
+    file_info.size_file_extra_internal = 0;
+    file_info.disk_offset = value32;
+    file_info_internal.offset_curfile = value32;
+#ifdef HAVE_AES
+    file_info_internal.aes_compression_method = 0;
+    file_info_internal.aes_encryption_mode = 0;
+    file_info_internal.aes_version = 0;
+#endif
+
+    if (err == UNZ_OK)
+        err = unzGetCurrentFileInfoField(file, &seek, filename, filename_size, file_info.size_filename, 1);
+
+    /* Read extrafield */
+    if (err == UNZ_OK)
+        err = unzGetCurrentFileInfoField(file, &seek, extrafield, extrafield_size, file_info.size_file_extra, 0);
+
+    if ((err == UNZ_OK) && (file_info.size_file_extra != 0))
+    {
+        if (seek != 0)
+        {
+            if (ZSEEK64(s->z_filefunc, s->filestream_with_CD, seek, ZLIB_FILEFUNC_SEEK_CUR) == 0)
+                seek = 0;
+            else
+                err = UNZ_ERRNO;
+        }
+
+        /* We are going to parse the extra field so we need to move back */
+        current_pos = ZTELL64(s->z_filefunc, s->filestream_with_CD);
+        if (current_pos < file_info.size_file_extra)
+            err = UNZ_ERRNO;
+        current_pos -= file_info.size_file_extra;
+        if (ZSEEK64(s->z_filefunc, s->filestream_with_CD, current_pos, ZLIB_FILEFUNC_SEEK_SET) != 0)
+            err = UNZ_ERRNO;
+
+        while ((err != UNZ_ERRNO) && (extra_pos < file_info.size_file_extra))
+        {
+            if (unzReadUInt16(&s->z_filefunc, s->filestream_with_CD, &extra_header_id) != UNZ_OK)
+                err = UNZ_ERRNO;
+            if (unzReadUInt16(&s->z_filefunc, s->filestream_with_CD, &extra_data_size) != UNZ_OK)
+                err = UNZ_ERRNO;
+
+            /* ZIP64 extra fields */
+            if (extra_header_id == 0x0001)
+            {
+                /* Subtract size of ZIP64 field, since ZIP64 is handled internally */
+                file_info.size_file_extra_internal += 2 + 2 + extra_data_size;
+
+                if (file_info.uncompressed_size == UINT32_MAX)
+                {
+                    if (unzReadUInt64(&s->z_filefunc, s->filestream_with_CD, &file_info.uncompressed_size) != UNZ_OK)
+                        err = UNZ_ERRNO;
+                }
+                if (file_info.compressed_size == UINT32_MAX)
+                {
+                    if (unzReadUInt64(&s->z_filefunc, s->filestream_with_CD, &file_info.compressed_size) != UNZ_OK)
+                        err = UNZ_ERRNO;
+                }
+                if (file_info_internal.offset_curfile == UINT32_MAX)
+                {
+                    /* Relative Header offset */
+                    if (unzReadUInt64(&s->z_filefunc, s->filestream_with_CD, &value64) != UNZ_OK)
+                        err = UNZ_ERRNO;
+                    file_info_internal.offset_curfile = value64;
+                    file_info.disk_offset = value64;
+                }
+                if (file_info.disk_num_start == UINT32_MAX)
+                {
+                    /* Disk Start Number */
+                    if (unzReadUInt32(&s->z_filefunc, s->filestream_with_CD, &file_info.disk_num_start) != UNZ_OK)
+                        err = UNZ_ERRNO;
+                }
+            }
+#ifdef HAVE_AES
+            /* AES header */
+            else if (extra_header_id == 0x9901)
+            {
+                uint8_t value8 = 0;
+
+                /* Subtract size of AES field, since AES is handled internally */
+                file_info.size_file_extra_internal += 2 + 2 + extra_data_size;
+
+                /* Verify version info */
+                if (unzReadUInt16(&s->z_filefunc, s->filestream_with_CD, &value16) != UNZ_OK)
+                    err = UNZ_ERRNO;
+                /* Support AE-1 and AE-2 */
+                if (value16 != 1 && value16 != 2)
+                    err = UNZ_ERRNO;
+                file_info_internal.aes_version = value16;
+                if (unzReadUInt8(&s->z_filefunc, s->filestream_with_CD, &value8) != UNZ_OK)
+                    err = UNZ_ERRNO;
+                if ((char)value8 != 'A')
+                    err = UNZ_ERRNO;
+                if (unzReadUInt8(&s->z_filefunc, s->filestream_with_CD, &value8) != UNZ_OK)
+                    err = UNZ_ERRNO;
+                if ((char)value8 != 'E')
+                    err = UNZ_ERRNO;
+                /* Get AES encryption strength and actual compression method */
+                if (unzReadUInt8(&s->z_filefunc, s->filestream_with_CD, &value8) != UNZ_OK)
+                    err = UNZ_ERRNO;
+                file_info_internal.aes_encryption_mode = value8;
+                if (unzReadUInt16(&s->z_filefunc, s->filestream_with_CD, &value16) != UNZ_OK)
+                    err = UNZ_ERRNO;
+                file_info_internal.aes_compression_method = value16;
+            }
+#endif
+            else
+            {
+                if (ZSEEK64(s->z_filefunc, s->filestream_with_CD,extra_data_size, ZLIB_FILEFUNC_SEEK_CUR) != 0)
+                    err = UNZ_ERRNO;
+            }
+
+            extra_pos += 2 + 2 + extra_data_size;
+        }
+    }
+
+    if (file_info.disk_num_start == s->gi.number_disk_with_CD)
+        file_info_internal.byte_before_the_zipfile = s->byte_before_the_zipfile;
+    else
+        file_info_internal.byte_before_the_zipfile = 0;
+
+    if (err == UNZ_OK)
+        err = unzGetCurrentFileInfoField(file, &seek, comment, comment_size, file_info.size_file_comment, 1);
+
+    if ((err == UNZ_OK) && (pfile_info != NULL))
+        *pfile_info = file_info;
+    if ((err == UNZ_OK) && (pfile_info_internal != NULL))
+        *pfile_info_internal = file_info_internal;
+
+    return err;
+}
+
+extern int ZEXPORT unzGetCurrentFileInfo(unzFile file, unz_file_info *pfile_info, char *filename,
+    uint16_t filename_size, void *extrafield, uint16_t extrafield_size, char *comment, uint16_t comment_size)
+{
+    unz_file_info64 file_info64;
+    int err = UNZ_OK;
+
+    err = unzGetCurrentFileInfoInternal(file, &file_info64, NULL, filename, filename_size,
+                extrafield, extrafield_size, comment, comment_size);
+
+    if ((err == UNZ_OK) && (pfile_info != NULL))
+    {
+        pfile_info->version = file_info64.version;
+        pfile_info->version_needed = file_info64.version_needed;
+        pfile_info->flag = file_info64.flag;
+        pfile_info->compression_method = file_info64.compression_method;
+        pfile_info->dos_date = file_info64.dos_date;
+        pfile_info->crc = file_info64.crc;
+
+        pfile_info->size_filename = file_info64.size_filename;
+        pfile_info->size_file_extra = file_info64.size_file_extra - file_info64.size_file_extra_internal;
+        pfile_info->size_file_comment = file_info64.size_file_comment;
+
+        pfile_info->disk_num_start = (uint16_t)file_info64.disk_num_start;
+        pfile_info->internal_fa = file_info64.internal_fa;
+        pfile_info->external_fa = file_info64.external_fa;
+
+        pfile_info->compressed_size = (uint32_t)file_info64.compressed_size;
+        pfile_info->uncompressed_size = (uint32_t)file_info64.uncompressed_size;
+    }
+    return err;
+}
+
+extern int ZEXPORT unzGetCurrentFileInfo64(unzFile file, unz_file_info64 * pfile_info, char *filename,
+    uint16_t filename_size, void *extrafield, uint16_t extrafield_size, char *comment, uint16_t comment_size)
+{
+    return unzGetCurrentFileInfoInternal(file, pfile_info, NULL, filename, filename_size,
+        extrafield, extrafield_size, comment,comment_size);
+}
+
+/* Read the local header of the current zipfile. Check the coherency of the local header and info in the
+   end of central directory about this file store in *piSizeVar the size of extra info in local header
+   (filename and size of extra field data) */
+static int unzCheckCurrentFileCoherencyHeader(unz64_internal *s, uint32_t *psize_variable, uint64_t *poffset_local_extrafield,
+    uint16_t *psize_local_extrafield)
+{
+    uint32_t magic = 0;
+    uint16_t value16 = 0;
+    uint32_t value32 = 0;
+    uint32_t flags = 0;
+    uint16_t size_filename = 0;
+    uint16_t size_extra_field = 0;
+    uint16_t compression_method = 0;
+    int err = UNZ_OK;
+
+    if (psize_variable == NULL)
+        return UNZ_PARAMERROR;
+    *psize_variable = 0;
+    if (poffset_local_extrafield == NULL)
+        return UNZ_PARAMERROR;
+    *poffset_local_extrafield = 0;
+    if (psize_local_extrafield == NULL)
+        return UNZ_PARAMERROR;
+    *psize_local_extrafield = 0;
+
+    err = unzGoToNextDisk((unzFile)s);
+    if (err != UNZ_OK)
+        return err;
+
+    if (ZSEEK64(s->z_filefunc, s->filestream, s->cur_file_info_internal.offset_curfile +
+        s->cur_file_info_internal.byte_before_the_zipfile, ZLIB_FILEFUNC_SEEK_SET) != 0)
+        return UNZ_ERRNO;
+
+    if (err == UNZ_OK)
+    {
+        if (unzReadUInt32(&s->z_filefunc, s->filestream, &magic) != UNZ_OK)
+            err = UNZ_ERRNO;
+        else if (magic != LOCALHEADERMAGIC)
+            err = UNZ_BADZIPFILE;
+    }
+
+    if (unzReadUInt16(&s->z_filefunc, s->filestream, &value16) != UNZ_OK)
+        err = UNZ_ERRNO;
+    if (unzReadUInt16(&s->z_filefunc, s->filestream, &value16) != UNZ_OK)
+        err = UNZ_ERRNO;
+    flags = value16;
+    if (unzReadUInt16(&s->z_filefunc, s->filestream, &value16) != UNZ_OK)
+        err = UNZ_ERRNO;
+    else if ((err == UNZ_OK) && (value16 != s->cur_file_info.compression_method))
+        err = UNZ_BADZIPFILE;
+
+    compression_method = s->cur_file_info.compression_method;
+#ifdef HAVE_AES
+    if (compression_method == AES_METHOD)
+        compression_method = s->cur_file_info_internal.aes_compression_method;
+#endif
+
+    if ((err == UNZ_OK) && (compression_method != 0) && (compression_method != Z_DEFLATED))
+    {
+#ifdef HAVE_BZIP2
+        if (compression_method != Z_BZIP2ED)
+#endif
+            err = UNZ_BADZIPFILE;
+    }
+
+    if (unzReadUInt32(&s->z_filefunc, s->filestream, &value32) != UNZ_OK) /* date/time */
+        err = UNZ_ERRNO;
+    if (unzReadUInt32(&s->z_filefunc, s->filestream, &value32) != UNZ_OK) /* crc */
+        err = UNZ_ERRNO;
+    else if ((err == UNZ_OK) && (value32 != s->cur_file_info.crc) && ((flags & 8) == 0))
+        err = UNZ_BADZIPFILE;
+    if (unzReadUInt32(&s->z_filefunc, s->filestream, &value32) != UNZ_OK) /* size compr */
+        err = UNZ_ERRNO;
+    else if ((value32 != UINT32_MAX) && (err == UNZ_OK) && (value32 != s->cur_file_info.compressed_size) && ((flags & 8) == 0))
+        err = UNZ_BADZIPFILE;
+    if (unzReadUInt32(&s->z_filefunc, s->filestream, &value32) != UNZ_OK) /* size uncompr */
+        err = UNZ_ERRNO;
+    else if ((value32 != UINT32_MAX) && (err == UNZ_OK) && (value32 != s->cur_file_info.uncompressed_size) && ((flags & 8) == 0))
+        err = UNZ_BADZIPFILE;
+    if (unzReadUInt16(&s->z_filefunc, s->filestream, &size_filename) != UNZ_OK)
+        err = UNZ_ERRNO;
+
+    *psize_variable += size_filename;
+
+    if (unzReadUInt16(&s->z_filefunc, s->filestream, &size_extra_field) != UNZ_OK)
+        err = UNZ_ERRNO;
+
+    *poffset_local_extrafield = s->cur_file_info_internal.offset_curfile + SIZEZIPLOCALHEADER + size_filename;
+    *psize_local_extrafield = size_extra_field;
+    *psize_variable += size_extra_field;
 
     return err;
 }
@@ -1064,62 +1031,49 @@ local int unzlocal_CheckCurrentFileCoherencyHeader (s,piSizeVar,
   Open for reading data the current file in the zipfile.
   If there is no error and the file is opened, the return value is UNZ_OK.
 */
-extern int ZEXPORT unzOpenCurrentFile3 (file, method, level, raw, password)
-    unzFile file;
-    int* method;
-    int* level;
-    int raw;
-    const char* password;
+extern int ZEXPORT unzOpenCurrentFile3(unzFile file, int *method, int *level, int raw, const char *password)
 {
-    int err=UNZ_OK;
-    uInt iSizeVar;
-    unz_s* s;
-    file_in_zip_read_info_s* pfile_in_zip_read_info;
-    uLong offset_local_extrafield;  /* offset of the local extra field */
-    uInt  size_local_extrafield;    /* size of the local extra field */
-#    ifndef NOUNCRYPT
+    unz64_internal *s = NULL;
+    file_in_zip64_read_info_s *pfile_in_zip_read_info = NULL;
+    uint16_t compression_method = 0;
+    uint64_t offset_local_extrafield = 0;
+    uint16_t size_local_extrafield = 0;
+    uint32_t size_variable = 0;
+    int err = UNZ_OK;
+#ifndef NOUNCRYPT
     char source[12];
-#    else
+#else
     if (password != NULL)
         return UNZ_PARAMERROR;
-#    endif
-
-    if (file==NULL)
+#endif
+    if (file == NULL)
         return UNZ_PARAMERROR;
-    s=(unz_s*)file;
+    s = (unz64_internal*)file;
     if (!s->current_file_ok)
         return UNZ_PARAMERROR;
 
     if (s->pfile_in_zip_read != NULL)
         unzCloseCurrentFile(file);
 
-    if (unzlocal_CheckCurrentFileCoherencyHeader(s,&iSizeVar,
-                &offset_local_extrafield,&size_local_extrafield)!=UNZ_OK)
+    if (unzCheckCurrentFileCoherencyHeader(s, &size_variable, &offset_local_extrafield, &size_local_extrafield) != UNZ_OK)
         return UNZ_BADZIPFILE;
-
-    pfile_in_zip_read_info = (file_in_zip_read_info_s*)
-                                        ALLOC(sizeof(file_in_zip_read_info_s));
-    if (pfile_in_zip_read_info==NULL)
-        return UNZ_INTERNALERROR;
-
-    pfile_in_zip_read_info->read_buffer=(char*)ALLOC(UNZ_BUFSIZE);
-    pfile_in_zip_read_info->offset_local_extrafield = offset_local_extrafield;
-    pfile_in_zip_read_info->size_local_extrafield = size_local_extrafield;
-    pfile_in_zip_read_info->pos_local_extrafield=0;
-    pfile_in_zip_read_info->raw=raw;
-
-    if (pfile_in_zip_read_info->read_buffer==NULL)
+    
+    compression_method = s->cur_file_info.compression_method;
+#ifdef HAVE_AES
+    if (compression_method == AES_METHOD)
     {
-        TRYFREE(pfile_in_zip_read_info);
-        return UNZ_INTERNALERROR;
+        compression_method = s->cur_file_info_internal.aes_compression_method;
+        if (password == NULL)
+        {
+            return UNZ_PARAMERROR;
+        }
     }
+#endif
 
-    pfile_in_zip_read_info->stream_initialised=0;
+    if (method != NULL)
+        *method = compression_method;
 
-    if (method!=NULL)
-        *method = (int)s->cur_file_info.compression_method;
-
-    if (level!=NULL)
+    if (level != NULL)
     {
         *level = 6;
         switch (s->cur_file_info.flag & 0x06)
@@ -1130,238 +1084,447 @@ extern int ZEXPORT unzOpenCurrentFile3 (file, method, level, raw, password)
         }
     }
 
-    if ((s->cur_file_info.compression_method!=0) &&
-        (s->cur_file_info.compression_method!=Z_DEFLATED))
-        return UNZ_BADZIPFILE;
-
-    pfile_in_zip_read_info->crc32_wait=s->cur_file_info.crc;
-    pfile_in_zip_read_info->crc32=0;
-    pfile_in_zip_read_info->compression_method =
-            s->cur_file_info.compression_method;
-    pfile_in_zip_read_info->filestream=s->filestream;
-    pfile_in_zip_read_info->z_filefunc=s->z_filefunc;
-    pfile_in_zip_read_info->byte_before_the_zipfile=s->byte_before_the_zipfile;
-
-    pfile_in_zip_read_info->stream.total_out = 0;
-
-    if ((s->cur_file_info.compression_method==Z_DEFLATED) &&
-        (!raw))
+    if ((compression_method != 0) && (compression_method != Z_DEFLATED))
     {
-      pfile_in_zip_read_info->stream.zalloc = (alloc_func)0;
-      pfile_in_zip_read_info->stream.zfree = (free_func)0;
-      pfile_in_zip_read_info->stream.opaque = (voidpf)0;
-      pfile_in_zip_read_info->stream.next_in = (voidpf)0;
-      pfile_in_zip_read_info->stream.avail_in = 0;
-
-      err=inflateInit2(&pfile_in_zip_read_info->stream, -MAX_WBITS);
-      if (err == Z_OK)
-        pfile_in_zip_read_info->stream_initialised=1;
-      else
-      {
-        TRYFREE(pfile_in_zip_read_info);
-        return err;
-      }
-        /* windowBits is passed < 0 to tell that there is no zlib header.
-         * Note that in this case inflate *requires* an extra "dummy" byte
-         * after the compressed stream in order to complete decompression and
-         * return Z_STREAM_END.
-         * In unzip, i don't wait absolutely Z_STREAM_END because I known the
-         * size of both compressed and uncompressed data
-         */
+#ifdef HAVE_BZIP2
+        if (compression_method != Z_BZIP2ED)
+#endif
+        {
+            return UNZ_BADZIPFILE;
+        }
     }
-    pfile_in_zip_read_info->rest_read_compressed =
-            s->cur_file_info.compressed_size ;
-    pfile_in_zip_read_info->rest_read_uncompressed =
-            s->cur_file_info.uncompressed_size ;
+    
+    pfile_in_zip_read_info = (file_in_zip64_read_info_s*)ALLOC(sizeof(file_in_zip64_read_info_s));
+    if (pfile_in_zip_read_info == NULL)
+        return UNZ_INTERNALERROR;
 
+    pfile_in_zip_read_info->read_buffer = (uint8_t*)ALLOC(UNZ_BUFSIZE);
+    if (pfile_in_zip_read_info->read_buffer == NULL)
+    {
+        TRYFREE(pfile_in_zip_read_info);
+        return UNZ_INTERNALERROR;
+    }
+    
+    pfile_in_zip_read_info->stream_initialised = 0;
 
-    pfile_in_zip_read_info->pos_in_zipfile =
-            s->cur_file_info_internal.offset_curfile + SIZEZIPLOCALHEADER +
-              iSizeVar;
+    pfile_in_zip_read_info->filestream = s->filestream;
+    pfile_in_zip_read_info->z_filefunc = s->z_filefunc;
 
-    pfile_in_zip_read_info->stream.avail_in = (uInt)0;
+    pfile_in_zip_read_info->raw = raw;
+    pfile_in_zip_read_info->crc32 = 0;
+    pfile_in_zip_read_info->crc32_expected = s->cur_file_info.crc;
+    pfile_in_zip_read_info->total_out_64 = 0;
+    pfile_in_zip_read_info->compression_method = compression_method;
+    
+    pfile_in_zip_read_info->offset_local_extrafield = offset_local_extrafield;
+    pfile_in_zip_read_info->size_local_extrafield = size_local_extrafield;
+    pfile_in_zip_read_info->pos_local_extrafield = 0;
+
+    pfile_in_zip_read_info->rest_read_compressed = s->cur_file_info.compressed_size;
+    pfile_in_zip_read_info->rest_read_uncompressed = s->cur_file_info.uncompressed_size;
+    pfile_in_zip_read_info->byte_before_the_zipfile = 0;
+
+    if (s->number_disk == s->gi.number_disk_with_CD)
+        pfile_in_zip_read_info->byte_before_the_zipfile = s->byte_before_the_zipfile;
+        
+    pfile_in_zip_read_info->pos_in_zipfile = s->cur_file_info_internal.offset_curfile + SIZEZIPLOCALHEADER + size_variable;
+
+    pfile_in_zip_read_info->stream.zalloc = (alloc_func)0;
+    pfile_in_zip_read_info->stream.zfree = (free_func)0;
+    pfile_in_zip_read_info->stream.opaque = (voidpf)s;
+    pfile_in_zip_read_info->stream.total_out = 0;
+    pfile_in_zip_read_info->stream.total_in = 0;
+    pfile_in_zip_read_info->stream.next_in = NULL;
+    pfile_in_zip_read_info->stream.avail_in = 0;
+
+    if (!raw)
+    {
+        if (compression_method == Z_BZIP2ED)
+        {
+#ifdef HAVE_BZIP2
+            pfile_in_zip_read_info->bstream.bzalloc = (void *(*) (void *, int, int))0;
+            pfile_in_zip_read_info->bstream.bzfree = (free_func)0;
+            pfile_in_zip_read_info->bstream.opaque = (voidpf)0;
+            pfile_in_zip_read_info->bstream.state = (voidpf)0;
+
+            err = BZ2_bzDecompressInit(&pfile_in_zip_read_info->bstream, 0, 0);
+            if (err == Z_OK)
+            {
+                pfile_in_zip_read_info->stream_initialised = Z_BZIP2ED;
+            }
+            else
+            {
+                TRYFREE(pfile_in_zip_read_info);
+                return err;
+            }
+#else
+            pfile_in_zip_read_info->raw = 1;
+#endif
+        }
+        else if (compression_method == Z_DEFLATED)
+        {
+#ifdef HAVE_APPLE_COMPRESSION
+            err = compression_stream_init(&pfile_in_zip_read_info->astream, COMPRESSION_STREAM_DECODE, COMPRESSION_ZLIB);
+            if (err == COMPRESSION_STATUS_ERROR)
+                err = UNZ_INTERNALERROR;
+            else
+                err = Z_OK;
+#else
+            err = inflateInit2(&pfile_in_zip_read_info->stream, -MAX_WBITS);
+#endif
+            if (err == Z_OK)
+            {
+                pfile_in_zip_read_info->stream_initialised = Z_DEFLATED;
+            }
+            else
+            {
+                TRYFREE(pfile_in_zip_read_info);
+                return err;
+            }
+            /* windowBits is passed < 0 to tell that there is no zlib header.
+             * Note that in this case inflate *requires* an extra "dummy" byte
+             * after the compressed stream in order to complete decompression and
+             * return Z_STREAM_END.
+             * In unzip, i don't wait absolutely Z_STREAM_END because I known the
+             * size of both compressed and uncompressed data
+             */
+        }
+    }
 
     s->pfile_in_zip_read = pfile_in_zip_read_info;
 
-#    ifndef NOUNCRYPT
-    if (password != NULL)
+#ifndef NOUNCRYPT
+    s->pcrc_32_tab = NULL;
+
+    if ((password != NULL) && ((s->cur_file_info.flag & 1) != 0))
     {
-        int i;
-        s->pcrc_32_tab = get_crc_table();
-        init_keys(password,s->keys,s->pcrc_32_tab);
-        if (ZSEEK(s->z_filefunc, s->filestream,
-                  s->pfile_in_zip_read->pos_in_zipfile +
-                     s->pfile_in_zip_read->byte_before_the_zipfile,
-                  SEEK_SET)!=0)
+        if (ZSEEK64(s->z_filefunc, s->filestream,
+                  s->pfile_in_zip_read->pos_in_zipfile + s->pfile_in_zip_read->byte_before_the_zipfile,
+                  ZLIB_FILEFUNC_SEEK_SET) != 0)
             return UNZ_INTERNALERROR;
-        if(ZREAD(s->z_filefunc, s->filestream,source, 12)<12)
-            return UNZ_INTERNALERROR;
+#ifdef HAVE_AES
+        if (s->cur_file_info.compression_method == AES_METHOD)
+        {
+            unsigned char passverify_archive[AES_PWVERIFYSIZE];
+            unsigned char passverify_password[AES_PWVERIFYSIZE];
+            unsigned char salt_value[AES_MAXSALTLENGTH];
+            uint32_t salt_length = 0;
 
-        for (i = 0; i<12; i++)
-            zdecode(s->keys,s->pcrc_32_tab,source[i]);
+            if ((s->cur_file_info_internal.aes_encryption_mode < 1) ||
+                (s->cur_file_info_internal.aes_encryption_mode > 3))
+                return UNZ_INTERNALERROR;
 
-        s->pfile_in_zip_read->pos_in_zipfile+=12;
-        s->encrypted=1;
+            salt_length = SALT_LENGTH(s->cur_file_info_internal.aes_encryption_mode);
+
+            if (ZREAD64(s->z_filefunc, s->filestream, salt_value, salt_length) != salt_length)
+                return UNZ_INTERNALERROR;
+            if (ZREAD64(s->z_filefunc, s->filestream, passverify_archive, AES_PWVERIFYSIZE) != AES_PWVERIFYSIZE)
+                return UNZ_INTERNALERROR;
+
+            fcrypt_init(s->cur_file_info_internal.aes_encryption_mode, (uint8_t *)password,
+                (uint32_t)strlen(password), salt_value, passverify_password, &s->pfile_in_zip_read->aes_ctx);
+
+            if (memcmp(passverify_archive, passverify_password, AES_PWVERIFYSIZE) != 0)
+                return UNZ_BADPASSWORD;
+
+            s->pfile_in_zip_read->rest_read_compressed -= salt_length + AES_PWVERIFYSIZE;
+            s->pfile_in_zip_read->rest_read_compressed -= AES_AUTHCODESIZE;
+
+            s->pfile_in_zip_read->pos_in_zipfile += salt_length + AES_PWVERIFYSIZE;
+        }
+        else
+#endif
+        {
+            int i;
+            uint8_t expected;
+            uint8_t actual;
+           
+            s->pcrc_32_tab = (const z_crc_t*)get_crc_table();
+            init_keys(password, s->keys, s->pcrc_32_tab);
+
+            if (ZREAD64(s->z_filefunc, s->filestream, source, 12) < 12)
+                return UNZ_INTERNALERROR;
+
+            for (i = 0; i < 12; i++)
+                zdecode(s->keys, s->pcrc_32_tab, source[i]);
+            expected = (s->cur_file_info.flag & (1 << 3)) ?
+                s->cur_file_info.dos_date >> 8 :
+                s->cur_file_info.crc >> 24;
+            actual = (uint8_t)source[11];
+            if ((actual != 0) && (expected != actual)) {
+              return UNZ_BADPASSWORD;
+            }
+
+            s->pfile_in_zip_read->rest_read_compressed -= 12;
+            s->pfile_in_zip_read->pos_in_zipfile += 12;
+        }
     }
-#    endif
-
+#endif
 
     return UNZ_OK;
 }
 
-extern int ZEXPORT unzOpenCurrentFile (file)
-    unzFile file;
+extern int ZEXPORT unzOpenCurrentFile(unzFile file)
 {
     return unzOpenCurrentFile3(file, NULL, NULL, 0, NULL);
 }
 
-extern int ZEXPORT unzOpenCurrentFilePassword (file, password)
-    unzFile file;
-    const char* password;
+extern int ZEXPORT unzOpenCurrentFilePassword(unzFile file, const char *password)
 {
     return unzOpenCurrentFile3(file, NULL, NULL, 0, password);
 }
 
-extern int ZEXPORT unzOpenCurrentFile2 (file,method,level,raw)
-    unzFile file;
-    int* method;
-    int* level;
-    int raw;
+extern int ZEXPORT unzOpenCurrentFile2(unzFile file, int *method, int *level, int raw)
 {
     return unzOpenCurrentFile3(file, method, level, raw, NULL);
 }
 
-/*
-  Read bytes from the current file.
-  buf contain buffer where data must be copied
-  len the size of buf.
+/* Read bytes from the current file.
+   buf contain buffer where data must be copied
+   len the size of buf.
 
-  return the number of byte copied if somes bytes are copied
-  return 0 if the end of file was reached
-  return <0 with error code if there is an error
-    (UNZ_ERRNO for IO error, or zLib error for uncompress error)
-*/
-extern int ZEXPORT unzReadCurrentFile  (file, buf, len)
-    unzFile file;
-    voidp buf;
-    unsigned len;
+   return the number of byte copied if some bytes are copied
+   return 0 if the end of file was reached
+   return <0 with error code if there is an error (UNZ_ERRNO for IO error, or zLib error for uncompress error) */
+extern int ZEXPORT unzReadCurrentFile(unzFile file, voidp buf, uint32_t len)
 {
-    int err=UNZ_OK;
-    uInt iRead = 0;
-    unz_s* s;
-    file_in_zip_read_info_s* pfile_in_zip_read_info;
-    if (file==NULL)
+    unz64_internal *s = NULL;
+    uint32_t read = 0;
+    int err = UNZ_OK;
+
+    if (file == NULL)
         return UNZ_PARAMERROR;
-    s=(unz_s*)file;
-    pfile_in_zip_read_info=s->pfile_in_zip_read;
+    s = (unz64_internal*)file;
 
-    if (pfile_in_zip_read_info==NULL)
+    if (s->pfile_in_zip_read == NULL)
         return UNZ_PARAMERROR;
-
-
-    if (pfile_in_zip_read_info->read_buffer == NULL)
+    if (s->pfile_in_zip_read->read_buffer == NULL)
         return UNZ_END_OF_LIST_OF_FILE;
-    if (len==0)
+    if (len == 0)
         return 0;
+    // avail_out is uInt, so uint32_t len might allow requesting a larger buffer than zlib can support
+    if (len > UINT_MAX)
+        return UNZ_PARAMERROR;
 
-    pfile_in_zip_read_info->stream.next_out = (Bytef*)buf;
+    s->pfile_in_zip_read->stream.next_out = (uint8_t*)buf;
+    s->pfile_in_zip_read->stream.avail_out = (uInt)len;
 
-    pfile_in_zip_read_info->stream.avail_out = (uInt)len;
-
-    if ((len>pfile_in_zip_read_info->rest_read_uncompressed) &&
-        (!(pfile_in_zip_read_info->raw)))
-        pfile_in_zip_read_info->stream.avail_out =
-            (uInt)pfile_in_zip_read_info->rest_read_uncompressed;
-
-    if ((len>pfile_in_zip_read_info->rest_read_compressed+
-           pfile_in_zip_read_info->stream.avail_in) &&
-         (pfile_in_zip_read_info->raw))
-        pfile_in_zip_read_info->stream.avail_out =
-            (uInt)pfile_in_zip_read_info->rest_read_compressed+
-            pfile_in_zip_read_info->stream.avail_in;
-
-    while (pfile_in_zip_read_info->stream.avail_out>0)
+    if ((s->pfile_in_zip_read->compression_method == 0) || (s->pfile_in_zip_read->raw))
     {
-        if ((pfile_in_zip_read_info->stream.avail_in==0) &&
-            (pfile_in_zip_read_info->rest_read_compressed>0))
+        if (len > s->pfile_in_zip_read->rest_read_compressed + s->pfile_in_zip_read->stream.avail_in)
+            s->pfile_in_zip_read->stream.avail_out = (uInt)s->pfile_in_zip_read->rest_read_compressed +
+            s->pfile_in_zip_read->stream.avail_in;
+    }
+
+    do
+    {
+        if (s->pfile_in_zip_read->stream.avail_in == 0)
         {
-            uInt uReadThis = UNZ_BUFSIZE;
-            if (pfile_in_zip_read_info->rest_read_compressed<uReadThis)
-                uReadThis = (uInt)pfile_in_zip_read_info->rest_read_compressed;
-            if (uReadThis == 0)
-                return UNZ_EOF;
-            if (ZSEEK(pfile_in_zip_read_info->z_filefunc,
-                      pfile_in_zip_read_info->filestream,
-                      pfile_in_zip_read_info->pos_in_zipfile +
-                         pfile_in_zip_read_info->byte_before_the_zipfile,
-                         ZLIB_FILEFUNC_SEEK_SET)!=0)
-                return UNZ_ERRNO;
-            if (ZREAD(pfile_in_zip_read_info->z_filefunc,
-                      pfile_in_zip_read_info->filestream,
-                      pfile_in_zip_read_info->read_buffer,
-                      uReadThis)!=uReadThis)
-                return UNZ_ERRNO;
+            uint32_t bytes_to_read = UNZ_BUFSIZE;
+            uint32_t bytes_not_read = 0;
+            uint32_t bytes_read = 0;
+            uint32_t total_bytes_read = 0;
 
+            if (s->pfile_in_zip_read->stream.next_in != NULL)
+                bytes_not_read = (uint32_t)(s->pfile_in_zip_read->read_buffer + UNZ_BUFSIZE -
+                    s->pfile_in_zip_read->stream.next_in);
+            bytes_to_read -= bytes_not_read;
+            if (bytes_not_read > 0)
+                memmove(s->pfile_in_zip_read->read_buffer, s->pfile_in_zip_read->stream.next_in, bytes_not_read);
+            if (s->pfile_in_zip_read->rest_read_compressed < bytes_to_read)
+                bytes_to_read = (uint32_t)s->pfile_in_zip_read->rest_read_compressed;
 
-#            ifndef NOUNCRYPT
-            if(s->encrypted)
+            while (total_bytes_read != bytes_to_read)
             {
-                uInt i;
-                for(i=0;i<uReadThis;i++)
-                  pfile_in_zip_read_info->read_buffer[i] =
-                      zdecode(s->keys,s->pcrc_32_tab,
-                              pfile_in_zip_read_info->read_buffer[i]);
+                if (ZSEEK64(s->pfile_in_zip_read->z_filefunc, s->pfile_in_zip_read->filestream,
+                        s->pfile_in_zip_read->pos_in_zipfile + s->pfile_in_zip_read->byte_before_the_zipfile,
+                        ZLIB_FILEFUNC_SEEK_SET) != 0)
+                    return UNZ_ERRNO;
+
+                bytes_read = ZREAD64(s->pfile_in_zip_read->z_filefunc, s->pfile_in_zip_read->filestream,
+                          s->pfile_in_zip_read->read_buffer + bytes_not_read + total_bytes_read,
+                          bytes_to_read - total_bytes_read);
+
+                total_bytes_read += bytes_read;
+                s->pfile_in_zip_read->pos_in_zipfile += bytes_read;
+
+                if (bytes_read == 0)
+                {
+                    if (ZERROR64(s->pfile_in_zip_read->z_filefunc, s->pfile_in_zip_read->filestream))
+                        return UNZ_ERRNO;
+
+                    err = unzGoToNextDisk(file);
+                    if (err != UNZ_OK)
+                        return err;
+
+                    s->pfile_in_zip_read->pos_in_zipfile = 0;
+                    s->pfile_in_zip_read->filestream = s->filestream;
+                }
             }
-#            endif
 
+#ifndef NOUNCRYPT
+            if ((s->cur_file_info.flag & 1) != 0)
+            {
+#ifdef HAVE_AES
+                if (s->cur_file_info.compression_method == AES_METHOD)
+                {
+                    fcrypt_decrypt(s->pfile_in_zip_read->read_buffer, bytes_to_read, &s->pfile_in_zip_read->aes_ctx);
+                }
+                else
+#endif
+                if (s->pcrc_32_tab != NULL)
+                {
+                    uint32_t i = 0;
 
-            pfile_in_zip_read_info->pos_in_zipfile += uReadThis;
+                    for (i = 0; i < total_bytes_read; i++)
+                      s->pfile_in_zip_read->read_buffer[i] =
+                          zdecode(s->keys, s->pcrc_32_tab, s->pfile_in_zip_read->read_buffer[i]);
+                }
+            }
+#endif
 
-            pfile_in_zip_read_info->rest_read_compressed-=uReadThis;
-
-            pfile_in_zip_read_info->stream.next_in =
-                (Bytef*)pfile_in_zip_read_info->read_buffer;
-            pfile_in_zip_read_info->stream.avail_in = (uInt)uReadThis;
+            s->pfile_in_zip_read->rest_read_compressed -= total_bytes_read;
+            s->pfile_in_zip_read->stream.next_in = (uint8_t*)s->pfile_in_zip_read->read_buffer;
+            s->pfile_in_zip_read->stream.avail_in = (uInt)(bytes_not_read + total_bytes_read);
         }
 
-        if ((pfile_in_zip_read_info->compression_method==0) || (pfile_in_zip_read_info->raw))
+        if ((s->pfile_in_zip_read->compression_method == 0) || (s->pfile_in_zip_read->raw))
         {
-            uInt uDoCopy,i ;
+            uint32_t i = 0;
+            uint32_t copy = 0;
 
-            if ((pfile_in_zip_read_info->stream.avail_in == 0) &&
-                (pfile_in_zip_read_info->rest_read_compressed == 0))
-                return (iRead==0) ? UNZ_EOF : iRead;
+            if ((s->pfile_in_zip_read->stream.avail_in == 0) &&
+                (s->pfile_in_zip_read->rest_read_compressed == 0))
+                return (read == 0) ? UNZ_EOF : read;
 
-            if (pfile_in_zip_read_info->stream.avail_out <
-                            pfile_in_zip_read_info->stream.avail_in)
-                uDoCopy = pfile_in_zip_read_info->stream.avail_out ;
+            if (s->pfile_in_zip_read->stream.avail_out < s->pfile_in_zip_read->stream.avail_in)
+                copy = s->pfile_in_zip_read->stream.avail_out;
             else
-                uDoCopy = pfile_in_zip_read_info->stream.avail_in ;
+                copy = s->pfile_in_zip_read->stream.avail_in;
 
-            for (i=0;i<uDoCopy;i++)
-                *(pfile_in_zip_read_info->stream.next_out+i) =
-                        *(pfile_in_zip_read_info->stream.next_in+i);
+            for (i = 0; i < copy; i++)
+                *(s->pfile_in_zip_read->stream.next_out + i) =
+                        *(s->pfile_in_zip_read->stream.next_in + i);
 
-            pfile_in_zip_read_info->crc32 = crc32(pfile_in_zip_read_info->crc32,
-                                pfile_in_zip_read_info->stream.next_out,
-                                uDoCopy);
-            pfile_in_zip_read_info->rest_read_uncompressed-=uDoCopy;
-            pfile_in_zip_read_info->stream.avail_in -= uDoCopy;
-            pfile_in_zip_read_info->stream.avail_out -= uDoCopy;
-            pfile_in_zip_read_info->stream.next_out += uDoCopy;
-            pfile_in_zip_read_info->stream.next_in += uDoCopy;
-            pfile_in_zip_read_info->stream.total_out += uDoCopy;
-            iRead += uDoCopy;
+            s->pfile_in_zip_read->total_out_64 = s->pfile_in_zip_read->total_out_64 + copy;
+            s->pfile_in_zip_read->rest_read_uncompressed -= copy;
+            s->pfile_in_zip_read->crc32 = (uint32_t)crc32(s->pfile_in_zip_read->crc32,
+                                s->pfile_in_zip_read->stream.next_out, copy);
+
+            s->pfile_in_zip_read->stream.avail_in -= copy;
+            s->pfile_in_zip_read->stream.avail_out -= copy;
+            s->pfile_in_zip_read->stream.next_out += copy;
+            s->pfile_in_zip_read->stream.next_in += copy;
+            s->pfile_in_zip_read->stream.total_out += copy;
+
+            read += copy;
         }
+        else if (s->pfile_in_zip_read->compression_method == Z_BZIP2ED)
+        {
+#ifdef HAVE_BZIP2
+            uint64_t total_out_before = 0;
+            uint64_t total_out_after = 0;
+            uint64_t out_bytes = 0;
+            const uint8_t *buf_before = NULL;
+
+            s->pfile_in_zip_read->bstream.next_in        = (char*)s->pfile_in_zip_read->stream.next_in;
+            s->pfile_in_zip_read->bstream.avail_in       = s->pfile_in_zip_read->stream.avail_in;
+            s->pfile_in_zip_read->bstream.total_in_lo32  = (uint32_t)s->pfile_in_zip_read->stream.total_in;
+            s->pfile_in_zip_read->bstream.total_in_hi32  = s->pfile_in_zip_read->stream.total_in >> 32;
+            
+            s->pfile_in_zip_read->bstream.next_out       = (char*)s->pfile_in_zip_read->stream.next_out;
+            s->pfile_in_zip_read->bstream.avail_out      = s->pfile_in_zip_read->stream.avail_out;
+            s->pfile_in_zip_read->bstream.total_out_lo32 = (uint32_t)s->pfile_in_zip_read->stream.total_out;
+            s->pfile_in_zip_read->bstream.total_out_hi32 = s->pfile_in_zip_read->stream.total_out >> 32;
+
+            total_out_before = s->pfile_in_zip_read->bstream.total_out_lo32 + 
+                (((uint32_t)s->pfile_in_zip_read->bstream.total_out_hi32) << 32);
+            buf_before = (const uint8_t*)s->pfile_in_zip_read->bstream.next_out;
+
+            err = BZ2_bzDecompress(&s->pfile_in_zip_read->bstream);
+
+            total_out_after = s->pfile_in_zip_read->bstream.total_out_lo32 + 
+                (((uint32_t)s->pfile_in_zip_read->bstream.total_out_hi32) << 32);
+
+            out_bytes = total_out_after - total_out_before;
+
+            s->pfile_in_zip_read->total_out_64 = s->pfile_in_zip_read->total_out_64 + out_bytes;
+            s->pfile_in_zip_read->rest_read_uncompressed -= out_bytes;
+            s->pfile_in_zip_read->crc32 = crc32(s->pfile_in_zip_read->crc32, buf_before, (uint32_t)out_bytes);
+
+            read += (uint32_t)out_bytes;
+
+            s->pfile_in_zip_read->stream.next_in   = (uint8_t*)s->pfile_in_zip_read->bstream.next_in;
+            s->pfile_in_zip_read->stream.avail_in  = s->pfile_in_zip_read->bstream.avail_in;
+            s->pfile_in_zip_read->stream.total_in  = s->pfile_in_zip_read->bstream.total_in_lo32;
+            s->pfile_in_zip_read->stream.next_out  = (uint8_t*)s->pfile_in_zip_read->bstream.next_out;
+            s->pfile_in_zip_read->stream.avail_out = s->pfile_in_zip_read->bstream.avail_out;
+            s->pfile_in_zip_read->stream.total_out = s->pfile_in_zip_read->bstream.total_out_lo32;
+
+            if (err == BZ_STREAM_END)
+                return (read == 0) ? UNZ_EOF : read;
+            if (err != BZ_OK)
+                break;
+#endif
+        }
+#ifdef HAVE_APPLE_COMPRESSION
         else
         {
-            uLong uTotalOutBefore,uTotalOutAfter;
-            const Bytef *bufBefore;
-            uLong uOutThis;
-            int flush=Z_SYNC_FLUSH;
+            uint64_t total_out_before = 0;
+            uint64_t total_out_after = 0;
+            uint64_t out_bytes = 0;
+            const uint8_t *buf_before = NULL;
 
-            uTotalOutBefore = pfile_in_zip_read_info->stream.total_out;
-            bufBefore = pfile_in_zip_read_info->stream.next_out;
+            s->pfile_in_zip_read->astream.src_ptr = s->pfile_in_zip_read->stream.next_in;
+            s->pfile_in_zip_read->astream.src_size = s->pfile_in_zip_read->stream.avail_in;
+            s->pfile_in_zip_read->astream.dst_ptr = s->pfile_in_zip_read->stream.next_out;
+            s->pfile_in_zip_read->astream.dst_size = len;
+
+            total_out_before = s->pfile_in_zip_read->stream.total_out;
+            buf_before = s->pfile_in_zip_read->stream.next_out;
+
+            compression_status status;
+            compression_stream_flags flags;
+
+            if (s->pfile_in_zip_read->stream.avail_in == 0)
+            {
+                flags = COMPRESSION_STREAM_FINALIZE;
+            }
+
+            status = compression_stream_process(&s->pfile_in_zip_read->astream, flags);
+
+            total_out_after = len - s->pfile_in_zip_read->astream.dst_size;
+            out_bytes = total_out_after - total_out_before;
+
+            s->pfile_in_zip_read->total_out_64 += out_bytes;
+            s->pfile_in_zip_read->rest_read_uncompressed -= out_bytes;
+            s->pfile_in_zip_read->crc32 =
+                crc32(s->pfile_in_zip_read->crc32, buf_before, (uint32_t)out_bytes);
+
+            read += (uint32_t)out_bytes;
+
+            s->pfile_in_zip_read->stream.next_in = s->pfile_in_zip_read->astream.src_ptr;
+            s->pfile_in_zip_read->stream.avail_in = s->pfile_in_zip_read->astream.src_size;
+            s->pfile_in_zip_read->stream.next_out = s->pfile_in_zip_read->astream.dst_ptr;
+            s->pfile_in_zip_read->stream.avail_out = s->pfile_in_zip_read->astream.dst_size;
+
+            if (status == COMPRESSION_STATUS_END)
+                return (read == 0) ? UNZ_EOF : read;
+            if (status == COMPRESSION_STATUS_ERROR)
+                return Z_DATA_ERROR;
+            return read;
+        }
+#else
+        else
+        {
+            uint64_t total_out_before = 0;
+            uint64_t total_out_after = 0;
+            uint64_t out_bytes = 0;
+            const uint8_t *buf_before = NULL;
+            int flush = Z_SYNC_FLUSH;
+
+            total_out_before = s->pfile_in_zip_read->stream.total_out;
+            buf_before = s->pfile_in_zip_read->stream.next_out;
 
             /*
             if ((pfile_in_zip_read_info->rest_read_uncompressed ==
@@ -1369,253 +1532,454 @@ extern int ZEXPORT unzReadCurrentFile  (file, buf, len)
                 (pfile_in_zip_read_info->rest_read_compressed == 0))
                 flush = Z_FINISH;
             */
-            err=inflate(&pfile_in_zip_read_info->stream,flush);
+            err = inflate(&s->pfile_in_zip_read->stream, flush);
 
-            if ((err>=0) && (pfile_in_zip_read_info->stream.msg!=NULL))
-              err = Z_DATA_ERROR;
+            if ((err >= 0) && (s->pfile_in_zip_read->stream.msg != NULL))
+                err = Z_DATA_ERROR;
 
-            uTotalOutAfter = pfile_in_zip_read_info->stream.total_out;
-            uOutThis = uTotalOutAfter-uTotalOutBefore;
+            total_out_after = s->pfile_in_zip_read->stream.total_out;
+            out_bytes = total_out_after - total_out_before;
 
-            pfile_in_zip_read_info->crc32 =
-                crc32(pfile_in_zip_read_info->crc32,bufBefore,
-                        (uInt)(uOutThis));
+            s->pfile_in_zip_read->total_out_64 += out_bytes;
+            s->pfile_in_zip_read->rest_read_uncompressed -= out_bytes;
+            s->pfile_in_zip_read->crc32 =
+                (uint32_t)crc32(s->pfile_in_zip_read->crc32,buf_before, (uint32_t)out_bytes);
 
-            pfile_in_zip_read_info->rest_read_uncompressed -=
-                uOutThis;
+            read += (uint32_t)out_bytes;
 
-            iRead += (uInt)(uTotalOutAfter - uTotalOutBefore);
-
-            if (err==Z_STREAM_END)
-                return (iRead==0) ? UNZ_EOF : iRead;
-            if (err!=Z_OK)
+            if (err == Z_STREAM_END)
+                return (read == 0) ? UNZ_EOF : read;
+            if (err != Z_OK)
                 break;
         }
+#endif
     }
+    while (s->pfile_in_zip_read->stream.avail_out > 0);
 
-    if (err==Z_OK)
-        return iRead;
+    if (err == Z_OK)
+        return read;
     return err;
 }
 
-
-/*
-  Give the current position in uncompressed data
-*/
-extern z_off_t ZEXPORT unztell (file)
-    unzFile file;
+extern int ZEXPORT unzGetLocalExtrafield(unzFile file, voidp buf, uint32_t len)
 {
-    unz_s* s;
-    file_in_zip_read_info_s* pfile_in_zip_read_info;
-    if (file==NULL)
+    unz64_internal *s = NULL;
+    uint64_t size_to_read = 0;
+    uint32_t read_now = 0;
+
+    if (file == NULL)
         return UNZ_PARAMERROR;
-    s=(unz_s*)file;
-    pfile_in_zip_read_info=s->pfile_in_zip_read;
-
-    if (pfile_in_zip_read_info==NULL)
-        return UNZ_PARAMERROR;
-
-    return (z_off_t)pfile_in_zip_read_info->stream.total_out;
-}
-
-
-/*
-  return 1 if the end of file was reached, 0 elsewhere
-*/
-extern int ZEXPORT unzeof (file)
-    unzFile file;
-{
-    unz_s* s;
-    file_in_zip_read_info_s* pfile_in_zip_read_info;
-    if (file==NULL)
-        return UNZ_PARAMERROR;
-    s=(unz_s*)file;
-    pfile_in_zip_read_info=s->pfile_in_zip_read;
-
-    if (pfile_in_zip_read_info==NULL)
+    s = (unz64_internal*)file;
+    if (s->pfile_in_zip_read == NULL)
         return UNZ_PARAMERROR;
 
-    if (pfile_in_zip_read_info->rest_read_uncompressed == 0)
-        return 1;
-    else
-        return 0;
-}
+    size_to_read = s->pfile_in_zip_read->size_local_extrafield - s->pfile_in_zip_read->pos_local_extrafield;
 
-
-
-/*
-  Read extra field from the current file (opened by unzOpenCurrentFile)
-  This is the local-header version of the extra field (sometimes, there is
-    more info in the local-header version than in the central-header)
-
-  if buf==NULL, it return the size of the local extra field that can be read
-
-  if buf!=NULL, len is the size of the buffer, the extra header is copied in
-    buf.
-  the return value is the number of bytes copied in buf, or (if <0)
-    the error code
-*/
-extern int ZEXPORT unzGetLocalExtrafield (file,buf,len)
-    unzFile file;
-    voidp buf;
-    unsigned len;
-{
-    unz_s* s;
-    file_in_zip_read_info_s* pfile_in_zip_read_info;
-    uInt read_now;
-    uLong size_to_read;
-
-    if (file==NULL)
-        return UNZ_PARAMERROR;
-    s=(unz_s*)file;
-    pfile_in_zip_read_info=s->pfile_in_zip_read;
-
-    if (pfile_in_zip_read_info==NULL)
-        return UNZ_PARAMERROR;
-
-    size_to_read = (pfile_in_zip_read_info->size_local_extrafield -
-                pfile_in_zip_read_info->pos_local_extrafield);
-
-    if (buf==NULL)
+    if (buf == NULL)
         return (int)size_to_read;
 
-    if (len>size_to_read)
-        read_now = (uInt)size_to_read;
+    if (len > size_to_read)
+        read_now = (uint32_t)size_to_read;
     else
-        read_now = (uInt)len ;
+        read_now = len;
 
-    if (read_now==0)
+    if (read_now == 0)
         return 0;
 
-    if (ZSEEK(pfile_in_zip_read_info->z_filefunc,
-              pfile_in_zip_read_info->filestream,
-              pfile_in_zip_read_info->offset_local_extrafield +
-              pfile_in_zip_read_info->pos_local_extrafield,
-              ZLIB_FILEFUNC_SEEK_SET)!=0)
+    if (ZSEEK64(s->pfile_in_zip_read->z_filefunc, s->pfile_in_zip_read->filestream,
+        s->pfile_in_zip_read->offset_local_extrafield + s->pfile_in_zip_read->pos_local_extrafield,
+        ZLIB_FILEFUNC_SEEK_SET) != 0)
         return UNZ_ERRNO;
 
-    if (ZREAD(pfile_in_zip_read_info->z_filefunc,
-              pfile_in_zip_read_info->filestream,
-              buf,read_now)!=read_now)
+    if (ZREAD64(s->pfile_in_zip_read->z_filefunc, s->pfile_in_zip_read->filestream, buf, read_now) != read_now)
         return UNZ_ERRNO;
 
     return (int)read_now;
 }
 
-/*
-  Close the file in zip opened with unzipOpenCurrentFile
-  Return UNZ_CRCERROR if all the file was read but the CRC is not good
-*/
-extern int ZEXPORT unzCloseCurrentFile (file)
-    unzFile file;
+extern int ZEXPORT unzCloseCurrentFile(unzFile file)
 {
-    int err=UNZ_OK;
+    unz64_internal *s = NULL;
+    file_in_zip64_read_info_s *pfile_in_zip_read_info = NULL;
+    int err = UNZ_OK;
 
-    unz_s* s;
-    file_in_zip_read_info_s* pfile_in_zip_read_info;
-    if (file==NULL)
+    if (file == NULL)
         return UNZ_PARAMERROR;
-    s=(unz_s*)file;
-    pfile_in_zip_read_info=s->pfile_in_zip_read;
-
-    if (pfile_in_zip_read_info==NULL)
+    s = (unz64_internal*)file;
+    pfile_in_zip_read_info = s->pfile_in_zip_read;
+    if (pfile_in_zip_read_info == NULL)
         return UNZ_PARAMERROR;
 
-
-    if ((pfile_in_zip_read_info->rest_read_uncompressed == 0) &&
-        (!pfile_in_zip_read_info->raw))
+#ifdef HAVE_AES
+    if (s->cur_file_info.compression_method == AES_METHOD)
     {
-        if (pfile_in_zip_read_info->crc32 != pfile_in_zip_read_info->crc32_wait)
-            err=UNZ_CRCERROR;
-    }
+        unsigned char authcode[AES_AUTHCODESIZE];
+        unsigned char rauthcode[AES_AUTHCODESIZE];
 
+        if (ZREAD64(s->z_filefunc, s->filestream, authcode, AES_AUTHCODESIZE) != AES_AUTHCODESIZE)
+            return UNZ_ERRNO;
+
+        if (fcrypt_end(rauthcode, &s->pfile_in_zip_read->aes_ctx) != AES_AUTHCODESIZE)
+            err = UNZ_CRCERROR;
+        if (memcmp(authcode, rauthcode, AES_AUTHCODESIZE) != 0)
+            err = UNZ_CRCERROR;
+    }
+    /* AES zip version AE-1 will expect a valid crc as well */
+    if ((s->cur_file_info.compression_method != AES_METHOD) ||
+        (s->cur_file_info_internal.aes_version == 0x0001))
+#endif
+    {
+        if ((pfile_in_zip_read_info->rest_read_uncompressed == 0) &&
+            (!pfile_in_zip_read_info->raw))
+        {
+            if (pfile_in_zip_read_info->crc32 != pfile_in_zip_read_info->crc32_expected)
+                err = UNZ_CRCERROR;
+        }
+    }
 
     TRYFREE(pfile_in_zip_read_info->read_buffer);
     pfile_in_zip_read_info->read_buffer = NULL;
-    if (pfile_in_zip_read_info->stream_initialised)
+    if (pfile_in_zip_read_info->stream_initialised == Z_DEFLATED)
+    {
+#ifdef HAVE_APPLE_COMPRESSION
+        if (compression_stream_destroy)
+            compression_stream_destroy(&pfile_in_zip_read_info->astream);
+#else
         inflateEnd(&pfile_in_zip_read_info->stream);
+#endif
+        
+    }
+#ifdef HAVE_BZIP2
+    else if (pfile_in_zip_read_info->stream_initialised == Z_BZIP2ED)
+        BZ2_bzDecompressEnd(&pfile_in_zip_read_info->bstream);
+#endif
 
     pfile_in_zip_read_info->stream_initialised = 0;
     TRYFREE(pfile_in_zip_read_info);
 
-    s->pfile_in_zip_read=NULL;
+    s->pfile_in_zip_read = NULL;
 
     return err;
 }
 
-
-/*
-  Get the global comment string of the ZipFile, in the szComment buffer.
-  uSizeBuf is the size of the szComment buffer.
-  return the number of byte copied or an error code <0
-*/
-extern int ZEXPORT unzGetGlobalComment (file, szComment, uSizeBuf)
-    unzFile file;
-    char *szComment;
-    uLong uSizeBuf;
+extern int ZEXPORT unzGoToFirstFile2(unzFile file, unz_file_info64 *pfile_info, char *filename,
+    uint16_t filename_size, void *extrafield, uint16_t extrafield_size, char *comment, uint16_t comment_size)
 {
-    unz_s* s;
-    uLong uReadThis ;
-    if (file==NULL)
+    unz64_internal *s = NULL;
+    int err = UNZ_OK;
+
+    if (file == NULL)
         return UNZ_PARAMERROR;
-    s=(unz_s*)file;
+    s = (unz64_internal*)file;
 
-    uReadThis = uSizeBuf;
-    if (uReadThis>s->gi.size_comment)
-        uReadThis = s->gi.size_comment;
+    if (s->gi.number_entry == 0)
+        return UNZ_END_OF_LIST_OF_FILE;
 
-    if (ZSEEK(s->z_filefunc,s->filestream,s->central_pos+22,ZLIB_FILEFUNC_SEEK_SET)!=0)
-        return UNZ_ERRNO;
+    s->pos_in_central_dir = s->offset_central_dir;
+    s->num_file = 0;
 
-    if (uReadThis>0)
+    err = unzGetCurrentFileInfoInternal(file, &s->cur_file_info, &s->cur_file_info_internal,
+            filename, filename_size, extrafield, extrafield_size, comment,comment_size);
+
+    s->current_file_ok = (err == UNZ_OK);
+    if ((err == UNZ_OK) && (pfile_info != NULL))
+        memcpy(pfile_info, &s->cur_file_info, sizeof(unz_file_info64));
+
+    return err;
+}
+
+extern int ZEXPORT unzGoToFirstFile(unzFile file)
+{
+    return unzGoToFirstFile2(file, NULL, NULL, 0, NULL, 0, NULL, 0);
+}
+
+extern int ZEXPORT unzGoToNextFile2(unzFile file, unz_file_info64 *pfile_info, char *filename,
+    uint16_t filename_size, void *extrafield, uint16_t extrafield_size, char *comment, uint16_t comment_size)
+{
+    unz64_internal *s = NULL;
+    int err = UNZ_OK;
+
+    if (file == NULL)
+        return UNZ_PARAMERROR;
+    s = (unz64_internal*)file;
+
+    if (!s->current_file_ok)
+        return UNZ_END_OF_LIST_OF_FILE;
+    if (s->gi.number_entry != UINT16_MAX)    /* 2^16 files overflow hack */
     {
-      *szComment='\0';
-      if (ZREAD(s->z_filefunc,s->filestream,szComment,uReadThis)!=uReadThis)
-        return UNZ_ERRNO;
+        if (s->num_file+1 == s->gi.number_entry)
+            return UNZ_END_OF_LIST_OF_FILE;
     }
 
-    if ((szComment != NULL) && (uSizeBuf > s->gi.size_comment))
-        *(szComment+s->gi.size_comment)='\0';
-    return (int)uReadThis;
+    s->pos_in_central_dir += SIZECENTRALDIRITEM + s->cur_file_info.size_filename +
+            s->cur_file_info.size_file_extra + s->cur_file_info.size_file_comment;
+    s->num_file += 1;
+
+    err = unzGetCurrentFileInfoInternal(file, &s->cur_file_info, &s->cur_file_info_internal,
+            filename, filename_size, extrafield,extrafield_size, comment, comment_size);
+
+    s->current_file_ok = (err == UNZ_OK);
+    if ((err == UNZ_OK) && (pfile_info != NULL))
+        memcpy(pfile_info, &s->cur_file_info, sizeof(unz_file_info64));
+
+    return err;
 }
 
-/* Additions by RX '2004 */
-extern uLong ZEXPORT unzGetOffset (file)
-    unzFile file;
+extern int ZEXPORT unzGoToNextFile(unzFile file)
 {
-    unz_s* s;
-
-    if (file==NULL)
-          return UNZ_PARAMERROR;
-    s=(unz_s*)file;
-    if (!s->current_file_ok)
-      return 0;
-    if (s->gi.number_entry != 0 && s->gi.number_entry != 0xffff)
-      if (s->num_file==s->gi.number_entry)
-         return 0;
-    return s->pos_in_central_dir;
+    return unzGoToNextFile2(file, NULL, NULL, 0, NULL, 0, NULL, 0);
 }
 
-extern int ZEXPORT unzSetOffset (file, pos)
-        unzFile file;
-        uLong pos;
+extern int ZEXPORT unzLocateFile(unzFile file, const char *filename, unzFileNameComparer filename_compare_func)
 {
-    unz_s* s;
-    int err;
+    unz64_internal *s = NULL;
+    unz_file_info64 cur_file_info_saved;
+    unz_file_info64_internal cur_file_info_internal_saved;
+    uint64_t num_file_saved = 0;
+    uint64_t pos_in_central_dir_saved = 0;
+    char current_filename[UNZ_MAXFILENAMEINZIP+1];
+    int err = UNZ_OK;
 
-    if (file==NULL)
+    if (file == NULL)
         return UNZ_PARAMERROR;
-    s=(unz_s*)file;
+    if (strlen(filename) >= UNZ_MAXFILENAMEINZIP)
+        return UNZ_PARAMERROR;
+    s = (unz64_internal*)file;
+    if (!s->current_file_ok)
+        return UNZ_END_OF_LIST_OF_FILE;
 
-    s->pos_in_central_dir = pos;
-    s->num_file = s->gi.number_entry;      /* hack */
-    err = unzlocal_GetCurrentFileInfoInternal(file,&s->cur_file_info,
-                                              &s->cur_file_info_internal,
-                                              NULL,0,NULL,0,NULL,0);
+    /* Save the current state */
+    num_file_saved = s->num_file;
+    pos_in_central_dir_saved = s->pos_in_central_dir;
+    cur_file_info_saved = s->cur_file_info;
+    cur_file_info_internal_saved = s->cur_file_info_internal;
+
+    err = unzGoToFirstFile2(file, NULL, current_filename, sizeof(current_filename)-1, NULL, 0, NULL, 0);
+
+    while (err == UNZ_OK)
+    {
+        if (filename_compare_func != NULL)
+            err = filename_compare_func(file, current_filename, filename);
+        else
+            err = strcmp(current_filename, filename);
+        if (err == 0)
+            return UNZ_OK;
+        err = unzGoToNextFile2(file, NULL, current_filename, sizeof(current_filename)-1, NULL, 0, NULL, 0);
+    }
+
+    /* We failed, so restore the state of the 'current file' to where we were. */
+    s->num_file = num_file_saved;
+    s->pos_in_central_dir = pos_in_central_dir_saved;
+    s->cur_file_info = cur_file_info_saved;
+    s->cur_file_info_internal = cur_file_info_internal_saved;
+    return err;
+}
+
+extern int ZEXPORT unzGetFilePos(unzFile file, unz_file_pos *file_pos)
+{
+    unz64_file_pos file_pos64;
+    int err = unzGetFilePos64(file, &file_pos64);
+    if (err == UNZ_OK)
+    {
+        file_pos->pos_in_zip_directory = (uint32_t)file_pos64.pos_in_zip_directory;
+        file_pos->num_of_file = (uint32_t)file_pos64.num_of_file;
+    }
+    return err;
+}
+
+extern int ZEXPORT unzGoToFilePos(unzFile file, unz_file_pos *file_pos)
+{
+    unz64_file_pos file_pos64;
+    if (file_pos == NULL)
+        return UNZ_PARAMERROR;
+    file_pos64.pos_in_zip_directory = file_pos->pos_in_zip_directory;
+    file_pos64.num_of_file = file_pos->num_of_file;
+    return unzGoToFilePos64(file, &file_pos64);
+}
+
+extern int ZEXPORT unzGetFilePos64(unzFile file, unz64_file_pos *file_pos)
+{
+    unz64_internal *s = NULL;
+
+    if (file == NULL || file_pos == NULL)
+        return UNZ_PARAMERROR;
+    s = (unz64_internal*)file;
+    if (!s->current_file_ok)
+        return UNZ_END_OF_LIST_OF_FILE;
+
+    file_pos->pos_in_zip_directory  = s->pos_in_central_dir;
+    file_pos->num_of_file = s->num_file;
+    return UNZ_OK;
+}
+
+extern int ZEXPORT unzGoToFilePos64(unzFile file, const unz64_file_pos *file_pos)
+{
+    unz64_internal *s = NULL;
+    int err = UNZ_OK;
+
+    if (file == NULL || file_pos == NULL)
+        return UNZ_PARAMERROR;
+    s = (unz64_internal*)file;
+
+    /* Jump to the right spot */
+    s->pos_in_central_dir = file_pos->pos_in_zip_directory;
+    s->num_file = file_pos->num_of_file;
+
+    /* Set the current file */
+    err = unzGetCurrentFileInfoInternal(file, &s->cur_file_info, &s->cur_file_info_internal, NULL, 0, NULL, 0, NULL, 0);
+    /* Return results */
     s->current_file_ok = (err == UNZ_OK);
     return err;
 }
 
-#ifdef _WIN32
-#    pragma warning(pop)
-#endif // _WIN32
+extern int32_t ZEXPORT unzGetOffset(unzFile file)
+{
+    uint64_t offset64 = 0;
+
+    if (file == NULL)
+        return UNZ_PARAMERROR;
+    offset64 = unzGetOffset64(file);
+    return (int32_t)offset64;
+}
+
+extern int64_t ZEXPORT unzGetOffset64(unzFile file)
+{
+    unz64_internal *s = NULL;
+
+    if (file == NULL)
+        return UNZ_PARAMERROR;
+    s = (unz64_internal*)file;
+    if (!s->current_file_ok)
+        return 0;
+    if (s->gi.number_entry != 0 && s->gi.number_entry != UINT16_MAX)
+    {
+        if (s->num_file == s->gi.number_entry)
+            return 0;
+    }
+    return s->pos_in_central_dir;
+}
+
+extern int ZEXPORT unzSetOffset(unzFile file, uint32_t pos)
+{
+    return unzSetOffset64(file, pos);
+}
+
+extern int ZEXPORT unzSetOffset64(unzFile file, uint64_t pos)
+{
+    unz64_internal *s = NULL;
+    int err = UNZ_OK;
+
+    if (file == NULL)
+        return UNZ_PARAMERROR;
+    s = (unz64_internal*)file;
+    s->pos_in_central_dir = pos;
+    s->num_file = s->gi.number_entry; /* hack */
+
+    err = unzGetCurrentFileInfoInternal(file, &s->cur_file_info, &s->cur_file_info_internal, NULL, 0, NULL, 0, NULL, 0);
+
+    s->current_file_ok = (err == UNZ_OK);
+    return err;
+}
+
+extern int32_t ZEXPORT unzTell(unzFile file)
+{
+    unz64_internal *s = NULL;
+    if (file == NULL)
+        return UNZ_PARAMERROR;
+    s = (unz64_internal*)file;
+    if (s->pfile_in_zip_read == NULL)
+        return UNZ_PARAMERROR;
+    return (int32_t)s->pfile_in_zip_read->stream.total_out;
+}
+
+extern int64_t ZEXPORT unzTell64(unzFile file)
+{
+    unz64_internal *s = NULL;
+    if (file == NULL)
+        return UNZ_PARAMERROR;
+    s = (unz64_internal*)file;
+    if (s->pfile_in_zip_read == NULL)
+        return UNZ_PARAMERROR;
+    return s->pfile_in_zip_read->total_out_64;
+}
+
+extern int ZEXPORT unzSeek(unzFile file, uint32_t offset, int origin)
+{
+    return unzSeek64(file, offset, origin);
+}
+
+extern int ZEXPORT unzSeek64(unzFile file, uint64_t offset, int origin)
+{
+    unz64_internal *s = NULL;
+    uint64_t stream_pos_begin = 0;
+    uint64_t stream_pos_end = 0;
+    uint64_t position = 0;
+    int is_within_buffer = 0;
+
+    if (file == NULL)
+        return UNZ_PARAMERROR;
+    s = (unz64_internal*)file;
+
+    if (s->pfile_in_zip_read == NULL)
+        return UNZ_ERRNO;
+    if (s->pfile_in_zip_read->compression_method != 0)
+        return UNZ_ERRNO;
+
+    if (origin == SEEK_SET)
+        position = offset;
+    else if (origin == SEEK_CUR)
+        position = s->pfile_in_zip_read->total_out_64 + offset;
+    else if (origin == SEEK_END)
+        position = s->cur_file_info.compressed_size + offset;
+    else
+        return UNZ_PARAMERROR;
+
+    if (position > s->cur_file_info.compressed_size)
+        return UNZ_PARAMERROR;
+
+    stream_pos_end = s->pfile_in_zip_read->pos_in_zipfile;
+    stream_pos_begin = stream_pos_end;
+
+    if (stream_pos_begin > UNZ_BUFSIZE)
+        stream_pos_begin -= UNZ_BUFSIZE;
+    else
+        stream_pos_begin = 0;
+
+    is_within_buffer = 
+        (s->pfile_in_zip_read->stream.avail_in != 0) &&
+        (s->pfile_in_zip_read->rest_read_compressed != 0 || s->cur_file_info.compressed_size < UNZ_BUFSIZE) &&
+        (position >= stream_pos_begin && position < stream_pos_end);
+
+    if (is_within_buffer)
+    {
+        s->pfile_in_zip_read->stream.next_in += position - s->pfile_in_zip_read->total_out_64;
+        s->pfile_in_zip_read->stream.avail_in = (uInt)(stream_pos_end - position);
+    }
+    else
+    {
+        s->pfile_in_zip_read->stream.avail_in = 0;
+        s->pfile_in_zip_read->stream.next_in = 0;
+
+        s->pfile_in_zip_read->pos_in_zipfile = s->pfile_in_zip_read->offset_local_extrafield + position;
+        s->pfile_in_zip_read->rest_read_compressed = s->cur_file_info.compressed_size - position;
+    }
+
+    s->pfile_in_zip_read->rest_read_uncompressed -= (position - s->pfile_in_zip_read->total_out_64);
+    s->pfile_in_zip_read->stream.total_out = (uint32_t)position;
+    s->pfile_in_zip_read->total_out_64 = position;
+
+    return UNZ_OK;
+}
+
+extern int ZEXPORT unzEndOfFile(unzFile file)
+{
+    unz64_internal *s = NULL;
+    if (file == NULL)
+        return UNZ_PARAMERROR;
+    s = (unz64_internal*)file;
+    if (s->pfile_in_zip_read == NULL)
+        return UNZ_PARAMERROR;
+    if (s->pfile_in_zip_read->rest_read_uncompressed == 0)
+        return 1;
+    return 0;
+}

--- a/contrib/unzip/unzip.c
+++ b/contrib/unzip/unzip.c
@@ -46,6 +46,9 @@
 #  include "crypt.h"
 #endif
 
+// these warnings are considered as errors on VS
+#pragma warning(disable : 4244) 
+
 #define DISKHEADERMAGIC             (0x08074b50)
 #define LOCALHEADERMAGIC            (0x04034b50)
 #define CENTRALHEADERMAGIC          (0x02014b50)

--- a/contrib/unzip/unzip.h
+++ b/contrib/unzip/unzip.h
@@ -1,49 +1,23 @@
 /* unzip.h -- IO for uncompress .zip files using zlib
-   Version 1.01e, February 12th, 2005
+   Version 1.2.0, September 16th, 2017
+   part of the MiniZip project
 
-   Copyright (C) 1998-2005 Gilles Vollant
+   Copyright (C) 2012-2017 Nathan Moinvaziri
+     https://github.com/nmoinvaz/minizip
+   Copyright (C) 2009-2010 Mathias Svensson
+     Modifications for Zip64 support on both zip and unzip
+     http://result42.com
+   Copyright (C) 2007-2008 Even Rouault
+     Modifications of Unzip for Zip64
+   Copyright (C) 1998-2010 Gilles Vollant
+     http://www.winimage.com/zLibDll/minizip.html
 
-   This unzip package allow extract file from .ZIP file, compatible with PKZip 2.04g
-     WinZip, InfoZip tools and compatible.
-
-   Multi volume ZipFile (span) are not supported.
-   Encryption compatible with pkzip 2.04g only supported
-   Old compressions used by old PKZip 1.x are not supported
-
-
-   I WAIT FEEDBACK at mail info@winimage.com
-   Visit also http://www.winimage.com/zLibDll/unzip.htm for evolution
-
-   Condition of use and distribution are the same than zlib :
-
-  This software is provided 'as-is', without any express or implied
-  warranty.  In no event will the authors be held liable for any damages
-  arising from the use of this software.
-
-  Permission is granted to anyone to use this software for any purpose,
-  including commercial applications, and to alter it and redistribute it
-  freely, subject to the following restrictions:
-
-  1. The origin of this software must not be misrepresented; you must not
-     claim that you wrote the original software. If you use this software
-     in a product, an acknowledgment in the product documentation would be
-     appreciated but is not required.
-  2. Altered source versions must be plainly marked as such, and must not be
-     misrepresented as being the original software.
-  3. This notice may not be removed or altered from any source distribution.
-
-
+   This program is distributed under the terms of the same license as zlib.
+   See the accompanying LICENSE file for the full text of the license.
 */
 
-/* for more info about .ZIP format, see
-      http://www.info-zip.org/pub/infozip/doc/appnote-981119-iz.zip
-      http://www.info-zip.org/pub/infozip/doc/
-   PkWare has also a specification at :
-      ftp://ftp.pkware.com/probdesc.zip
-*/
-
-#ifndef _unz_H
-#define _unz_H
+#ifndef _UNZ_H
+#define _UNZ_H
 
 #ifdef __cplusplus
 extern "C" {
@@ -57,15 +31,20 @@ extern "C" {
 #include "ioapi.h"
 #endif
 
+#ifdef HAVE_BZIP2
+#include "bzlib.h"
+#endif
+
+#define Z_BZIP2ED 12
+
 #if defined(STRICTUNZIP) || defined(STRICTZIPUNZIP)
 /* like the STRICT of WIN32, we define a pointer that cannot be converted
     from (void*) without cast */
-typedef struct TagunzFile__ { int unused; } unzFile__;
-typedef unzFile__ *unzFile;
+typedef struct TagunzFile__ { int unused; } unz_file__;
+typedef unz_file__ *unzFile;
 #else
 typedef voidp unzFile;
 #endif
-
 
 #define UNZ_OK                          (0)
 #define UNZ_END_OF_LIST_OF_FILE         (-100)
@@ -75,280 +54,255 @@ typedef voidp unzFile;
 #define UNZ_BADZIPFILE                  (-103)
 #define UNZ_INTERNALERROR               (-104)
 #define UNZ_CRCERROR                    (-105)
-
-/* tm_unz contain date/time info */
-typedef struct tm_unz_s
-{
-    uInt tm_sec;            /* seconds after the minute - [0,59] */
-    uInt tm_min;            /* minutes after the hour - [0,59] */
-    uInt tm_hour;           /* hours since midnight - [0,23] */
-    uInt tm_mday;           /* day of the month - [1,31] */
-    uInt tm_mon;            /* months since January - [0,11] */
-    uInt tm_year;           /* years - [1980..2044] */
-} tm_unz;
+#define UNZ_BADPASSWORD                 (-106)
 
 /* unz_global_info structure contain global data about the ZIPfile
    These data comes from the end of central dir */
+typedef struct unz_global_info64_s
+{
+    uint64_t number_entry;          /* total number of entries in the central dir on this disk */
+    uint32_t number_disk_with_CD;   /* number the the disk with central dir, used for spanning ZIP*/
+    uint16_t size_comment;          /* size of the global comment of the zipfile */
+} unz_global_info64;
+
 typedef struct unz_global_info_s
 {
-    uLong number_entry;         /* total number of entries in
-                       the central dir on this disk */
-    uLong size_comment;         /* size of the global comment of the zipfile */
+    uint32_t number_entry;          /* total number of entries in the central dir on this disk */
+    uint32_t number_disk_with_CD;   /* number the the disk with central dir, used for spanning ZIP*/
+    uint16_t size_comment;          /* size of the global comment of the zipfile */
 } unz_global_info;
 
-
 /* unz_file_info contain information about a file in the zipfile */
+typedef struct unz_file_info64_s
+{
+    uint16_t version;               /* version made by                 2 bytes */
+    uint16_t version_needed;        /* version needed to extract       2 bytes */
+    uint16_t flag;                  /* general purpose bit flag        2 bytes */
+    uint16_t compression_method;    /* compression method              2 bytes */
+    uint32_t dos_date;              /* last mod file date in Dos fmt   4 bytes */
+    uint32_t crc;                   /* crc-32                          4 bytes */
+    uint64_t compressed_size;       /* compressed size                 8 bytes */
+    uint64_t uncompressed_size;     /* uncompressed size               8 bytes */
+    uint16_t size_filename;         /* filename length                 2 bytes */
+    uint16_t size_file_extra;       /* extra field length              2 bytes */
+    uint16_t size_file_comment;     /* file comment length             2 bytes */
+
+    uint32_t disk_num_start;        /* disk number start               4 bytes */
+    uint16_t internal_fa;           /* internal file attributes        2 bytes */
+    uint32_t external_fa;           /* external file attributes        4 bytes */
+
+    uint64_t disk_offset;
+
+    uint16_t size_file_extra_internal;
+} unz_file_info64;
+
 typedef struct unz_file_info_s
 {
-    uLong version;              /* version made by                 2 bytes */
-    uLong version_needed;       /* version needed to extract       2 bytes */
-    uLong flag;                 /* general purpose bit flag        2 bytes */
-    uLong compression_method;   /* compression method              2 bytes */
-    uLong dosDate;              /* last mod file date in Dos fmt   4 bytes */
-    uLong crc;                  /* crc-32                          4 bytes */
-    uLong compressed_size;      /* compressed size                 4 bytes */
-    uLong uncompressed_size;    /* uncompressed size               4 bytes */
-    uLong size_filename;        /* filename length                 2 bytes */
-    uLong size_file_extra;      /* extra field length              2 bytes */
-    uLong size_file_comment;    /* file comment length             2 bytes */
+    uint16_t version;               /* version made by                 2 bytes */
+    uint16_t version_needed;        /* version needed to extract       2 bytes */
+    uint16_t flag;                  /* general purpose bit flag        2 bytes */
+    uint16_t compression_method;    /* compression method              2 bytes */
+    uint32_t dos_date;              /* last mod file date in Dos fmt   4 bytes */
+    uint32_t crc;                   /* crc-32                          4 bytes */
+    uint32_t compressed_size;       /* compressed size                 4 bytes */
+    uint32_t uncompressed_size;     /* uncompressed size               4 bytes */
+    uint16_t size_filename;         /* filename length                 2 bytes */
+    uint16_t size_file_extra;       /* extra field length              2 bytes */
+    uint16_t size_file_comment;     /* file comment length             2 bytes */
 
-    uLong disk_num_start;       /* disk number start               2 bytes */
-    uLong internal_fa;          /* internal file attributes        2 bytes */
-    uLong external_fa;          /* external file attributes        4 bytes */
+    uint16_t disk_num_start;        /* disk number start               2 bytes */
+    uint16_t internal_fa;           /* internal file attributes        2 bytes */
+    uint32_t external_fa;           /* external file attributes        4 bytes */
 
-    tm_unz tmu_date;
+    uint64_t disk_offset;
 } unz_file_info;
 
-extern int ZEXPORT unzStringFileNameCompare OF ((const char* fileName1,
-                                                 const char* fileName2,
-                                                 int iCaseSensitivity));
-/*
-   Compare two filename (fileName1,fileName2).
-   If iCaseSenisivity = 1, comparision is case sensitivity (like strcmp)
-   If iCaseSenisivity = 2, comparision is not case sensitivity (like strcmpi
-                                or strcasecmp)
-   If iCaseSenisivity = 0, case sensitivity is defaut of your operating system
-    (like 1 on Unix, 2 on Windows)
-*/
+/***************************************************************************/
+/* Opening and close a zip file */
 
+extern unzFile ZEXPORT unzOpen(const char *path);
+extern unzFile ZEXPORT unzOpen64(const void *path);
+/* Open a Zip file.
 
-extern unzFile ZEXPORT unzOpen OF((const char *path));
-/*
-  Open a Zip file. path contain the full pathname (by example,
-     on a Windows XP computer "c:\\zlib\\zlib113.zip" or on an Unix computer
-     "zlib/zlib113.zip".
-     If the zipfile cannot be opened (file don't exist or in not valid), the
-       return value is NULL.
-     Else, the return value is a unzFile Handle, usable with other function
-       of this unzip package.
-*/
+   path should contain the full path (by example, on a Windows XP computer 
+      "c:\\zlib\\zlib113.zip" or on an Unix computer "zlib/zlib113.zip". 
+   return NULL if zipfile cannot be opened or doesn't exist
+   return unzFile handle if no error
 
-extern unzFile ZEXPORT unzOpen2 OF((const char *path,
-                                    zlib_filefunc_def* pzlib_filefunc_def));
-/*
-   Open a Zip file, like unzOpen, but provide a set of file low level API
-      for read/write the zip file (see ioapi.h)
-*/
+   NOTE: The "64" function take a const void *pointer, because  the path is just the value passed to the
+   open64_file_func callback. Under Windows, if UNICODE is defined, using fill_fopen64_filefunc, the path 
+   is a pointer to a wide unicode string  (LPCTSTR is LPCWSTR), so const char *does not describe the reality */
 
-extern int ZEXPORT unzClose OF((unzFile file));
-/*
-  Close a ZipFile opened with unzipOpen.
-  If there is files inside the .Zip opened with unzOpenCurrentFile (see later),
-    these files MUST be closed with unzipCloseCurrentFile before call unzipClose.
-  return UNZ_OK if there is no problem. */
+extern unzFile ZEXPORT unzOpen2(const char *path, zlib_filefunc_def *pzlib_filefunc_def);
+/* Open a Zip file, like unzOpen, but provide a set of file low level API for read/write operations */
+extern unzFile ZEXPORT unzOpen2_64(const void *path, zlib_filefunc64_def *pzlib_filefunc_def);
+/* Open a Zip file, like unz64Open, but provide a set of file low level API for read/write 64-bit operations */
 
-extern int ZEXPORT unzGetGlobalInfo OF((unzFile file,
-                                        unz_global_info *pglobal_info));
-/*
-  Write info about the ZipFile in the *pglobal_info structure.
-  No preparation of the structure is needed
-  return UNZ_OK if there is no problem. */
+extern int ZEXPORT unzClose(unzFile file);
+/* Close a ZipFile opened with unzOpen. If there is files inside the .Zip opened with unzOpenCurrentFile,
+   these files MUST be closed with unzipCloseCurrentFile before call unzipClose.
 
+   return UNZ_OK if there is no error */
 
-extern int ZEXPORT unzGetGlobalComment OF((unzFile file,
-                                           char *szComment,
-                                           uLong uSizeBuf));
-/*
-  Get the global comment string of the ZipFile, in the szComment buffer.
-  uSizeBuf is the size of the szComment buffer.
-  return the number of byte copied or an error code <0
-*/
+extern int ZEXPORT unzGetGlobalInfo(unzFile file, unz_global_info *pglobal_info);
+extern int ZEXPORT unzGetGlobalInfo64(unzFile file, unz_global_info64 *pglobal_info);
+/* Write info about the ZipFile in the *pglobal_info structure.
 
+   return UNZ_OK if no error */
+
+extern int ZEXPORT unzGetGlobalComment(unzFile file, char *comment, uint16_t comment_size);
+/* Get the global comment string of the ZipFile, in the comment buffer.
+
+   uSizeBuf is the size of the szComment buffer.
+   return the number of byte copied or an error code <0 */
 
 /***************************************************************************/
-/* Unzip package allow you browse the directory of the zipfile */
+/* Reading the content of the current zipfile, you can open it, read data from it, and close it
+   (you can close it before reading all the file) */
 
-extern int ZEXPORT unzGoToFirstFile OF((unzFile file));
-/*
-  Set the current file of the zipfile to the first file.
-  return UNZ_OK if there is no problem
-*/
+extern int ZEXPORT unzOpenCurrentFile(unzFile file);
+/* Open for reading data the current file in the zipfile.
 
-extern int ZEXPORT unzGoToNextFile OF((unzFile file));
-/*
-  Set the current file of the zipfile to the next file.
-  return UNZ_OK if there is no problem
-  return UNZ_END_OF_LIST_OF_FILE if the actual file was the latest.
-*/
+   return UNZ_OK if no error */
 
-extern int ZEXPORT unzLocateFile OF((unzFile file,
-                     const char *szFileName,
-                     int iCaseSensitivity));
-/*
-  Try locate the file szFileName in the zipfile.
-  For the iCaseSensitivity signification, see unzStringFileNameCompare
+extern int ZEXPORT unzOpenCurrentFilePassword(unzFile file, const char *password);
+/* Open for reading data the current file in the zipfile.
+   password is a crypting password
 
-  return value :
-  UNZ_OK if the file is found. It becomes the current file.
-  UNZ_END_OF_LIST_OF_FILE if the file is not found
-*/
+   return UNZ_OK if no error */
 
+extern int ZEXPORT unzOpenCurrentFile2(unzFile file, int *method, int *level, int raw);
+/* Same as unzOpenCurrentFile, but open for read raw the file (not uncompress)
+   if raw==1 *method will receive method of compression, *level will receive level of compression
 
-/* ****************************************** */
-/* Ryan supplied functions */
-/* unz_file_info contain information about a file in the zipfile */
+   NOTE: you can set level parameter as NULL (if you did not want known level,
+         but you CANNOT set method parameter as NULL */
+
+extern int ZEXPORT unzOpenCurrentFile3(unzFile file, int *method, int *level, int raw, const char *password);
+/* Same as unzOpenCurrentFile, but takes extra parameter password for encrypted files */
+
+extern int ZEXPORT unzReadCurrentFile(unzFile file, voidp buf, uint32_t len);
+/* Read bytes from the current file (opened by unzOpenCurrentFile)
+   buf contain buffer where data must be copied
+   len the size of buf.
+
+   return the number of byte copied if somes bytes are copied
+   return 0 if the end of file was reached
+   return <0 with error code if there is an error (UNZ_ERRNO for IO error, or zLib error for uncompress error) */
+
+extern int ZEXPORT unzGetCurrentFileInfo(unzFile file, unz_file_info *pfile_info, char *filename, 
+    uint16_t filename_size, void *extrafield, uint16_t extrafield_size, char *comment, uint16_t comment_size);
+extern int ZEXPORT unzGetCurrentFileInfo64(unzFile file, unz_file_info64 *pfile_info, char *filename,
+    uint16_t filename_size, void *extrafield, uint16_t extrafield_size, char *comment, uint16_t comment_size);
+/* Get Info about the current file
+
+   pfile_info if != NULL, the *pfile_info structure will contain somes info about the current file
+   filename if != NULL, the file name string will be copied in filename 
+   filename_size is the size of the filename buffer
+   extrafield if != NULL, the extra field information from the central header will be copied in to
+   extrafield_size is the size of the extraField buffer 
+   comment if != NULL, the comment string of the file will be copied in to
+   comment_size is the size of the comment buffer */
+
+extern int ZEXPORT unzGetLocalExtrafield(unzFile file, voidp buf, uint32_t len);
+/* Read extra field from the current file (opened by unzOpenCurrentFile)
+   This is the local-header version of the extra field (sometimes, there is
+   more info in the local-header version than in the central-header)
+
+   if buf == NULL, it return the size of the local extra field
+   if buf != NULL, len is the size of the buffer, the extra header is copied in buf.
+
+   return number of bytes copied in buf, or (if <0) the error code */
+
+extern int ZEXPORT unzCloseCurrentFile(unzFile file);
+/* Close the file in zip opened with unzOpenCurrentFile
+
+   return UNZ_CRCERROR if all the file was read but the CRC is not good */
+
+/***************************************************************************/
+/* Browse the directory of the zipfile */
+
+typedef int (*unzFileNameComparer)(unzFile file, const char *filename1, const char *filename2);
+typedef int (*unzIteratorFunction)(unzFile file);
+typedef int (*unzIteratorFunction2)(unzFile file, unz_file_info64 *pfile_info, char *filename,
+    uint16_t filename_size, void *extrafield, uint16_t extrafield_size, char *comment, uint16_t comment_size);
+
+extern int ZEXPORT unzGoToFirstFile(unzFile file);
+/* Set the current file of the zipfile to the first file.
+
+   return UNZ_OK if no error */
+
+extern int ZEXPORT unzGoToFirstFile2(unzFile file, unz_file_info64 *pfile_info, char *filename,
+    uint16_t filename_size, void *extrafield, uint16_t extrafield_size, char *comment, uint16_t comment_size);
+/* Set the current file of the zipfile to the first file and retrieves the current info on success. 
+   Not as seek intensive as unzGoToFirstFile + unzGetCurrentFileInfo.
+
+   return UNZ_OK if no error */
+
+extern int ZEXPORT unzGoToNextFile(unzFile file);
+/* Set the current file of the zipfile to the next file.
+
+   return UNZ_OK if no error
+   return UNZ_END_OF_LIST_OF_FILE if the actual file was the latest */
+
+extern int ZEXPORT unzGoToNextFile2(unzFile file, unz_file_info64 *pfile_info, char *filename,
+    uint16_t filename_size, void *extrafield, uint16_t extrafield_size, char *comment, uint16_t comment_size);
+/* Set the current file of the zipfile to the next file and retrieves the current 
+   info on success. Does less seeking around than unzGotoNextFile + unzGetCurrentFileInfo.
+
+   return UNZ_OK if no error
+   return UNZ_END_OF_LIST_OF_FILE if the actual file was the latest */
+
+extern int ZEXPORT unzLocateFile(unzFile file, const char *filename, unzFileNameComparer filename_compare_func);
+/* Try locate the file szFileName in the zipfile. For custom filename comparison pass in comparison function.
+
+   return UNZ_OK if the file is found (it becomes the current file)
+   return UNZ_END_OF_LIST_OF_FILE if the file is not found */
+
+/***************************************************************************/
+/* Raw access to zip file */
+
 typedef struct unz_file_pos_s
 {
-    uLong pos_in_zip_directory;   /* offset in zip file directory */
-    uLong num_of_file;            /* # of file */
+    uint32_t pos_in_zip_directory;  /* offset in zip file directory */
+    uint32_t num_of_file;           /* # of file */
 } unz_file_pos;
 
-extern int ZEXPORT unzGetFilePos(
-    unzFile file,
-    unz_file_pos* file_pos);
+extern int ZEXPORT unzGetFilePos(unzFile file, unz_file_pos *file_pos);
+extern int ZEXPORT unzGoToFilePos(unzFile file, unz_file_pos *file_pos);
 
-extern int ZEXPORT unzGoToFilePos(
-    unzFile file,
-    unz_file_pos* file_pos);
+typedef struct unz64_file_pos_s
+{
+    uint64_t pos_in_zip_directory;   /* offset in zip file directory */
+    uint64_t num_of_file;            /* # of file */
+} unz64_file_pos;
 
-/* ****************************************** */
+extern int ZEXPORT unzGetFilePos64(unzFile file, unz64_file_pos *file_pos);
+extern int ZEXPORT unzGoToFilePos64(unzFile file, const unz64_file_pos *file_pos);
 
-extern int ZEXPORT unzGetCurrentFileInfo OF((unzFile file,
-                         unz_file_info *pfile_info,
-                         char *szFileName,
-                         uLong fileNameBufferSize,
-                         void *extraField,
-                         uLong extraFieldBufferSize,
-                         char *szComment,
-                         uLong commentBufferSize));
-/*
-  Get Info about the current file
-  if pfile_info!=NULL, the *pfile_info structure will contain somes info about
-        the current file
-  if szFileName!=NULL, the filemane string will be copied in szFileName
-            (fileNameBufferSize is the size of the buffer)
-  if extraField!=NULL, the extra field information will be copied in extraField
-            (extraFieldBufferSize is the size of the buffer).
-            This is the Central-header version of the extra field
-  if szComment!=NULL, the comment string of the file will be copied in szComment
-            (commentBufferSize is the size of the buffer)
-*/
-
-/***************************************************************************/
-/* for reading the content of the current zipfile, you can open it, read data
-   from it, and close it (you can close it before reading all the file)
-   */
-
-extern int ZEXPORT unzOpenCurrentFile OF((unzFile file));
-/*
-  Open for reading data the current file in the zipfile.
-  If there is no error, the return value is UNZ_OK.
-*/
-
-extern int ZEXPORT unzOpenCurrentFilePassword OF((unzFile file,
-                                                  const char* password));
-/*
-  Open for reading data the current file in the zipfile.
-  password is a crypting password
-  If there is no error, the return value is UNZ_OK.
-*/
-
-extern int ZEXPORT unzOpenCurrentFile2 OF((unzFile file,
-                                           int* method,
-                                           int* level,
-                                           int raw));
-/*
-  Same than unzOpenCurrentFile, but open for read raw the file (not uncompress)
-    if raw==1
-  *method will receive method of compression, *level will receive level of
-     compression
-  note : you can set level parameter as NULL (if you did not want known level,
-         but you CANNOT set method parameter as NULL
-*/
-
-extern int ZEXPORT unzOpenCurrentFile3 OF((unzFile file,
-                                           int* method,
-                                           int* level,
-                                           int raw,
-                                           const char* password));
-/*
-  Same than unzOpenCurrentFile, but open for read raw the file (not uncompress)
-    if raw==1
-  *method will receive method of compression, *level will receive level of
-     compression
-  note : you can set level parameter as NULL (if you did not want known level,
-         but you CANNOT set method parameter as NULL
-*/
-
-
-extern int ZEXPORT unzCloseCurrentFile OF((unzFile file));
-/*
-  Close the file in zip opened with unzOpenCurrentFile
-  Return UNZ_CRCERROR if all the file was read but the CRC is not good
-*/
-
-extern int ZEXPORT unzReadCurrentFile OF((unzFile file,
-                      voidp buf,
-                      unsigned len));
-/*
-  Read bytes from the current file (opened by unzOpenCurrentFile)
-  buf contain buffer where data must be copied
-  len the size of buf.
-
-  return the number of byte copied if somes bytes are copied
-  return 0 if the end of file was reached
-  return <0 with error code if there is an error
-    (UNZ_ERRNO for IO error, or zLib error for uncompress error)
-*/
-
-extern z_off_t ZEXPORT unztell OF((unzFile file));
-/*
-  Give the current position in uncompressed data
-*/
-
-extern int ZEXPORT unzeof OF((unzFile file));
-/*
-  return 1 if the end of file was reached, 0 elsewhere
-*/
-
-extern int ZEXPORT unzGetLocalExtrafield OF((unzFile file,
-                                             voidp buf,
-                                             unsigned len));
-/*
-  Read extra field from the current file (opened by unzOpenCurrentFile)
-  This is the local-header version of the extra field (sometimes, there is
-    more info in the local-header version than in the central-header)
-
-  if buf==NULL, it return the size of the local extra field
-
-  if buf!=NULL, len is the size of the buffer, the extra header is copied in
-    buf.
-  the return value is the number of bytes copied in buf, or (if <0)
-    the error code
-*/
-
-/***************************************************************************/
-
+extern int32_t ZEXPORT unzGetOffset(unzFile file);
+extern int64_t ZEXPORT unzGetOffset64(unzFile file);
 /* Get the current file offset */
-extern uLong ZEXPORT unzGetOffset (unzFile file);
 
+extern int ZEXPORT unzSetOffset(unzFile file, uint32_t pos);
+extern int ZEXPORT unzSetOffset64(unzFile file, uint64_t pos);
 /* Set the current file offset */
-extern int ZEXPORT unzSetOffset (unzFile file, uLong pos);
 
+extern int32_t ZEXPORT unzTell(unzFile file);
+extern int64_t ZEXPORT unzTell64(unzFile file);
+/* return current position in uncompressed data */
 
+extern int ZEXPORT unzSeek(unzFile file, uint32_t offset, int origin);
+extern int ZEXPORT unzSeek64(unzFile file, uint64_t offset, int origin);
+/* Seek within the uncompressed data if compression method is storage */
+
+extern int ZEXPORT unzEndOfFile(unzFile file);
+/* return 1 if the end of file was reached, 0 elsewhere */
+
+/***************************************************************************/
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* _unz_H */
+#endif /* _UNZ_H */

--- a/contrib/zip/src/zip.c
+++ b/contrib/zip/src/zip.c
@@ -1,975 +1,2023 @@
-/*
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
- * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
- * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
- */
-#define __STDC_WANT_LIB_EXT1__ 1
+/* zip.c -- IO on .zip files using zlib
+   Version 1.2.0, September 16th, 2017
+   part of the MiniZip project
 
+   Copyright (C) 2010-2017 Nathan Moinvaziri
+     Modifications for AES, PKWARE disk spanning
+     https://github.com/nmoinvaz/minizip
+   Copyright (C) 2009-2010 Mathias Svensson
+     Modifications for Zip64 support
+     http://result42.com
+   Copyright (C) 1998-2010 Gilles Vollant
+     http://www.winimage.com/zLibDll/minizip.html
+
+   This program is distributed under the terms of the same license as zlib.
+   See the accompanying LICENSE file for the full text of the license.
+*/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <limits.h>
 #include <errno.h>
-#include <sys/stat.h>
-#include <time.h>
 
-#if defined(_WIN32) || defined(__WIN32__) || defined(_MSC_VER) ||              \
-    defined(__MINGW32__)
-/* Win32, DOS, MSVC, MSVS */
-#include <direct.h>
-
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4706)
-#endif // _MSC_VER
-
-#define MKDIR(DIRNAME) _mkdir(DIRNAME)
-#define STRCLONE(STR) ((STR) ? _strdup(STR) : NULL)
-#define HAS_DEVICE(P)                                                          \
-  ((((P)[0] >= 'A' && (P)[0] <= 'Z') || ((P)[0] >= 'a' && (P)[0] <= 'z')) &&   \
-   (P)[1] == ':')
-#define FILESYSTEM_PREFIX_LEN(P) (HAS_DEVICE(P) ? 2 : 0)
-
-#else
-
-#include <unistd.h> // needed for symlink() on BSD
-int symlink(const char *target, const char *linkpath); // needed on Linux
-
-#define MKDIR(DIRNAME) mkdir(DIRNAME, 0755)
-#define STRCLONE(STR) ((STR) ? strdup(STR) : NULL)
-
-#endif
-
-#include "miniz.h"
+#include "zlib.h"
 #include "zip.h"
 
-#ifndef HAS_DEVICE
-#define HAS_DEVICE(P) 0
+#ifdef HAVE_AES
+#  define AES_METHOD          (99)
+#  define AES_PWVERIFYSIZE    (2)
+#  define AES_AUTHCODESIZE    (10)
+#  define AES_MAXSALTLENGTH   (16)
+#  define AES_VERSION         (0x0001)
+#  define AES_ENCRYPTIONMODE  (0x03)
+
+#  include "aes/aes.h"
+#  include "aes/fileenc.h"
+#  include "aes/prng.h"
+#endif
+#ifdef HAVE_APPLE_COMPRESSION
+#  include <compression.h>
 #endif
 
-#ifndef FILESYSTEM_PREFIX_LEN
-#define FILESYSTEM_PREFIX_LEN(P) 0
+#ifndef NOCRYPT
+#  include "crypt.h"
 #endif
 
-#ifndef ISSLASH
-#define ISSLASH(C) ((C) == '/' || (C) == '\\')
+#define SIZEDATA_INDATABLOCK        (4096-(4*4))
+
+#define DISKHEADERMAGIC             (0x08074b50)
+#define LOCALHEADERMAGIC            (0x04034b50)
+#define CENTRALHEADERMAGIC          (0x02014b50)
+#define ENDHEADERMAGIC              (0x06054b50)
+#define ZIP64ENDHEADERMAGIC         (0x06064b50)
+#define ZIP64ENDLOCHEADERMAGIC      (0x07064b50)
+#define DATADESCRIPTORMAGIC         (0x08074b50)
+
+#define FLAG_LOCALHEADER_OFFSET     (0x06)
+#define CRC_LOCALHEADER_OFFSET      (0x0e)
+
+#define SIZECENTRALHEADER           (0x2e) /* 46 */
+#define SIZECENTRALHEADERLOCATOR    (0x14) /* 20 */
+#define SIZECENTRALDIRITEM          (0x2e)
+#define SIZEZIPLOCALHEADER          (0x1e)
+
+#ifndef BUFREADCOMMENT
+#  define BUFREADCOMMENT            (0x400)
+#endif
+#ifndef VERSIONMADEBY
+#  define VERSIONMADEBY             (0x0) /* platform dependent */
 #endif
 
-#define CLEANUP(ptr)                                                           \
-  do {                                                                         \
-    if (ptr) {                                                                 \
-      free((void *)ptr);                                                       \
-      ptr = NULL;                                                              \
-    }                                                                          \
-  } while (0)
+#ifndef Z_BUFSIZE
+#  define Z_BUFSIZE                 (UINT16_MAX)
+#endif
 
-static const char *base_name(const char *name) {
-  char const *p;
-  char const *base = name += FILESYSTEM_PREFIX_LEN(name);
-  int all_slashes = 1;
+#ifndef ALLOC
+#  define ALLOC(size) (malloc(size))
+#endif
+#ifndef TRYFREE
+#  define TRYFREE(p) {if (p) free(p);}
+#endif
 
-  for (p = name; *p; p++) {
-    if (ISSLASH(*p))
-      base = p + 1;
+/* NOT sure that this work on ALL platform */
+#define MAKEULONG64(a, b) ((uint64_t)(((unsigned long)(a)) | ((uint64_t)((unsigned long)(b))) << 32))
+
+#ifndef DEF_MEM_LEVEL
+#  if MAX_MEM_LEVEL >= 8
+#    define DEF_MEM_LEVEL 8
+#  else
+#    define DEF_MEM_LEVEL  MAX_MEM_LEVEL
+#  endif
+#endif
+
+const char zip_copyright[] = " zip 1.01 Copyright 1998-2004 Gilles Vollant - http://www.winimage.com/zLibDll";
+
+typedef struct linkedlist_datablock_internal_s
+{
+    struct linkedlist_datablock_internal_s *next_datablock;
+    uint32_t    avail_in_this_block;
+    uint32_t    filled_in_this_block;
+    uint32_t    unused; /* for future use and alignment */
+    uint8_t     data[SIZEDATA_INDATABLOCK];
+} linkedlist_datablock_internal;
+
+typedef struct linkedlist_data_s
+{
+    linkedlist_datablock_internal *first_block;
+    linkedlist_datablock_internal *last_block;
+} linkedlist_data;
+
+typedef struct
+{
+    z_stream stream;                /* zLib stream structure for inflate */
+#ifdef HAVE_BZIP2
+    bz_stream bstream;              /* bzLib stream structure for bziped */
+#endif
+#ifdef HAVE_APPLE_COMPRESSION
+    compression_stream astream;     /* libcompression stream structure */
+#endif
+#ifdef HAVE_AES
+    fcrypt_ctx aes_ctx;
+    prng_ctx aes_rng[1];
+#endif
+    int      stream_initialised;    /* 1 is stream is initialized */
+    uint32_t pos_in_buffered_data;  /* last written byte in buffered_data */
+
+    uint64_t pos_local_header;      /* offset of the local header of the file currently writing */
+    char    *central_header;        /* central header data for the current file */
+    uint16_t size_centralextra;
+    uint16_t size_centralheader;    /* size of the central header for cur file */
+    uint16_t size_centralextrafree; /* Extra bytes allocated to the central header but that are not used */
+    uint16_t size_comment;
+    uint16_t flag;                  /* flag of the file currently writing */
+
+    uint16_t method;                /* compression method written to file.*/
+    uint16_t compression_method;    /* compression method to use */
+    int      raw;                   /* 1 for directly writing raw data */
+    uint8_t  buffered_data[Z_BUFSIZE];  /* buffer contain compressed data to be writ*/
+    uint32_t dos_date;
+    uint32_t crc32;
+    int      zip64;                 /* add ZIP64 extended information in the extra field */
+    uint32_t number_disk;           /* number of current disk used for spanning ZIP */
+    uint64_t total_compressed;
+    uint64_t total_uncompressed;
+#ifndef NOCRYPT
+    uint32_t keys[3];          /* keys defining the pseudo-random sequence */
+    const z_crc_t *pcrc_32_tab;
+#endif
+} curfile64_info;
+
+typedef struct
+{
+    zlib_filefunc64_32_def z_filefunc;
+    voidpf filestream;              /* io structure of the zipfile */
+    voidpf filestream_with_CD;      /* io structure of the zipfile with the central dir */
+    linkedlist_data central_dir;    /* datablock with central dir in construction*/
+    int in_opened_file_inzip;       /* 1 if a file in the zip is currently writ.*/
+    int append;                     /* append mode */
+    curfile64_info ci;              /* info on the file currently writing */
+
+    uint64_t add_position_when_writting_offset;
+    uint64_t number_entry;
+    uint64_t disk_size;             /* size of each disk */
+    uint32_t number_disk;           /* number of the current disk, used for spanning ZIP */
+    uint32_t number_disk_with_CD;   /* number the the disk with central dir, used for spanning ZIP */
+#ifndef NO_ADDFILEINEXISTINGZIP
+    char *globalcomment;
+#endif
+} zip64_internal;
+
+/* Allocate a new data block */
+static linkedlist_datablock_internal *allocate_new_datablock(void)
+{
+    linkedlist_datablock_internal *ldi = NULL;
+
+    ldi = (linkedlist_datablock_internal*)ALLOC(sizeof(linkedlist_datablock_internal));
+
+    if (ldi != NULL)
+    {
+        ldi->next_datablock = NULL;
+        ldi->filled_in_this_block = 0;
+        ldi->avail_in_this_block = SIZEDATA_INDATABLOCK;
+    }
+    return ldi;
+}
+
+/* Free data block in linked list */
+static void free_datablock(linkedlist_datablock_internal *ldi)
+{
+    while (ldi != NULL)
+    {
+        linkedlist_datablock_internal *ldinext = ldi->next_datablock;
+        TRYFREE(ldi);
+        ldi = ldinext;
+    }
+}
+
+/* Initialize linked list */
+static void init_linkedlist(linkedlist_data *ll)
+{
+    ll->first_block = ll->last_block = NULL;
+}
+
+/* Free entire linked list and all data blocks */
+static void free_linkedlist(linkedlist_data *ll)
+{
+    free_datablock(ll->first_block);
+    ll->first_block = ll->last_block = NULL;
+}
+
+/* Add data to linked list data block */
+static int add_data_in_datablock(linkedlist_data *ll, const void *buf, uint32_t len)
+{
+    linkedlist_datablock_internal *ldi = NULL;
+    const unsigned char *from_copy = NULL;
+
+    if (ll == NULL)
+        return ZIP_INTERNALERROR;
+
+    if (ll->last_block == NULL)
+    {
+        ll->first_block = ll->last_block = allocate_new_datablock();
+        if (ll->first_block == NULL)
+            return ZIP_INTERNALERROR;
+    }
+
+    ldi = ll->last_block;
+    from_copy = (unsigned char*)buf;
+
+    while (len > 0)
+    {
+        uint32_t copy_this = 0;
+        uint32_t i = 0;
+        unsigned char *to_copy = NULL;
+
+        if (ldi->avail_in_this_block == 0)
+        {
+            ldi->next_datablock = allocate_new_datablock();
+            if (ldi->next_datablock == NULL)
+                return ZIP_INTERNALERROR;
+            ldi = ldi->next_datablock ;
+            ll->last_block = ldi;
+        }
+
+        if (ldi->avail_in_this_block < len)
+            copy_this = ldi->avail_in_this_block;
+        else
+            copy_this = len;
+
+        to_copy = &(ldi->data[ldi->filled_in_this_block]);
+
+        for (i = 0; i < copy_this; i++)
+            *(to_copy+i) = *(from_copy+i);
+
+        ldi->filled_in_this_block += copy_this;
+        ldi->avail_in_this_block -= copy_this;
+        from_copy += copy_this;
+        len -= copy_this;
+    }
+    return ZIP_OK;
+}
+
+/* Inputs a long in LSB order to the given file: nbByte == 1, 2 ,4 or 8 (byte, short or long, uint64_t) */
+static int zipWriteValue(const zlib_filefunc64_32_def *pzlib_filefunc_def, voidpf filestream,
+    uint64_t x, uint32_t len)
+{
+    unsigned char buf[8];
+    uint32_t n = 0;
+
+    for (n = 0; n < len; n++)
+    {
+        buf[n] = (unsigned char)(x & 0xff);
+        x >>= 8;
+    }
+
+    if (x != 0)
+    {
+        /* Data overflow - hack for ZIP64 (X Roche) */
+        for (n = 0; n < len; n++)
+        {
+            buf[n] = 0xff;
+        }
+    }
+
+    if (ZWRITE64(*pzlib_filefunc_def, filestream, buf, len) != len)
+        return ZIP_ERRNO;
+
+    return ZIP_OK;
+}
+
+static void zipWriteValueToMemory(void* dest, uint64_t x, uint32_t len)
+{
+    unsigned char *buf = (unsigned char*)dest;
+    uint32_t n = 0;
+
+    for (n = 0; n < len; n++)
+    {
+        buf[n] = (unsigned char)(x & 0xff);
+        x >>= 8;
+    }
+
+    if (x != 0)
+    {
+       /* data overflow - hack for ZIP64 */
+       for (n = 0; n < len; n++)
+       {
+          buf[n] = 0xff;
+       }
+    }
+}
+
+static void zipWriteValueToMemoryAndMove(unsigned char **dest_ptr, uint64_t x, uint32_t len)
+{
+    zipWriteValueToMemory(*dest_ptr, x, len);
+    *dest_ptr += len;
+}
+
+static int zipReadUInt8(const zlib_filefunc64_32_def *pzlib_filefunc_def, voidpf filestream, uint8_t *value)
+{
+    uint8_t c = 0;
+    if (ZREAD64(*pzlib_filefunc_def, filestream, &c, 1) == 1)
+    {
+        *value = (uint8_t)c;
+        return ZIP_OK;
+    }
+    if (ZERROR64(*pzlib_filefunc_def, filestream))
+        return ZIP_ERRNO;
+    return ZIP_EOF;
+}
+
+static int zipReadUInt16(const zlib_filefunc64_32_def *pzlib_filefunc_def, voidpf filestream, uint16_t *value)
+{
+    uint16_t x = 0;
+    uint8_t c = 0;
+    int err = ZIP_OK;
+
+    err = zipReadUInt8(pzlib_filefunc_def, filestream, &c);
+    x = (uint16_t)c;
+    if (err == ZIP_OK)
+        err = zipReadUInt8(pzlib_filefunc_def, filestream, &c);
+    x += ((uint16_t)c) << 8;
+
+    if (err == ZIP_OK)
+        *value = x;
     else
-      all_slashes = 0;
-  }
-
-  /* If NAME is all slashes, arrange to return `/'. */
-  if (*base == '\0' && ISSLASH(*name) && all_slashes)
-    --base;
-
-  return base;
+        *value = 0;
+    return err;
 }
 
-static int mkpath(char *path) {
-  char *p;
-  char npath[MAX_PATH + 1];
-  int len = 0;
-  int has_device = HAS_DEVICE(path);
+static int zipReadUInt32(const zlib_filefunc64_32_def *pzlib_filefunc_def, voidpf filestream, uint32_t *value)
+{
+    uint32_t x = 0;
+    uint8_t c = 0;
+    int err = ZIP_OK;
 
-  memset(npath, 0, MAX_PATH + 1);
-  if (has_device) {
-    // only on windows
-    npath[0] = path[0];
-    npath[1] = path[1];
-    len = 2;
-  }
-  for (p = path + len; *p && len < MAX_PATH; p++) {
-    if (ISSLASH(*p) && ((!has_device && len > 0) || (has_device && len > 2))) {
-#if defined(_WIN32) || defined(__WIN32__) || defined(_MSC_VER) ||              \
-    defined(__MINGW32__)
-#else
-      if ('\\' == *p) {
-        *p = '/';
-      }
+    err = zipReadUInt8(pzlib_filefunc_def, filestream, &c);
+    x = (uint32_t)c;
+    if (err == ZIP_OK)
+        err = zipReadUInt8(pzlib_filefunc_def, filestream, &c);
+    x += ((uint32_t)c) << 8;
+    if (err == ZIP_OK)
+        err = zipReadUInt8(pzlib_filefunc_def, filestream, &c);
+    x += ((uint32_t)c) << 16;
+    if (err == ZIP_OK)
+        err = zipReadUInt8(pzlib_filefunc_def, filestream, &c);
+    x += ((uint32_t)c) << 24;
+
+    if (err == ZIP_OK)
+        *value = x;
+    else
+        *value = 0;
+    return err;
+}
+
+static int zipReadUInt64(const zlib_filefunc64_32_def *pzlib_filefunc_def, voidpf filestream, uint64_t *value)
+{
+    uint64_t x = 0;
+    uint8_t c = 0;
+    int err = ZIP_OK;
+
+    err = zipReadUInt8(pzlib_filefunc_def, filestream, &c);
+    x = (uint64_t)c;
+    if (err == ZIP_OK)
+        err = zipReadUInt8(pzlib_filefunc_def, filestream, &c);
+    x += ((uint64_t)c) << 8;
+    if (err == ZIP_OK)
+        err = zipReadUInt8(pzlib_filefunc_def, filestream, &c);
+    x += ((uint64_t)c) << 16;
+    if (err == ZIP_OK)
+        err = zipReadUInt8(pzlib_filefunc_def, filestream, &c);
+    x += ((uint64_t)c) << 24;
+    if (err == ZIP_OK)
+        err = zipReadUInt8(pzlib_filefunc_def, filestream, &c);
+    x += ((uint64_t)c) << 32;
+    if (err == ZIP_OK)
+        err = zipReadUInt8(pzlib_filefunc_def, filestream, &c);
+    x += ((uint64_t)c) << 40;
+    if (err == ZIP_OK)
+        err = zipReadUInt8(pzlib_filefunc_def, filestream, &c);
+    x += ((uint64_t)c) << 48;
+    if (err == ZIP_OK)
+        err = zipReadUInt8(pzlib_filefunc_def, filestream, &c);
+    x += ((uint64_t)c) << 56;
+
+    if (err == ZIP_OK)
+        *value = x;
+    else
+        *value = 0;
+
+    return err;
+}
+
+/* Gets the amount of bytes left to write to the current disk for spanning archives */
+static void zipGetDiskSizeAvailable(zipFile file, uint64_t *size_available)
+{
+    zip64_internal *zi = NULL;
+    uint64_t current_disk_size = 0;
+
+    zi = (zip64_internal*)file;
+    ZSEEK64(zi->z_filefunc, zi->filestream, 0, ZLIB_FILEFUNC_SEEK_END);
+    current_disk_size = ZTELL64(zi->z_filefunc, zi->filestream);
+    *size_available = zi->disk_size - current_disk_size;
+}
+
+/* Goes to a specific disk number for spanning archives */
+static int zipGoToSpecificDisk(zipFile file, uint32_t number_disk, int open_existing)
+{
+    zip64_internal *zi = NULL;
+    int err = ZIP_OK;
+
+    zi = (zip64_internal*)file;
+    if (zi->disk_size == 0)
+        return err;
+
+    if ((zi->filestream != NULL) && (zi->filestream != zi->filestream_with_CD))
+        ZCLOSE64(zi->z_filefunc, zi->filestream);
+
+    zi->filestream = ZOPENDISK64(zi->z_filefunc, zi->filestream_with_CD, number_disk, (open_existing == 1) ?
+            (ZLIB_FILEFUNC_MODE_READ | ZLIB_FILEFUNC_MODE_WRITE | ZLIB_FILEFUNC_MODE_EXISTING) :
+            (ZLIB_FILEFUNC_MODE_READ | ZLIB_FILEFUNC_MODE_WRITE | ZLIB_FILEFUNC_MODE_CREATE));
+
+    if (zi->filestream == NULL)
+        err = ZIP_ERRNO;
+
+    return err;
+}
+
+/* Goes to the first disk in a spanned archive */
+static int zipGoToFirstDisk(zipFile file)
+{
+    zip64_internal *zi = NULL;
+    uint32_t number_disk_next = 0;
+    int err = ZIP_OK;
+
+    zi = (zip64_internal*)file;
+
+    if (zi->disk_size == 0)
+        return err;
+    number_disk_next = 0;
+    if (zi->number_disk_with_CD > 0)
+        number_disk_next = zi->number_disk_with_CD - 1;
+    err = zipGoToSpecificDisk(file, number_disk_next, (zi->append == APPEND_STATUS_ADDINZIP));
+    if ((err == ZIP_ERRNO) && (zi->append == APPEND_STATUS_ADDINZIP))
+        err = zipGoToSpecificDisk(file, number_disk_next, 0);
+    if (err == ZIP_OK)
+        zi->number_disk = number_disk_next;
+    ZSEEK64(zi->z_filefunc, zi->filestream, 0, ZLIB_FILEFUNC_SEEK_END);
+    return err;
+}
+
+/* Goes to the next disk in a spanned archive */
+static int zipGoToNextDisk(zipFile file)
+{
+    zip64_internal *zi = NULL;
+    uint64_t size_available_in_disk = 0;
+    uint32_t number_disk_next = 0;
+    int err = ZIP_OK;
+
+    zi = (zip64_internal*)file;
+    if (zi->disk_size == 0)
+        return err;
+
+    number_disk_next = zi->number_disk + 1;
+
+    do
+    {
+        err = zipGoToSpecificDisk(file, number_disk_next, (zi->append == APPEND_STATUS_ADDINZIP));
+        if ((err == ZIP_ERRNO) && (zi->append == APPEND_STATUS_ADDINZIP))
+            err = zipGoToSpecificDisk(file, number_disk_next, 0);
+        if (err != ZIP_OK)
+            break;
+        zipGetDiskSizeAvailable(file, &size_available_in_disk);
+        zi->number_disk = number_disk_next;
+        zi->number_disk_with_CD = zi->number_disk + 1;
+
+        number_disk_next += 1;
+    }
+    while (size_available_in_disk <= 0);
+
+    return err;
+}
+
+/* Locate the Central directory of a zipfile (at the end, just before the global comment) */
+static uint64_t zipSearchCentralDir(const zlib_filefunc64_32_def *pzlib_filefunc_def, voidpf filestream)
+{
+    unsigned char *buf = NULL;
+    uint64_t file_size = 0;
+    uint64_t back_read = 4;
+    uint64_t max_back = UINT16_MAX; /* maximum size of global comment */
+    uint64_t pos_found = 0;
+    uint32_t read_size = 0;
+    uint64_t read_pos = 0;
+    uint32_t i = 0;
+
+    buf = (unsigned char*)ALLOC(BUFREADCOMMENT+4);
+    if (buf == NULL)
+        return 0;
+
+    if (ZSEEK64(*pzlib_filefunc_def, filestream, 0, ZLIB_FILEFUNC_SEEK_END) != 0)
+    {
+        TRYFREE(buf);
+        return 0;
+    }
+
+    file_size = ZTELL64(*pzlib_filefunc_def, filestream);
+
+    if (max_back > file_size)
+        max_back = file_size;
+
+    while (back_read < max_back)
+    {
+        if (back_read + BUFREADCOMMENT > max_back)
+            back_read = max_back;
+        else
+            back_read += BUFREADCOMMENT;
+
+        read_pos = file_size-back_read;
+        read_size = ((BUFREADCOMMENT+4) < (file_size - read_pos)) ?
+                     (BUFREADCOMMENT+4) : (uint32_t)(file_size - read_pos);
+
+        if (ZSEEK64(*pzlib_filefunc_def, filestream, read_pos, ZLIB_FILEFUNC_SEEK_SET) != 0)
+            break;
+        if (ZREAD64(*pzlib_filefunc_def, filestream, buf, read_size) != read_size)
+            break;
+
+        for (i = read_size-3; (i--) > 0;)
+            if ((*(buf+i)) == (ENDHEADERMAGIC & 0xff) &&
+                (*(buf+i+1)) == (ENDHEADERMAGIC >> 8 & 0xff) &&
+                (*(buf+i+2)) == (ENDHEADERMAGIC >> 16 & 0xff) &&
+                (*(buf+i+3)) == (ENDHEADERMAGIC >> 24 & 0xff))
+            {
+                pos_found = read_pos+i;
+                break;
+            }
+
+        if (pos_found != 0)
+            break;
+    }
+    TRYFREE(buf);
+    return pos_found;
+}
+
+/* Locate the Central directory 64 of a zipfile (at the end, just before the global comment) */
+static uint64_t zipSearchCentralDir64(const zlib_filefunc64_32_def *pzlib_filefunc_def, voidpf filestream,
+    const uint64_t endcentraloffset)
+{
+    uint64_t offset = 0;
+    uint32_t value32 = 0;
+
+    /* Zip64 end of central directory locator */
+    if (ZSEEK64(*pzlib_filefunc_def, filestream, endcentraloffset - SIZECENTRALHEADERLOCATOR, ZLIB_FILEFUNC_SEEK_SET) != 0)
+        return 0;
+
+    /* Read locator signature */
+    if (zipReadUInt32(pzlib_filefunc_def, filestream, &value32) != ZIP_OK)
+        return 0;
+    if (value32 != ZIP64ENDLOCHEADERMAGIC)
+        return 0;
+    /* Number of the disk with the start of the zip64 end of  central directory */
+    if (zipReadUInt32(pzlib_filefunc_def, filestream, &value32) != ZIP_OK)
+        return 0;
+    /* Relative offset of the zip64 end of central directory record */
+    if (zipReadUInt64(pzlib_filefunc_def, filestream, &offset) != ZIP_OK)
+        return 0;
+    /* Total number of disks */
+    if (zipReadUInt32(pzlib_filefunc_def, filestream, &value32) != ZIP_OK)
+        return 0;
+    /* Goto end of central directory record */
+    if (ZSEEK64(*pzlib_filefunc_def,filestream, offset, ZLIB_FILEFUNC_SEEK_SET) != 0)
+        return 0;
+    /* The signature */
+    if (zipReadUInt32(pzlib_filefunc_def, filestream, &value32) != ZIP_OK)
+        return 0;
+    if (value32 != ZIP64ENDHEADERMAGIC)
+        return 0;
+
+    return offset;
+}
+
+extern zipFile ZEXPORT zipOpen4(const void *path, int append, uint64_t disk_size, const char **globalcomment,
+    zlib_filefunc64_32_def *pzlib_filefunc64_32_def)
+{
+    zip64_internal ziinit;
+    zip64_internal *zi = NULL;
+#ifndef NO_ADDFILEINEXISTINGZIP
+    uint64_t byte_before_the_zipfile = 0;   /* byte before the zipfile, (>0 for sfx)*/
+    uint64_t size_central_dir = 0;          /* size of the central directory  */
+    uint64_t offset_central_dir = 0;        /* offset of start of central directory */
+    uint64_t number_entry_CD = 0;           /* total number of entries in the central dir */
+    uint64_t number_entry = 0;
+    uint64_t central_pos = 0;
+    uint64_t size_central_dir_to_read = 0;
+    uint16_t value16 = 0;
+    uint32_t value32 = 0;
+    uint16_t size_comment = 0;
+    size_t buf_size = SIZEDATA_INDATABLOCK;
+    void *buf_read = NULL;
 #endif
+    int err = ZIP_OK;
+    int mode = 0;
 
-      if (MKDIR(npath) == -1) {
-        if (errno != EEXIST) {
-          return -1;
+    ziinit.z_filefunc.zseek32_file = NULL;
+    ziinit.z_filefunc.ztell32_file = NULL;
+
+    if (pzlib_filefunc64_32_def == NULL)
+        fill_fopen64_filefunc(&ziinit.z_filefunc.zfile_func64);
+    else
+        ziinit.z_filefunc = *pzlib_filefunc64_32_def;
+
+    if (append == APPEND_STATUS_CREATE)
+        mode = (ZLIB_FILEFUNC_MODE_READ | ZLIB_FILEFUNC_MODE_WRITE | ZLIB_FILEFUNC_MODE_CREATE);
+    else
+        mode = (ZLIB_FILEFUNC_MODE_READ | ZLIB_FILEFUNC_MODE_WRITE | ZLIB_FILEFUNC_MODE_EXISTING);
+
+    ziinit.filestream = ZOPEN64(ziinit.z_filefunc, path, mode);
+    if (ziinit.filestream == NULL)
+        return NULL;
+
+    if (append == APPEND_STATUS_CREATEAFTER)
+    {
+        /* Don't support spanning ZIP with APPEND_STATUS_CREATEAFTER */
+        if (disk_size > 0)
+            return NULL;
+
+        ZSEEK64(ziinit.z_filefunc,ziinit.filestream,0,SEEK_END);
+    }
+
+    ziinit.filestream_with_CD = ziinit.filestream;
+    ziinit.append = append;
+    ziinit.number_disk = 0;
+    ziinit.number_disk_with_CD = 0;
+    ziinit.disk_size = disk_size;
+    ziinit.in_opened_file_inzip = 0;
+    ziinit.ci.stream_initialised = 0;
+    ziinit.number_entry = 0;
+    ziinit.add_position_when_writting_offset = 0;
+    init_linkedlist(&(ziinit.central_dir));
+
+    zi = (zip64_internal*)ALLOC(sizeof(zip64_internal));
+    if (zi == NULL)
+    {
+        ZCLOSE64(ziinit.z_filefunc,ziinit.filestream);
+        return NULL;
+    }
+
+#ifndef NO_ADDFILEINEXISTINGZIP
+    /* Add file in a zipfile */
+    ziinit.globalcomment = NULL;
+    if (append == APPEND_STATUS_ADDINZIP)
+    {
+        /* Read and Cache Central Directory Records */
+        central_pos = zipSearchCentralDir(&ziinit.z_filefunc,ziinit.filestream);
+        /* Disable to allow appending to empty ZIP archive (must be standard zip, not zip64)
+            if (central_pos == 0)
+                err = ZIP_ERRNO;
+        */
+
+        if (err == ZIP_OK)
+        {
+            /* Read end of central directory info */
+            if (ZSEEK64(ziinit.z_filefunc, ziinit.filestream, central_pos,ZLIB_FILEFUNC_SEEK_SET) != 0)
+                err = ZIP_ERRNO;
+
+            /* The signature, already checked */
+            if (zipReadUInt32(&ziinit.z_filefunc, ziinit.filestream, &value32) != ZIP_OK)
+                err = ZIP_ERRNO;
+            /* Number of this disk */
+            if (zipReadUInt16(&ziinit.z_filefunc, ziinit.filestream, &value16) != ZIP_OK)
+                err = ZIP_ERRNO;
+            ziinit.number_disk = value16;
+            /* Number of the disk with the start of the central directory */
+            if (zipReadUInt16(&ziinit.z_filefunc, ziinit.filestream, &value16) != ZIP_OK)
+                err = ZIP_ERRNO;
+            ziinit.number_disk_with_CD = value16;
+            /* Total number of entries in the central dir on this disk */
+            number_entry = 0;
+            if (zipReadUInt16(&ziinit.z_filefunc, ziinit.filestream, &value16) != ZIP_OK)
+                err = ZIP_ERRNO;
+            else
+                number_entry = value16;
+            /* Total number of entries in the central dir */
+            number_entry_CD = 0;
+            if (zipReadUInt16(&ziinit.z_filefunc, ziinit.filestream, &value16) != ZIP_OK)
+                err = ZIP_ERRNO;
+            else
+                number_entry_CD = value16;
+            if (number_entry_CD!=number_entry)
+                err = ZIP_BADZIPFILE;
+            /* Size of the central directory */
+            size_central_dir = 0;
+            if (zipReadUInt32(&ziinit.z_filefunc, ziinit.filestream, &value32) != ZIP_OK)
+                err = ZIP_ERRNO;
+            else
+                size_central_dir = value32;
+            /* Offset of start of central directory with respect to the starting disk number */
+            offset_central_dir = 0;
+            if (zipReadUInt32(&ziinit.z_filefunc, ziinit.filestream, &value32) != ZIP_OK)
+                err = ZIP_ERRNO;
+            else
+                offset_central_dir = value32;
+            /* Zipfile global comment length */
+            if (zipReadUInt16(&ziinit.z_filefunc, ziinit.filestream, &size_comment) != ZIP_OK)
+                err = ZIP_ERRNO;
+
+            if ((err == ZIP_OK) && ((number_entry_CD == UINT16_MAX) || (offset_central_dir == UINT32_MAX)))
+            {
+                /* Format should be Zip64, as the central directory or file size is too large */
+                central_pos = zipSearchCentralDir64(&ziinit.z_filefunc, ziinit.filestream, central_pos);
+
+                if (central_pos)
+                {
+                    uint64_t sizeEndOfCentralDirectory;
+
+                    if (ZSEEK64(ziinit.z_filefunc, ziinit.filestream, central_pos, ZLIB_FILEFUNC_SEEK_SET) != 0)
+                        err = ZIP_ERRNO;
+
+                    /* The signature, already checked */
+                    if (zipReadUInt32(&ziinit.z_filefunc, ziinit.filestream, &value32) != ZIP_OK)
+                        err = ZIP_ERRNO;
+                    /* Size of zip64 end of central directory record */
+                    if (zipReadUInt64(&ziinit.z_filefunc, ziinit.filestream, &sizeEndOfCentralDirectory) != ZIP_OK)
+                        err = ZIP_ERRNO;
+                    /* Version made by */
+                    if (zipReadUInt16(&ziinit.z_filefunc, ziinit.filestream, &value16) != ZIP_OK)
+                        err = ZIP_ERRNO;
+                    /* Version needed to extract */
+                    if (zipReadUInt16(&ziinit.z_filefunc, ziinit.filestream, &value16) != ZIP_OK)
+                        err = ZIP_ERRNO;
+                    /* Number of this disk */
+                    if (zipReadUInt32(&ziinit.z_filefunc, ziinit.filestream, &ziinit.number_disk) != ZIP_OK)
+                        err = ZIP_ERRNO;
+                    /* Number of the disk with the start of the central directory */
+                    if (zipReadUInt32(&ziinit.z_filefunc, ziinit.filestream, &ziinit.number_disk_with_CD) != ZIP_OK)
+                        err = ZIP_ERRNO;
+                    /* Total number of entries in the central directory on this disk */
+                    if (zipReadUInt64(&ziinit.z_filefunc, ziinit.filestream, &number_entry) != ZIP_OK)
+                        err = ZIP_ERRNO;
+                    /* Total number of entries in the central directory */
+                    if (zipReadUInt64(&ziinit.z_filefunc, ziinit.filestream, &number_entry_CD) != ZIP_OK)
+                        err = ZIP_ERRNO;
+                    if (number_entry_CD!=number_entry)
+                        err = ZIP_BADZIPFILE;
+                    /* Size of the central directory */
+                    if (zipReadUInt64(&ziinit.z_filefunc, ziinit.filestream, &size_central_dir) != ZIP_OK)
+                        err = ZIP_ERRNO;
+                    /* Offset of start of central directory with respect to the starting disk number */
+                    if (zipReadUInt64(&ziinit.z_filefunc, ziinit.filestream, &offset_central_dir) != ZIP_OK)
+                        err = ZIP_ERRNO;
+                }
+                else
+                    err = ZIP_BADZIPFILE;
+             }
         }
-      }
-    }
-    npath[len++] = *p;
-  }
 
-  return 0;
-}
-
-static char *strrpl(const char *str, size_t n, char oldchar, char newchar) {
-  char c;
-  size_t i;
-  char *rpl = (char *)calloc((1 + n), sizeof(char));
-  char *begin = rpl;
-  if (!rpl) {
-    return NULL;
-  }
-
-  for (i = 0; (i < n) && (c = *str++); ++i) {
-    if (c == oldchar) {
-      c = newchar;
-    }
-    *rpl++ = c;
-  }
-
-  return begin;
-}
-
-struct zip_entry_t {
-  int index;
-  char *name;
-  mz_uint64 uncomp_size;
-  mz_uint64 comp_size;
-  mz_uint32 uncomp_crc32;
-  mz_uint64 offset;
-  mz_uint8 header[MZ_ZIP_LOCAL_DIR_HEADER_SIZE];
-  mz_uint64 header_offset;
-  mz_uint16 method;
-  mz_zip_writer_add_state state;
-  tdefl_compressor comp;
-  mz_uint32 external_attr;
-  time_t m_time;
-};
-
-struct zip_t {
-  mz_zip_archive archive;
-  mz_uint level;
-  struct zip_entry_t entry;
-};
-
-struct zip_t *zip_open(const char *zipname, int level, char mode) {
-  struct zip_t *zip = NULL;
-
-  if (!zipname || strlen(zipname) < 1) {
-    // zip_t archive name is empty or NULL
-    goto cleanup;
-  }
-
-  if (level < 0)
-    level = MZ_DEFAULT_LEVEL;
-  if ((level & 0xF) > MZ_UBER_COMPRESSION) {
-    // Wrong compression level
-    goto cleanup;
-  }
-
-  zip = (struct zip_t *)calloc((size_t)1, sizeof(struct zip_t));
-  if (!zip)
-    goto cleanup;
-
-  zip->level = (mz_uint)level;
-  switch (mode) {
-  case 'w':
-    // Create a new archive.
-    if (!mz_zip_writer_init_file(&(zip->archive), zipname, 0)) {
-      // Cannot initialize zip_archive writer
-      goto cleanup;
-    }
-    break;
-
-  case 'r':
-  case 'a':
-    if (!mz_zip_reader_init_file(
-            &(zip->archive), zipname,
-            zip->level | MZ_ZIP_FLAG_DO_NOT_SORT_CENTRAL_DIRECTORY)) {
-      // An archive file does not exist or cannot initialize
-      // zip_archive reader
-      goto cleanup;
-    }
-    if (mode == 'a' &&
-        !mz_zip_writer_init_from_reader(&(zip->archive), zipname)) {
-      mz_zip_reader_end(&(zip->archive));
-      goto cleanup;
-    }
-    break;
-
-  default:
-    goto cleanup;
-  }
-
-  return zip;
-
-cleanup:
-  CLEANUP(zip);
-  return NULL;
-}
-
-void zip_close(struct zip_t *zip) {
-  if (zip) {
-    // Always finalize, even if adding failed for some reason, so we have a
-    // valid central directory.
-    mz_zip_writer_finalize_archive(&(zip->archive));
-
-    mz_zip_writer_end(&(zip->archive));
-    mz_zip_reader_end(&(zip->archive));
-
-    CLEANUP(zip);
-  }
-}
-
-int zip_is64(struct zip_t *zip) {
-  if (!zip) {
-    // zip_t handler is not initialized
-    return -1;
-  }
-
-  if (!zip->archive.m_pState) {
-    // zip state is not initialized
-    return -1;
-  }
-
-  return (int)zip->archive.m_pState->m_zip64;
-}
-
-int zip_entry_open(struct zip_t *zip, const char *entryname) {
-  size_t entrylen = 0;
-  mz_zip_archive *pzip = NULL;
-  mz_uint num_alignment_padding_bytes, level;
-  mz_zip_archive_file_stat stats;
-
-  if (!zip || !entryname) {
-    return -1;
-  }
-
-  entrylen = strlen(entryname);
-  if (entrylen < 1) {
-    return -1;
-  }
-
-  /*
-    .ZIP File Format Specification Version: 6.3.3
-
-    4.4.17.1 The name of the file, with optional relative path.
-    The path stored MUST not contain a drive or
-    device letter, or a leading slash.  All slashes
-    MUST be forward slashes '/' as opposed to
-    backwards slashes '\' for compatibility with Amiga
-    and UNIX file systems etc.  If input came from standard
-    input, there is no file name field.
-  */
-  zip->entry.name = strrpl(entryname, entrylen, '\\', '/');
-  if (!zip->entry.name) {
-    // Cannot parse zip entry name
-    return -1;
-  }
-
-  pzip = &(zip->archive);
-  if (pzip->m_zip_mode == MZ_ZIP_MODE_READING) {
-    zip->entry.index =
-        mz_zip_reader_locate_file(pzip, zip->entry.name, NULL, 0);
-    if (zip->entry.index < 0) {
-      goto cleanup;
-    }
-
-    if (!mz_zip_reader_file_stat(pzip, (mz_uint)zip->entry.index, &stats)) {
-      goto cleanup;
-    }
-
-    zip->entry.comp_size = stats.m_comp_size;
-    zip->entry.uncomp_size = stats.m_uncomp_size;
-    zip->entry.uncomp_crc32 = stats.m_crc32;
-    zip->entry.offset = stats.m_central_dir_ofs;
-    zip->entry.header_offset = stats.m_local_header_ofs;
-    zip->entry.method = stats.m_method;
-    zip->entry.external_attr = stats.m_external_attr;
-    zip->entry.m_time = stats.m_time;
-
-    return 0;
-  }
-
-  zip->entry.index = (int)zip->archive.m_total_files;
-  zip->entry.comp_size = 0;
-  zip->entry.uncomp_size = 0;
-  zip->entry.uncomp_crc32 = MZ_CRC32_INIT;
-  zip->entry.offset = zip->archive.m_archive_size;
-  zip->entry.header_offset = zip->archive.m_archive_size;
-  memset(zip->entry.header, 0, MZ_ZIP_LOCAL_DIR_HEADER_SIZE * sizeof(mz_uint8));
-  zip->entry.method = 0;
-
-  // UNIX or APPLE
-#if MZ_PLATFORM == 3 || MZ_PLATFORM == 19
-  // regular file with rw-r--r-- persmissions
-  zip->entry.external_attr = (mz_uint32)(0100644) << 16;
-#else
-  zip->entry.external_attr = 0;
-#endif
-
-  num_alignment_padding_bytes =
-      mz_zip_writer_compute_padding_needed_for_file_alignment(pzip);
-
-  if (!pzip->m_pState || (pzip->m_zip_mode != MZ_ZIP_MODE_WRITING)) {
-    // Wrong zip mode
-    goto cleanup;
-  }
-  if (zip->level & MZ_ZIP_FLAG_COMPRESSED_DATA) {
-    // Wrong zip compression level
-    goto cleanup;
-  }
-  // no zip64 support yet
-  if ((pzip->m_total_files == 0xFFFF) ||
-      ((pzip->m_archive_size + num_alignment_padding_bytes +
-        MZ_ZIP_LOCAL_DIR_HEADER_SIZE + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE +
-        entrylen) > 0xFFFFFFFF)) {
-    // No zip64 support yet
-    goto cleanup;
-  }
-  if (!mz_zip_writer_write_zeros(pzip, zip->entry.offset,
-                                 num_alignment_padding_bytes +
-                                     sizeof(zip->entry.header))) {
-    // Cannot memset zip entry header
-    goto cleanup;
-  }
-
-  zip->entry.header_offset += num_alignment_padding_bytes;
-  if (pzip->m_file_offset_alignment) {
-    MZ_ASSERT(
-        (zip->entry.header_offset & (pzip->m_file_offset_alignment - 1)) == 0);
-  }
-  zip->entry.offset += num_alignment_padding_bytes + sizeof(zip->entry.header);
-
-  if (pzip->m_pWrite(pzip->m_pIO_opaque, zip->entry.offset, zip->entry.name,
-                     entrylen) != entrylen) {
-    // Cannot write data to zip entry
-    goto cleanup;
-  }
-
-  zip->entry.offset += entrylen;
-  level = zip->level & 0xF;
-  if (level) {
-    zip->entry.state.m_pZip = pzip;
-    zip->entry.state.m_cur_archive_file_ofs = zip->entry.offset;
-    zip->entry.state.m_comp_size = 0;
-
-    if (tdefl_init(&(zip->entry.comp), mz_zip_writer_add_put_buf_callback,
-                   &(zip->entry.state),
-                   (int)tdefl_create_comp_flags_from_zip_params(
-                       (int)level, -15, MZ_DEFAULT_STRATEGY)) !=
-        TDEFL_STATUS_OKAY) {
-      // Cannot initialize the zip compressor
-      goto cleanup;
-    }
-  }
-
-  zip->entry.m_time = time(NULL);
-
-  return 0;
-
-cleanup:
-  CLEANUP(zip->entry.name);
-  return -1;
-}
-
-int zip_entry_openbyindex(struct zip_t *zip, int index) {
-  mz_zip_archive *pZip = NULL;
-  mz_zip_archive_file_stat stats;
-  mz_uint namelen;
-  const mz_uint8 *pHeader;
-  const char *pFilename;
-
-  if (!zip) {
-    // zip_t handler is not initialized
-    return -1;
-  }
-
-  pZip = &(zip->archive);
-  if (pZip->m_zip_mode != MZ_ZIP_MODE_READING) {
-    // open by index requires readonly mode
-    return -1;
-  }
-
-  if (index < 0 || (mz_uint)index >= pZip->m_total_files) {
-    // index out of range
-    return -1;
-  }
-
-  if (!(pHeader = &MZ_ZIP_ARRAY_ELEMENT(
-            &pZip->m_pState->m_central_dir, mz_uint8,
-            MZ_ZIP_ARRAY_ELEMENT(&pZip->m_pState->m_central_dir_offsets,
-                                 mz_uint32, index)))) {
-    // cannot find header in central directory
-    return -1;
-  }
-
-  namelen = MZ_READ_LE16(pHeader + MZ_ZIP_CDH_FILENAME_LEN_OFS);
-  pFilename = (const char *)pHeader + MZ_ZIP_CENTRAL_DIR_HEADER_SIZE;
-
-  /*
-    .ZIP File Format Specification Version: 6.3.3
-
-    4.4.17.1 The name of the file, with optional relative path.
-    The path stored MUST not contain a drive or
-    device letter, or a leading slash.  All slashes
-    MUST be forward slashes '/' as opposed to
-    backwards slashes '\' for compatibility with Amiga
-    and UNIX file systems etc.  If input came from standard
-    input, there is no file name field.
-  */
-  zip->entry.name = strrpl(pFilename, namelen, '\\', '/');
-  if (!zip->entry.name) {
-    // local entry name is NULL
-    return -1;
-  }
-
-  if (!mz_zip_reader_file_stat(pZip, (mz_uint)index, &stats)) {
-    return -1;
-  }
-
-  zip->entry.index = index;
-  zip->entry.comp_size = stats.m_comp_size;
-  zip->entry.uncomp_size = stats.m_uncomp_size;
-  zip->entry.uncomp_crc32 = stats.m_crc32;
-  zip->entry.offset = stats.m_central_dir_ofs;
-  zip->entry.header_offset = stats.m_local_header_ofs;
-  zip->entry.method = stats.m_method;
-  zip->entry.external_attr = stats.m_external_attr;
-  zip->entry.m_time = stats.m_time;
-
-  return 0;
-}
-
-int zip_entry_close(struct zip_t *zip) {
-  mz_zip_archive *pzip = NULL;
-  mz_uint level;
-  tdefl_status done;
-  mz_uint16 entrylen;
-  mz_uint16 dos_time, dos_date;
-  int status = -1;
-
-  if (!zip) {
-    // zip_t handler is not initialized
-    goto cleanup;
-  }
-
-  pzip = &(zip->archive);
-  if (pzip->m_zip_mode == MZ_ZIP_MODE_READING) {
-    status = 0;
-    goto cleanup;
-  }
-
-  level = zip->level & 0xF;
-  if (level) {
-    done = tdefl_compress_buffer(&(zip->entry.comp), "", 0, TDEFL_FINISH);
-    if (done != TDEFL_STATUS_DONE && done != TDEFL_STATUS_OKAY) {
-      // Cannot flush compressed buffer
-      goto cleanup;
-    }
-    zip->entry.comp_size = zip->entry.state.m_comp_size;
-    zip->entry.offset = zip->entry.state.m_cur_archive_file_ofs;
-    zip->entry.method = MZ_DEFLATED;
-  }
-
-  entrylen = (mz_uint16)strlen(zip->entry.name);
-  // no zip64 support yet
-  if ((zip->entry.comp_size > 0xFFFFFFFF) || (zip->entry.offset > 0xFFFFFFFF)) {
-    // No zip64 support, yet
-    goto cleanup;
-  }
-
-  mz_zip_time_t_to_dos_time(zip->entry.m_time, &dos_time, &dos_date);
-  if (!mz_zip_writer_create_local_dir_header(
-          pzip, zip->entry.header, entrylen, 0, zip->entry.uncomp_size,
-          zip->entry.comp_size, zip->entry.uncomp_crc32, zip->entry.method, 0,
-          dos_time, dos_date)) {
-    // Cannot create zip entry header
-    goto cleanup;
-  }
-
-  if (pzip->m_pWrite(pzip->m_pIO_opaque, zip->entry.header_offset,
-                     zip->entry.header,
-                     sizeof(zip->entry.header)) != sizeof(zip->entry.header)) {
-    // Cannot write zip entry header
-    goto cleanup;
-  }
-
-  if (!mz_zip_writer_add_to_central_dir(
-          pzip, zip->entry.name, entrylen, NULL, 0, "", 0,
-          zip->entry.uncomp_size, zip->entry.comp_size, zip->entry.uncomp_crc32,
-          zip->entry.method, 0, dos_time, dos_date, zip->entry.header_offset,
-          zip->entry.external_attr)) {
-    // Cannot write to zip central dir
-    goto cleanup;
-  }
-
-  pzip->m_total_files++;
-  pzip->m_archive_size = zip->entry.offset;
-  status = 0;
-
-cleanup:
-  if (zip) {
-    zip->entry.m_time = 0;
-    CLEANUP(zip->entry.name);
-  }
-  return status;
-}
-
-const char *zip_entry_name(struct zip_t *zip) {
-  if (!zip) {
-    // zip_t handler is not initialized
-    return NULL;
-  }
-
-  return zip->entry.name;
-}
-
-int zip_entry_index(struct zip_t *zip) {
-  if (!zip) {
-    // zip_t handler is not initialized
-    return -1;
-  }
-
-  return zip->entry.index;
-}
-
-int zip_entry_isdir(struct zip_t *zip) {
-  if (!zip) {
-    // zip_t handler is not initialized
-    return -1;
-  }
-
-  if (zip->entry.index < 0) {
-    // zip entry is not opened
-    return -1;
-  }
-
-  return (int)mz_zip_reader_is_file_a_directory(&zip->archive,
-                                                (mz_uint)zip->entry.index);
-}
-
-unsigned long long zip_entry_size(struct zip_t *zip) {
-  return zip ? zip->entry.uncomp_size : 0;
-}
-
-unsigned int zip_entry_crc32(struct zip_t *zip) {
-  return zip ? zip->entry.uncomp_crc32 : 0;
-}
-
-int zip_entry_write(struct zip_t *zip, const void *buf, size_t bufsize) {
-  mz_uint level;
-  mz_zip_archive *pzip = NULL;
-  tdefl_status status;
-
-  if (!zip) {
-    // zip_t handler is not initialized
-    return -1;
-  }
-
-  pzip = &(zip->archive);
-  if (buf && bufsize > 0) {
-    zip->entry.uncomp_size += bufsize;
-    zip->entry.uncomp_crc32 = (mz_uint32)mz_crc32(
-        zip->entry.uncomp_crc32, (const mz_uint8 *)buf, bufsize);
-
-    level = zip->level & 0xF;
-    if (!level) {
-      if ((pzip->m_pWrite(pzip->m_pIO_opaque, zip->entry.offset, buf,
-                          bufsize) != bufsize)) {
-        // Cannot write buffer
-        return -1;
-      }
-      zip->entry.offset += bufsize;
-      zip->entry.comp_size += bufsize;
-    } else {
-      status = tdefl_compress_buffer(&(zip->entry.comp), buf, bufsize,
-                                     TDEFL_NO_FLUSH);
-      if (status != TDEFL_STATUS_DONE && status != TDEFL_STATUS_OKAY) {
-        // Cannot compress buffer
-        return -1;
-      }
-    }
-  }
-
-  return 0;
-}
-
-int zip_entry_fwrite(struct zip_t *zip, const char *filename) {
-  int status = 0;
-  size_t n = 0;
-  FILE *stream = NULL;
-  mz_uint8 buf[MZ_ZIP_MAX_IO_BUF_SIZE];
-  struct MZ_FILE_STAT_STRUCT file_stat;
-
-  if (!zip) {
-    // zip_t handler is not initialized
-    return -1;
-  }
-
-  memset(buf, 0, MZ_ZIP_MAX_IO_BUF_SIZE);
-  memset((void *)&file_stat, 0, sizeof(struct MZ_FILE_STAT_STRUCT));
-  if (MZ_FILE_STAT(filename, &file_stat) != 0) {
-    // problem getting information - check errno
-    return -1;
-  }
-
-  if ((file_stat.st_mode & 0200) == 0) {
-    // MS-DOS read-only attribute
-    zip->entry.external_attr |= 0x01;
-  }
-  zip->entry.external_attr |= (mz_uint32)((file_stat.st_mode & 0xFFFF) << 16);
-  zip->entry.m_time = file_stat.st_mtime;
-
-#if defined(_MSC_VER)
-  if (fopen_s(&stream, filename, "rb"))
-#else
-  if (!(stream = fopen(filename, "rb")))
-#endif
-  {
-    // Cannot open filename
-    return -1;
-  }
-
-  while ((n = fread(buf, sizeof(mz_uint8), MZ_ZIP_MAX_IO_BUF_SIZE, stream)) >
-         0) {
-    if (zip_entry_write(zip, buf, n) < 0) {
-      status = -1;
-      break;
-    }
-  }
-  fclose(stream);
-
-  return status;
-}
-
-ssize_t zip_entry_read(struct zip_t *zip, void **buf, size_t *bufsize) {
-  mz_zip_archive *pzip = NULL;
-  mz_uint idx;
-  size_t size = 0;
-
-  if (!zip) {
-    // zip_t handler is not initialized
-    return -1;
-  }
-
-  pzip = &(zip->archive);
-  if (pzip->m_zip_mode != MZ_ZIP_MODE_READING || zip->entry.index < 0) {
-    // the entry is not found or we do not have read access
-    return -1;
-  }
-
-  idx = (mz_uint)zip->entry.index;
-  if (mz_zip_reader_is_file_a_directory(pzip, idx)) {
-    // the entry is a directory
-    return -1;
-  }
-
-  *buf = mz_zip_reader_extract_to_heap(pzip, idx, &size, 0);
-  if (*buf && bufsize) {
-    *bufsize = size;
-  }
-  return size;
-}
-
-ssize_t zip_entry_noallocread(struct zip_t *zip, void *buf, size_t bufsize) {
-  mz_zip_archive *pzip = NULL;
-
-  if (!zip) {
-    // zip_t handler is not initialized
-    return -1;
-  }
-
-  pzip = &(zip->archive);
-  if (pzip->m_zip_mode != MZ_ZIP_MODE_READING || zip->entry.index < 0) {
-    // the entry is not found or we do not have read access
-    return -1;
-  }
-
-  if (!mz_zip_reader_extract_to_mem_no_alloc(pzip, (mz_uint)zip->entry.index,
-                                             buf, bufsize, 0, NULL, 0)) {
-    return -1;
-  }
-
-  return (ssize_t)zip->entry.uncomp_size;
-}
-
-int zip_entry_fread(struct zip_t *zip, const char *filename) {
-  mz_zip_archive *pzip = NULL;
-  mz_uint idx;
-#if defined(_MSC_VER)
-#else
-  mz_uint32 xattr = 0;
-#endif
-  mz_zip_archive_file_stat info;
-
-  if (!zip) {
-    // zip_t handler is not initialized
-    return -1;
-  }
-
-  memset((void *)&info, 0, sizeof(mz_zip_archive_file_stat));
-  pzip = &(zip->archive);
-  if (pzip->m_zip_mode != MZ_ZIP_MODE_READING || zip->entry.index < 0) {
-    // the entry is not found or we do not have read access
-    return -1;
-  }
-
-  idx = (mz_uint)zip->entry.index;
-  if (mz_zip_reader_is_file_a_directory(pzip, idx)) {
-    // the entry is a directory
-    return -1;
-  }
-
-  if (!mz_zip_reader_extract_to_file(pzip, idx, filename, 0)) {
-    return -1;
-  }
-
-#if defined(_MSC_VER)
-#else
-  if (!mz_zip_reader_file_stat(pzip, idx, &info)) {
-    // Cannot get information about zip archive;
-    return -1;
-  }
-
-  xattr = (info.m_external_attr >> 16) & 0xFFFF;
-  if (xattr > 0) {
-    if (chmod(filename, (mode_t)xattr) < 0) {
-      return -1;
-    }
-  }
-#endif
-
-  return 0;
-}
-
-int zip_entry_extract(struct zip_t *zip,
-                      size_t (*on_extract)(void *arg, unsigned long long offset,
-                                           const void *buf, size_t bufsize),
-                      void *arg) {
-  mz_zip_archive *pzip = NULL;
-  mz_uint idx;
-
-  if (!zip) {
-    // zip_t handler is not initialized
-    return -1;
-  }
-
-  pzip = &(zip->archive);
-  if (pzip->m_zip_mode != MZ_ZIP_MODE_READING || zip->entry.index < 0) {
-    // the entry is not found or we do not have read access
-    return -1;
-  }
-
-  idx = (mz_uint)zip->entry.index;
-  return (mz_zip_reader_extract_to_callback(pzip, idx, on_extract, arg, 0))
-             ? 0
-             : -1;
-}
-
-int zip_total_entries(struct zip_t *zip) {
-  if (!zip) {
-    // zip_t handler is not initialized
-    return -1;
-  }
-
-  return (int)zip->archive.m_total_files;
-}
-
-int zip_create(const char *zipname, const char *filenames[], size_t len) {
-  int status = 0;
-  size_t i;
-  mz_zip_archive zip_archive;
-  struct MZ_FILE_STAT_STRUCT file_stat;
-  mz_uint32 ext_attributes = 0;
-
-  if (!zipname || strlen(zipname) < 1) {
-    // zip_t archive name is empty or NULL
-    return -1;
-  }
-
-  // Create a new archive.
-  if (!memset(&(zip_archive), 0, sizeof(zip_archive))) {
-    // Cannot memset zip archive
-    return -1;
-  }
-
-  if (!mz_zip_writer_init_file(&zip_archive, zipname, 0)) {
-    // Cannot initialize zip_archive writer
-    return -1;
-  }
-
-  memset((void *)&file_stat, 0, sizeof(struct MZ_FILE_STAT_STRUCT));
-
-  for (i = 0; i < len; ++i) {
-    const char *name = filenames[i];
-    if (!name) {
-      status = -1;
-      break;
-    }
-
-    if (MZ_FILE_STAT(name, &file_stat) != 0) {
-      // problem getting information - check errno
-      status = -1;
-      break;
-    }
-
-    if ((file_stat.st_mode & 0200) == 0) {
-      // MS-DOS read-only attribute
-      ext_attributes |= 0x01;
-    }
-    ext_attributes |= (mz_uint32)((file_stat.st_mode & 0xFFFF) << 16);
-
-    if (!mz_zip_writer_add_file(&zip_archive, base_name(name), name, "", 0,
-                                ZIP_DEFAULT_COMPRESSION_LEVEL,
-                                ext_attributes)) {
-      // Cannot add file to zip_archive
-      status = -1;
-      break;
-    }
-  }
-
-  mz_zip_writer_finalize_archive(&zip_archive);
-  mz_zip_writer_end(&zip_archive);
-  return status;
-}
-
-int zip_extract(const char *zipname, const char *dir,
-                int (*on_extract)(const char *filename, void *arg), void *arg) {
-  int status = -1;
-  mz_uint i, n;
-  char path[MAX_PATH + 1];
-  char symlink_to[MAX_PATH + 1];
-  mz_zip_archive zip_archive;
-  mz_zip_archive_file_stat info;
-  size_t dirlen = 0;
-#if defined(_MSC_VER)
-#else
-  mz_uint32 xattr = 0;
-#endif
-
-
-  memset(path, 0, sizeof(path));
-  memset(symlink_to, 0, sizeof(symlink_to));
-  if (!memset(&(zip_archive), 0, sizeof(zip_archive))) {
-    // Cannot memset zip archive
-    return -1;
-  }
-
-  if (!zipname || !dir) {
-    // Cannot parse zip archive name
-    return -1;
-  }
-
-  dirlen = strlen(dir);
-  if (dirlen + 1 > MAX_PATH) {
-    return -1;
-  }
-
-  // Now try to open the archive.
-  if (!mz_zip_reader_init_file(&zip_archive, zipname, 0)) {
-    // Cannot initialize zip_archive reader
-    return -1;
-  }
-
-  memset((void *)&info, 0, sizeof(mz_zip_archive_file_stat));
-
-#if defined(_MSC_VER)
-  strcpy_s(path, MAX_PATH, dir);
-#else
-  strcpy(path, dir);
-#endif
-
-  if (!ISSLASH(path[dirlen - 1])) {
-#if defined(_WIN32) || defined(__WIN32__)
-    path[dirlen] = '\\';
-#else
-    path[dirlen] = '/';
-#endif
-    ++dirlen;
-  }
-
-  // Get and print information about each file in the archive.
-  n = mz_zip_reader_get_num_files(&zip_archive);
-  for (i = 0; i < n; ++i) {
-    if (!mz_zip_reader_file_stat(&zip_archive, i, &info)) {
-      // Cannot get information about zip archive;
-      goto out;
-    }
-#if defined(_MSC_VER)
-    strncpy_s(&path[dirlen], MAX_PATH - dirlen, info.m_filename,
-              MAX_PATH - dirlen);
-#else
-    strncpy(&path[dirlen], info.m_filename, MAX_PATH - dirlen);
-#endif
-    if (mkpath(path) < 0) {
-      // Cannot make a path
-      goto out;
-    }
-
-    if ((((info.m_version_made_by >> 8) == 3) ||
-         ((info.m_version_made_by >> 8) ==
-          19)) // if zip is produced on Unix or macOS (3 and 19 from
-               // section 4.4.2.2 of zip standard)
-        && info.m_external_attr &
-               (0x20 << 24)) { // and has sym link attribute (0x80 is file, 0x40
-                               // is directory)
-#if defined(_WIN32) || defined(__WIN32__) || defined(_MSC_VER) ||              \
-    defined(__MINGW32__)
-#else
-      if (info.m_uncomp_size > MAX_PATH ||
-          !mz_zip_reader_extract_to_mem_no_alloc(&zip_archive, i, symlink_to,
-                                                 MAX_PATH, 0, NULL, 0)) {
-        goto out;
-      }
-      symlink_to[info.m_uncomp_size] = '\0';
-      if (symlink(symlink_to, path) != 0) {
-        goto out;
-      }
-#endif
-    } else {
-      if (!mz_zip_reader_is_file_a_directory(&zip_archive, i)) {
-        if (!mz_zip_reader_extract_to_file(&zip_archive, i, path, 0)) {
-          // Cannot extract zip archive to file
-          goto out;
+        if ((err == ZIP_OK) && (central_pos < offset_central_dir + size_central_dir))
+            err = ZIP_BADZIPFILE;
+
+        if ((err == ZIP_OK) && (size_comment > 0))
+        {
+            ziinit.globalcomment = (char*)ALLOC(size_comment+1);
+            if (ziinit.globalcomment)
+            {
+                if (ZREAD64(ziinit.z_filefunc, ziinit.filestream, ziinit.globalcomment, size_comment) != size_comment)
+                    err = ZIP_ERRNO;
+                else
+                    ziinit.globalcomment[size_comment] = 0;
+            }
         }
-      }
 
-#if defined(_MSC_VER)
-#else
-      xattr = (info.m_external_attr >> 16) & 0xFFFF;
-      if (xattr > 0) {
-        if (chmod(path, (mode_t)xattr) < 0) {
-          goto out;
+        if (err != ZIP_OK)
+        {
+            ZCLOSE64(ziinit.z_filefunc, ziinit.filestream);
+            TRYFREE(ziinit.globalcomment);
+            TRYFREE(zi);
+            return NULL;
         }
-      }
+
+        byte_before_the_zipfile = central_pos - (offset_central_dir+size_central_dir);
+        ziinit.add_position_when_writting_offset = byte_before_the_zipfile;
+
+        /* Store central directory in memory */
+        size_central_dir_to_read = size_central_dir;
+        buf_size = SIZEDATA_INDATABLOCK;
+        buf_read = (void*)ALLOC(buf_size);
+
+        if (ZSEEK64(ziinit.z_filefunc, ziinit.filestream,
+                offset_central_dir + byte_before_the_zipfile, ZLIB_FILEFUNC_SEEK_SET) != 0)
+            err = ZIP_ERRNO;
+
+        while ((size_central_dir_to_read > 0) && (err == ZIP_OK))
+        {
+            uint64_t read_this = SIZEDATA_INDATABLOCK;
+            if (read_this > size_central_dir_to_read)
+                read_this = size_central_dir_to_read;
+
+            if (ZREAD64(ziinit.z_filefunc, ziinit.filestream, buf_read, (uint32_t)read_this) != read_this)
+                err = ZIP_ERRNO;
+
+            if (err == ZIP_OK)
+                err = add_data_in_datablock(&ziinit.central_dir, buf_read, (uint32_t)read_this);
+
+            size_central_dir_to_read -= read_this;
+        }
+        TRYFREE(buf_read);
+
+        ziinit.number_entry = number_entry_CD;
+
+        if (ZSEEK64(ziinit.z_filefunc, ziinit.filestream,
+                offset_central_dir+byte_before_the_zipfile, ZLIB_FILEFUNC_SEEK_SET) != 0)
+            err = ZIP_ERRNO;
+    }
+
+    if (globalcomment)
+        *globalcomment = ziinit.globalcomment;
+#endif
+
+    if (err != ZIP_OK)
+    {
+#ifndef NO_ADDFILEINEXISTINGZIP
+        TRYFREE(ziinit.globalcomment);
+#endif
+        TRYFREE(zi);
+        return NULL;
+    }
+
+    *zi = ziinit;
+    zipGoToFirstDisk((zipFile)zi);
+    return(zipFile)zi;
+}
+
+extern zipFile ZEXPORT zipOpen2(const char *path, int append, const char **globalcomment,
+    zlib_filefunc_def *pzlib_filefunc32_def)
+{
+    if (pzlib_filefunc32_def != NULL)
+    {
+        zlib_filefunc64_32_def zlib_filefunc64_32_def_fill;
+        fill_zlib_filefunc64_32_def_from_filefunc32(&zlib_filefunc64_32_def_fill,pzlib_filefunc32_def);
+        return zipOpen4(path, append, 0, globalcomment, &zlib_filefunc64_32_def_fill);
+    }
+    return zipOpen4(path, append, 0, globalcomment, NULL);
+}
+
+extern zipFile ZEXPORT zipOpen2_64(const void *path, int append, const char **globalcomment,
+    zlib_filefunc64_def *pzlib_filefunc_def)
+{
+    if (pzlib_filefunc_def != NULL)
+    {
+        zlib_filefunc64_32_def zlib_filefunc64_32_def_fill;
+        zlib_filefunc64_32_def_fill.zfile_func64 = *pzlib_filefunc_def;
+        zlib_filefunc64_32_def_fill.ztell32_file = NULL;
+        zlib_filefunc64_32_def_fill.zseek32_file = NULL;
+        return zipOpen4(path, append, 0, globalcomment, &zlib_filefunc64_32_def_fill);
+    }
+    return zipOpen4(path, append, 0, globalcomment, NULL);
+}
+
+extern zipFile ZEXPORT zipOpen3(const char *path, int append, uint64_t disk_size, const char **globalcomment,
+    zlib_filefunc_def *pzlib_filefunc32_def)
+{
+    if (pzlib_filefunc32_def != NULL)
+    {
+        zlib_filefunc64_32_def zlib_filefunc64_32_def_fill;
+        fill_zlib_filefunc64_32_def_from_filefunc32(&zlib_filefunc64_32_def_fill,pzlib_filefunc32_def);
+        return zipOpen4(path, append, disk_size, globalcomment, &zlib_filefunc64_32_def_fill);
+    }
+    return zipOpen4(path, append, disk_size, globalcomment, NULL);
+}
+
+extern zipFile ZEXPORT zipOpen3_64(const void *path, int append, uint64_t disk_size, const char **globalcomment,
+    zlib_filefunc64_def *pzlib_filefunc_def)
+{
+    if (pzlib_filefunc_def != NULL)
+    {
+        zlib_filefunc64_32_def zlib_filefunc64_32_def_fill;
+        zlib_filefunc64_32_def_fill.zfile_func64 = *pzlib_filefunc_def;
+        zlib_filefunc64_32_def_fill.ztell32_file = NULL;
+        zlib_filefunc64_32_def_fill.zseek32_file = NULL;
+        return zipOpen4(path, append, disk_size, globalcomment, &zlib_filefunc64_32_def_fill);
+    }
+    return zipOpen4(path, append, disk_size, globalcomment, NULL);
+}
+
+extern zipFile ZEXPORT zipOpen(const char *path, int append)
+{
+    return zipOpen3(path, append, 0, NULL, NULL);
+}
+
+extern zipFile ZEXPORT zipOpen64(const void *path, int append)
+{
+    return zipOpen3_64(path, append, 0, NULL, NULL);
+}
+
+extern int ZEXPORT zipOpenNewFileInZip_internal(zipFile file,
+                                                const char *filename,
+                                                const zip_fileinfo *zipfi,
+                                                const void *extrafield_local,
+                                                uint16_t size_extrafield_local,
+                                                const void *extrafield_global,
+                                                uint16_t size_extrafield_global,
+                                                const char *comment,
+                                                uint16_t flag_base,
+                                                int zip64,
+                                                uint16_t method,
+                                                int level,
+                                                int raw,
+                                                int windowBits,
+                                                int memLevel,
+                                                int strategy,
+                                                const char *password,
+                                                int aes,
+                                                uint16_t version_madeby)
+{
+    zip64_internal *zi = NULL;
+    uint64_t size_available = 0;
+    uint64_t size_needed = 0;
+    uint16_t size_filename = 0;
+    uint16_t size_comment = 0;
+    uint16_t i = 0;
+    unsigned char *central_dir = NULL;
+    int err = ZIP_OK;
+
+#ifdef NOCRYPT
+    if (password != NULL)
+        return ZIP_PARAMERROR;
+#endif
+
+    if (file == NULL)
+        return ZIP_PARAMERROR;
+
+    if ((method != 0) &&
+#ifdef HAVE_BZIP2
+        (method != Z_BZIP2ED) &&
+#endif
+        (method != Z_DEFLATED))
+        return ZIP_PARAMERROR;
+
+    zi = (zip64_internal*)file;
+
+    if (zi->in_opened_file_inzip == 1)
+    {
+        err = zipCloseFileInZip (file);
+        if (err != ZIP_OK)
+            return err;
+    }
+
+    if (filename == NULL)
+        filename = "-";
+    if (comment != NULL)
+        size_comment = (uint16_t)strlen(comment);
+
+    size_filename = (uint16_t)strlen(filename);
+
+    if (zipfi == NULL)
+        zi->ci.dos_date = 0;
+    else
+    {
+        if (zipfi->dos_date != 0)
+            zi->ci.dos_date = zipfi->dos_date;
+    }
+
+    zi->ci.method = method;
+    zi->ci.compression_method = method;
+    zi->ci.raw = raw;
+    zi->ci.flag = flag_base | 8;
+    if ((level == 8) || (level == 9))
+        zi->ci.flag |= 2;
+    if (level == 2)
+        zi->ci.flag |= 4;
+    if (level == 1)
+        zi->ci.flag |= 6;
+
+    if (password != NULL)
+    {
+        zi->ci.flag |= 1;
+#ifdef HAVE_AES
+        if (aes)
+            zi->ci.method = AES_METHOD;
+#endif
+    }
+    else
+    {
+        zi->ci.flag &= ~1;
+    }
+
+    if (zi->disk_size > 0)
+    {
+        if ((zi->number_disk == 0) && (zi->number_entry == 0))
+            err = zipWriteValue(&zi->z_filefunc, zi->filestream, (uint32_t)DISKHEADERMAGIC, 4);
+
+        /* Make sure enough space available on current disk for local header */
+        zipGetDiskSizeAvailable((zipFile)zi, &size_available);
+        size_needed = 30 + size_filename + size_extrafield_local;
+#ifdef HAVE_AES
+        if (zi->ci.method == AES_METHOD)
+            size_needed += 11;
+#endif
+        if (size_available < size_needed)
+            zipGoToNextDisk((zipFile)zi);
+    }
+
+    zi->ci.zip64 = zip64;
+
+    zi->ci.pos_local_header = ZTELL64(zi->z_filefunc, zi->filestream);
+    if (zi->ci.pos_local_header >= UINT32_MAX)
+        zi->ci.zip64 = 1;
+
+    zi->ci.size_comment = size_comment;
+    zi->ci.size_centralheader = SIZECENTRALHEADER + size_filename + size_extrafield_global;
+    zi->ci.size_centralextra = size_extrafield_global;
+    zi->ci.size_centralextrafree = 32; /* Extra space reserved for ZIP64 extra info */
+#ifdef HAVE_AES
+    if (zi->ci.method == AES_METHOD)
+        zi->ci.size_centralextrafree += 11; /* Extra space reserved for AES extra info */
+#endif
+    zi->ci.central_header = (char*)ALLOC((uint32_t)zi->ci.size_centralheader + zi->ci.size_centralextrafree + size_comment);
+    zi->ci.number_disk = zi->number_disk;
+
+    /* Write central directory header */
+    central_dir = (unsigned char*)zi->ci.central_header;
+    zipWriteValueToMemoryAndMove(&central_dir, (uint32_t)CENTRALHEADERMAGIC, 4);
+    zipWriteValueToMemoryAndMove(&central_dir, version_madeby, 2);
+    if (zi->ci.zip64)
+        zipWriteValueToMemoryAndMove(&central_dir, (uint16_t)45, 2);
+    else
+        zipWriteValueToMemoryAndMove(&central_dir, (uint16_t)20, 2);
+    zipWriteValueToMemoryAndMove(&central_dir, zi->ci.flag, 2);
+    zipWriteValueToMemoryAndMove(&central_dir, zi->ci.method, 2);
+    zipWriteValueToMemoryAndMove(&central_dir, zi->ci.dos_date, 4);
+    zipWriteValueToMemoryAndMove(&central_dir, (uint32_t)0, 4); /*crc*/
+    zipWriteValueToMemoryAndMove(&central_dir, (uint32_t)0, 4); /*compr size*/
+    zipWriteValueToMemoryAndMove(&central_dir, (uint32_t)0, 4); /*uncompr size*/
+    zipWriteValueToMemoryAndMove(&central_dir, size_filename, 2);
+    zipWriteValueToMemoryAndMove(&central_dir, size_extrafield_global, 2);
+    zipWriteValueToMemoryAndMove(&central_dir, size_comment, 2);
+    zipWriteValueToMemoryAndMove(&central_dir, (uint16_t)zi->ci.number_disk, 2); /*disk nm start*/
+
+    if (zipfi == NULL)
+        zipWriteValueToMemoryAndMove(&central_dir, (uint16_t)0, 2);
+    else
+        zipWriteValueToMemoryAndMove(&central_dir, zipfi->internal_fa, 2);
+    if (zipfi == NULL)
+        zipWriteValueToMemoryAndMove(&central_dir, (uint32_t)0, 4);
+    else
+        zipWriteValueToMemoryAndMove(&central_dir, zipfi->external_fa, 4);
+    if (zi->ci.pos_local_header >= UINT32_MAX)
+        zipWriteValueToMemoryAndMove(&central_dir, UINT32_MAX, 4);
+    else
+        zipWriteValueToMemoryAndMove(&central_dir,
+            (uint32_t)(zi->ci.pos_local_header - zi->add_position_when_writting_offset), 4);
+
+    for (i = 0; i < size_filename; i++)
+        zi->ci.central_header[SIZECENTRALHEADER+i] = filename[i];
+    for (i = 0; i < size_extrafield_global; i++)
+        zi->ci.central_header[SIZECENTRALHEADER+size_filename+i] =
+            ((const char*)extrafield_global)[i];
+
+    /* Store comment at the end for later repositioning */
+    for (i = 0; i < size_comment; i++)
+        zi->ci.central_header[zi->ci.size_centralheader+
+            zi->ci.size_centralextrafree+i] = comment[i];
+
+    if (zi->ci.central_header == NULL)
+        return ZIP_INTERNALERROR;
+
+    /* Write the local header */
+    if (err == ZIP_OK)
+        err = zipWriteValue(&zi->z_filefunc, zi->filestream, (uint32_t)LOCALHEADERMAGIC, 4);
+
+    if (err == ZIP_OK)
+    {
+        if (zi->ci.zip64)
+            err = zipWriteValue(&zi->z_filefunc, zi->filestream, (uint16_t)45, 2); /* version needed to extract */
+        else
+            err = zipWriteValue(&zi->z_filefunc, zi->filestream, (uint16_t)20, 2); /* version needed to extract */
+    }
+    if (err == ZIP_OK)
+        err = zipWriteValue(&zi->z_filefunc, zi->filestream, zi->ci.flag, 2);
+    if (err == ZIP_OK)
+        err = zipWriteValue(&zi->z_filefunc, zi->filestream, zi->ci.method, 2);
+    if (err == ZIP_OK)
+        err = zipWriteValue(&zi->z_filefunc, zi->filestream, zi->ci.dos_date, 4);
+
+    /* CRC & compressed size & uncompressed size is in data descriptor */
+    if (err == ZIP_OK)
+        err = zipWriteValue(&zi->z_filefunc, zi->filestream, (uint32_t)0, 4); /* crc 32, unknown */
+    if (err == ZIP_OK)
+        err = zipWriteValue(&zi->z_filefunc, zi->filestream, (uint32_t)0, 4); /* compressed size, unknown */
+    if (err == ZIP_OK)
+        err = zipWriteValue(&zi->z_filefunc, zi->filestream, (uint32_t)0, 4); /* uncompressed size, unknown */
+    if (err == ZIP_OK)
+        err = zipWriteValue(&zi->z_filefunc, zi->filestream, size_filename, 2);
+    if (err == ZIP_OK)
+    {
+        uint64_t size_extrafield = size_extrafield_local;
+#ifdef HAVE_AES
+        if (zi->ci.method == AES_METHOD)
+            size_extrafield += 11;
+#endif
+        err = zipWriteValue(&zi->z_filefunc, zi->filestream, (uint16_t)size_extrafield, 2);
+    }
+    if ((err == ZIP_OK) && (size_filename > 0))
+    {
+        if (ZWRITE64(zi->z_filefunc, zi->filestream, filename, size_filename) != size_filename)
+            err = ZIP_ERRNO;
+    }
+    if ((err == ZIP_OK) && (size_extrafield_local > 0))
+    {
+        if (ZWRITE64(zi->z_filefunc, zi->filestream, extrafield_local, size_extrafield_local) != size_extrafield_local)
+            err = ZIP_ERRNO;
+    }
+
+#ifdef HAVE_AES
+    /* Write the AES extended info */
+    if ((err == ZIP_OK) && (zi->ci.method == AES_METHOD))
+    {
+        int headerid = 0x9901;
+        short datasize = 7;
+
+        err = zipWriteValue(&zi->z_filefunc, zi->filestream, headerid, 2);
+        if (err == ZIP_OK)
+            err = zipWriteValue(&zi->z_filefunc, zi->filestream, datasize, 2);
+        if (err == ZIP_OK)
+            err = zipWriteValue(&zi->z_filefunc, zi->filestream, AES_VERSION, 2);
+        if (err == ZIP_OK)
+            err = zipWriteValue(&zi->z_filefunc, zi->filestream, 'A', 1);
+        if (err == ZIP_OK)
+            err = zipWriteValue(&zi->z_filefunc, zi->filestream, 'E', 1);
+        if (err == ZIP_OK)
+            err = zipWriteValue(&zi->z_filefunc, zi->filestream, AES_ENCRYPTIONMODE, 1);
+        if (err == ZIP_OK)
+            err = zipWriteValue(&zi->z_filefunc, zi->filestream, zi->ci.compression_method, 2);
+    }
+#endif
+
+    zi->ci.crc32 = 0;
+    zi->ci.stream_initialised = 0;
+    zi->ci.pos_in_buffered_data = 0;
+    zi->ci.total_compressed = 0;
+    zi->ci.total_uncompressed = 0;
+
+#ifdef HAVE_BZIP2
+    zi->ci.bstream.avail_in = (uint16_t)0;
+    zi->ci.bstream.avail_out = (uint16_t)Z_BUFSIZE;
+    zi->ci.bstream.next_out = (char*)zi->ci.buffered_data;
+    zi->ci.bstream.total_in_hi32 = 0;
+    zi->ci.bstream.total_in_lo32 = 0;
+    zi->ci.bstream.total_out_hi32 = 0;
+    zi->ci.bstream.total_out_lo32 = 0;
+#endif
+
+    zi->ci.stream.avail_in = (uint16_t)0;
+    zi->ci.stream.avail_out = Z_BUFSIZE;
+    zi->ci.stream.next_out = zi->ci.buffered_data;
+    zi->ci.stream.total_in = 0;
+    zi->ci.stream.total_out = 0;
+    zi->ci.stream.data_type = Z_BINARY;
+
+    if ((err == ZIP_OK) && (!zi->ci.raw))
+    {
+        if (method == Z_DEFLATED)
+        {
+            zi->ci.stream.zalloc = (alloc_func)0;
+            zi->ci.stream.zfree = (free_func)0;
+            zi->ci.stream.opaque = (voidpf)zi;
+
+            if (windowBits > 0)
+                windowBits = -windowBits;
+
+#ifdef HAVE_APPLE_COMPRESSION
+            err = compression_stream_init(&zi->ci.astream, COMPRESSION_STREAM_ENCODE, COMPRESSION_ZLIB);
+            if (err == COMPRESSION_STATUS_ERROR)
+                err = Z_ERRNO;
+            else
+                err = Z_OK;
+#else
+            err = deflateInit2(&zi->ci.stream, level, Z_DEFLATED, windowBits, memLevel, strategy);
+#endif
+            if (err == Z_OK)
+                zi->ci.stream_initialised = Z_DEFLATED;
+        }
+        else if (method == Z_BZIP2ED)
+        {
+#ifdef HAVE_BZIP2
+            zi->ci.bstream.bzalloc = 0;
+            zi->ci.bstream.bzfree = 0;
+            zi->ci.bstream.opaque = (voidpf)0;
+
+            err = BZ2_bzCompressInit(&zi->ci.bstream, level, 0, 35);
+            if (err == BZ_OK)
+                zi->ci.stream_initialised = Z_BZIP2ED;
+#endif
+        }
+    }
+
+#ifndef NOCRYPT
+    if ((err == Z_OK) && (password != NULL))
+    {
+#ifdef HAVE_AES
+        if (zi->ci.method == AES_METHOD)
+        {
+            unsigned char passverify[AES_PWVERIFYSIZE];
+            unsigned char saltvalue[AES_MAXSALTLENGTH];
+            uint16_t saltlength = 0;
+
+            if ((AES_ENCRYPTIONMODE < 1) || (AES_ENCRYPTIONMODE > 3))
+                return Z_ERRNO;
+
+            saltlength = SALT_LENGTH(AES_ENCRYPTIONMODE);
+
+            prng_init(cryptrand, zi->ci.aes_rng);
+            prng_rand(saltvalue, saltlength, zi->ci.aes_rng);
+            prng_end(zi->ci.aes_rng);
+
+            fcrypt_init(AES_ENCRYPTIONMODE, (uint8_t *)password, (uint32_t)strlen(password), saltvalue, passverify, &zi->ci.aes_ctx);
+
+            if (ZWRITE64(zi->z_filefunc, zi->filestream, saltvalue, saltlength) != saltlength)
+                err = ZIP_ERRNO;
+            if (ZWRITE64(zi->z_filefunc, zi->filestream, passverify, AES_PWVERIFYSIZE) != AES_PWVERIFYSIZE)
+                err = ZIP_ERRNO;
+
+            zi->ci.total_compressed += saltlength + AES_PWVERIFYSIZE + AES_AUTHCODESIZE;
+        }
+        else
+#endif
+        {
+            unsigned char buf_head[RAND_HEAD_LEN];
+            uint32_t size_head = 0;
+            uint8_t verify1 = 0;
+            uint8_t verify2 = 0;
+
+            zi->ci.pcrc_32_tab = get_crc_table();
+
+            /*
+            Info-ZIP modification to ZipCrypto format:
+            If bit 3 of the general purpose bit flag is set, it uses high byte of 16-bit File Time. 
+            */
+            verify1 = (uint8_t)((zi->ci.dos_date >> 16) & 0xff);
+            verify2 = (uint8_t)((zi->ci.dos_date >> 8) & 0xff);
+
+            size_head = crypthead(password, buf_head, RAND_HEAD_LEN, zi->ci.keys, zi->ci.pcrc_32_tab, verify1, verify2);
+            zi->ci.total_compressed += size_head;
+
+            if (ZWRITE64(zi->z_filefunc, zi->filestream, buf_head, size_head) != size_head)
+                err = ZIP_ERRNO;
+        }
+    }
+#endif
+
+    if (err == Z_OK)
+        zi->in_opened_file_inzip = 1;
+    return err;
+}
+
+extern int ZEXPORT zipOpenNewFileInZip5(zipFile file, const char *filename, const zip_fileinfo *zipfi,
+    const void *extrafield_local, uint16_t size_extrafield_local, const void *extrafield_global,
+    uint16_t size_extrafield_global, const char *comment, uint16_t flag_base, int zip64, uint16_t method, int level, int raw,
+    int windowBits, int memLevel, int strategy, const char *password, int aes)
+{
+    return zipOpenNewFileInZip_internal(file, filename, zipfi, extrafield_local, size_extrafield_local, extrafield_global,
+        size_extrafield_global, comment, flag_base, zip64, method, level, raw, windowBits, memLevel, strategy, password, aes,
+        VERSIONMADEBY);
+}
+
+extern int ZEXPORT zipOpenNewFileInZip4_64(zipFile file, const char *filename, const zip_fileinfo *zipfi,
+    const void *extrafield_local, uint16_t size_extrafield_local, const void *extrafield_global,
+    uint16_t size_extrafield_global, const char *comment, uint16_t method, int level, int raw, int windowBits, int memLevel,
+    int strategy, const char *password, ZIP_UNUSED uint32_t crc_for_crypting, uint16_t version_madeby, uint16_t flag_base, int zip64)
+{
+    uint8_t aes = 0;
+#ifdef HAVE_AES
+    aes = 1;
+#endif
+    return zipOpenNewFileInZip_internal(file, filename, zipfi, extrafield_local, size_extrafield_local, extrafield_global,
+        size_extrafield_global, comment, flag_base, zip64, method, level, raw, windowBits, memLevel, strategy, password, aes,
+        version_madeby);
+}
+
+extern int ZEXPORT zipOpenNewFileInZip4(zipFile file, const char *filename, const zip_fileinfo *zipfi,
+    const void *extrafield_local, uint16_t size_extrafield_local, const void *extrafield_global,
+    uint16_t size_extrafield_global, const char *comment, uint16_t method, int level, int raw, int windowBits,
+    int memLevel, int strategy, const char *password, ZIP_UNUSED uint32_t crc_for_crypting, uint16_t version_madeby, uint16_t flag_base)
+{
+    return zipOpenNewFileInZip4_64(file, filename, zipfi, extrafield_local, size_extrafield_local,
+        extrafield_global, size_extrafield_global, comment, method, level, raw, windowBits, memLevel,
+        strategy, password, crc_for_crypting, version_madeby, flag_base, 0);
+}
+
+extern int ZEXPORT zipOpenNewFileInZip3(zipFile file, const char *filename, const zip_fileinfo *zipfi,
+    const void *extrafield_local, uint16_t size_extrafield_local, const void *extrafield_global,
+    uint16_t size_extrafield_global, const char *comment, uint16_t method, int level, int raw, int windowBits,
+    int memLevel, int strategy, const char *password, ZIP_UNUSED uint32_t crc_for_crypting)
+{
+    return zipOpenNewFileInZip4_64(file, filename, zipfi, extrafield_local, size_extrafield_local,
+        extrafield_global, size_extrafield_global, comment, method, level, raw, windowBits, memLevel,
+        strategy, password, crc_for_crypting, VERSIONMADEBY, 0, 0);
+}
+
+extern int ZEXPORT zipOpenNewFileInZip3_64(zipFile file, const char *filename, const zip_fileinfo *zipfi,
+    const void *extrafield_local, uint16_t size_extrafield_local, const void *extrafield_global,
+    uint16_t size_extrafield_global, const char *comment, uint16_t method, int level, int raw, int windowBits,
+    int memLevel, int strategy, const char *password, ZIP_UNUSED uint32_t crc_for_crypting, int zip64)
+{
+    return zipOpenNewFileInZip4_64(file, filename, zipfi, extrafield_local, size_extrafield_local,
+        extrafield_global, size_extrafield_global, comment, method, level, raw, windowBits, memLevel, strategy,
+        password, crc_for_crypting, VERSIONMADEBY, 0, zip64);
+}
+
+extern int ZEXPORT zipOpenNewFileInZip2(zipFile file, const char *filename, const zip_fileinfo *zipfi,
+    const void *extrafield_local, uint16_t size_extrafield_local, const void *extrafield_global,
+    uint16_t size_extrafield_global, const char *comment, uint16_t method, int level, int raw)
+{
+    return zipOpenNewFileInZip4_64(file, filename, zipfi, extrafield_local, size_extrafield_local,
+        extrafield_global, size_extrafield_global, comment, method, level, raw, -MAX_WBITS, DEF_MEM_LEVEL,
+        Z_DEFAULT_STRATEGY, NULL, 0, VERSIONMADEBY, 0, 0);
+}
+
+extern int ZEXPORT zipOpenNewFileInZip2_64(zipFile file, const char *filename, const zip_fileinfo *zipfi,
+    const void *extrafield_local, uint16_t size_extrafield_local, const void *extrafield_global,
+    uint16_t size_extrafield_global, const char *comment, uint16_t method, int level, int raw, int zip64)
+{
+    return zipOpenNewFileInZip4_64(file, filename, zipfi, extrafield_local, size_extrafield_local,
+        extrafield_global, size_extrafield_global, comment, method, level, raw, -MAX_WBITS, DEF_MEM_LEVEL,
+        Z_DEFAULT_STRATEGY, NULL, 0, VERSIONMADEBY, 0, zip64);
+}
+
+extern int ZEXPORT zipOpenNewFileInZip64(zipFile file, const char *filename, const zip_fileinfo *zipfi,
+    const void *extrafield_local, uint16_t size_extrafield_local, const void *extrafield_global,
+    uint16_t size_extrafield_global, const char *comment, uint16_t method, int level, int zip64)
+{
+    return zipOpenNewFileInZip4_64(file, filename, zipfi, extrafield_local, size_extrafield_local,
+        extrafield_global, size_extrafield_global, comment, method, level, 0, -MAX_WBITS, DEF_MEM_LEVEL,
+        Z_DEFAULT_STRATEGY, NULL, 0, VERSIONMADEBY, 0, zip64);
+}
+
+extern int ZEXPORT zipOpenNewFileInZip(zipFile file, const char *filename, const zip_fileinfo *zipfi,
+    const void *extrafield_local, uint16_t size_extrafield_local, const void *extrafield_global,
+    uint16_t size_extrafield_global, const char *comment, uint16_t method, int level)
+{
+    return zipOpenNewFileInZip4_64(file, filename, zipfi, extrafield_local, size_extrafield_local,
+        extrafield_global, size_extrafield_global, comment, method, level, 0, -MAX_WBITS, DEF_MEM_LEVEL,
+        Z_DEFAULT_STRATEGY, NULL, 0, VERSIONMADEBY, 0, 0);
+}
+
+/* Flushes the write buffer to disk */
+static int zipFlushWriteBuffer(zip64_internal *zi)
+{
+    uint64_t size_available = 0;
+    uint32_t written = 0;
+    uint32_t total_written = 0;
+    uint32_t write = 0;
+    uint32_t max_write = 0;
+    int err = ZIP_OK;
+
+    if ((zi->ci.flag & 1) != 0)
+    {
+#ifndef NOCRYPT
+#ifdef HAVE_AES
+        if (zi->ci.method == AES_METHOD)
+        {
+            fcrypt_encrypt(zi->ci.buffered_data, zi->ci.pos_in_buffered_data, &zi->ci.aes_ctx);
+        }
+        else
+#endif
+        {
+            uint32_t i = 0;
+            uint8_t t = 0;
+
+            for (i = 0; i < zi->ci.pos_in_buffered_data; i++)
+                zi->ci.buffered_data[i] = (uint8_t)zencode(zi->ci.keys, zi->ci.pcrc_32_tab, zi->ci.buffered_data[i], t);
+        }
 #endif
     }
 
-    if (on_extract) {
-      if (on_extract(path, arg) < 0) {
-        goto out;
-      }
+    write = zi->ci.pos_in_buffered_data;
+
+    do
+    {
+        max_write = write;
+
+        if (zi->disk_size > 0)
+        {
+            zipGetDiskSizeAvailable((zipFile)zi, &size_available);
+
+            if (size_available == 0)
+            {
+                err = zipGoToNextDisk((zipFile)zi);
+                if (err != ZIP_OK)
+                    return err;
+            }
+
+            if (size_available < (uint64_t)max_write)
+                max_write = (uint32_t)size_available;
+        }
+
+        written = ZWRITE64(zi->z_filefunc, zi->filestream, zi->ci.buffered_data + total_written, max_write);
+        if (written != max_write)
+        {
+            err = ZIP_ERRNO;
+            break;
+        }
+
+        total_written += written;
+        write -= written;
     }
-  }
-  status = 0;
+    while (write > 0);
 
-out:
-  // Close the archive, freeing any resources it was using
-  if (!mz_zip_reader_end(&zip_archive)) {
-    // Cannot end zip reader
-    status = -1;
-  }
+    zi->ci.total_compressed += zi->ci.pos_in_buffered_data;
 
-  return status;
+#ifdef HAVE_BZIP2
+    if (zi->ci.compression_method == Z_BZIP2ED)
+    {
+        zi->ci.total_uncompressed += zi->ci.bstream.total_in_lo32;
+        zi->ci.bstream.total_in_lo32 = 0;
+        zi->ci.bstream.total_in_hi32 = 0;
+    }
+    else
+#endif
+    {
+        zi->ci.total_uncompressed += zi->ci.stream.total_in;
+        zi->ci.stream.total_in = 0;
+    }
+
+    zi->ci.pos_in_buffered_data = 0;
+
+    return err;
 }
 
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif // _MSC_VER
+extern int ZEXPORT zipWriteInFileInZip(zipFile file, const void *buf, uint32_t len)
+{
+    zip64_internal *zi = NULL;
+    int err = ZIP_OK;
+
+    if (file == NULL)
+        return ZIP_PARAMERROR;
+    zi = (zip64_internal*)file;
+
+    if (zi->in_opened_file_inzip == 0)
+        return ZIP_PARAMERROR;
+
+    zi->ci.crc32 = (uint32_t)crc32(zi->ci.crc32, buf, len);
+
+#ifdef HAVE_BZIP2
+    if ((zi->ci.compression_method == Z_BZIP2ED) && (!zi->ci.raw))
+    {
+        zi->ci.bstream.next_in = (void*)buf;
+        zi->ci.bstream.avail_in = len;
+        err = BZ_RUN_OK;
+
+        while ((err == BZ_RUN_OK) && (zi->ci.bstream.avail_in > 0))
+        {
+            if (zi->ci.bstream.avail_out == 0)
+            {
+                err = zipFlushWriteBuffer(zi);
+                
+                zi->ci.bstream.avail_out = (uint16_t)Z_BUFSIZE;
+                zi->ci.bstream.next_out = (char*)zi->ci.buffered_data;
+            }
+            else
+            {
+                uint32_t total_out_before_lo = zi->ci.bstream.total_out_lo32;
+                uint32_t total_out_before_hi = zi->ci.bstream.total_out_hi32;
+
+                err = BZ2_bzCompress(&zi->ci.bstream, BZ_RUN);
+
+                zi->ci.pos_in_buffered_data += (uint16_t)(zi->ci.bstream.total_out_lo32 - total_out_before_lo);
+            }
+        }
+
+        if (err == BZ_RUN_OK)
+            err = ZIP_OK;
+    }
+    else
+#endif
+    {
+        zi->ci.stream.next_in = (uint8_t*)buf;
+        zi->ci.stream.avail_in = len;
+
+        while ((err == ZIP_OK) && (zi->ci.stream.avail_in > 0))
+        {
+            if (zi->ci.stream.avail_out == 0)
+            {
+                err = zipFlushWriteBuffer(zi);
+                
+                zi->ci.stream.avail_out = Z_BUFSIZE;
+                zi->ci.stream.next_out = zi->ci.buffered_data;
+            }
+
+            if (err != ZIP_OK)
+                break;
+
+            if ((zi->ci.compression_method == Z_DEFLATED) && (!zi->ci.raw))
+            {
+#ifdef HAVE_APPLE_COMPRESSION
+                uint32_t total_out_before = (uint32_t)zi->ci.stream.total_out;
+
+                zi->ci.astream.src_ptr = zi->ci.stream.next_in;
+                zi->ci.astream.src_size = zi->ci.stream.avail_in;
+                zi->ci.astream.dst_ptr = zi->ci.stream.next_out;
+                zi->ci.astream.dst_size = zi->ci.stream.avail_out;
+
+                compression_status status = 0;
+                compression_stream_flags flags = 0;
+
+                status = compression_stream_process(&zi->ci.astream, flags);
+
+                uint32_t total_out_after = len - zi->ci.astream.src_size;
+
+                zi->ci.stream.next_in = zi->ci.astream.src_ptr;
+                zi->ci.stream.avail_in = zi->ci.astream.src_size;
+                zi->ci.stream.next_out = zi->ci.astream.dst_ptr;
+                zi->ci.stream.avail_out = zi->ci.astream.dst_size;
+                zi->ci.stream.total_in += total_out_after;
+                //zi->ci.stream.total_out += copy_this;
+                zi->ci.pos_in_buffered_data += total_out_after;
+
+                if (status == COMPRESSION_STATUS_ERROR)
+                    err = ZIP_INTERNALERROR;
+#else
+                uint32_t total_out_before = (uint32_t)zi->ci.stream.total_out;
+                err = deflate(&zi->ci.stream, Z_NO_FLUSH);
+                zi->ci.pos_in_buffered_data += (uint32_t)(zi->ci.stream.total_out - total_out_before);
+#endif
+            }
+            else
+            {
+                uint32_t copy_this = 0;
+                uint32_t i = 0;
+                if (zi->ci.stream.avail_in < zi->ci.stream.avail_out)
+                    copy_this = zi->ci.stream.avail_in;
+                else
+                    copy_this = zi->ci.stream.avail_out;
+
+                for (i = 0; i < copy_this; i++)
+                    *(((char*)zi->ci.stream.next_out)+i) =
+                        *(((const char*)zi->ci.stream.next_in)+i);
+
+                zi->ci.stream.avail_in -= copy_this;
+                zi->ci.stream.avail_out -= copy_this;
+                zi->ci.stream.next_in += copy_this;
+                zi->ci.stream.next_out += copy_this;
+                zi->ci.stream.total_in += copy_this;
+                zi->ci.stream.total_out += copy_this;
+                zi->ci.pos_in_buffered_data += copy_this;
+            }
+        }
+    }
+
+    return err;
+}
+
+extern int ZEXPORT zipCloseFileInZipRaw64(zipFile file, uint64_t uncompressed_size, uint32_t crc32)
+{
+    zip64_internal *zi = NULL;
+    uint16_t extra_data_size = 0;
+    uint32_t i = 0;
+    unsigned char *extra_info = NULL;
+    int err = ZIP_OK;
+
+    if (file == NULL)
+        return ZIP_PARAMERROR;
+    zi = (zip64_internal*)file;
+
+    if (zi->in_opened_file_inzip == 0)
+        return ZIP_PARAMERROR;
+    zi->ci.stream.avail_in = 0;
+
+    if (!zi->ci.raw)
+    {
+        if (zi->ci.compression_method == Z_DEFLATED)
+        {
+            while (err == ZIP_OK)
+            {
+                uint32_t total_out_before = 0;
+                
+                if (zi->ci.stream.avail_out == 0)
+                {
+                    err = zipFlushWriteBuffer(zi);
+
+                    zi->ci.stream.avail_out = Z_BUFSIZE;
+                    zi->ci.stream.next_out = zi->ci.buffered_data;
+                }
+                
+                if (err != ZIP_OK)
+                    break;
+                
+#ifdef HAVE_APPLE_COMPRESSION
+                total_out_before = zi->ci.stream.total_out;
+
+                zi->ci.astream.src_ptr = zi->ci.stream.next_in;
+                zi->ci.astream.src_size = zi->ci.stream.avail_in;
+                zi->ci.astream.dst_ptr = zi->ci.stream.next_out;
+                zi->ci.astream.dst_size = zi->ci.stream.avail_out;
+
+                compression_status status = 0;
+                status = compression_stream_process(&zi->ci.astream, COMPRESSION_STREAM_FINALIZE);
+
+                uint32_t total_out_after = Z_BUFSIZE - zi->ci.astream.dst_size;
+
+                zi->ci.stream.next_in = zi->ci.astream.src_ptr;
+                zi->ci.stream.avail_in = zi->ci.astream.src_size;
+                zi->ci.stream.next_out = zi->ci.astream.dst_ptr;
+                zi->ci.stream.avail_out = zi->ci.astream.dst_size;
+                //zi->ci.stream.total_in += total_out_after;
+                //zi->ci.stream.total_out += copy_this;
+                zi->ci.pos_in_buffered_data += total_out_after;
+
+                if (status == COMPRESSION_STATUS_ERROR)
+                {
+                    err = ZIP_INTERNALERROR;
+                }
+                else if (status == COMPRESSION_STATUS_END)
+                {
+                    err = Z_STREAM_END;
+                }
+#else
+                total_out_before = (uint32_t)zi->ci.stream.total_out;
+                err = deflate(&zi->ci.stream, Z_FINISH);
+                zi->ci.pos_in_buffered_data += (uint16_t)(zi->ci.stream.total_out - total_out_before);
+#endif
+            }
+        }
+        else if (zi->ci.compression_method == Z_BZIP2ED)
+        {
+#ifdef HAVE_BZIP2
+            err = BZ_FINISH_OK;
+            while (err == BZ_FINISH_OK)
+            {
+                uint32_t total_out_before = 0;
+                
+                if (zi->ci.bstream.avail_out == 0)
+                {
+                    err = zipFlushWriteBuffer(zi);
+                    
+                    zi->ci.bstream.avail_out = (uint16_t)Z_BUFSIZE;
+                    zi->ci.bstream.next_out = (char*)zi->ci.buffered_data;
+                }
+                
+                total_out_before = zi->ci.bstream.total_out_lo32;
+                err = BZ2_bzCompress(&zi->ci.bstream, BZ_FINISH);
+                if (err == BZ_STREAM_END)
+                    err = Z_STREAM_END;
+                zi->ci.pos_in_buffered_data += (uint16_t)(zi->ci.bstream.total_out_lo32 - total_out_before);
+            }
+
+            if (err == BZ_FINISH_OK)
+                err = ZIP_OK;
+#endif
+        }
+    }
+
+    if (err == Z_STREAM_END)
+        err = ZIP_OK; /* this is normal */
+
+    if ((zi->ci.pos_in_buffered_data > 0) && (err == ZIP_OK))
+    {
+        err = zipFlushWriteBuffer(zi);
+    }
+
+#ifdef HAVE_AES
+    if (zi->ci.method == AES_METHOD)
+    {
+        unsigned char authcode[AES_AUTHCODESIZE];
+
+        fcrypt_end(authcode, &zi->ci.aes_ctx);
+
+        if (ZWRITE64(zi->z_filefunc, zi->filestream, authcode, AES_AUTHCODESIZE) != AES_AUTHCODESIZE)
+            err = ZIP_ERRNO;
+    }
+#endif
+
+    if (!zi->ci.raw)
+    {
+        if (zi->ci.compression_method == Z_DEFLATED)
+        {
+            int tmp_err = 0;
+#ifdef HAVE_APPLE_COMPRESSION
+            tmp_err = compression_stream_destroy(&zi->ci.astream);
+#else
+            tmp_err = deflateEnd(&zi->ci.stream);
+#endif
+            if (err == ZIP_OK)
+                err = tmp_err;
+            zi->ci.stream_initialised = 0;
+        }
+#ifdef HAVE_BZIP2
+        else if (zi->ci.compression_method == Z_BZIP2ED)
+        {
+            int tmperr = BZ2_bzCompressEnd(&zi->ci.bstream);
+            if (err == ZIP_OK)
+                err = tmperr;
+            zi->ci.stream_initialised = 0;
+        }
+#endif
+
+        crc32 = zi->ci.crc32;
+        uncompressed_size = zi->ci.total_uncompressed;
+    }
+
+    /* Write data descriptor */
+    if (err == ZIP_OK)
+        err = zipWriteValue(&zi->z_filefunc, zi->filestream, (uint32_t)DATADESCRIPTORMAGIC, 4);
+    if (err == ZIP_OK)
+        err = zipWriteValue(&zi->z_filefunc, zi->filestream, crc32, 4);
+    if (err == ZIP_OK)
+    {
+        if (zi->ci.zip64)
+            err = zipWriteValue(&zi->z_filefunc, zi->filestream, zi->ci.total_compressed, 8);
+        else
+            err = zipWriteValue(&zi->z_filefunc, zi->filestream, (uint32_t)zi->ci.total_compressed, 4);
+    }
+    if (err == ZIP_OK)
+    {
+        if (zi->ci.zip64)
+            err = zipWriteValue(&zi->z_filefunc, zi->filestream, uncompressed_size, 8);
+        else
+            err = zipWriteValue(&zi->z_filefunc, zi->filestream, (uint32_t)uncompressed_size, 4);
+    }
+
+    /* Update crc and sizes to central directory */
+    zipWriteValueToMemory(zi->ci.central_header + 16, crc32, 4); /* crc */
+    if (zi->ci.total_compressed >= UINT32_MAX)
+        zipWriteValueToMemory(zi->ci.central_header + 20, UINT32_MAX, 4); /* compr size */
+    else
+        zipWriteValueToMemory(zi->ci.central_header + 20, zi->ci.total_compressed, 4); /* compr size */
+    if (uncompressed_size >= UINT32_MAX)
+        zipWriteValueToMemory(zi->ci.central_header + 24, UINT32_MAX, 4); /* uncompr size */
+    else
+        zipWriteValueToMemory(zi->ci.central_header + 24, uncompressed_size, 4); /* uncompr size */
+    if (zi->ci.stream.data_type == Z_ASCII)
+        zipWriteValueToMemory(zi->ci.central_header + 36, (uint16_t)Z_ASCII, 2); /* internal file attrib */
+
+    /* Add ZIP64 extra info field for uncompressed size */
+    if (uncompressed_size >= UINT32_MAX)
+        extra_data_size += 8;
+    /* Add ZIP64 extra info field for compressed size */
+    if (zi->ci.total_compressed >= UINT32_MAX)
+        extra_data_size += 8;
+    /* Add ZIP64 extra info field for relative offset to local file header of current file */
+    if (zi->ci.pos_local_header >= UINT32_MAX)
+        extra_data_size += 8;
+
+    /* Add ZIP64 extra info header to central directory */
+    if (extra_data_size > 0)
+    {
+        if ((uint32_t)(extra_data_size + 4) > zi->ci.size_centralextrafree)
+            return ZIP_BADZIPFILE;
+
+        extra_info = (unsigned char*)zi->ci.central_header + zi->ci.size_centralheader;
+
+        zipWriteValueToMemoryAndMove(&extra_info, 0x0001, 2);
+        zipWriteValueToMemoryAndMove(&extra_info, extra_data_size, 2);
+
+        if (uncompressed_size >= UINT32_MAX)
+            zipWriteValueToMemoryAndMove(&extra_info, uncompressed_size, 8);
+        if (zi->ci.total_compressed >= UINT32_MAX)
+            zipWriteValueToMemoryAndMove(&extra_info, zi->ci.total_compressed, 8);
+        if (zi->ci.pos_local_header >= UINT32_MAX)
+            zipWriteValueToMemoryAndMove(&extra_info, zi->ci.pos_local_header, 8);
+
+        zi->ci.size_centralextrafree -= extra_data_size + 4;
+        zi->ci.size_centralheader += extra_data_size + 4;
+        zi->ci.size_centralextra += extra_data_size + 4;
+
+        zipWriteValueToMemory(zi->ci.central_header + 30, zi->ci.size_centralextra, 2);
+    }
+
+#ifdef HAVE_AES
+    /* Write AES extra info header to central directory */
+    if (zi->ci.method == AES_METHOD)
+    {
+        extra_info = (unsigned char*)zi->ci.central_header + zi->ci.size_centralheader;
+        extra_data_size = 7;
+
+        if ((uint32_t)(extra_data_size + 4) > zi->ci.size_centralextrafree)
+            return ZIP_BADZIPFILE;
+
+        zipWriteValueToMemoryAndMove(&extra_info, 0x9901, 2);
+        zipWriteValueToMemoryAndMove(&extra_info, extra_data_size, 2);
+        zipWriteValueToMemoryAndMove(&extra_info, AES_VERSION, 2);
+        zipWriteValueToMemoryAndMove(&extra_info, 'A', 1);
+        zipWriteValueToMemoryAndMove(&extra_info, 'E', 1);
+        zipWriteValueToMemoryAndMove(&extra_info, AES_ENCRYPTIONMODE, 1);
+        zipWriteValueToMemoryAndMove(&extra_info, zi->ci.compression_method, 2);
+
+        zi->ci.size_centralextrafree -= extra_data_size + 4;
+        zi->ci.size_centralheader += extra_data_size + 4;
+        zi->ci.size_centralextra += extra_data_size + 4;
+
+        zipWriteValueToMemory(zi->ci.central_header + 30, zi->ci.size_centralextra, 2);
+    }
+#endif
+    /* Restore comment to correct position */
+    for (i = 0; i < zi->ci.size_comment; i++)
+        zi->ci.central_header[zi->ci.size_centralheader+i] =
+            zi->ci.central_header[zi->ci.size_centralheader+zi->ci.size_centralextrafree+i];
+    zi->ci.size_centralheader += zi->ci.size_comment;
+
+    if (err == ZIP_OK)
+        err = add_data_in_datablock(&zi->central_dir, zi->ci.central_header, zi->ci.size_centralheader);
+
+    free(zi->ci.central_header);
+
+    zi->number_entry++;
+    zi->in_opened_file_inzip = 0;
+
+    return err;
+}
+
+extern int ZEXPORT zipCloseFileInZipRaw(zipFile file, uint32_t uncompressed_size, uint32_t crc32)
+{
+    return zipCloseFileInZipRaw64(file, uncompressed_size, crc32);
+}
+
+extern int ZEXPORT zipCloseFileInZip(zipFile file)
+{
+    return zipCloseFileInZipRaw(file, 0, 0);
+}
+
+extern int ZEXPORT zipClose(zipFile file, const char *global_comment)
+{
+    return zipClose_64(file, global_comment);
+}
+
+extern int ZEXPORT zipClose_64(zipFile file, const char *global_comment)
+{
+    return zipClose2_64(file, global_comment, VERSIONMADEBY);
+}
+
+extern int ZEXPORT zipClose2_64(zipFile file, const char *global_comment, uint16_t version_madeby)
+{
+    zip64_internal *zi = NULL;
+    uint32_t size_centraldir = 0;
+    uint16_t size_global_comment = 0;
+    uint64_t centraldir_pos_inzip = 0;
+    uint64_t pos = 0;
+    uint64_t cd_pos = 0;
+    uint32_t write = 0;
+    int err = ZIP_OK;
+
+    if (file == NULL)
+        return ZIP_PARAMERROR;
+    zi = (zip64_internal*)file;
+
+    if (zi->in_opened_file_inzip == 1)
+        err = zipCloseFileInZip(file);
+
+#ifndef NO_ADDFILEINEXISTINGZIP
+    if (global_comment == NULL)
+        global_comment = zi->globalcomment;
+#endif
+
+    if (zi->filestream != zi->filestream_with_CD)
+    {
+        if (ZCLOSE64(zi->z_filefunc, zi->filestream) != 0)
+            if (err == ZIP_OK)
+                err = ZIP_ERRNO;
+        if (zi->disk_size > 0)
+            zi->number_disk_with_CD = zi->number_disk + 1;
+        zi->filestream = zi->filestream_with_CD;
+    }
+
+    centraldir_pos_inzip = ZTELL64(zi->z_filefunc, zi->filestream);
+
+    if (err == ZIP_OK)
+    {
+        linkedlist_datablock_internal *ldi = zi->central_dir.first_block;
+        while (ldi != NULL)
+        {
+            if ((err == ZIP_OK) && (ldi->filled_in_this_block > 0))
+            {
+                write = ZWRITE64(zi->z_filefunc, zi->filestream, ldi->data, ldi->filled_in_this_block);
+                if (write != ldi->filled_in_this_block)
+                    err = ZIP_ERRNO;
+            }
+
+            size_centraldir += ldi->filled_in_this_block;
+            ldi = ldi->next_datablock;
+        }
+    }
+
+    free_linkedlist(&(zi->central_dir));
+
+    pos = centraldir_pos_inzip - zi->add_position_when_writting_offset;
+
+    /* Write the ZIP64 central directory header */
+    if (pos >= UINT32_MAX || zi->number_entry > UINT16_MAX)
+    {
+        uint64_t zip64_eocd_pos_inzip = ZTELL64(zi->z_filefunc, zi->filestream);
+        uint32_t zip64_datasize = 44;
+
+        err = zipWriteValue(&zi->z_filefunc, zi->filestream, (uint32_t)ZIP64ENDHEADERMAGIC, 4);
+
+        /* Size of this 'zip64 end of central directory' */
+        if (err == ZIP_OK)
+            err = zipWriteValue(&zi->z_filefunc, zi->filestream, (uint64_t)zip64_datasize, 8);
+        /* Version made by */
+        if (err == ZIP_OK)
+            err = zipWriteValue(&zi->z_filefunc, zi->filestream, version_madeby, 2);
+        /* version needed */
+        if (err == ZIP_OK)
+            err = zipWriteValue(&zi->z_filefunc, zi->filestream, (uint16_t)45, 2);
+        /* Number of this disk */
+        if (err == ZIP_OK)
+            err = zipWriteValue(&zi->z_filefunc, zi->filestream, zi->number_disk_with_CD, 4);
+        /* Number of the disk with the start of the central directory */
+        if (err == ZIP_OK)
+            err = zipWriteValue(&zi->z_filefunc, zi->filestream, zi->number_disk_with_CD, 4);
+        /* Total number of entries in the central dir on this disk */
+        if (err == ZIP_OK)
+            err = zipWriteValue(&zi->z_filefunc, zi->filestream, zi->number_entry, 8);
+        /* Total number of entries in the central dir */
+        if (err == ZIP_OK)
+            err = zipWriteValue(&zi->z_filefunc, zi->filestream, zi->number_entry, 8);
+        /* Size of the central directory */
+        if (err == ZIP_OK)
+            err = zipWriteValue(&zi->z_filefunc, zi->filestream, (uint64_t)size_centraldir, 8);
+
+        if (err == ZIP_OK)
+        {
+            /* Offset of start of central directory with respect to the starting disk number */
+            cd_pos = centraldir_pos_inzip - zi->add_position_when_writting_offset;
+            err = zipWriteValue(&zi->z_filefunc, zi->filestream, cd_pos, 8);
+        }
+        if (err == ZIP_OK)
+            err = zipWriteValue(&zi->z_filefunc, zi->filestream, (uint32_t)ZIP64ENDLOCHEADERMAGIC, 4);
+
+        /* Number of the disk with the start of the central directory */
+        if (err == ZIP_OK)
+            err = zipWriteValue(&zi->z_filefunc, zi->filestream, zi->number_disk_with_CD, 4);
+        /* Relative offset to the Zip64EndOfCentralDirectory */
+        if (err == ZIP_OK)
+        {
+            cd_pos = zip64_eocd_pos_inzip - zi->add_position_when_writting_offset;
+            err = zipWriteValue(&zi->z_filefunc, zi->filestream, cd_pos, 8);
+        }
+        /* Number of the disk with the start of the central directory */
+        if (err == ZIP_OK)
+            err = zipWriteValue(&zi->z_filefunc, zi->filestream, zi->number_disk_with_CD + 1, 4);
+    }
+
+    /* Write the central directory header */
+
+    /* Signature */
+    if (err == ZIP_OK)
+        err = zipWriteValue(&zi->z_filefunc, zi->filestream, (uint32_t)ENDHEADERMAGIC, 4);
+    /* Number of this disk */
+    if (err == ZIP_OK)
+        err = zipWriteValue(&zi->z_filefunc, zi->filestream, (uint16_t)zi->number_disk_with_CD, 2);
+    /* Number of the disk with the start of the central directory */
+    if (err == ZIP_OK)
+        err = zipWriteValue(&zi->z_filefunc, zi->filestream, (uint16_t)zi->number_disk_with_CD, 2);
+    /* Total number of entries in the central dir on this disk */
+    if (err == ZIP_OK)
+    {
+        if (zi->number_entry >= UINT16_MAX)
+            err = zipWriteValue(&zi->z_filefunc, zi->filestream, UINT16_MAX, 2); /* use value in ZIP64 record */
+        else
+            err = zipWriteValue(&zi->z_filefunc, zi->filestream, (uint16_t)zi->number_entry, 2);
+    }
+    /* Total number of entries in the central dir */
+    if (err == ZIP_OK)
+    {
+        if (zi->number_entry >= UINT16_MAX)
+            err = zipWriteValue(&zi->z_filefunc, zi->filestream, UINT16_MAX, 2); /* use value in ZIP64 record */
+        else
+            err = zipWriteValue(&zi->z_filefunc, zi->filestream, (uint16_t)zi->number_entry, 2);
+    }
+    /* Size of the central directory */
+    if (err == ZIP_OK)
+        err = zipWriteValue(&zi->z_filefunc, zi->filestream, size_centraldir, 4);
+    /* Offset of start of central directory with respect to the starting disk number */
+    if (err == ZIP_OK)
+    {
+        cd_pos = centraldir_pos_inzip - zi->add_position_when_writting_offset;
+        if (pos >= UINT32_MAX)
+            err = zipWriteValue(&zi->z_filefunc, zi->filestream, UINT32_MAX, 4);
+        else
+            err = zipWriteValue(&zi->z_filefunc, zi->filestream, (uint32_t)cd_pos, 4);
+    }
+
+    /* Write global comment */
+
+    if (global_comment != NULL)
+        size_global_comment = (uint16_t)strlen(global_comment);
+    if (err == ZIP_OK)
+        err = zipWriteValue(&zi->z_filefunc, zi->filestream, size_global_comment, 2);
+    if (err == ZIP_OK && size_global_comment > 0)
+    {
+        if (ZWRITE64(zi->z_filefunc, zi->filestream, global_comment, size_global_comment) != size_global_comment)
+            err = ZIP_ERRNO;
+    }
+
+    if ((ZCLOSE64(zi->z_filefunc, zi->filestream) != 0) && (err == ZIP_OK))
+        err = ZIP_ERRNO;
+
+#ifndef NO_ADDFILEINEXISTINGZIP
+    TRYFREE(zi->globalcomment);
+#endif
+    TRYFREE(zi);
+
+    return err;
+}

--- a/contrib/zip/src/zip.c
+++ b/contrib/zip/src/zip.c
@@ -45,6 +45,9 @@
 #  include "crypt.h"
 #endif
 
+// these warnings are considered as errors on VS
+#pragma warning(disable : 4100) 
+
 #define SIZEDATA_INDATABLOCK        (4096-(4*4))
 
 #define DISKHEADERMAGIC             (0x08074b50)

--- a/contrib/zip/src/zip.h
+++ b/contrib/zip/src/zip.h
@@ -1,331 +1,212 @@
-/*
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
- * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
- * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
- * IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
- * OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
- * ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
- * OTHER DEALINGS IN THE SOFTWARE.
- */
+/* zip.h -- IO on .zip files using zlib
+   Version 1.2.0, September 16th, 2017
+   part of the MiniZip project
 
-#pragma once
-#ifndef ZIP_H
-#define ZIP_H
+   Copyright (C) 2012-2017 Nathan Moinvaziri
+     https://github.com/nmoinvaz/minizip
+   Copyright (C) 2009-2010 Mathias Svensson
+     Modifications for Zip64 support
+     http://result42.com
+   Copyright (C) 1998-2010 Gilles Vollant
+     http://www.winimage.com/zLibDll/minizip.html
 
-#include <string.h>
-#include <sys/types.h>
+   This program is distributed under the terms of the same license as zlib.
+   See the accompanying LICENSE file for the full text of the license.
+*/
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4127 )
-#endif //_MSC_VER
+#ifndef _ZIP_H
+#define _ZIP_H
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#if !defined(_SSIZE_T_DEFINED) && !defined(_SSIZE_T_DEFINED_) &&               \
-    !defined(__DEFINED_ssize_t) && !defined(__ssize_t_defined) &&              \
-    !defined(_SSIZE_T) && !defined(_SSIZE_T_) && !defined(_SSIZE_T_DECLARED)
+#ifndef _ZLIB_H
+#  include "zlib.h"
+#endif
 
-// 64-bit Windows is the only mainstream platform
-// where sizeof(long) != sizeof(void*)
-#ifdef _WIN64
-typedef long long ssize_t; /* byte count or error */
+#ifndef _ZLIBIOAPI_H
+#  include "ioapi.h"
+#endif
+
+#ifdef HAVE_BZIP2
+#  include "bzlib.h"
+#endif
+
+#define Z_BZIP2ED 12
+
+#if defined(STRICTZIP) || defined(STRICTZIPUNZIP)
+/* like the STRICT of WIN32, we define a pointer that cannot be converted
+    from (void*) without cast */
+typedef struct TagzipFile__ { int unused; } zip_file__;
+typedef zip_file__ *zipFile;
 #else
-typedef long ssize_t; /* byte count or error */
+typedef voidp zipFile;
 #endif
 
-#define _SSIZE_T_DEFINED
-#define _SSIZE_T_DEFINED_
-#define __DEFINED_ssize_t
-#define __ssize_t_defined
-#define _SSIZE_T
-#define _SSIZE_T_
-#define _SSIZE_T_DECLARED
+#define ZIP_OK                          (0)
+#define ZIP_EOF                         (0)
+#define ZIP_ERRNO                       (Z_ERRNO)
+#define ZIP_PARAMERROR                  (-102)
+#define ZIP_BADZIPFILE                  (-103)
+#define ZIP_INTERNALERROR               (-104)
 
+#ifndef DEF_MEM_LEVEL
+#  if MAX_MEM_LEVEL >= 8
+#    define DEF_MEM_LEVEL 8
+#  else
+#    define DEF_MEM_LEVEL  MAX_MEM_LEVEL
+#  endif
 #endif
 
-#ifndef MAX_PATH
-#define MAX_PATH 32767 /* # chars in a path name including NULL */
-#endif
+typedef struct
+{
+    uint32_t    dos_date;
+    uint16_t    internal_fa;        /* internal file attributes        2 bytes */
+    uint32_t    external_fa;        /* external file attributes        4 bytes */
+} zip_fileinfo;
 
-/**
- * @mainpage
- *
- * Documenation for @ref zip.
- */
+#define APPEND_STATUS_CREATE        (0)
+#define APPEND_STATUS_CREATEAFTER   (1)
+#define APPEND_STATUS_ADDINZIP      (2)
 
-/**
- * @addtogroup zip
- * @{
- */
+/***************************************************************************/
+/* Writing a zip file */
 
-/**
- * Default zip compression level.
- */
+extern zipFile ZEXPORT zipOpen(const char *path, int append);
+extern zipFile ZEXPORT zipOpen64(const void *path, int append);
+/* Create a zipfile.
 
-#define ZIP_DEFAULT_COMPRESSION_LEVEL 6
+   path should contain the full path (by example, on a Windows XP computer 
+      "c:\\zlib\\zlib113.zip" or on an Unix computer "zlib/zlib113.zip". 
 
-/**
- * @struct zip_t
- *
- * This data structure is used throughout the library to represent zip archive -
- * forward declaration.
- */
-struct zip_t;
+   return NULL if zipfile cannot be opened
+   return zipFile handle if no error
 
-/**
- * Opens zip archive with compression level using the given mode.
- *
- * @param zipname zip archive file name.
- * @param level compression level (0-9 are the standard zlib-style levels).
- * @param mode file access mode.
- *        - 'r': opens a file for reading/extracting (the file must exists).
- *        - 'w': creates an empty file for writing.
- *        - 'a': appends to an existing archive.
- *
- * @return the zip archive handler or NULL on error
- */
-extern struct zip_t *zip_open(const char *zipname, int level, char mode);
+   If the file path exist and append == APPEND_STATUS_CREATEAFTER, the zip
+   will be created at the end of the file. (useful if the file contain a self extractor code)
+   If the file path exist and append == APPEND_STATUS_ADDINZIP, we will add files in existing 
+   zip (be sure you don't add file that doesn't exist)
 
-/**
- * Closes the zip archive, releases resources - always finalize.
- *
- * @param zip zip archive handler.
- */
-extern void zip_close(struct zip_t *zip);
+   NOTE: There is no delete function into a zipfile. If you want delete file into a zipfile, 
+   you must open a zipfile, and create another. Of course, you can use RAW reading and writing to copy
+   the file you did not want delete. */
 
-/**
- * Determines if the archive has a zip64 end of central directory headers.
- *
- * @param zip zip archive handler.
- *
- * @return the return code - 1 (true), 0 (false), negative number (< 0) on
- *         error.
- */
-extern int zip_is64(struct zip_t *zip);
+extern zipFile ZEXPORT zipOpen2(const char *path, int append, const char **globalcomment, 
+    zlib_filefunc_def *pzlib_filefunc_def);
 
-/**
- * Opens an entry by name in the zip archive.
- *
- * For zip archive opened in 'w' or 'a' mode the function will append
- * a new entry. In readonly mode the function tries to locate the entry
- * in global dictionary.
- *
- * @param zip zip archive handler.
- * @param entryname an entry name in local dictionary.
- *
- * @return the return code - 0 on success, negative number (< 0) on error.
- */
-extern int zip_entry_open(struct zip_t *zip, const char *entryname);
+extern zipFile ZEXPORT zipOpen2_64(const void *path, int append, const char **globalcomment, 
+    zlib_filefunc64_def *pzlib_filefunc_def);
 
-/**
- * Opens a new entry by index in the zip archive.
- *
- * This function is only valid if zip archive was opened in 'r' (readonly) mode.
- *
- * @param zip zip archive handler.
- * @param index index in local dictionary.
- *
- * @return the return code - 0 on success, negative number (< 0) on error.
- */
-extern int zip_entry_openbyindex(struct zip_t *zip, int index);
+extern zipFile ZEXPORT zipOpen3(const char *path, int append, uint64_t disk_size, 
+    const char **globalcomment, zlib_filefunc_def *pzlib_filefunc_def);
+/* Same as zipOpen2 but allows specification of spanned zip size */
 
-/**
- * Closes a zip entry, flushes buffer and releases resources.
- *
- * @param zip zip archive handler.
- *
- * @return the return code - 0 on success, negative number (< 0) on error.
- */
-extern int zip_entry_close(struct zip_t *zip);
+extern zipFile ZEXPORT zipOpen3_64(const void *path, int append, uint64_t disk_size, 
+    const char **globalcomment, zlib_filefunc64_def *pzlib_filefunc_def);
 
-/**
- * Returns a local name of the current zip entry.
- *
- * The main difference between user's entry name and local entry name
- * is optional relative path.
- * Following .ZIP File Format Specification - the path stored MUST not contain
- * a drive or device letter, or a leading slash.
- * All slashes MUST be forward slashes '/' as opposed to backwards slashes '\'
- * for compatibility with Amiga and UNIX file systems etc.
- *
- * @param zip: zip archive handler.
- *
- * @return the pointer to the current zip entry name, or NULL on error.
- */
-extern const char *zip_entry_name(struct zip_t *zip);
+extern int ZEXPORT zipOpenNewFileInZip(zipFile file, const char *filename, const zip_fileinfo *zipfi,
+    const void *extrafield_local, uint16_t size_extrafield_local, const void *extrafield_global, 
+    uint16_t size_extrafield_global, const char *comment, uint16_t method, int level);
+/* Open a file in the ZIP for writing.
 
-/**
- * Returns an index of the current zip entry.
- *
- * @param zip zip archive handler.
- *
- * @return the index on success, negative number (< 0) on error.
- */
-extern int zip_entry_index(struct zip_t *zip);
+   filename : the filename in zip (if NULL, '-' without quote will be used
+   *zipfi contain supplemental information
+   extrafield_local buffer to store the local header extra field data, can be NULL
+   size_extrafield_local size of extrafield_local buffer
+   extrafield_global buffer to store the global header extra field data, can be NULL
+   size_extrafield_global size of extrafield_local buffer
+   comment buffer for comment string
+   method contain the compression method (0 for store, Z_DEFLATED for deflate)
+   level contain the level of compression (can be Z_DEFAULT_COMPRESSION)
+   zip64 is set to 1 if a zip64 extended information block should be added to the local file header.
+   this MUST be '1' if the uncompressed size is >= 0xffffffff. */
 
-/**
- * Determines if the current zip entry is a directory entry.
- *
- * @param zip zip archive handler.
- *
- * @return the return code - 1 (true), 0 (false), negative number (< 0) on
- *         error.
- */
-extern int zip_entry_isdir(struct zip_t *zip);
+extern int ZEXPORT zipOpenNewFileInZip64(zipFile file, const char *filename, const zip_fileinfo *zipfi,
+    const void *extrafield_local, uint16_t size_extrafield_local, const void *extrafield_global,
+    uint16_t size_extrafield_global, const char *comment, uint16_t method, int level, int zip64);
+/* Same as zipOpenNewFileInZip with zip64 support */
 
-/**
- * Returns an uncompressed size of the current zip entry.
- *
- * @param zip zip archive handler.
- *
- * @return the uncompressed size in bytes.
- */
-extern unsigned long long zip_entry_size(struct zip_t *zip);
+extern int ZEXPORT zipOpenNewFileInZip2(zipFile file, const char *filename, const zip_fileinfo *zipfi,
+    const void *extrafield_local, uint16_t size_extrafield_local, const void *extrafield_global,
+    uint16_t size_extrafield_global, const char *comment, uint16_t method, int level, int raw);
+/* Same as zipOpenNewFileInZip, except if raw=1, we write raw file */
 
-/**
- * Returns CRC-32 checksum of the current zip entry.
- *
- * @param zip zip archive handler.
- *
- * @return the CRC-32 checksum.
- */
-extern unsigned int zip_entry_crc32(struct zip_t *zip);
+extern int ZEXPORT zipOpenNewFileInZip2_64(zipFile file, const char *filename, const zip_fileinfo *zipfi,
+    const void *extrafield_local, uint16_t size_extrafield_local, const void *extrafield_global,
+    uint16_t size_extrafield_global, const char *comment, uint16_t method, int level, int raw, int zip64);
+/* Same as zipOpenNewFileInZip3 with zip64 support */
 
-/**
- * Compresses an input buffer for the current zip entry.
- *
- * @param zip zip archive handler.
- * @param buf input buffer.
- * @param bufsize input buffer size (in bytes).
- *
- * @return the return code - 0 on success, negative number (< 0) on error.
- */
-extern int zip_entry_write(struct zip_t *zip, const void *buf, size_t bufsize);
+extern int ZEXPORT zipOpenNewFileInZip3(zipFile file, const char *filename, const zip_fileinfo *zipfi,
+    const void *extrafield_local, uint16_t size_extrafield_local, const void *extrafield_global,
+    uint16_t size_extrafield_global, const char *comment, uint16_t method, int level, int raw, int windowBits, int memLevel,
+    int strategy, const char *password, ZIP_UNUSED uint32_t crc_for_crypting);
+/* Same as zipOpenNewFileInZip2, except
+    windowBits, memLevel, strategy : see parameter strategy in deflateInit2
+    password : crypting password (NULL for no crypting)
+    crc_for_crypting : crc of file to compress (needed for crypting) */
 
-/**
- * Compresses a file for the current zip entry.
- *
- * @param zip zip archive handler.
- * @param filename input file.
- *
- * @return the return code - 0 on success, negative number (< 0) on error.
- */
-extern int zip_entry_fwrite(struct zip_t *zip, const char *filename);
+extern int ZEXPORT zipOpenNewFileInZip3_64(zipFile file, const char *filename, const zip_fileinfo *zipfi,
+    const void *extrafield_local, uint16_t size_extrafield_local, const void *extrafield_global,
+    uint16_t size_extrafield_global, const char *comment, uint16_t method, int level, int raw, int windowBits, int memLevel,
+    int strategy, const char *password, ZIP_UNUSED uint32_t crc_for_crypting, int zip64);
+/* Same as zipOpenNewFileInZip3 with zip64 support */
 
-/**
- * Extracts the current zip entry into output buffer.
- *
- * The function allocates sufficient memory for a output buffer.
- *
- * @param zip zip archive handler.
- * @param buf output buffer.
- * @param bufsize output buffer size (in bytes).
- *
- * @note remember to release memory allocated for a output buffer.
- *       for large entries, please take a look at zip_entry_extract function.
- *
- * @return the return code - the number of bytes actually read on success.
- *         Otherwise a -1 on error.
- */
-extern ssize_t zip_entry_read(struct zip_t *zip, void **buf, size_t *bufsize);
+extern int ZEXPORT zipOpenNewFileInZip4(zipFile file, const char *filename, const zip_fileinfo *zipfi,
+    const void *extrafield_local, uint16_t size_extrafield_local, const void *extrafield_global,
+    uint16_t size_extrafield_global, const char *comment, uint16_t method, int level, int raw, int windowBits, int memLevel,
+    int strategy, const char *password, ZIP_UNUSED uint32_t crc_for_crypting, uint16_t version_madeby, uint16_t flag_base);
+/* Same as zipOpenNewFileInZip3 except versionMadeBy & flag fields */
 
-/**
- * Extracts the current zip entry into a memory buffer using no memory
- * allocation.
- *
- * @param zip zip archive handler.
- * @param buf preallocated output buffer.
- * @param bufsize output buffer size (in bytes).
- *
- * @note ensure supplied output buffer is large enough.
- *       zip_entry_size function (returns uncompressed size for the current
- *       entry) can be handy to estimate how big buffer is needed. for large
- * entries, please take a look at zip_entry_extract function.
- *
- * @return the return code - the number of bytes actually read on success.
- *         Otherwise a -1 on error (e.g. bufsize is not large enough).
- */
-extern ssize_t zip_entry_noallocread(struct zip_t *zip, void *buf,
-                                     size_t bufsize);
+extern int ZEXPORT zipOpenNewFileInZip4_64(zipFile file, const char *filename, const zip_fileinfo *zipfi,
+    const void *extrafield_local, uint16_t size_extrafield_local, const void *extrafield_global,
+    uint16_t size_extrafield_global, const char *comment, uint16_t method, int level, int raw, int windowBits, int memLevel,
+    int strategy, const char *password, ZIP_UNUSED uint32_t crc_for_crypting, uint16_t version_madeby, uint16_t flag_base, int zip64);
+/* Same as zipOpenNewFileInZip4 with zip64 support */
 
-/**
- * Extracts the current zip entry into output file.
- *
- * @param zip zip archive handler.
- * @param filename output file.
- *
- * @return the return code - 0 on success, negative number (< 0) on error.
- */
-extern int zip_entry_fread(struct zip_t *zip, const char *filename);
+extern int ZEXPORT zipOpenNewFileInZip5(zipFile file,
+                                        const char *filename,
+                                        const zip_fileinfo *zipfi,
+                                        const void *extrafield_local,
+                                        uint16_t size_extrafield_local,
+                                        const void *extrafield_global,
+                                        uint16_t size_extrafield_global,
+                                        const char *comment,
+                                        uint16_t flag_base,
+                                        int zip64,
+                                        uint16_t method,
+                                        int level,
+                                        int raw,
+                                        int windowBits,
+                                        int memLevel,
+                                        int strategy,
+                                        const char *password,
+                                        int aes);
+/* Allowing optional aes */
 
-/**
- * Extracts the current zip entry using a callback function (on_extract).
- *
- * @param zip zip archive handler.
- * @param on_extract callback function.
- * @param arg opaque pointer (optional argument, which you can pass to the
- *        on_extract callback)
- *
- * @return the return code - 0 on success, negative number (< 0) on error.
- */
-extern int
-zip_entry_extract(struct zip_t *zip,
-                  size_t (*on_extract)(void *arg, unsigned long long offset,
-                                       const void *data, size_t size),
-                  void *arg);
+extern int ZEXPORT zipWriteInFileInZip(zipFile file, const void *buf, uint32_t len);
+/* Write data in the zipfile */
 
-/**
- * Returns the number of all entries (files and directories) in the zip archive.
- *
- * @param zip zip archive handler.
- *
- * @return the return code - the number of entries on success, negative number
- *         (< 0) on error.
- */
-extern int zip_total_entries(struct zip_t *zip);
+extern int ZEXPORT zipCloseFileInZip(zipFile file);
+/* Close the current file in the zipfile */
 
-/**
- * Creates a new archive and puts files into a single zip archive.
- *
- * @param zipname zip archive file.
- * @param filenames input files.
- * @param len: number of input files.
- *
- * @return the return code - 0 on success, negative number (< 0) on error.
- */
-extern int zip_create(const char *zipname, const char *filenames[], size_t len);
+extern int ZEXPORT zipCloseFileInZipRaw(zipFile file, uint32_t uncompressed_size, uint32_t crc32);
+extern int ZEXPORT zipCloseFileInZipRaw64(zipFile file, uint64_t uncompressed_size, uint32_t crc32);
+/* Close the current file in the zipfile, for file opened with parameter raw=1 in zipOpenNewFileInZip2
+   where raw is compressed data. Parameters uncompressed_size and crc32 are value for the uncompressed data. */
 
-/**
- * Extracts a zip archive file into directory.
- *
- * If on_extract_entry is not NULL, the callback will be called after
- * successfully extracted each zip entry.
- * Returning a negative value from the callback will cause abort and return an
- * error. The last argument (void *arg) is optional, which you can use to pass
- * data to the on_extract_entry callback.
- *
- * @param zipname zip archive file.
- * @param dir output directory.
- * @param on_extract_entry on extract callback.
- * @param arg opaque pointer.
- *
- * @return the return code - 0 on success, negative number (< 0) on error.
- */
-extern int zip_extract(const char *zipname, const char *dir,
-                       int (*on_extract_entry)(const char *filename, void *arg),
-                       void *arg);
+extern int ZEXPORT zipClose(zipFile file, const char *global_comment);
+/* Close the zipfile */
 
-/** @} */
+extern int ZEXPORT zipClose_64(zipFile file, const char *global_comment);
 
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif //_MSC_VER
+extern int ZEXPORT zipClose2_64(zipFile file, const char *global_comment, uint16_t version_madeby);
+/* Same as zipClose_64 except version_madeby field */
+
+/***************************************************************************/
 
 #ifdef __cplusplus
 }
 #endif
 
-#endif
+#endif /* _ZIP_H */


### PR DESCRIPTION
Hi,

Compiling Assimp with MinGW (without ASSIMP_USE_HUNTER) doesn't work because of a recent change in ZipArchiveIOSystem.cpp :
```cpp
#if defined (ASSIMP_USE_HUNTER) || defined (__MINGW32__) // GH#3144
    mapping.zopen_file = (open_file_func)open;
    mapping.zread_file = (read_file_func)read;
    mapping.zwrite_file = (write_file_func)write;
    mapping.ztell_file = (tell_file_func)tell;
    mapping.zseek_file = (seek_file_func)seek;
    mapping.zclose_file = (close_file_func)close;
    mapping.zerror_file = (error_file_func)testerror;
#else
    mapping.zopen_file = open;
    mapping.zread_file = read;
    mapping.zwrite_file = write;
    mapping.ztell_file = tell;
    mapping.zseek_file = seek;
    mapping.zclose_file = close;
    mapping.zerror_file = testerror;
#endif
```

The issue is that the Minizip version provided by Hunter seems to be a Minizip 1.2 version which define `error_file_func`
And on the other hand, the version of minizip used in Assimp (in contrib/zip and contrib/unzip) is much less recent and doesn't define `error_file_func` but `testerror_file_func`
A quick and easy fix would be to remove the `|| defined (__MINGW32__)` and adding cast to the Minizip `testerror_file_func` in the else.

IMO a better solution would be to update the version of Minizip used in contrib (so we use similar headers in Hunter and contrib Minizip), which I propose via this PR.

The changed have been compiled and tested for MinGW and VS 2019, by exporting a 3MF package and reload it with Assimp Viewer