### PR TITLE
Fix importer ReadFile issues on file open error or when opening empty files

### DIFF
--- a/code/AssetLib/3DS/3DSLoader.cpp
+++ b/code/AssetLib/3DS/3DSLoader.cpp
@@ -143,7 +143,13 @@ void Discreet3DSImporter::SetupProperties(const Importer * /*pImp*/) {
 // Imports the given file into the given scene structure.
 void Discreet3DSImporter::InternReadFile(const std::string &pFile,
         aiScene *pScene, IOSystem *pIOHandler) {
-    StreamReaderLE theStream(pIOHandler->Open(pFile, "rb"));
+
+    auto theFile = pIOHandler->Open(pFile, "rb");
+    if (!theFile) {
+        throw DeadlyImportError("3DS: Could not open ", pFile);
+    }
+
+    StreamReaderLE theStream(theFile);
 
     // We should have at least one chunk
     if (theStream.GetRemainingSize() < 16) {

--- a/code/AssetLib/AMF/AMFImporter.cpp
+++ b/code/AssetLib/AMF/AMFImporter.cpp
@@ -268,6 +268,7 @@ void AMFImporter::ParseFile(const std::string &pFile, IOSystem *pIOHandler) {
     mXmlParser = new XmlParser();
     if (!mXmlParser->parse(file.get())) {
         delete mXmlParser;
+        mXmlParser = nullptr;
         throw DeadlyImportError("Failed to create XML reader for file" + pFile + ".");
     }
 

--- a/code/AssetLib/Assbin/AssbinLoader.cpp
+++ b/code/AssetLib/Assbin/AssbinLoader.cpp
@@ -671,7 +671,7 @@ void AssbinImporter::ReadBinaryScene(IOStream *stream, aiScene *scene) {
 void AssbinImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSystem *pIOHandler) {
     IOStream *stream = pIOHandler->Open(pFile, "rb");
     if (nullptr == stream) {
-        return;
+        throw DeadlyImportError("ASSBIN: Could not open ", pFile);
     }
 
     // signature

--- a/code/AssetLib/COB/COBLoader.cpp
+++ b/code/AssetLib/COB/COBLoader.cpp
@@ -137,7 +137,13 @@ void COBImporter::SetupProperties(const Importer * /*pImp*/) {
 // Imports the given file into the given scene structure.
 void COBImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSystem *pIOHandler) {
     COB::Scene scene;
-    std::unique_ptr<StreamReaderLE> stream(new StreamReaderLE(pIOHandler->Open(pFile, "rb")));
+
+    auto file = pIOHandler->Open(pFile, "rb");
+    if (!file) {
+        ThrowException("Could not open " + pFile);
+    }
+
+    std::unique_ptr<StreamReaderLE> stream(new StreamReaderLE(file));
 
     // check header
     char head[32];

--- a/code/AssetLib/Irr/IRRLoader.cpp
+++ b/code/AssetLib/Irr/IRRLoader.cpp
@@ -859,13 +859,13 @@ void IRRImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
 
 	// Check whether we can read from the file
 	if (file.get() == nullptr) {
-		throw DeadlyImportError("Failed to open IRR file " + pFile);
+        throw DeadlyImportError("Failed to open IRR file ", pFile);
 	}
 
 	// Construct the irrXML parser
 	XmlParser st;
     if (!st.parse( file.get() )) {
-        return;
+        throw DeadlyImportError("XML parse error while loading IRR file ", pFile);
     }
     pugi::xml_node rootElement = st.getRootNode();
 

--- a/code/AssetLib/Irr/IRRMeshLoader.cpp
+++ b/code/AssetLib/Irr/IRRMeshLoader.cpp
@@ -135,12 +135,12 @@ void IRRMeshImporter::InternReadFile(const std::string &pFile,
 
 	// Check whether we can read from the file
 	if (file.get() == NULL)
-		throw DeadlyImportError("Failed to open IRRMESH file " + pFile);
+        throw DeadlyImportError("Failed to open IRRMESH file ", pFile);
 
 	// Construct the irrXML parser
 	XmlParser parser;
     if (!parser.parse( file.get() )) {
-        return;
+        throw DeadlyImportError("XML parse error while loading IRRMESH file ", pFile);
     }
     XmlNode root = parser.getRootNode();
 

--- a/code/AssetLib/MS3D/MS3DLoader.cpp
+++ b/code/AssetLib/MS3D/MS3DLoader.cpp
@@ -215,7 +215,12 @@ void MS3DImporter :: CollectChildJoints(const std::vector<TempJoint>& joints, ai
 void MS3DImporter::InternReadFile( const std::string& pFile,
     aiScene* pScene, IOSystem* pIOHandler)
 {
-    StreamReaderLE stream(pIOHandler->Open(pFile,"rb"));
+
+    auto file = pIOHandler->Open(pFile, "rb");
+    if (!file)
+        throw DeadlyImportError("MS3D: Could not open ", pFile);
+
+    StreamReaderLE stream(file);
 
     // CanRead() should have done this already
     char head[10];

--- a/code/AssetLib/NDO/NDOLoader.cpp
+++ b/code/AssetLib/NDO/NDOLoader.cpp
@@ -116,7 +116,13 @@ void NDOImporter::SetupProperties(const Importer* /*pImp*/)
 void NDOImporter::InternReadFile( const std::string& pFile,
     aiScene* pScene, IOSystem* pIOHandler)
 {
-    StreamReaderBE reader(pIOHandler->Open( pFile, "rb"));
+
+    auto file = pIOHandler->Open( pFile, "rb");
+    if (!file) {
+        throw DeadlyImportError("Nendo: Could not open ", pFile);
+    }
+
+    StreamReaderBE reader(file);
 
     // first 9 bytes are nendo file format ("nendo 1.n")
     const char* head = (const char*)reader.GetPtr();

--- a/code/AssetLib/Q3D/Q3DLoader.cpp
+++ b/code/AssetLib/Q3D/Q3DLoader.cpp
@@ -106,7 +106,12 @@ const aiImporterDesc *Q3DImporter::GetInfo() const {
 // Imports the given file into the given scene structure.
 void Q3DImporter::InternReadFile(const std::string &pFile,
         aiScene *pScene, IOSystem *pIOHandler) {
-    StreamReaderLE stream(pIOHandler->Open(pFile, "rb"));
+
+    auto file = pIOHandler->Open(pFile, "rb");
+    if (!file)
+        throw DeadlyImportError("Quick3D: Could not open ", pFile);
+
+    StreamReaderLE stream(file);
 
     // The header is 22 bytes large
     if (stream.GetRemainingSize() < 22)

--- a/code/AssetLib/SIB/SIBImporter.cpp
+++ b/code/AssetLib/SIB/SIBImporter.cpp
@@ -804,7 +804,12 @@ static void ReadScene(SIB *sib, StreamReaderLE *stream) {
 // Imports the given file into the given scene structure.
 void SIBImporter::InternReadFile(const std::string &pFile,
         aiScene *pScene, IOSystem *pIOHandler) {
-    StreamReaderLE stream(pIOHandler->Open(pFile, "rb"));
+
+    auto file = pIOHandler->Open(pFile, "rb");
+    if (!file)
+        throw DeadlyImportError("SIB: Could not open ", pFile);
+
+    StreamReaderLE stream(file);
 
     // We should have at least one chunk
     if (stream.GetRemainingSize() < 16)

--- a/code/AssetLib/XGL/XGLLoader.cpp
+++ b/code/AssetLib/XGL/XGLLoader.cpp
@@ -200,7 +200,7 @@ void XGLImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
 	// parse the XML file
     mXmlParser = new XmlParser;
     if (!mXmlParser->parse(stream.get())) {
-		return;
+        throw DeadlyImportError("XML parse error while loading XGL file ", pFile);
 	}
 
 	TempScope scope;


### PR DESCRIPTION
Addresses #3888.

Affects importers: amf, 3ds, cob, ms3d, nendo, quick3d, sib, assbin, irr, irrmesh, xgl.

Does *not* address #3849 (CanRead). That is addressed by #3850.

This PR does not have any dependencies.