### PR TITLE
Fix issues stopping PyAssimp's sample.py from working under Python 3

### DIFF
--- a/port/PyAssimp/README.md
+++ b/port/PyAssimp/README.md
@@ -42,8 +42,8 @@ substituted by assertions ...):
 
 ```python
 
-from pyassimp import load
-with load('hello.3ds') as scene:
+from pyassimp import load_scopedz
+with load_scoped('hello.3ds') as scene:
 
   assert len(scene.meshes)
   mesh = scene.meshes[0]
@@ -58,8 +58,8 @@ scene:
 
 ```python
 
-from pyassimp import load
-with load('hello.3ds') as scene:
+from pyassimp import load_scoped
+with load_scoped('hello.3ds') as scene:
 
   for c in scene.rootnode.children:
       print(str(c))

--- a/port/PyAssimp/README.md
+++ b/port/PyAssimp/README.md
@@ -42,7 +42,7 @@ substituted by assertions ...):
 
 ```python
 
-from pyassimp import load_scopedz
+from pyassimp import load_scoped
 with load_scoped('hello.3ds') as scene:
 
   assert len(scene.meshes)

--- a/port/PyAssimp/README.rst
+++ b/port/PyAssimp/README.rst
@@ -49,8 +49,8 @@ substituted by assertions ...):
 .. code:: python
 
 
-    from pyassimp import load
-    with load('hello.3ds') as scene:
+    from pyassimp import load_scoped
+    with load_scoped('hello.3ds') as scene:
 
         assert len(scene.meshes)
         mesh = scene.meshes[0]
@@ -64,8 +64,8 @@ Another example to list the 'top nodes' in a scene:
 .. code:: python
 
 
-    from pyassimp import load
-    with load('hello.3ds') as scene:
+    from pyassimp import load_scoped
+    with load_scoped('hello.3ds') as scene:
 
         for c in scene.rootnode.children:
             print(str(c))

--- a/port/PyAssimp/pyassimp/core.py
+++ b/port/PyAssimp/pyassimp/core.py
@@ -281,7 +281,6 @@ def release(scene):
     '''
     _assimp_lib.release(ctypes.pointer(scene))
 
-@contextmanager
 def load(filename,
          file_type  = None,
          processing = postprocess.aiProcess_Triangulate):
@@ -329,10 +328,19 @@ def load(filename,
         raise AssimpError('Could not import file!')
     scene = _init(model.contents)
     recur_pythonize(scene.rootnode, scene)
+    return scene
+
+@contextmanager
+def load_scoped(filename,
+                file_type  = None,
+                processing = postprocess.aiProcess_Triangulate):
+    scene = None
     try:
+        scene = load(filename=filename, file_type=file_type, processing=processing)
         yield scene
     finally:
-        release(scene)
+        if scene is not None:
+            release(scene)
 
 def export(scene,
            filename,

--- a/port/PyAssimp/pyassimp/core.py
+++ b/port/PyAssimp/pyassimp/core.py
@@ -211,7 +211,7 @@ def _init(self, target = None, parent = None):
 
 
             else: # starts with 'm' but not iterable
-                setattr(target, m, obj)
+                setattr(target, name, obj)
                 logger.debug("Added " + name + " as self." + name + " (type: " + str(type(obj)) + ")")
 
                 if _is_init_type(obj):

--- a/port/PyAssimp/scripts/sample.py
+++ b/port/PyAssimp/scripts/sample.py
@@ -5,6 +5,8 @@
 This module demonstrates the functionality of PyAssimp.
 """
 
+from __future__ import print_function
+
 import sys
 import logging
 logging.basicConfig(level=logging.INFO)
@@ -24,19 +26,19 @@ def main(filename=None):
     
     #the model we load
     print("MODEL:" + filename)
-    print
+    print("")
     
     #write some statistics
     print("SCENE:")
     print("  meshes:" + str(len(scene.meshes)))
     print("  materials:" + str(len(scene.materials)))
     print("  textures:" + str(len(scene.textures)))
-    print
+    print("")
     
     print("NODES:")
     recur_node(scene.rootnode)
 
-    print
+    print("")
     print("MESHES:")
     for index, mesh in enumerate(scene.meshes):
         print("  MESH" + str(index+1))
@@ -58,14 +60,14 @@ def main(filename=None):
         print("    uv-component-count:" + str(len(mesh.numuvcomponents)))
         print("    faces:" + str(len(mesh.faces)) + " -> first:\n" + str(mesh.faces[:3]))
         print("    bones:" + str(len(mesh.bones)) + " -> first:" + str([str(b) for b in mesh.bones[:3]]))
-        print
+        print("")
 
     print("MATERIALS:")
     for index, material in enumerate(scene.materials):
         print("  MATERIAL (id:" + str(index+1) + ")")
         for key, value in material.properties.items():
             print("    %s: %s" % (key, value))
-    print
+    print("")
     
     print("TEXTURES:")
     for index, texture in enumerate(scene.textures):

--- a/port/PyAssimp/setup.py
+++ b/port/PyAssimp/setup.py
@@ -1,7 +1,7 @@
  #!/usr/bin/env python
  # -*- coding: utf-8 -*-
 import os
-from distutils.core import setup
+from setuptools import setup
 
 def readme():
     with open('README.rst') as f:
@@ -22,5 +22,6 @@ setup(name='pyassimp',
                   ('share/pyassimp', ['README.rst']),
                   ('share/examples/pyassimp', ['scripts/' + f for f in os.listdir('scripts/')])
                  ],
-      requires=['numpy']
+      requires=['numpy'],
+      test_suite='tests',
       )

--- a/port/PyAssimp/setup.py
+++ b/port/PyAssimp/setup.py
@@ -22,6 +22,6 @@ setup(name='pyassimp',
                   ('share/pyassimp', ['README.rst']),
                   ('share/examples/pyassimp', ['scripts/' + f for f in os.listdir('scripts/')])
                  ],
-      requires=['numpy'],
+      install_requires=['numpy'],
       test_suite='tests',
       )

--- a/port/PyAssimp/tests.py
+++ b/port/PyAssimp/tests.py
@@ -1,0 +1,37 @@
+import os.path
+import unittest
+
+import pyassimp
+
+# Find the root path of the test file so we can find the
+# test models above our directory
+HERE = os.path.abspath(os.path.dirname(__file__))
+MODELS_DIR = os.path.abspath(os.path.join(HERE, '..', '..', 'test', 'models'))
+TEST_SKINNED_MODEL = os.path.join(MODELS_DIR, 'glTF2', 'simple_skin', 'simple_skin.gltf')
+TEST_COLLADA = os.path.join(MODELS_DIR, 'Collada', 'COLLADA.dae')
+
+
+class PyAssimpTests(unittest.TestCase):
+    def test_skinned(self):
+        with pyassimp.load_scoped(TEST_SKINNED_MODEL) as scene:
+            self.assertIsNotNone(scene.rootnode)
+            self.assertEqual(len(scene.meshes), 1)
+            bone_names = [b.name for b in scene.meshes[0].bones]
+            self.assertEqual(["nodes_1", "nodes_2"], bone_names)
+
+    def test_collada_parses(self):
+        with pyassimp.load_scoped(TEST_COLLADA) as scene:
+            self.assertIsNotNone(scene.rootnode)
+
+    def test_regular_load(self):
+        scene = None
+        try:
+            scene = pyassimp.load(TEST_SKINNED_MODEL)
+            self.assertIsNotNone(scene.rootnode)
+        finally:
+            if scene:
+                pyassimp.release(scene)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Revert https://github.com/assimp/assimp/commit/b4fc41bc094574400b0a688ec1381888e40ee99c

The issue it intended to fix was already fixed by https://github.com/assimp/assimp/commit/f305f105512237d7b44ec6c28492ac943e47fbcc, and setting `name` instead of `m` breaks access to `scene.rootnode` / `mRootNode` and any other non-iterable m-prefixed attr. Problem was just that the fix was only in `master` and they were testing against `4.1.4`.

This fixes failure with:

```
$ python scripts/sample.py ../../test/models/glTF2/simple_skin/simple_skin.gltf 
Traceback (most recent call last):
  File "scripts/sample.py", line 91, in <module>
    main(sys.argv[1])
  File "scripts/sample.py", line 25, in main
    scene = pyassimp.load(filename, processing=pyassimp.postprocess.aiProcess_Triangulate)
  File "/home/user/source/assimp/port/PyAssimp/pyassimp/core.py", line 330, in load
    recur_pythonize(scene.rootnode, scene)
