### PR TITLE
Fix a memory leak in glTF2.

### DIFF
--- a/code/AssetLib/glTF2/glTF2Asset.inl
+++ b/code/AssetLib/glTF2/glTF2Asset.inl
@@ -383,6 +383,7 @@ unsigned int LazyDict<T>::Remove(const char *id) {
     mAsset.mUsedIds[id] = false;
     mObjsById.erase(id);
     mObjsByOIndex.erase(index);
+    delete mObjs[index];
     mObjs.erase(mObjs.begin() + index);
 
     //update index of object in mObjs;


### PR DESCRIPTION
The destructor of LazyDict uses `delete` but `delete` was not used for objects removed by LazyDict::Remove.