### PR TITLE
Fix for Xcode build.

### DIFF
--- a/include/assimp/material.h
+++ b/include/assimp/material.h
@@ -457,8 +457,6 @@ enum aiBlendMode {
 #endif
 };
 
-#include "./Compiler/pushpack1.h"
-
 // ---------------------------------------------------------------------------
 /** @brief Defines how an UV channel is transformed.
  *
@@ -499,8 +497,6 @@ struct aiUVTransform {
     }
 #endif
 };
-
-#include "./Compiler/poppack1.h"
 
 //! @cond AI_DOX_INCLUDE_INTERNAL
 // ---------------------------------------------------------------------------

--- a/include/assimp/texture.h
+++ b/include/assimp/texture.h
@@ -80,8 +80,6 @@ extern "C" {
 #   define AI_MAKE_EMBEDDED_TEXNAME(_n_) AI_EMBEDDED_TEXNAME_PREFIX # _n_
 #endif
 
-#include "./Compiler/pushpack1.h"
-
 // --------------------------------------------------------------------------------
 /** @brief Helper structure to represent a texel in a ARGB8888 format
 *
@@ -113,8 +111,6 @@ struct aiTexel {
 #endif // __cplusplus
 
 } PACK_STRUCT;
-
-#include "./Compiler/poppack1.h"
 
 #define HINTMAXTEXTURELEN 9
 


### PR DESCRIPTION
When you generate a static library framework build and you include it in a project 

`texture.h` and `material.h` result in the following errors

```
'./Compiler/pushpack1.h' file not found
'./Compiler/poppack1.h' file not found
```

Looks like it's the same issue as #2219, but for the two aforementioned files.