### PR TITLE
fixed export exceptions on import

### DIFF
--- a/code/AssetLib/3MF/D3MFOpcPackage.cpp
+++ b/code/AssetLib/3MF/D3MFOpcPackage.cpp
@@ -156,7 +156,7 @@ D3MFOpcPackage::D3MFOpcPackage(IOSystem *pIOHandler, const std::string &rFile) :
             mRootStream = mZipArchive->Open(rootFile.c_str());
             ai_assert(mRootStream != nullptr);
             if (nullptr == mRootStream) {
-                throw DeadlyExportError("Cannot open root-file in archive : " + rootFile);
+                throw DeadlyImportError("Cannot open root-file in archive : " + rootFile);
             }
 
         } else if (file == D3MF::XmlTag::CONTENT_TYPES_ARCHIVE) {

--- a/code/AssetLib/Ogre/OgreBinarySerializer.cpp
+++ b/code/AssetLib/Ogre/OgreBinarySerializer.cpp
@@ -181,13 +181,13 @@ Mesh *OgreBinarySerializer::ImportMesh(MemoryStreamReader *stream) {
 
     uint16_t id = serializer.ReadHeader(false);
     if (id != HEADER_CHUNK_ID) {
-        throw DeadlyExportError("Invalid Ogre Mesh file header.");
+        throw DeadlyImportError("Invalid Ogre Mesh file header.");
     }
 
     /// @todo Check what we can actually support.
     std::string version = serializer.ReadLine();
     if (version != MESH_VERSION_1_8) {
-        throw DeadlyExportError("Mesh version ", version, " not supported by this importer. Run OgreMeshUpgrader tool on the file and try again.",
+        throw DeadlyImportError("Mesh version ", version, " not supported by this importer. Run OgreMeshUpgrader tool on the file and try again.",
                                                     " Supported versions: ", MESH_VERSION_1_8);
     }
 
@@ -797,13 +797,13 @@ MemoryStreamReaderPtr OgreBinarySerializer::OpenReader(Assimp::IOSystem *pIOHand
 void OgreBinarySerializer::ReadSkeleton(Skeleton *skeleton) {
     uint16_t id = ReadHeader(false);
     if (id != HEADER_CHUNK_ID) {
-        throw DeadlyExportError("Invalid Ogre Skeleton file header.");
+        throw DeadlyImportError("Invalid Ogre Skeleton file header.");
     }
 
     // This deserialization supports both versions of the skeleton spec
     std::string version = ReadLine();
     if (version != SKELETON_VERSION_1_8 && version != SKELETON_VERSION_1_1) {
-        throw DeadlyExportError("Skeleton version ", version, " not supported by this importer.",
+        throw DeadlyImportError("Skeleton version ", version, " not supported by this importer.",
                                                     " Supported versions: ", SKELETON_VERSION_1_8, " and ", SKELETON_VERSION_1_1);
     }
 


### PR DESCRIPTION
Ogre and 3MF imports threw `DeadlyExportError`s under some circumstances. Bad for people who assumed that they only needed to catch `DeadlyImportError`s. Changed them to `DeadlyImportError`s.