AttributeError: 'Scene' object has no attribute 'rootnode'
```

### Split contextmanager portion of `pyassimp.load()` into `pyassimp.load_scoped()`

Added in efbabf3b0daccb976639a3734fa9018c4b3e13fa, without splitting this out there's no way to use a `scene` in a block other than the one it was allocated in. I added a separate `load_scoped()` that has the contextmanager semantics that were added to `load()`. It'd be nicer to add a `__exit__` to the `Scene` struct that could automatically clean things up, but doesn't seem like that'd be possible without pushing parts of `core.py` into `structs.py`

This fixes failure with:

```
$ python scripts/sample.py ../../test/models/glTF2/simple_skin/simple_skin.gltf 
MODEL:../../test/models/glTF2/simple_skin/simple_skin.gltf
SCENE:
Traceback (most recent call last):
  File "scripts/sample.py", line 89, in <module>
    main(sys.argv[1])
  File "scripts/sample.py", line 31, in main
    print("  meshes:" + str(len(scene.meshes)))
AttributeError: '_GeneratorContextManager' object has no attribute 'meshes'
```

### Make sample.py parse under Python 3

The bare `print` is a no-op under Python 3, so added a `future` import for Python 2 and changed it to `print("")`.

### Tests

I also added some simple smoke tests that can be run with `python setup.py test`.