### PR TITLE
Interpolate euler rotations for quaternion animations

### DIFF
--- a/code/AssetLib/FBX/FBXConverter.h
+++ b/code/AssetLib/FBX/FBXConverter.h
@@ -361,6 +361,7 @@ private:
 
     // ------------------------------------------------------------------------------------------------
     KeyFrameListList GetKeyframeList(const std::vector<const AnimationCurveNode*>& nodes, int64_t start, int64_t stop);
+    KeyFrameListList GetRotationKeyframeList(const std::vector<const AnimationCurveNode*>& nodes, int64_t start, int64_t stop);
 
     // ------------------------------------------------------------------------------------------------
     KeyTimeList GetKeyTimeList(const KeyFrameListList& inputs);


### PR DESCRIPTION
FBX uses euler rotation but assimp library's base type is
quaternion. When assimp convert FBX some animation information
can be lost.
This patch interpolates euler-angle rotations and insert
additional keyframes for the FBX format.

#4215 