### PR TITLE
Fix aiString length not updated in the EmbedTextures postprocess task

### DIFF
--- a/code/PostProcessing/EmbedTexturesProcess.cpp
+++ b/code/PostProcessing/EmbedTexturesProcess.cpp
@@ -89,7 +89,7 @@ void EmbedTexturesProcess::Execute(aiScene* pScene) {
                 // Indeed embed
                 if (addTexture(pScene, path.data)) {
                     auto embeddedTextureId = pScene->mNumTextures - 1u;
-                    ::ai_snprintf(path.data, 1024, "*%u", embeddedTextureId);
+                    path.length = ::ai_snprintf(path.data, 1024, "*%u", embeddedTextureId);
                     material->AddProperty(&path, AI_MATKEY_TEXTURE(tt, texId));
                     embeddedTexturesCount++;
                 }


### PR DESCRIPTION
`aiString` length was not updated when the texture path was replaced with the embedded path (i.e. `*0`) after performing the EmbedTextures postprocess task. 

This created all sort of problems when performing string manipulation using the `aiString::length` field instead of interpreting `aiString::data` as c-string (think of applications using UTF8 strings). 

I also wrote a small unit test for this change, but decided against pushing it because I don't know in which file to put it.
Let me know if I should add it to the pr.