### PR TITLE
Update gitignore for default VS2019 behaviour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ build
 *.VC.db-wal
 *.VC.opendb
 *.ipch
+.vs/
+out/
+CMakeSettings.json
 
 # Output
 bin/


### PR DESCRIPTION
VS2019 has improved native support for cmake projects, opened via "Open Folder".

This creates some extra files in-tree:
- "CMakeSettings.json" file with your VS settings (toolchain, enabled configurations etc)
- ".vs/" folder for Visual Studio's Intellisense database
- "out/" folder for the build artifacts.

This PR adds these to gitignore to avoid accidentally committing any of these