### PR TITLE
X3D exporter: Modified meta data comment in exported files

### DIFF
--- a/code/AssetLib/X3D/X3DExporter.cpp
+++ b/code/AssetLib/X3D/X3DExporter.cpp
@@ -656,7 +656,7 @@ X3DExporter::X3DExporter(const char *pFileName, IOSystem *pIOSystem, const aiSce
     attr_list.clear();
     // <head>: meta data.
     NodeHelper_OpenNode("head", 1);
-    XML_Write(mIndentationString + "<!-- All \"meta\" from this section tou will found in <Scene> node as MetadataString nodes. -->\n");
+    XML_Write(mIndentationString + "<!-- Meta Data -->\n");
     NodeHelper_CloseNode("head", 1);
     // Scene node.
     NodeHelper_OpenNode("Scene", 1);


### PR DESCRIPTION
At first I was going to fix the typo ("tou" -> "you"), but decided to just drop the details out of the comment completely.

A comment about MetadataString and Scene nodes is very specific to assimp, and wouldn't really mean anything to anybody else looking at the file. Also it's for developers, and is neither meaningful nor useful to users. So, I removed the details.

Notes about exporter behavior should go in assimp's documentation, where it is meaningful and also a lot easier to find. It shouldn't go in exported files.