### PR TITLE
Fix cctype calls

### DIFF
--- a/code/AssetLib/BVH/BVHLoader.cpp
+++ b/code/AssetLib/BVH/BVHLoader.cpp
@@ -359,7 +359,7 @@ void BVHLoader::ReadMotion(aiScene * /*pScene*/) {
 std::string BVHLoader::GetNextToken() {
     // skip any preceding whitespace
     while (mReader != mBuffer.end()) {
-        if (!isspace(*mReader))
+        if (!isspace((unsigned char)*mReader))
             break;
 
         // count lines
@@ -372,7 +372,7 @@ std::string BVHLoader::GetNextToken() {
     // collect all chars till the next whitespace. BVH is easy in respect to that.
     std::string token;
     while (mReader != mBuffer.end()) {
-        if (isspace(*mReader))
+        if (isspace((unsigned char)*mReader))
             break;
 
         token.push_back(*mReader);


### PR DESCRIPTION
Cast to unsigned char as required by C++ (see C++ **[cctype.syn]** -> ISO C99 section 7.4, [see also](https://en.cppreference.com/w/cpp/string/byte/isspace)).

Addresses #3867.