### PR TITLE
Add zlibstatic to the list of exported targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -454,7 +454,7 @@ IF(ASSIMP_HUNTER_ENABLED)
 ELSE()
   # If the zlib is already found outside, add an export in case assimpTargets can't find it.
   IF( ZLIB_FOUND )
-    INSTALL( TARGETS zlib
+    INSTALL( TARGETS zlib zlibstatic
         EXPORT "${TARGETS_EXPORT_NAME}")
   ENDIF()
 


### PR DESCRIPTION
Hello.
This patch fixes zlibstatic being missing from export set when zlib is used as a static lib with assimp. Otherwise I get the error like this:
```
CMake Error: install(EXPORT "assimpTargets" ...) includes target "assimp" which requires target "zlibstatic" that is not in the export set.
```