### PR TITLE
Allow dlclose of so library by avoiding unique symbols.

### DIFF
--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -174,6 +174,7 @@ SET( Common_SRCS
   Common/ImporterRegistry.cpp
   Common/DefaultProgressHandler.h
   Common/DefaultIOStream.cpp
+  Common/IOSystem.cpp
   Common/DefaultIOSystem.cpp
   Common/ZipArchiveIOSystem.cpp
   Common/PolyTools.h

--- a/code/Common/IOSystem.cpp
+++ b/code/Common/IOSystem.cpp
@@ -1,0 +1,56 @@
+/*
+---------------------------------------------------------------------------
+Open Asset Import Library (assimp)
+---------------------------------------------------------------------------
+
+Copyright (c) 2006-2019, assimp team
+
+
+
+All rights reserved.
+
+Redistribution and use of this software in source and binary forms,
+with or without modification, are permitted provided that the following
+conditions are met:
+
+* Redistributions of source code must retain the above
+  copyright notice, this list of conditions and the
+  following disclaimer.
+
+* Redistributions in binary form must reproduce the above
+  copyright notice, this list of conditions and the
+  following disclaimer in the documentation and/or other
+  materials provided with the distribution.
+
+* Neither the name of the assimp team, nor the names of its
+  contributors may be used to endorse or promote products
+  derived from this software without specific prior
+  written permission of the assimp team.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+---------------------------------------------------------------------------
+*/
+/** @file Default implementation of IOSystem using the standard C file functions */
+
+#include <assimp/IOSystem.hpp>
+
+using namespace Assimp;
+
+//const std::string Assimp::StaticDummyString;
+const std::string &IOSystem::CurrentDirectory() const {
+    if ( m_pathStack.empty() ) {
+        static const std::string Dummy = std::string();
+        return Dummy;
+    }
+    return m_pathStack[ m_pathStack.size()-1 ];
+}

--- a/include/assimp/IOSystem.hpp
+++ b/include/assimp/IOSystem.hpp
@@ -289,15 +289,6 @@ AI_FORCE_INLINE bool IOSystem::PushDirectory( const std::string &path ) {
 }
 
 // ----------------------------------------------------------------------------
-AI_FORCE_INLINE const std::string &IOSystem::CurrentDirectory() const {
-    if ( m_pathStack.empty() ) {
-        static const std::string Dummy;
-        return Dummy;
-    }
-    return m_pathStack[ m_pathStack.size()-1 ];
-}
-
-// ----------------------------------------------------------------------------
 AI_FORCE_INLINE size_t IOSystem::StackSize() const {
     return m_pathStack.size();
 }


### PR DESCRIPTION
The libassimp.so library contains one symbol of type STB_GNU_UNIQUE, meaning that the library can not be unloaded with dlclose after it has been loaded with dlopen. If a plugin links with the assimp library, this plugin will not be able to unload either.

The following symbol is the problem:
nm -DC /lib/x86_64-linux-gnu/libassimp.so.5.0.0 | grep " u "
0000000000c40f20 u Assimp::IOSystem::CurrentDirectory[abi:cxx11]() const::Dummy

A simple fix will be to remove the inlining of this function.