### PR TITLE
Reapply [amf] Fix crash when file could not be parsed.

### DIFF
--- a/code/AssetLib/AMF/AMFImporter.cpp
+++ b/code/AssetLib/AMF/AMFImporter.cpp
@@ -268,7 +268,8 @@ void AMFImporter::ParseFile(const std::string &pFile, IOSystem *pIOHandler) {
     mXmlParser = new XmlParser();
     if (!mXmlParser->parse(file.get())) {
         delete mXmlParser;
-        throw DeadlyImportError("Failed to create XML reader for file" + pFile + ".");
+        mXmlParser = nullptr;
+        throw DeadlyImportError("Failed to create XML reader for file ", pFile, ".");
     }
 
     // Start reading, search for root tag <amf>


### PR DESCRIPTION
This change was part of PR #3890, but was later lost in a merge. I kind of suspected this would happen, because of a minor conflict between two of my PRs. 

This PR reapplies the fix. Original commit was https://github.com/assimp/assimp/pull/3890/commits/785cca1bb43f9e6047cb566a910fcd0e3d49951f

---

Fix double free of mXmlParser (deleted but not reset in ParseFile, then deleted again in ~AMFImporter).