### PR TITLE
Update Gitignore exclude x64 folder generated by build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ CMakeSettings.json
 # Output
 bin/
 lib/
-
+x64/
 # QtCreator
 CMakeLists.txt.user
 


### PR DESCRIPTION
Hi this folder is generated by build was causing me some trouble when working with git (not sure if its created by unreal engine build tools , cmake or vs ?) .