### PR TITLE
Added missing include 

### DIFF
--- a/code/Common/ImporterRegistry.cpp
+++ b/code/Common/ImporterRegistry.cpp
@@ -46,6 +46,7 @@ directly (unless you are adding new loaders), instead use the
 corresponding preprocessor flag to selectively disable formats.
 */
 
+#include <assimp/anim.h>
 #include <assimp/BaseImporter.h>
 #include <vector>
 #include <cstdlib>


### PR DESCRIPTION
When assimp is built with cmake options
```
-DASSIMP_BUILD_ALL_IMPORTERS_BY_DEFAULT=OFF
-DASSIMP_BUILD_ALL_EXPORTERS_BY_DEFAULT=OFF
-DASSIMP_BUILD_B3D_IMPORTER=ON
```

build fails on clang because `aiNodeAnim` and `aiAnimation` are forward declared but include is missing

```
In file included from /Users/lerppana/Github/assimp/code/Common/ImporterRegistry.cpp:49:
In file included from /Users/lerppana/Github/assimp/include/assimp/BaseImporter.h:52:
In file included from /Users/lerppana/Github/assimp/include/assimp/Exceptional.h:49:
In file included from /Users/lerppana/Github/assimp/include/assimp/DefaultIOStream.h:55:
In file included from /Users/lerppana/Github/assimp/include/assimp/IOStream.hpp:53:
In file included from /Users/lerppana/Github/assimp/include/assimp/types.h:78:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/string:506:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/string_view:175:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/__string:57:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/algorithm:643:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/memory:2080:19: error: invalid application of 'sizeof' to an incomplete type 'aiNodeAnim'
    static_assert(sizeof(_Tp) > 0,
                  ^~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/memory:2345:7: note: in instantiation of member function 'std::default_delete<aiNodeAnim>::operator()' requested here
      __ptr_.second()(__tmp);
      ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/memory:2299:19: note: in instantiation of member function 'std::unique_ptr<aiNodeAnim>::reset' requested here
  ~unique_ptr() { reset(); }
                  ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/memory:1686:92: note: in instantiation of member function 'std::unique_ptr<aiNodeAnim>::~unique_ptr' requested here
    _LIBCPP_DEPRECATED_IN_CXX17 _LIBCPP_INLINE_VISIBILITY void destroy(pointer __p) {__p->~_Tp();}
                                                                                           ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/memory:1578:21: note: in instantiation of member function 'std::allocator<std::unique_ptr<aiNodeAnim>>::destroy' requested here
                __a.destroy(__p);
                    ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/memory:1419:14: note: in instantiation of function template specialization 'std::allocator_traits<std::allocator<std::unique_ptr<aiNodeAnim>>>::__destroy<std::unique_ptr<aiNodeAnim>>' requested here
            {__destroy(__has_destroy<allocator_type, _Tp*>(), __a, __p);}
             ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/vector:428:25: note: in instantiation of function template specialization 'std::allocator_traits<std::allocator<std::unique_ptr<aiNodeAnim>>>::destroy<std::unique_ptr<aiNodeAnim>>' requested here
        __alloc_traits::destroy(__alloc(), _VSTD::__to_address(--__soon_to_be_end));
                        ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/vector:371:29: note: in instantiation of member function 'std::__vector_base<std::unique_ptr<aiNodeAnim>, std::allocator<std::unique_ptr<aiNodeAnim>>>::__destruct_at_end' requested here
    void clear() _NOEXCEPT {__destruct_at_end(__begin_);}
                            ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/vector:465:9: note: in instantiation of member function 'std::__vector_base<std::unique_ptr<aiNodeAnim>, std::allocator<std::unique_ptr<aiNodeAnim>>>::clear' requested here
        clear();
        ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/vector:497:5: note: in instantiation of member function 'std::__vector_base<std::unique_ptr<aiNodeAnim>, std::allocator<std::unique_ptr<aiNodeAnim>>>::~__vector_base' requested here
    vector() _NOEXCEPT_(is_nothrow_default_constructible<allocator_type>::value)
    ^
/Users/lerppana/Github/assimp/code/AssetLib/B3D/B3DImporter.h:65:5: note: in instantiation of member function 'std::vector<std::unique_ptr<aiNodeAnim>>::vector' requested here
    B3DImporter() = default;
    ^
/Users/lerppana/Github/assimp/code/AssetLib/B3D/B3DImporter.h:57:8: note: forward declaration of 'aiNodeAnim'
struct aiNodeAnim;
       ^
In file included from /Users/lerppana/Github/assimp/code/Common/ImporterRegistry.cpp:49:
In file included from /Users/lerppana/Github/assimp/include/assimp/BaseImporter.h:52:
In file included from /Users/lerppana/Github/assimp/include/assimp/Exceptional.h:49:
In file included from /Users/lerppana/Github/assimp/include/assimp/DefaultIOStream.h:55:
In file included from /Users/lerppana/Github/assimp/include/assimp/IOStream.hpp:53:
In file included from /Users/lerppana/Github/assimp/include/assimp/types.h:78:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/string:506:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/string_view:175:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/__string:57:
In file included from /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/algorithm:643:
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/memory:2080:19: error: invalid application of 'sizeof' to an incomplete type 'aiAnimation'
    static_assert(sizeof(_Tp) > 0,
                  ^~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/memory:2345:7: note: in instantiation of member function 'std::default_delete<aiAnimation>::operator()' requested here
      __ptr_.second()(__tmp);
      ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/memory:2299:19: note: in instantiation of member function 'std::unique_ptr<aiAnimation>::reset' requested here
  ~unique_ptr() { reset(); }
                  ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/memory:1686:92: note: in instantiation of member function 'std::unique_ptr<aiAnimation>::~unique_ptr' requested here
    _LIBCPP_DEPRECATED_IN_CXX17 _LIBCPP_INLINE_VISIBILITY void destroy(pointer __p) {__p->~_Tp();}
                                                                                           ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/memory:1578:21: note: in instantiation of member function 'std::allocator<std::unique_ptr<aiAnimation>>::destroy' requested here
                __a.destroy(__p);
                    ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/memory:1419:14: note: in instantiation of function template specialization 'std::allocator_traits<std::allocator<std::unique_ptr<aiAnimation>>>::__destroy<std::unique_ptr<aiAnimation>>' requested here
            {__destroy(__has_destroy<allocator_type, _Tp*>(), __a, __p);}
             ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/vector:428:25: note: in instantiation of function template specialization 'std::allocator_traits<std::allocator<std::unique_ptr<aiAnimation>>>::destroy<std::unique_ptr<aiAnimation>>' requested here
        __alloc_traits::destroy(__alloc(), _VSTD::__to_address(--__soon_to_be_end));
                        ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/vector:371:29: note: in instantiation of member function 'std::__vector_base<std::unique_ptr<aiAnimation>, std::allocator<std::unique_ptr<aiAnimation>>>::__destruct_at_end' requested here
    void clear() _NOEXCEPT {__destruct_at_end(__begin_);}
                            ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/vector:465:9: note: in instantiation of member function 'std::__vector_base<std::unique_ptr<aiAnimation>, std::allocator<std::unique_ptr<aiAnimation>>>::clear' requested here
        clear();
        ^
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX11.3.sdk/usr/include/c++/v1/vector:497:5: note: in instantiation of member function 'std::__vector_base<std::unique_ptr<aiAnimation>, std::allocator<std::unique_ptr<aiAnimation>>>::~__vector_base' requested here
    vector() _NOEXCEPT_(is_nothrow_default_constructible<allocator_type>::value)
    ^
/Users/lerppana/Github/assimp/code/AssetLib/B3D/B3DImporter.h:65:5: note: in instantiation of member function 'std::vector<std::unique_ptr<aiAnimation>>::vector' requested here
    B3DImporter() = default;
    ^
/Users/lerppana/Github/assimp/code/AssetLib/B3D/B3DImporter.h:59:8: note: forward declaration of 'aiAnimation'
struct aiAnimation;
```