### PR TITLE
Remove optimization fence preventing automatic move

### DIFF
--- a/code/AssetLib/STEPParser/STEPFileReader.cpp
+++ b/code/AssetLib/STEPParser/STEPFileReader.cpp
@@ -325,7 +325,7 @@ std::shared_ptr<const EXPRESS::DataType> EXPRESS::DataType::Parse(const char*& i
                 std::transform(s.begin(),s.end(),s.begin(),&ai_tolower<char> );
                 if (schema->IsKnownToken(s)) {
                     for(cur = t+1;*cur++ != '(';);
-                    const std::shared_ptr<const EXPRESS::DataType> dt = Parse(cur);
+                    std::shared_ptr<const EXPRESS::DataType> dt = Parse(cur);
                     inout = *cur ? cur+1 : cur;
                     return dt;
                 }


### PR DESCRIPTION
I ran clang-tidy on the most recent RC, and found a performance bug. There was a const qualifier on a return value which prevented the compiler from doing an automatic move of the shared_ptr return value. 