### PR TITLE
fix mdl3457 normals direction

### DIFF
--- a/code/AssetLib/MDL/MDLLoader.cpp
+++ b/code/AssetLib/MDL/MDLLoader.cpp
@@ -708,6 +708,7 @@ void MDLImporter::InternReadFile_3DGS_MDL345() {
 
                 // read the normal vector from the precalculated normal table
                 MD2::LookupNormalIndex(pcVertices[iIndex].normalIndex, pcMesh->mNormals[iCurrent]);
+                pcMesh->mNormals[iCurrent] *= -1;
                 // pcMesh->mNormals[iCurrent].y *= -1.0f;
 
                 // read texture coordinates
@@ -763,6 +764,7 @@ void MDLImporter::InternReadFile_3DGS_MDL345() {
 
                 // read the normal vector from the precalculated normal table
                 MD2::LookupNormalIndex(pcVertices[iIndex].normalIndex, pcMesh->mNormals[iCurrent]);
+                pcMesh->mNormals[iCurrent] *= -1;
                 // pcMesh->mNormals[iCurrent].y *= -1.0f;
 
                 // read texture coordinates
@@ -1844,7 +1846,7 @@ void MDLImporter::GenerateOutputMeshes_3DGS_MDL7(
                 for (unsigned int c = 0; c < 3; ++c) {
                     const uint32_t iIndex = oldFace.mIndices[c];
                     pcMesh->mVertices[iCurrent] = groupData.vPositions[iIndex];
-                    pcMesh->mNormals[iCurrent] = groupData.vNormals[iIndex];
+                    pcMesh->mNormals[iCurrent] = -groupData.vNormals[iIndex];
 
                     if (!groupData.vTextureCoords1.empty()) {
 


### PR DESCRIPTION
Assuming here that test models have correct normals direction.
Importer loads them flipped:
![image](https://user-images.githubusercontent.com/1734117/116659404-37bb1f80-a99a-11eb-8194-8449e2d22a92.png)

after:
![image](https://user-images.githubusercontent.com/1734117/116659148-cd09e400-a999-11eb-94b9-b2fc98aaa23e.png)
