### PR TITLE
Added checks for out of bounds data access/writing

### DIFF
--- a/code/AssetLib/glTF/glTFCommon.h
+++ b/code/AssetLib/glTF/glTFCommon.h
@@ -300,7 +300,7 @@ public:
 
     inline unsigned int GetIndex() const { return index; }
 
-    operator bool() const { return vector != 0; }
+    operator bool() const { return vector != nullptr && index < vector->size(); }
 
     T *operator->() { return (*vector)[index]; }
 

--- a/code/AssetLib/glTF2/glTF2Asset.inl
+++ b/code/AssetLib/glTF2/glTF2Asset.inl
@@ -600,6 +600,10 @@ inline void Buffer::Read(Value &obj, Asset &r) {
 inline bool Buffer::LoadFromStream(IOStream &stream, size_t length, size_t baseOffset) {
     byteLength = length ? length : stream.FileSize();
 
+    if (byteLength > stream.FileSize()) {
+        throw DeadlyImportError("GLTF: Invalid byteLength exceeds size of actual data.");
+    }
+
     if (baseOffset) {
         stream.Seek(baseOffset, aiOrigin_SET);
     }
@@ -809,11 +813,6 @@ inline void Accessor::Sparse::PatchData(unsigned int elementSize) {
         }
 
         offset *= elementSize;
-
-        if (offset + elementSize > data.size()) {
-            throw DeadlyImportError("Invalid sparse accessor. Byte offset for patching points outside allocated memory.");
-        }
-
         std::memcpy(data.data() + offset, pValues, elementSize);
 
         pValues += elementSize;
@@ -868,9 +867,6 @@ inline void Accessor::Read(Value &obj, Asset &r) {
             //indices componentType
             sparse->indicesType = MemberOrDefault(*indicesValue, "componentType", ComponentType_BYTE);
             //sparse->indices->Read(*indicesValue, r);
-        } else {
-            // indicesType
-            sparse->indicesType = MemberOrDefault(*sparseValue, "componentType", ComponentType_UNSIGNED_SHORT);
         }
 
         // value
@@ -883,6 +879,8 @@ inline void Accessor::Read(Value &obj, Asset &r) {
             //sparse->values->Read(*valuesValue, r);
         }
 
+        // indicesType
+        sparse->indicesType = MemberOrDefault(*sparseValue, "componentType", ComponentType_UNSIGNED_SHORT);
 
         const unsigned int elementSize = GetElementSize();
         const size_t dataSize = count * elementSize;

--- a/include/assimp/Vertex.h
+++ b/include/assimp/Vertex.h
@@ -135,7 +135,9 @@ public:
     /** Extract a particular vertex from a anim mesh and interleave all components */
     explicit Vertex(const aiAnimMesh* msh, unsigned int idx) {
         ai_assert(idx < msh->mNumVertices);
-        position = msh->mVertices[idx];
+        if (msh->HasPositions()) {
+            position = msh->mVertices[idx];
+        }
 
         if (msh->HasNormals()) {
             normal = msh->mNormals[idx];


### PR DESCRIPTION
Three fixes:
* Check that positions exist in a mesh before accessing them
* Reject files with an invalid byteLength value
* Ensure we don't access the vector in a Ref object with an out of bounds index