### PR TITLE
Fix bug in aiMetadata constructor that overwrites an array of one of …

### DIFF
--- a/include/assimp/metadata.h
+++ b/include/assimp/metadata.h
@@ -202,17 +202,17 @@ struct aiMetadata {
             } break;
             case AI_AISTRING: {
                 aiString v;
-                rhs.Get<aiString>(mKeys[i], v);
+                rhs.Get<aiString>(i, v);
                 mValues[i].mData = new aiString(v);
             } break;
             case AI_AIVECTOR3D: {
                 aiVector3D v;
-                rhs.Get<aiVector3D>(mKeys[i], v);
+                rhs.Get<aiVector3D>(i, v);
                 mValues[i].mData = new aiVector3D(v);
             } break;
             case AI_AIMETADATA: {
                 aiMetadata v;
-                rhs.Get<aiMetadata>(mKeys[i], v);
+                rhs.Get<aiMetadata>(i, v);
                 mValues[i].mData = new aiMetadata(v);
             } break;
 #ifndef SWIG

--- a/include/assimp/metadata.h
+++ b/include/assimp/metadata.h
@@ -156,7 +156,7 @@ struct aiMetadata {
 
 #ifdef __cplusplus
 
-    /** 
+    /**
      *  @brief  The default constructor, set all members to zero by default.
      */
     aiMetadata() AI_NO_EXCEPT
@@ -202,17 +202,17 @@ struct aiMetadata {
             } break;
             case AI_AISTRING: {
                 aiString v;
-                rhs.Get<aiString>(i, v);
+                rhs.Get<aiString>(static_cast<unsigned int>(i), v);
                 mValues[i].mData = new aiString(v);
             } break;
             case AI_AIVECTOR3D: {
                 aiVector3D v;
-                rhs.Get<aiVector3D>(i, v);
+                rhs.Get<aiVector3D>(static_cast<unsigned int>(i), v);
                 mValues[i].mData = new aiVector3D(v);
             } break;
             case AI_AIMETADATA: {
                 aiMetadata v;
-                rhs.Get<aiMetadata>(i, v);
+                rhs.Get<aiMetadata>(static_cast<unsigned int>(i), v);
                 mValues[i].mData = new aiMetadata(v);
             } break;
 #ifndef SWIG


### PR DESCRIPTION
…aiString, aiVector3D, or aiMetadata with the first entry

aiMetadata copy constructor calls aiMetadata::Get on the copied from aiMetadata using the const aiString &key version. When
this is called on the metadata of an array type, this overwrites all entries with the first entry. This is due to the key
of all entries in an array being the name of the array. ie, in a glTF2 file with an extension:

```
"Extension" : [
	"Value1",
	"Value2",
	"Value3"
]

```
the aiMetadata struct for the "Extension" entry will have 3 entries with key/value pairs as:

```
"Extension"/"Value1"
"Extension"/"Value2"
"Extension"/"Value3"

```
So when the copy constructor calls the key based aiMetadata::Get, it will find "Value1" for all three entries.

This change simply replaces the key based aiMetadata::Get with the index based aiMetadata::Get