### PR TITLE
support missing closing brace in material list after Ascii Scene Exporter v2.51

### DIFF
--- a/code/AssetLib/ASE/ASEParser.cpp
+++ b/code/AssetLib/ASE/ASEParser.cpp
@@ -498,6 +498,12 @@ void Parser::ParseLV1MaterialListBlock() {
                 ParseLV2MaterialBlock(sMat);
                 continue;
             }
+            if( iDepth == 1 ){
+                // CRUDE HACK: support missing brace after "Ascii Scene Exporter v2.51"
+                LogWarning("Missing closing brace in material list");
+                --filePtr;
+                return;
+            }
         }
         AI_ASE_HANDLE_TOP_LEVEL_SECTION();
     }


### PR DESCRIPTION
I'v got good amount of ase models, failing to load due to this exporter bug. Apparently some loaders do handle this.
Possibly more persistent way would be checking for global keywords at this point, if `MATERIAL_LIST` block may contain anything besides `MATERIAL_COUNT` & `MATERIAL` keywords.