### PR TITLE
Remove newline from name of Blender importer.

### DIFF
--- a/code/AssetLib/Blender/BlenderLoader.cpp
+++ b/code/AssetLib/Blender/BlenderLoader.cpp
@@ -88,7 +88,7 @@ using namespace Assimp::Blender;
 using namespace Assimp::Formatter;
 
 static const aiImporterDesc blenderDesc = {
-    "Blender 3D Importer \nhttp://www.blender3d.org",
+    "Blender 3D Importer (http://www.blender3d.org)",
     "",
     "",
     "No animation support yet",


### PR DESCRIPTION
Addresses #3797.

Website should probably also be moved to the comments to be consistent with the rest of the importers, although I did not do it as the comment field is already occupied and I don't have enough coffee in me yet to make formatting decisions.

Alternate change could be to add a dedicated website field to importer descriptions.