### PR TITLE
Fix fbx exporter bug if root node contains meshes.

### DIFF
--- a/code/AssetLib/FBX/FBXExporter.cpp
+++ b/code/AssetLib/FBX/FBXExporter.cpp
@@ -541,10 +541,15 @@ void FBXExporter::WriteReferences ()
 // (before any actual data is written)
 // ---------------------------------------------------------------
 
-size_t count_nodes(const aiNode* n) {
-    size_t count = 1;
+size_t count_nodes(const aiNode* n, const aiNode* root) {
+    size_t count;
+    if (n == root || n->mNumMeshes > 1) {
+        count = n->mNumMeshes;
+    } else {
+        count = 1;
+    }
     for (size_t i = 0; i < n->mNumChildren; ++i) {
-        count += count_nodes(n->mChildren[i]);
+        count += count_nodes(n->mChildren[i], root);
     }
     return count;
 }
@@ -714,7 +719,7 @@ void FBXExporter::WriteDefinitions ()
 
     // Model / FbxNode
     // <~~ node hierarchy
-    count = int32_t(count_nodes(mScene->mRootNode)) - 1; // (not counting root node)
+    count = int32_t(count_nodes(mScene->mRootNode, mScene->mRootNode));
     if (count) {
         n = FBX::Node("ObjectType", "Model");
         n.AddChild("Count", count);
@@ -2625,17 +2630,14 @@ void FBXExporter::WriteModelNodes(
                 ],
                 new_node_uid
             );
-            // write model node
-            FBX::Node m("Model");
+
+            aiNode new_node;
             // take name from mesh name, if it exists
-            std::string name = mScene->mMeshes[node->mMeshes[i]]->mName.C_Str();
-            name += FBX::SEPARATOR + "Model";
-            m.AddProperties(new_node_uid, name, "Mesh");
-            m.AddChild("Version", int32_t(232));
-            FBX::Node p("Properties70");
-            p.AddP70enum("InheritType", 1);
-            m.AddChild(p);
-            m.Dump(outstream, binary, 1);
+            new_node.mName = mScene->mMeshes[node->mMeshes[i]]->mName;
+            // write model node
+            WriteModelNode(
+                outstream, binary, &new_node, new_node_uid, "Mesh", transform_chain
+            );
         }
     }
 


### PR DESCRIPTION
When I export a FBX file from the following code, the exported cube is not visible in Visual Studio 2019.

1. In FBXExporter::WriteDefinitions(), count_nodes() - 1 is 0 even if the root node contains meshes. Model definitions are not written to the exported file.
2. In FBXExporter::WriteModelNodes(), model objects should have "Shading: T" or "Culling: "CullingOff"" line to show meshes.

```
void FBXExportTest()
{
	// modified from  https://github.com/assimp/assimp/issues/203
	aiScene scene;
	scene.mRootNode = new aiNode();

	scene.mMaterials = new aiMaterial*[ 1 ];
	scene.mMaterials[ 0 ] = nullptr;
	scene.mNumMaterials = 1;

	scene.mMaterials[ 0 ] = new aiMaterial();

	scene.mMeshes = new aiMesh*[ 1 ];
	scene.mMeshes[ 0 ] = nullptr;
	scene.mNumMeshes = 1;

	scene.mMeshes[ 0 ] = new aiMesh();
	scene.mMeshes[ 0 ]->mMaterialIndex = 0;

	scene.mRootNode->mName = "Node0";
	scene.mRootNode->mMeshes = new unsigned int[ 1 ];
	scene.mRootNode->mMeshes[ 0 ] = 0;
	scene.mRootNode->mNumMeshes = 1;

	auto pMesh = scene.mMeshes[ 0 ];
	pMesh->mName = "Mesh0";

	std::vector<aiVector3D> vertices;
	std::vector<aiVector3D> normals;
	std::vector<aiVector3D> uvs;

	//Default Fill Location Vector
	int draw_order[36] =
	{
		0,2,1,      2,3,1,
		1,3,5,      3,7,5,
		5,7,4,      7,6,4,
		4,6,0,      6,2,0,
		4,0,5,      0,1,5,
		2,6,3,      6,7,3
	};

	aiVector3D data[8] =
	{
		aiVector3D(-1.0f/2.0f,1.0f/2.0f,1.0f/2.0f),
		aiVector3D(1.0f/2.0f,1.0f/2.0f,1.0f/2.0f),
		aiVector3D(-1.0f/2.0f,-1.0f/2.0f,1.0f/2.0f),
		aiVector3D(1.0f/2.0f,-1.0f/2.0f,1.0f/2.0f),
		aiVector3D(-1.0f/2.0f,1.0f/2.0f,-1.0f/2.0f),
		aiVector3D(1.0f/2.0f,1.0f/2.0f,-1.0f/2.0f),
		aiVector3D(-1.0f/2.0f,-1.0f/2.0f,-1.0f/2.0f),
		aiVector3D(1.0f/2.0f,-1.0f/2.0f,-1.0f/2.0f)
	};

	for(int i = 0; i < 36; i++)
	{
		vertices.push_back(data[draw_order[i]]);
	}

	const auto& vVertices = vertices;

	pMesh->mVertices = new aiVector3D[ vVertices.size() ];
	pMesh->mNumVertices = vVertices.size();
	memcpy(pMesh->mVertices, vertices.data(), sizeof(aiVector3D) * vVertices.size());

	pMesh->mFaces = new aiFace[ vVertices.size() / 3 ];
	pMesh->mNumFaces = (unsigned int)(vVertices.size() / 3);

	int k = 0;
	for(int i = 0; i < (vVertices.size() / 3); i++)
	{
		aiFace &face = pMesh->mFaces[i];
		face.mIndices = new unsigned int[3];
		face.mNumIndices = 3;

		face.mIndices[0] = k;
		face.mIndices[1] = k+1;
		face.mIndices[2] = k+2;
		k = k + 3;
	}

	Assimp::Exporter Exporter;
	Exporter.Export(&scene, "fbxa", "test.fbx");
}
```