### PR TITLE
Fix glTF from memory loading .bin with a custom IOHandler

### DIFF
--- a/code/AssetLib/glTF/glTFAsset.inl
+++ b/code/AssetLib/glTF/glTFAsset.inl
@@ -40,6 +40,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 #include <assimp/StringUtils.h>
+#include <assimp/MemoryIOWrapper.h>
 #include <iomanip>
 
 // Header files, Assimp
@@ -331,7 +332,10 @@ inline void Buffer::Read(Value &obj, Asset &r) {
         }
     } else { // Local file
         if (byteLength > 0) {
-            std::string dir = !r.mCurrentAssetDir.empty() ? (r.mCurrentAssetDir) : "";
+            std::string dir = !r.mCurrentAssetDir.empty() ? (
+                r.mCurrentAssetDir.back() == '/' ?
+                   r.mCurrentAssetDir : r.mCurrentAssetDir + '/'
+            ) : "";
 
             IOStream *file = r.OpenFile(dir + uri, "rb");
             if (file) {
@@ -1276,7 +1280,9 @@ inline void Asset::Load(const std::string &pFile, bool isBinary) {
 
     /*int pos = std::max(int(pFile.rfind('/')), int(pFile.rfind('\\')));
     if (pos != int(std::string::npos)) mCurrentAssetDir = pFile.substr(0, pos + 1);*/
-    mCurrentAssetDir = getCurrentAssetDir(pFile);
+    if (0 != strncmp(pFile.c_str(), AI_MEMORYIO_MAGIC_FILENAME, AI_MEMORYIO_MAGIC_FILENAME_LENGTH)) {
+        mCurrentAssetDir = getCurrentAssetDir(pFile);
+    }
 
     shared_ptr<IOStream> stream(OpenFile(pFile.c_str(), "rb", true));
     if (!stream) {

--- a/code/AssetLib/glTF2/glTF2Asset.inl
+++ b/code/AssetLib/glTF2/glTF2Asset.inl
@@ -44,6 +44,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <assimp/StringUtils.h>
 #include <assimp/DefaultLogger.hpp>
+#include <assimp/MemoryIOWrapper.h>
 
 using namespace Assimp;
 
@@ -400,7 +401,10 @@ inline void Buffer::Read(Value &obj, Asset &r) {
         }
     } else { // Local file
         if (byteLength > 0) {
-            std::string dir = !r.mCurrentAssetDir.empty() ? (r.mCurrentAssetDir) : "";
+            std::string dir = !r.mCurrentAssetDir.empty() ? (
+                r.mCurrentAssetDir.back() == '/' ?
+                   r.mCurrentAssetDir : r.mCurrentAssetDir + '/'
+            ) : "";
 
             IOStream *file = r.OpenFile(dir + uri, "rb");
             if (file) {
@@ -1590,8 +1594,10 @@ inline void Asset::Load(const std::string &pFile, bool isBinary) {
     /*int pos = std::max(int(pFile.rfind('/')), int(pFile.rfind('\\')));
     if (pos != int(std::string::npos)) */
 
-    mCurrentAssetDir = glTFCommon::getCurrentAssetDir(pFile);
-
+    if (0 != strncmp(pFile.c_str(), AI_MEMORYIO_MAGIC_FILENAME, AI_MEMORYIO_MAGIC_FILENAME_LENGTH)) {
+        mCurrentAssetDir = glTFCommon::getCurrentAssetDir(pFile);
+    }
+    
     shared_ptr<IOStream> stream(OpenFile(pFile.c_str(), "rb", true));
     if (!stream) {
         throw DeadlyImportError("GLTF: Could not open file for reading");


### PR DESCRIPTION
This is my first time exploring the source code and contributing. I've been looking around for hours trying to fix this and I came across these two commits which could have interfered:
- https://github.com/assimp/assimp/commit/d2ed36756c7b844268367fdcde27e0f1846102e2
- https://github.com/assimp/assimp/commit/0357333c8185ef7a4446502cebc9ef239564c67a

I eventually figured out the problem was with:
`mCurrentAssetDir = glTFCommon::getCurrentAssetDir(pFile);`

When trying to load a .gltf with a custom IO handler (for my purpose, loading assets through http and custom protocols), it will eventually request the .bin file. If loaded from memory, it will use `MemoryIOWrapper` and run function `MemoryIOWrapper::Open`

However, before my commit, it would send  `$$$___magic___$$$scene.bin` as `const char* pFile` to `MemoryIOWrapper::Open`. This causes it to access the original glTF data instead of the requested `scene.bin`.

In my commit, adding the conditional around:
`mCurrentAssetDir = glTFCommon::getCurrentAssetDir(pFile);`

Causes `scene.bin` to be sent to `MemoryIOWrapper::Open` which correctly resolves the file.

Let me know if I need to update my code. I compiled and tested this on master and it worked fine! (though updating from 5.0.1 to master causes me to crash a lot more often :disappointed: I may send more PRs)

P.S. I used `strncmp` instead of `pFile.compare()` as it wasn't doing the same thing. `strncmp` is also used in `MemoryIOWrapper.h`



