### PR TITLE
Fix M3D import crash and memory leak.

### DIFF
--- a/code/AssetLib/M3D/M3DImporter.cpp
+++ b/code/AssetLib/M3D/M3DImporter.cpp
@@ -233,12 +233,12 @@ void M3DImporter::importMaterials(const M3DWrapper &m3d) {
     ASSIMP_LOG_DEBUG("M3D: importMaterials ", mScene->mNumMaterials);
 
     // add a default material as first
-    aiMaterial *mat = new aiMaterial;
-    mat->AddProperty(&name, AI_MATKEY_NAME);
+    aiMaterial *defaultMat = new aiMaterial;
+    defaultMat->AddProperty(&name, AI_MATKEY_NAME);
     c.a = 1.0f;
     c.b = c.g = c.r = 0.6f;
-    mat->AddProperty(&c, 1, AI_MATKEY_COLOR_DIFFUSE);
-    mScene->mMaterials[0] = mat;
+    defaultMat->AddProperty(&c, 1, AI_MATKEY_COLOR_DIFFUSE);
+    mScene->mMaterials[0] = defaultMat;
 
     if (!m3d->nummaterial || !m3d->material) {
         return;
@@ -300,12 +300,12 @@ void M3DImporter::importMaterials(const M3DWrapper &m3d) {
                     m->prop[j].value.textureid < m3d->numtexture &&
                     m3d->texture[m->prop[j].value.textureid].name) {
                 name.Set(std::string(std::string(m3d->texture[m->prop[j].value.textureid].name) + ".png"));
-                mat->AddProperty(&name, aiTxProps[k].pKey, aiTxProps[k].type, aiTxProps[k].index);
+                newMat->AddProperty(&name, aiTxProps[k].pKey, aiTxProps[k].type, aiTxProps[k].index);
                 n = 0;
-                mat->AddProperty(&n, 1, _AI_MATKEY_UVWSRC_BASE, aiProps[k].type, aiProps[k].index);
+                newMat->AddProperty(&n, 1, _AI_MATKEY_UVWSRC_BASE, aiProps[k].type, aiProps[k].index);
             }
         }
-        mScene->mMaterials[i + 1] = mat;
+        mScene->mMaterials[i + 1] = newMat;
     }
 }
 

--- a/test/unit/utM3DImportExport.cpp
+++ b/test/unit/utM3DImportExport.cpp
@@ -50,35 +50,32 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using namespace Assimp;
 
-class utM3DImportExport : public AbstractImportExportBase {
-public:
-	bool importerTest() override  {
-        Assimp::Importer importer;
-        const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/M3D/cube_normals.m3d", aiProcess_ValidateDataStructure);
+TEST(utM3DImportExport, import_cube_normals) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/M3D/cube_normals.m3d", aiProcess_ValidateDataStructure);
 #ifndef ASSIMP_BUILD_NO_M3D_IMPORTER
-		return nullptr != scene;
+    ASSERT_NE(nullptr, scene);
 #else
-        return nullptr == scene;
+    ASSERT_EQ(nullptr, scene);
 #endif // ASSIMP_BUILD_NO_M3D_IMPORTER
-    }
+}
 
-#ifndef ASSIMP_BUILD_NO_EXPORT
-    bool exporterTest() override {
-		Assimp::Importer importer;
-		const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/M3D/cube_normals.m3d", aiProcess_ValidateDataStructure);
-		Exporter exporter;
-		aiReturn ret = exporter.Export(scene, "m3d", ASSIMP_TEST_MODELS_DIR "/M3D/cube_normals_out.m3d");
-		return ret == AI_SUCCESS;
-    }
-#endif
-};
-
-TEST_F(utM3DImportExport, importM3DFromFileTest) {
-    EXPECT_TRUE(importerTest());
+TEST(utM3DImportExport, import_cube_usemtl) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/M3D/cube_usemtl.m3d", aiProcess_ValidateDataStructure);
+#ifndef ASSIMP_BUILD_NO_M3D_IMPORTER
+    ASSERT_NE(nullptr, scene);
+#else
+    ASSERT_EQ(nullptr, scene);
+#endif // ASSIMP_BUILD_NO_M3D_IMPORTER
 }
 
 #ifndef ASSIMP_BUILD_NO_EXPORT
-TEST_F(utM3DImportExport, exportM3DFromFileTest) {
-	EXPECT_TRUE(exporterTest());
+TEST(utM3DImportExport, export_cube_normals) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/M3D/cube_normals.m3d", aiProcess_ValidateDataStructure);
+    Exporter exporter;
+    aiReturn ret = exporter.Export(scene, "m3d", ASSIMP_TEST_MODELS_DIR "/M3D/cube_normals_out.m3d");
+    ASSERT_EQ(AI_SUCCESS, ret);
 }
 #endif //  ASSIMP_BUILD_NO_EXPORT

--- a/test/unit/utM3DImportExport.cpp
+++ b/test/unit/utM3DImportExport.cpp
@@ -43,39 +43,41 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "AbstractImportExportBase.h"
 #include "UnitTestPCH.h"
 
-#include <assimp/Importer.hpp>
-#include <assimp/Exporter.hpp>
 #include <assimp/postprocess.h>
