### PR TITLE
Remove newline from name of Blender importer.

### DIFF
--- a/code/AssetLib/Blender/BlenderLoader.cpp
+++ b/code/AssetLib/Blender/BlenderLoader.cpp
@@ -88,7 +88,7 @@ using namespace Assimp::Blender;
 using namespace Assimp::Formatter;
 
 static const aiImporterDesc blenderDesc = {
-    "Blender 3D Importer \nhttp://www.blender3d.org",
+    "Blender 3D Importer (http://www.blender3d.org)",
     "",
     "",
     "No animation support yet",


### PR DESCRIPTION
Addresses #3797.

Re-submitting this as a quick fix to the immediate issue while I think about the website field (#3799).