### PR TITLE
fix bug in vertex_color animation

### DIFF
--- a/code/AssetLib/FBX/FBXConverter.cpp
+++ b/code/AssetLib/FBX/FBXConverter.cpp
@@ -857,6 +857,10 @@ bool FBXConverter::GenerateTransformationNodeChain(const Model &model, const std
     // for (const auto &transform : chain) {
     // skip inverse chain for no preservePivots
     for (unsigned int i = TransformationComp_Translation; i < TransformationComp_MAXIMUM; i++) {
+      const TransformationComp comp = static_cast<TransformationComp>(i);
+      if (comp == TransformationComp_Rotation) {
+          continue;
+      }
       nd->mTransformation = nd->mTransformation * chain[i];
     }
     output_nodes.push_back(std::move(nd));


### PR DESCRIPTION
First off, on behalf of the [Lumberyard](https://aws.amazon.com/lumberyard/) team at Amazon, thank you for assimp. It has been very helpful to us.

In our use of assimp, we have discovered a bug in vertex_color_animation, which we have fixed by skipping TransformComp_Rotation (since it is applied elsewhere in the code). This pull request is how we have fixed it, please consider it for merge.