### PR TITLE
Add support for arm 64 bit

### DIFF
--- a/port/PyAssimp/pyassimp/helper.py
+++ b/port/PyAssimp/pyassimp/helper.py
@@ -27,6 +27,7 @@ if os.name=='posix':
     additional_dirs.append('./')
     additional_dirs.append('/usr/lib/')
     additional_dirs.append('/usr/lib/x86_64-linux-gnu/')
+    additional_dirs.append('/usr/lib/aarch64-linux-gnu/')
     additional_dirs.append('/usr/local/lib/')
 
     if 'LD_LIBRARY_PATH' in os.environ:


### PR DESCRIPTION
The helper function which locates assimp for the python port fails on arm64 simply because it's only looking in the x86_64 directory.  This simple add makes pyassimp properly work on aarch64.