### PR TITLE
Silence uninitialized variable warning in 3MF importer

### DIFF
--- a/code/AssetLib/3MF/D3MFImporter.cpp
+++ b/code/AssetLib/3MF/D3MFImporter.cpp
@@ -427,7 +427,7 @@ private:
                 aiFace face = ReadTriangle(currentNode);
                 faces.push_back(face);
 
-                int pid, p1;
+                int pid = 0, p1;
                 bool hasPid = getNodeAttribute(currentNode, D3MF::XmlTag::pid, pid);
                 bool hasP1 = getNodeAttribute(currentNode, D3MF::XmlTag::p1, p1);
 


### PR DESCRIPTION
Silence  uninitialized variable warning in 3MF importer

```
code/AssetLib/3MF/D3MFImporter.cpp:435:58: error: ‘pid’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  435 |                     auto it = mResourcesDictionnary.find(pid);
```

This is a false positive (`pid` is only used if `getNodeAttribute` set it and returned true) but the compiler can't see that.