### PR TITLE
Manage /R/N lines ends correctly on binary files, tested with solidworks PLY export

### DIFF
--- a/code/AssetLib/Ply/PlyParser.cpp
+++ b/code/AssetLib/Ply/PlyParser.cpp
@@ -419,8 +419,7 @@ bool PLY::DOM::ParseHeader(IOStreamBuffer<char> &streamBuffer, std::vector<char>
         if (PLY::Element::ParseElement(streamBuffer, buffer, &out)) {
             // add the element to the list of elements
             alElements.push_back(out);
-        } else if ( TokenMatch(buffer, "end_header\r", 11) || //checks for header end with /r/n ending
-                    TokenMatch(buffer, "end_header", 10)) { //checks for /n ending, if it doesn't end with /r/n
+        } else if (TokenMatch(buffer, "end_header", 10)) { //checks for /n ending, if it doesn't end with /r/n
             // we have reached the end of the header
             break;
         } else {
@@ -501,6 +500,11 @@ bool PLY::DOM::ParseInstanceBinary(IOStreamBuffer<char> &streamBuffer, DOM *p_pc
     }
 
     streamBuffer.getNextBlock(buffer);
+
+    // remove first char if it's /n in case of file with /r/n
+    if (((char *)&buffer[0])[0] == '\n')
+        buffer.erase(buffer.begin(), buffer.begin() + 1);
+
     unsigned int bufferSize = static_cast<unsigned int>(buffer.size());
     const char *pCur = (char *)&buffer[0];
     if (!p_pcOut->ParseElementInstanceListsBinary(streamBuffer, buffer, pCur, bufferSize, loader, p_bBE)) {


### PR DESCRIPTION
Correction from issue #3711
The deduction was correct but the correction didn't work on the solidworks.ply test file from the issue.

This change force the skip the /n char in the beginning of the buffer when it's present.

