### PR TITLE
Fix possible nullptr dereferencing in material parsing

### DIFF
--- a/code/AssetLib/Obj/ObjFileMtlImporter.cpp
+++ b/code/AssetLib/Obj/ObjFileMtlImporter.cpp
@@ -232,6 +232,12 @@ void ObjFileMtlImporter::getIlluminationModel(int &illum_model) {
 //  Loads a single float value.
 void ObjFileMtlImporter::getFloatValue(ai_real &value) {
     m_DataIt = CopyNextWord<DataArrayIt>(m_DataIt, m_DataItEnd, &m_buffer[0], BUFFERSIZE);
+    size_t len = std::strlen(&m_buffer[0]);
+    if (0 == len) {
+        value = 0.0f;
+        return;
+    }
+    
     value = (ai_real)fast_atof(&m_buffer[0]);
 }
 


### PR DESCRIPTION
* Return 0.0f for empty buffer
* closes https://github.com/assimp/assimp/issues/3442