### PR TITLE
Delete irrXML_note.txt

### DIFF
--- a/contrib/irrXML_note.txt
+++ b/contrib/irrXML_note.txt
@@ -1,6 +1,0 @@
-
-IrrXML
-Downloaded September 2008
-
-- fixed a minor compiler warning (vs 2005, shift too large)
-- fixed an issue regarding wchar_t/unsigned short


### PR DESCRIPTION
- Remove deprecated notes from irrxml