### PR TITLE
including <exception>

### DIFF
--- a/include/assimp/Importer.hpp
+++ b/include/assimp/Importer.hpp
@@ -59,7 +59,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // Public ASSIMP data structures
 #include <assimp/types.h>
 
-//#include <exception>
+#include <exception>
 
 namespace Assimp {
 // =======================================================================


### PR DESCRIPTION
When compiling on Linux, it was spitting out a error at include/assimp/Importer.hpp. Idk why "_#include <exception>_" was commented out, but I undid that comment.

I'm new to opensource btw, I don't really know what I'm doing.