### PR TITLE
include/material.h: Fixed broken C support

### DIFF
--- a/include/assimp/material.h
+++ b/include/assimp/material.h
@@ -1499,7 +1499,7 @@ ASSIMP_API C_ENUM aiReturn aiGetMaterialFloatArray(
         ai_real *pOut,
         unsigned int *pMax);
 
-#ifdef __cplusplus
+#if 1 //def __cplusplus
 
 // ---------------------------------------------------------------------------
 /** @brief Retrieve a single float property with a specific key from the material.
@@ -1520,7 +1520,7 @@ ASSIMP_API C_ENUM aiReturn aiGetMaterialFloatArray(
 * @return Specifies whether the key has been found. If not, the output
 *   float remains unmodified.*/
 // ---------------------------------------------------------------------------
-inline aiReturn aiGetMaterialFloat(const aiMaterial *pMat,
+inline aiReturn aiGetMaterialFloat(const C_STRUCT aiMaterial *pMat,
         const char *pKey,
         unsigned int type,
         unsigned int index,
@@ -1530,8 +1530,8 @@ inline aiReturn aiGetMaterialFloat(const aiMaterial *pMat,
 
 #else
 
-// Use our friend, the C preprocessor
-#define aiGetMaterialFloat (pMat, type, index, pKey, pOut) \
+// Use our friend, the C preprocessor   // The macro does not work with e.g. AI_MATKEY_OPACITY expanding into 3 args
+#define aiGetMaterialFloat(pMat, type, index, pKey, pOut) \
         aiGetMaterialFloatArray(pMat, type, index, pKey, pOut, NULL)
 
 #endif //!__cplusplus
@@ -1548,7 +1548,7 @@ ASSIMP_API C_ENUM aiReturn aiGetMaterialIntegerArray(const C_STRUCT aiMaterial *
         int *pOut,
         unsigned int *pMax);
 
-#ifdef __cplusplus
+#if 1 //def __cplusplus
 
 // ---------------------------------------------------------------------------
 /** @brief Retrieve an integer property with a specific key from a material
@@ -1566,7 +1566,7 @@ inline aiReturn aiGetMaterialInteger(const C_STRUCT aiMaterial *pMat,
 #else
 
 // use our friend, the C preprocessor
-#define aiGetMaterialInteger (pMat, type, index, pKey, pOut) \
+#define aiGetMaterialInteger(pMat, type, index, pKey, pOut) \
         aiGetMaterialIntegerArray(pMat, type, index, pKey, pOut, NULL)
 
 #endif //!__cplusplus

--- a/include/assimp/material.h
+++ b/include/assimp/material.h
@@ -1499,8 +1499,6 @@ ASSIMP_API C_ENUM aiReturn aiGetMaterialFloatArray(
         ai_real *pOut,
         unsigned int *pMax);
 
-#if 1 //def __cplusplus
-
 // ---------------------------------------------------------------------------
 /** @brief Retrieve a single float property with a specific key from the material.
 *
@@ -1528,14 +1526,6 @@ inline aiReturn aiGetMaterialFloat(const C_STRUCT aiMaterial *pMat,
     return aiGetMaterialFloatArray(pMat, pKey, type, index, pOut, (unsigned int *)0x0);
 }
 
-#else
-
-// Use our friend, the C preprocessor   // The macro does not work with e.g. AI_MATKEY_OPACITY expanding into 3 args
-#define aiGetMaterialFloat(pMat, type, index, pKey, pOut) \
-        aiGetMaterialFloatArray(pMat, type, index, pKey, pOut, NULL)
-
-#endif //!__cplusplus
-
 // ---------------------------------------------------------------------------
 /** @brief Retrieve an array of integer values with a specific key
  *  from a material
@@ -1547,8 +1537,6 @@ ASSIMP_API C_ENUM aiReturn aiGetMaterialIntegerArray(const C_STRUCT aiMaterial *
         unsigned int index,
         int *pOut,
         unsigned int *pMax);
-
-#if 1 //def __cplusplus
 
 // ---------------------------------------------------------------------------
 /** @brief Retrieve an integer property with a specific key from a material
@@ -1562,14 +1550,6 @@ inline aiReturn aiGetMaterialInteger(const C_STRUCT aiMaterial *pMat,
         int *pOut) {
     return aiGetMaterialIntegerArray(pMat, pKey, type, index, pOut, (unsigned int *)0x0);
 }
-
-#else
-
-// use our friend, the C preprocessor
-#define aiGetMaterialInteger(pMat, type, index, pKey, pOut) \
-        aiGetMaterialIntegerArray(pMat, type, index, pKey, pOut, NULL)
-
-#endif //!__cplusplus
 
 // ---------------------------------------------------------------------------
 /** @brief Retrieve a color value from the material property table


### PR DESCRIPTION
- The aiGetMaterialFloat() and aiGetMaterialInteger() C preprocessor definitions were broken because:
   - They had a space before the opening parenthesis
   - Using material key definitions expanding 1 to argument into 3 breaks the invocation of macros expecting 5 parameters