### PR TITLE
Fix non skipped CR in header parsing for binary PLY

### DIFF
--- a/code/AssetLib/Ply/PlyParser.cpp
+++ b/code/AssetLib/Ply/PlyParser.cpp
@@ -419,7 +419,8 @@ bool PLY::DOM::ParseHeader(IOStreamBuffer<char> &streamBuffer, std::vector<char>
         if (PLY::Element::ParseElement(streamBuffer, buffer, &out)) {
             // add the element to the list of elements
             alElements.push_back(out);
-        } else if (TokenMatch(buffer, "end_header", 10)) {
+        } else if ( TokenMatch(buffer, "end_header\r", 11) || //checks for header end with /r/n ending
+                    TokenMatch(buffer, "end_header", 10)) { //checks for /n ending, if it doesn't end with /r/n
             // we have reached the end of the header
             break;
         } else {


### PR DESCRIPTION
Hi,
This PR tries to fix #3711

The problem is, that the pointer for the current symbol parsing points is on a newline ('\n') when the header was written with windows line endings (' \r\n'). Instead, if should point to the first byte of the binary data after the header.

With this PR, the header parser first checks if the end token of a PLY header is a windows new line and, if not, if it has a normal new line (which is in assimp defined as '\n' or '\r'). 

We cannot check if the current pointer is a new line and skip, as the binary representation can be, by accident, be a new line while the header was not decoded with ' \r\n'. Therefore the fix should work on the following possibilities for the header ending:

- windows new-line: "header_end\r\nB" 
    - -> after header reading, the current pointer points at "B"
- first byte after header is a ' \n': "header_end\n\nB" 
    - -> after header reading, the current pointer points at "\n"
- normal new line ' \n': "header_end\nB" 
    - -> after header reading, the current pointer points at "B"

And I can also not go back with the pointer, as the header token is deleted from the buffer during the matching.

This fix is the least invasive one I could create and I hope the comments in the code are sufficient.
I think a more clearer version would require some more rewrite of more functions.