### PR TITLE
Use POINTER(char) for binary data. For pyassimp issue #2339: Can't load OBJ

### DIFF
--- a/port/PyAssimp/pyassimp/structs.py
+++ b/port/PyAssimp/pyassimp/structs.py
@@ -1,6 +1,6 @@
 #-*- coding: utf-8 -*-
 
-from ctypes import POINTER, c_void_p, c_uint, c_char, c_float, Structure, c_char_p, c_double, c_ubyte, c_size_t, c_uint32
+from ctypes import POINTER, c_void_p, c_uint, c_char, c_float, Structure, c_double, c_ubyte, c_size_t, c_uint32
 
 
 class Vector2D(Structure):
@@ -1121,7 +1121,7 @@ class Scene(Structure):
             ("mMetadata", POINTER(Metadata)),
 
             # Internal data, do not touch
-            ("mPrivate", c_char_p),
+            ("mPrivate", POINTER(c_char)),
         ]
 
 assimp_structs_as_tuple = (Matrix4x4,


### PR DESCRIPTION
Found this in the ctypes documentation:
"For a general character pointer that may also point to binary data,
POINTER(c_char) must be used." c_char_p is for a zero-terminated string.

Reference: https://docs.python.org/3/library/ctypes.html#ctypes.c_char_p

Applying this change to the 4.1.4 release fixes #2339 for me in Ubuntu.
The issue isn't consistent since I can't reproduce it with master, but this
still appears to be a correct change since it does fix the 4.1.4 released code for me.

To confirm mPrivate points to binary data and not a string, it is set like this [here](https://github.com/assimp/assimp/blob/3fead344ad06446ce2dca9ea528fcca7b6948e35/code/Common/Version.cpp#L139):
`mPrivate(new Assimp::ScenePrivateData())`