+#include <assimp/Exporter.hpp>
 #include <assimp/Importer.hpp>
 
 using namespace Assimp;
 
-TEST(utM3DImportExport, import_cube_normals) {
-    Assimp::Importer importer;
-    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/M3D/cube_normals.m3d", aiProcess_ValidateDataStructure);
+class utM3DImportExport : public AbstractImportExportBase {
+public:
+    bool importerTest() override {
+        Assimp::Importer importer;
+        const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/M3D/cube_normals.m3d", aiProcess_ValidateDataStructure);
 #ifndef ASSIMP_BUILD_NO_M3D_IMPORTER
-    ASSERT_NE(nullptr, scene);
+        return nullptr != scene;
 #else
-    ASSERT_EQ(nullptr, scene);
+        return nullptr == scene;
 #endif // ASSIMP_BUILD_NO_M3D_IMPORTER
-}
+    }
 
-TEST(utM3DImportExport, import_cube_usemtl) {
-    Assimp::Importer importer;
-    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/M3D/cube_usemtl.m3d", aiProcess_ValidateDataStructure);
-#ifndef ASSIMP_BUILD_NO_M3D_IMPORTER
-    ASSERT_NE(nullptr, scene);
-#else
-    ASSERT_EQ(nullptr, scene);
-#endif // ASSIMP_BUILD_NO_M3D_IMPORTER
+#ifndef ASSIMP_BUILD_NO_EXPORT
+    bool exporterTest() override {
+        Assimp::Importer importer;
+        const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/M3D/cube_normals.m3d", aiProcess_ValidateDataStructure);
+        Exporter exporter;
+        aiReturn ret = exporter.Export(scene, "m3d", ASSIMP_TEST_MODELS_DIR "/M3D/cube_normals_out.m3d");
+        return ret == AI_SUCCESS;
+    }
+#endif
+};
+
+TEST_F(utM3DImportExport, importM3DFromFileTest) {
+    EXPECT_TRUE(importerTest());
 }
 
 #ifndef ASSIMP_BUILD_NO_EXPORT
-TEST(utM3DImportExport, export_cube_normals) {
-    Assimp::Importer importer;
-    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/M3D/cube_normals.m3d", aiProcess_ValidateDataStructure);
-    Exporter exporter;
-    aiReturn ret = exporter.Export(scene, "m3d", ASSIMP_TEST_MODELS_DIR "/M3D/cube_normals_out.m3d");
-    ASSERT_EQ(AI_SUCCESS, ret);
+TEST_F(utM3DImportExport, exportM3DFromFileTest) {
+    EXPECT_TRUE(exporterTest());
 }
 #endif //  ASSIMP_BUILD_NO_EXPORT

--- a/test/unit/utM3DImportExport.cpp
+++ b/test/unit/utM3DImportExport.cpp
@@ -43,19 +43,20 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "AbstractImportExportBase.h"
 #include "UnitTestPCH.h"
 
-#include <assimp/postprocess.h>
+#include <assimp/Importer.hpp>
 #include <assimp/Exporter.hpp>
+#include <assimp/postprocess.h>
 #include <assimp/Importer.hpp>
 
 using namespace Assimp;
 
 class utM3DImportExport : public AbstractImportExportBase {
 public:
-    bool importerTest() override {
+	bool importerTest() override  {
         Assimp::Importer importer;
         const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/M3D/cube_normals.m3d", aiProcess_ValidateDataStructure);
 #ifndef ASSIMP_BUILD_NO_M3D_IMPORTER
-        return nullptr != scene;
+		return nullptr != scene;
 #else
         return nullptr == scene;
 #endif // ASSIMP_BUILD_NO_M3D_IMPORTER
@@ -63,11 +64,11 @@ public:
 
 #ifndef ASSIMP_BUILD_NO_EXPORT
     bool exporterTest() override {
-        Assimp::Importer importer;
-        const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/M3D/cube_normals.m3d", aiProcess_ValidateDataStructure);
-        Exporter exporter;
-        aiReturn ret = exporter.Export(scene, "m3d", ASSIMP_TEST_MODELS_DIR "/M3D/cube_normals_out.m3d");
-        return ret == AI_SUCCESS;
+		Assimp::Importer importer;
+		const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/M3D/cube_normals.m3d", aiProcess_ValidateDataStructure);
+		Exporter exporter;
+		aiReturn ret = exporter.Export(scene, "m3d", ASSIMP_TEST_MODELS_DIR "/M3D/cube_normals_out.m3d");
+		return ret == AI_SUCCESS;
     }
 #endif
 };
@@ -78,6 +79,6 @@ TEST_F(utM3DImportExport, importM3DFromFileTest) {
 
 #ifndef ASSIMP_BUILD_NO_EXPORT
 TEST_F(utM3DImportExport, exportM3DFromFileTest) {
-    EXPECT_TRUE(exporterTest());
+	EXPECT_TRUE(exporterTest());
 }
 #endif //  ASSIMP_BUILD_NO_EXPORT


### PR DESCRIPTION
The same default material pointer was assigned to all the materials in the scene, so poor destructor tried to free the same pointer multiple times.