### PR TITLE
Fixing 3DS import for CHUNK_TRMATRIX translation vector.

### DIFF
--- a/code/AssetLib/3DS/3DSLoader.cpp
+++ b/code/AssetLib/3DS/3DSLoader.cpp
@@ -981,9 +981,9 @@ void Discreet3DSImporter::ParseMeshChunk() {
         mMesh.mMat.a3 = stream->GetF4();
         mMesh.mMat.b3 = stream->GetF4();
         mMesh.mMat.c3 = stream->GetF4();
-        mMesh.mMat.a4 = stream->GetF4();
-        mMesh.mMat.b4 = stream->GetF4();
-        mMesh.mMat.c4 = stream->GetF4();
+        mMesh.mMat.d1 = stream->GetF4();
+        mMesh.mMat.d2 = stream->GetF4();
+        mMesh.mMat.d3 = stream->GetF4();
     } break;
 
     case Discreet3DS::CHUNK_MAPLIST: {


### PR DESCRIPTION
Fixing wrong transformation matrix import for 3DS in alignment with 3DS exporter.