### PR TITLE
Eliminate maybe-uninitialized warnings which are treated as errors

### DIFF
--- a/code/AssetLib/M3D/m3d.h
+++ b/code/AssetLib/M3D/m3d.h
@@ -1642,7 +1642,7 @@ static int _m3dstbi__expand_png_palette(_m3dstbi__png *a, unsigned char *palette
 static int _m3dstbi__parse_png_file(_m3dstbi__png *z, int scan, int req_comp) {
     unsigned char palette[1024], pal_img_n = 0;
     unsigned char has_trans = 0, tc[3] = {};
-    _m3dstbi__uint16 tc16[3];
+    _m3dstbi__uint16 tc16[3] = {};
     _m3dstbi__uint32 ioff = 0, idata_limit = 0, i, pal_len = 0;
     int first = 1, k, interlace = 0, color = 0;
     _m3dstbi__context *s = z->s;


### PR DESCRIPTION
The array `tc16[3]` in ` code/AssetLib/M3D/m3d.h:1645` is not initialized and may cause `maybe-uninitialized` warnings when building release version of the library.