### PR TITLE
fixed incorrect/misleading comment at end of scene.h

### DIFF
--- a/include/assimp/scene.h
+++ b/include/assimp/scene.h
@@ -437,7 +437,7 @@ struct aiScene
 };
 
 #ifdef __cplusplus
-} //! namespace Assimp
-#endif
+} 
+#endif //! extern "C"
 
 #endif // AI_SCENE_H_INC


### PR DESCRIPTION
changed comment for the ending brace in scene.h to the same comment as used in mesh.h (changing explanation from 'end of namespace' to 'end of extern c section') 