### PR TITLE
moved MD2/MDC tables from BSS to const data

### DIFF
--- a/code/AssetLib/MD2/MD2NormalTable.h
+++ b/code/AssetLib/MD2/MD2NormalTable.h
@@ -51,7 +51,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define AI_MDL_NORMALTABLE_H_INC
 
 
-float g_avNormals[162][3] = {
+const float g_avNormals[162][3] = {
 { -0.525731f,  0.000000f,  0.850651f },
 { -0.442863f,  0.238856f,  0.864188f },
 { -0.295242f,  0.000000f,  0.955423f },

--- a/code/AssetLib/MDC/MDCNormalTable.h
+++ b/code/AssetLib/MDC/MDCNormalTable.h
@@ -36,7 +36,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define MDC_NORMAL_TABLE_INCLUDED
 
 /* mdc decoding normal table */
-float mdcNormals[ 256 ][ 3 ] =
+const float mdcNormals[ 256 ][ 3 ] =
 {
     { 1.000000f, 0.000000f, 0.000000f },
     { 0.980785f, 0.195090f, 0.000000f },


### PR DESCRIPTION
Visual C++ was unable to identify them as constant data during optimization. Now they definitely go to the read-only section.