### PR TITLE
Add support for normal maps, the classic way

### DIFF
--- a/code/AssetLib/Obj/ObjFileMtlImporter.cpp
+++ b/code/AssetLib/Obj/ObjFileMtlImporter.cpp
@@ -61,7 +61,8 @@ static const std::string EmissiveTexture1 = "map_emissive";
 static const std::string EmissiveTexture2 = "map_Ke";
 static const std::string BumpTexture1 = "map_bump";
 static const std::string BumpTexture2 = "bump";
-static const std::string NormalTexture = "map_Kn";
+static const std::string NormalTextureV1 = "map_Kn";
+static const std::string NormalTextureV2 = "norm";
 static const std::string ReflectionTexture = "refl";
 static const std::string DisplacementTexture1 = "map_disp";
 static const std::string DisplacementTexture2 = "disp";
@@ -321,7 +322,7 @@ void ObjFileMtlImporter::getTexture() {
         // Bump texture
         out = &m_pModel->m_pCurrentMaterial->textureBump;
         clampIndex = ObjFile::Material::TextureBumpType;
-    } else if (!ASSIMP_strincmp(pPtr, NormalTexture.c_str(), static_cast<unsigned int>(NormalTexture.size()))) {
+    } else if (!ASSIMP_strincmp(pPtr, NormalTextureV1.c_str(), static_cast<unsigned int>(NormalTextureV1.size())) || !ASSIMP_strincmp(pPtr, NormalTextureV2.c_str(), static_cast<unsigned int>(NormalTextureV2.size()))) {
         // Normal map
         out = &m_pModel->m_pCurrentMaterial->textureNormal;
         clampIndex = ObjFile::Material::TextureNormalType;


### PR DESCRIPTION
- get compatible to tinyobjloader and other importers
- closes https://github.com/assimp/assimp/issues/3726