### PR TITLE
Flip the check on _MSC_VER for using TR1 containers.

### DIFF
--- a/code/AssetLib/FBX/FBXCompileConfig.h
+++ b/code/AssetLib/FBX/FBXCompileConfig.h
@@ -62,16 +62,16 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef ASSIMP_FBX_USE_UNORDERED_MULTIMAP
 #   include <unordered_map>
 #   include <unordered_set>
-#   if _MSC_VER > 1600
-#       define fbx_unordered_map unordered_map
-#       define fbx_unordered_multimap unordered_multimap
-#       define fbx_unordered_set unordered_set
-#       define fbx_unordered_multiset unordered_multiset
-#   else
+#   if defined(_MSC_VER) && _MSC_VER <= 1600
 #       define fbx_unordered_map tr1::unordered_map
 #       define fbx_unordered_multimap tr1::unordered_multimap
 #       define fbx_unordered_set tr1::unordered_set
 #       define fbx_unordered_multiset tr1::unordered_multiset
+#   else
+#       define fbx_unordered_map unordered_map
+#       define fbx_unordered_multimap unordered_multimap
+#       define fbx_unordered_set unordered_set
+#       define fbx_unordered_multiset unordered_multiset
 #   endif
 #endif
 

--- a/code/AssetLib/Step/STEPFile.h
+++ b/code/AssetLib/Step/STEPFile.h
@@ -57,7 +57,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef _MSC_VER
 #    pragma warning(push)
 #    pragma warning(disable : 4127 4456 4245 4512 )
-#endif // _MSC_VER 
+#endif // _MSC_VER
 
 //
 #if _MSC_VER > 1500 || (defined __GNUC___)
@@ -69,12 +69,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef ASSIMP_STEP_USE_UNORDERED_MULTIMAP
 #    include <unordered_map>
-#    if _MSC_VER > 1600
-#        define step_unordered_map unordered_map
-#        define step_unordered_multimap unordered_multimap
-#    else
+#    if defined(_MSC_VER) && _MSC_VER <= 1600
 #        define step_unordered_map tr1::unordered_map
 #        define step_unordered_multimap tr1::unordered_multimap
+#    else
+#        define step_unordered_map unordered_map
+#        define step_unordered_multimap unordered_multimap
 #    endif
 #endif
 

--- a/code/AssetLib/Step/StepExporter.cpp
+++ b/code/AssetLib/Step/StepExporter.cpp
@@ -75,12 +75,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef ASSIMP_STEP_USE_UNORDERED_MULTIMAP
 #   include <unordered_map>
-#   if _MSC_VER > 1600
-#       define step_unordered_map unordered_map
-#       define step_unordered_multimap unordered_multimap
-#   else
+#   if defined(_MSC_VER) && _MSC_VER <= 1600
 #       define step_unordered_map tr1::unordered_map
 #       define step_unordered_multimap tr1::unordered_multimap
+#   else
+#       define step_unordered_map unordered_map
+#       define step_unordered_multimap unordered_multimap
 #   endif
 #endif
 
@@ -302,7 +302,7 @@ void StepExporter::WriteFile()
             dv23.Normalize();
             dv31.Normalize();
             dv13.Normalize();
-            
+
             aiVector3D dvY = dv12;
             aiVector3D dvX = dvY ^ dv13;
             dvX.Normalize();

--- a/code/AssetLib/glTF/glTFAsset.h
+++ b/code/AssetLib/glTF/glTFAsset.h
@@ -92,10 +92,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef ASSIMP_GLTF_USE_UNORDERED_MULTIMAP
 #   include <unordered_map>
-#   if _MSC_VER > 1600
-#       define gltf_unordered_map unordered_map
-#   else
+#   if defined(_MSC_VER) && _MSC_VER <= 1600
 #       define gltf_unordered_map tr1::unordered_map
+#   else
+#       define gltf_unordered_map unordered_map
 #   endif
 #endif
 

--- a/code/AssetLib/glTF/glTFCommon.h
+++ b/code/AssetLib/glTF/glTFCommon.h
@@ -74,10 +74,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef ASSIMP_GLTF_USE_UNORDERED_MULTIMAP
 #include <unordered_map>
-#if _MSC_VER > 1600
-#define gltf_unordered_map unordered_map
-#else
+#if defined(_MSC_VER) && _MSC_VER <= 1600
 #define gltf_unordered_map tr1::unordered_map
+#else
+#define gltf_unordered_map unordered_map
 #endif
 #endif
 

--- a/code/AssetLib/glTF2/glTF2Asset.h
+++ b/code/AssetLib/glTF2/glTF2Asset.h
@@ -98,12 +98,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef ASSIMP_GLTF_USE_UNORDERED_MULTIMAP
 #include <unordered_map>
 #include <unordered_set>
-#if _MSC_VER > 1600
-#define gltf_unordered_map unordered_map
-#define gltf_unordered_set unordered_set
-#else
+#if defined(_MSC_VER) && _MSC_VER <= 1600
 #define gltf_unordered_map tr1::unordered_map
 #define gltf_unordered_set tr1::unordered_set
+#else
+#define gltf_unordered_map unordered_map
+#define gltf_unordered_set unordered_set
 #endif
 #endif
 


### PR DESCRIPTION
Non-TR1 version would be the default now, across all compilers. For MSVC the behavior stays the same.

Note that due to the typo `__GNUC___` above, GCC/Clang is not using unordered containers as of now.