### PR TITLE
Update D3MFOpcPackage.cpp

### DIFF
--- a/code/AssetLib/3MF/D3MFOpcPackage.cpp
+++ b/code/AssetLib/3MF/D3MFOpcPackage.cpp
@@ -149,7 +149,7 @@ D3MFOpcPackage::D3MFOpcPackage(IOSystem *pIOHandler, const std::string &rFile) :
 
             IOStream *fileStream = mZipArchive->Open(file.c_str());
             if (nullptr == fileStream) {
-                ai_assert(fileStream != nullptr);
+                ASSIMP_LOG_ERROR("Filestream is nullptr.");
                 continue;
             }
 


### PR DESCRIPTION
- Log an error in case of a nullptr-exception in reading out the 3MF-Archive
- closes https://github.com/assimp/assimp/issues/4153