### PR TITLE
Renaming PI to aiPi.

### DIFF
--- a/include/assimp/MathFunctions.h
+++ b/include/assimp/MathFunctions.h
@@ -87,7 +87,7 @@ inline IntegerType lcm( IntegerType a, IntegerType b ) {
     }
 	return a / t * b;
 }
-/// @brief  Will return the smallest epsilon-value for the requested type. 
+/// @brief  Will return the smallest epsilon-value for the requested type.
 /// @return The numercical limit epsilon depending on its type.
 template<class T>
 inline T getEpsilon() {
@@ -97,7 +97,7 @@ inline T getEpsilon() {
 /// @brief  Will return the constant PI for the requested type.
 /// @return Pi
 template<class T>
-inline T PI() {
+inline T aiPi() {
     return static_cast<T>(3.14159265358979323846);
 }
 

--- a/test/unit/AssimpAPITest_aiMatrix4x4.cpp
+++ b/test/unit/AssimpAPITest_aiMatrix4x4.cpp
@@ -57,7 +57,7 @@ protected:
     aiMatrix4x4 get_predetermined_transformation_matrix_for_decomposition() const {
         aiMatrix4x4 t, r;
         aiMatrix4x4::Translation(aiVector3D(14,-25,-8), t);
-        aiMatrix4x4::Rotation(Math::PI<float>() / 4.0f, aiVector3D(1).Normalize(), r);
+        aiMatrix4x4::Rotation(Math::aiPi<float>() / 4.0f, aiVector3D(1).Normalize(), r);
         return t * r;
     }
 

--- a/test/unit/AssimpAPITest_aiQuaternion.cpp
+++ b/test/unit/AssimpAPITest_aiQuaternion.cpp
@@ -59,7 +59,7 @@ TEST_F(AssimpAPITest_aiQuaternion, aiCreateQuaternionFromMatrixTest) {
     // to prevent running into division by zero.
     aiMatrix3x3 m, r;
     aiMatrix3x3::Translation(aiVector2D(14,-25), m);
-    aiMatrix3x3::RotationZ(Math::PI<float>() / 4.0f, r);
+    aiMatrix3x3::RotationZ(Math::aiPi<float>() / 4.0f, r);
     m = m * r;
 
     result_cpp = aiQuaternion(m);
@@ -127,8 +127,8 @@ TEST_F(AssimpAPITest_aiQuaternion, aiQuaternionInterpolateTest) {
     // Use predetermined quaternions to prevent division by zero
     // during slerp calculations.
     const float INTERPOLATION(0.5f);
-    const auto q1 = aiQuaternion(aiVector3D(-1,1,1).Normalize(), Math::PI<float>() / 4.0f);
-    const auto q2 = aiQuaternion(aiVector3D(1,2,1).Normalize(), Math::PI<float>() / 2.0f);
+    const auto q1 = aiQuaternion(aiVector3D(-1,1,1).Normalize(), Math::aiPi<float>() / 4.0f);
+    const auto q2 = aiQuaternion(aiVector3D(1,2,1).Normalize(), Math::aiPi<float>() / 2.0f);
     aiQuaternion::Interpolate(result_cpp, q1, q2, INTERPOLATION);
     aiQuaternionInterpolate(&result_c, &q1, &q2, INTERPOLATION);
     EXPECT_EQ(result_cpp, result_c);

--- a/test/unit/MathTest.cpp
+++ b/test/unit/MathTest.cpp
@@ -51,6 +51,6 @@ const float AssimpMathTest::Epsilon = Math::getEpsilon<float>();
 RandomUniformFloatGenerator AssimpMathTest::RandNonZero(1.0f, 100.0f);
 
 // Initialize with an interval of [-PI,PI] inclusively.
-RandomUniformFloatGenerator AssimpMathTest::RandPI(-Math::PI<float>(), Math::PI<float>());
+RandomUniformFloatGenerator AssimpMathTest::RandPI(-Math::aiPi<float>(), Math::aiPi<float>());
 
 }


### PR DESCRIPTION
Fixes #3310

This change renames the function PI to aiPi to avoid having it clash with the common macro convention of ALL_UPPERCASE_LETTERS. Because the function PI was included in a public header (that then got included everywhere), it would occasionally get stomped on if included in a translation unit that _also_ defined the macro PI (a fairly common definition I'd wager).

I chose `aiPi` over `ai_pi` as it seemed to better match some existing types I saw? If we want it to be `ai_pi` just let me know. :)