### PR TITLE
updated MIN_IOS_VERSION to 10.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ tools/assimp_qt_viewer/moc_glview.cpp_parameters
 tools/assimp_qt_viewer/moc_mainwindow.cpp
 tools/assimp_qt_viewer/moc_mainwindow.cpp_parameters
 tools/assimp_qt_viewer/ui_mainwindow.h
+
+#Generated directory
+generated/*

--- a/port/iOS/build.sh
+++ b/port/iOS/build.sh
@@ -22,7 +22,7 @@ BUILD_TYPE=Release
 ################################################
 # 		 Minimum iOS deployment target version
 ################################################
-MIN_IOS_VERSION="6.0"
+MIN_IOS_VERSION="10.0"
 
 IOS_SDK_TARGET=$MIN_IOS_VERSION
 XCODE_ROOT_DIR=$(xcode-select  --print-path)
@@ -60,8 +60,8 @@ build_arch()
 
     unset DEVROOT SDKROOT CFLAGS LDFLAGS CPPFLAGS CXXFLAGS CMAKE_CLI_INPUT
            
-	#export CC="$(xcrun -sdk iphoneos -find clang)"
-    #export CPP="$CC -E"
+	export CC="$(xcrun -sdk iphoneos -find clang)"
+    export CPP="$CC -E"
     export DEVROOT=$XCODE_ROOT_DIR/Platforms/$IOS_SDK_DEVICE.platform/Developer
     export SDKROOT=$DEVROOT/SDKs/$IOS_SDK_DEVICE$IOS_SDK_VERSION.sdk
     export CFLAGS="-arch $1 -pipe -no-cpp-precomp -stdlib=$CPP_STD_LIB -isysroot $SDKROOT -I$SDKROOT/usr/include/ -miphoneos-version-min=$IOS_SDK_TARGET"


### PR DESCRIPTION
I took some time to try and get assimp iOS port working the last couple of days I found that 1 variable in the ./build.sh file was the issue. 

After finding the issue and updating MIN_IOS_VERSION to 10.0 I was able to build the iOS binaries and I was able to do it on a new M1 Mac Mini. 

There were also some permission issue and some compile issues with compiling the example files however I did not update anything to fix the issue I just committed out that section in the main CMakeList.text so that I could run cmake. We should solve this issue for Mac users and I'm happy to continue to contribute if that would be helpful. 