### PR TITLE
Fix MDC loader

### DIFF
--- a/code/AssetLib/MDC/MDCLoader.cpp
+++ b/code/AssetLib/MDC/MDCLoader.cpp
@@ -250,7 +250,7 @@ void MDCImporter::InternReadFile(
 
     // get the number of valid surfaces
     BE_NCONST MDC::Surface *pcSurface, *pcSurface2;
-    pcSurface = pcSurface2 = new (mBuffer + pcHeader->ulOffsetSurfaces) MDC::Surface;
+    pcSurface = pcSurface2 = reinterpret_cast<BE_NCONST MDC::Surface *>(mBuffer + pcHeader->ulOffsetSurfaces);
     unsigned int iNumShaders = 0;
     for (unsigned int i = 0; i < pcHeader->ulNumSurfaces; ++i) {
         // validate the surface header
@@ -260,7 +260,7 @@ void MDCImporter::InternReadFile(
             ++pScene->mNumMeshes;
         }
         iNumShaders += pcSurface2->ulNumShaders;
-        pcSurface2 = new ((int8_t *)pcSurface2 + pcSurface2->ulOffsetEnd) MDC::Surface;
+        pcSurface2 = reinterpret_cast<BE_NCONST MDC::Surface *>((BE_NCONST int8_t *)pcSurface2 + pcSurface2->ulOffsetEnd);
     }
     aszShaders.reserve(iNumShaders);
     pScene->mMeshes = new aiMesh *[pScene->mNumMeshes];
@@ -405,7 +405,7 @@ void MDCImporter::InternReadFile(
             pcFaceCur->mIndices[2] = iOutIndex + 0;
         }
 
-        pcSurface = new ((int8_t *)pcSurface + pcSurface->ulOffsetEnd) MDC::Surface;
+        pcSurface = reinterpret_cast<BE_NCONST MDC::Surface *>((BE_NCONST int8_t *)pcSurface + pcSurface->ulOffsetEnd);
     }
 
     // create a flat node graph with a root node and one child for each surface


### PR DESCRIPTION
placement new was clearing input buffer by constructor, which was nothing to do with adequate parsing
changes are not analyzed in depth, but at least test model and models of Wolf:ET are loading and not crashing