### PR TITLE
fixed bloat in SIB importer

### DIFF
--- a/code/AssetLib/SIB/SIBImporter.cpp
+++ b/code/AssetLib/SIB/SIBImporter.cpp
@@ -179,8 +179,7 @@ static void UnknownChunk(StreamReaderLE * /*stream*/, const SIBChunk &chunk) {
 // Reads a UTF-16LE string and returns it at UTF-8.
 static aiString ReadString(StreamReaderLE *stream, uint32_t numWChars) {
     if (nullptr == stream || 0 == numWChars) {
-        static const aiString empty;
-        return empty;
+        return aiString();
     }
 
     // Allocate buffers (max expansion is 1 byte -> 4 bytes for UTF-8)


### PR DESCRIPTION
The SIB importer, upon needing an empty aiString, did not create a new one but rather copied a predefined global empty string.

Since aiStrings contain large buffers, Assimp copied 1028 B of zeros instead of setting five bytes (at least when compiled with Visual C++). Since aiString is a user-defined type without a constexpr constructor, Visual C++ had to generate a thread-safe run-time initializer as well.

Now it’s just two instructions.