### PR TITLE
glTF2: Improved support for AI_MATKEY_OPACITY

### DIFF
--- a/code/AssetLib/glTF2/glTF2Exporter.cpp
+++ b/code/AssetLib/glTF2/glTF2Exporter.cpp
@@ -778,19 +778,17 @@ void glTF2Exporter::ExportMaterials()
         mat.Get(AI_MATKEY_TWOSIDED, m->doubleSided);
         mat.Get(AI_MATKEY_GLTF_ALPHACUTOFF, m->alphaCutoff);
 
+        float opacity;
         aiString alphaMode;
 
+        if (mat.Get(AI_MATKEY_OPACITY, opacity) == AI_SUCCESS) {
+            if (opacity < 1) {
+                m->alphaMode = "BLEND";
+                m->pbrMetallicRoughness.baseColorFactor[3] *= opacity;
+            }
+        }
         if (mat.Get(AI_MATKEY_GLTF_ALPHAMODE, alphaMode) == AI_SUCCESS) {
             m->alphaMode = alphaMode.C_Str();
-        } else {
-            float opacity;
-
-            if (mat.Get(AI_MATKEY_OPACITY, opacity) == AI_SUCCESS) {
-                if (opacity < 1) {
-                    m->alphaMode = "BLEND";
-                    m->pbrMetallicRoughness.baseColorFactor[3] *= opacity;
-                }
-            }
         }
 
         {

--- a/code/AssetLib/glTF2/glTF2Importer.cpp
+++ b/code/AssetLib/glTF2/glTF2Importer.cpp
@@ -267,6 +267,7 @@ static aiMaterial *ImportMaterial(std::vector<int> &embeddedTexIdxs, Asset &r, M
         SetMaterialColorProperty(r, mat.emissiveFactor, aimat, AI_MATKEY_COLOR_EMISSIVE);
 
         aimat->AddProperty(&mat.doubleSided, 1, AI_MATKEY_TWOSIDED);
+        aimat->AddProperty(&mat.pbrMetallicRoughness.baseColorFactor[3], 1, AI_MATKEY_OPACITY);
 
         aiString alphaMode(mat.alphaMode);
         aimat->AddProperty(&alphaMode, AI_MATKEY_GLTF_ALPHAMODE);


### PR DESCRIPTION
- Exporter: Writing opacity to pbrMetallicRoughness.baseColorFactor[3] even when alphaMode is set
- Importer: Setting AI_MATKEY_OPACITY from pbrMetallicRoughness.baseColorFactor[3]