### PR TITLE
Fix CanRead() to return true on success path

### DIFF
--- a/code/AssetLib/glTF2/glTF2Importer.cpp
+++ b/code/AssetLib/glTF2/glTF2Importer.cpp
@@ -122,7 +122,7 @@ bool glTF2Importer::CanRead(const std::string &pFile, IOSystem *pIOHandler, bool
 		return asset.CanRead(pFile, extension == "glb");
 	}
 
-    return false;
+    return true;
 }
 
 static aiTextureMapMode ConvertWrappingMode(SamplerWrap gltfWrapMode) {


### PR DESCRIPTION
One of our user has submitted this bug fix to our project. We think the fix should be sent to upstream as well.