### PR TITLE
Fix build failure on Linux

### DIFF
--- a/code/Common/ZipArchiveIOSystem.cpp
+++ b/code/Common/ZipArchiveIOSystem.cpp
@@ -152,7 +152,7 @@ zlib_filefunc_def IOSystem2Unzip::get(IOSystem *pIOHandler) {
     mapping.ztell_file = (tell_file_func)tell;
     mapping.zseek_file = (seek_file_func)seek;
     mapping.zclose_file = (close_file_func)close;
-    mapping.zerror_file = (error_file_func)testerror;
+    mapping.zerror_file = testerror;
 
     mapping.opaque = reinterpret_cast<voidpf>(pIOHandler);
 


### PR DESCRIPTION
This is a partial revert of 54be7ac582599df9f32503ed435b65911a6ebc8b (2020-12-24 Update unzip contrib)

Fixes the following build failure seen when compiling under Linux x86_64 using GCC 10.2.0:

    /usr/src/git/assimp/code/Common/ZipArchiveIOSystem.cpp: In static member function 'static zlib_filefunc_def Assimp::IOSystem2Unzip::get(Assimp::IOSystem*)':
    /usr/src/git/assimp/code/Common/ZipArchiveIOSystem.cpp:155:28: error: 'error_file_func' was not declared in this scope; did you mean 'testerror_file_func'?
      155 |     mapping.zerror_file = (error_file_func)testerror;
          |                            ^~~~~~~~~~~~~~~
          |                            testerror_file_func
    make[2]: *** [code/CMakeFiles/assimp.dir/build.make:186: code/CMakeFiles/assimp.dir/Common/ZipArchiveIOSystem.cpp.o] 
    Error 1