### PR TITLE
more range-based for

### DIFF
--- a/code/AssetLib/glTF2/glTF2Importer.cpp
+++ b/code/AssetLib/glTF2/glTF2Importer.cpp
@@ -992,8 +992,8 @@ void ParseExtensions(aiMetadata *metadata, const CustomExtension &extension) {
         metadata->Add(extension.name.c_str(), extension.mBoolValue.value);
     } else if (extension.mValues.isPresent) {
         aiMetadata val;
-        for (size_t i = 0; i < extension.mValues.value.size(); ++i) {
-            ParseExtensions(&val, extension.mValues.value[i]);
+        for (auto const & subExtension : extension.mValues.value) {
+            ParseExtensions(&val, subExtension);
         }
         metadata->Add(extension.name.c_str(), val);
     }
@@ -1001,8 +1001,8 @@ void ParseExtensions(aiMetadata *metadata, const CustomExtension &extension) {
 
 void ParseExtras(aiMetadata *metadata, const CustomExtension &extension) {
     if (extension.mValues.isPresent) {
-        for (size_t i = 0; i < extension.mValues.value.size(); ++i) {
-            ParseExtensions(metadata, extension.mValues.value[i]);
+        for (auto const & subExtension : extension.mValues.value) {
+            ParseExtensions(metadata, subExtension);
         }
     }
 }


### PR DESCRIPTION
f6b4370f6ac1bf2db0ef9edeb0ff1ce8c7e61aab and 7c822f23bd075d3621d2e2f33188e1659f657b31 introduced raw loops on data types with heavy nesting; range-based for suits better here