### PR TITLE
Fix file-extension check for X3D-files

### DIFF
--- a/code/AssetLib/X3D/X3DImporter.cpp
+++ b/code/AssetLib/X3D/X3DImporter.cpp
@@ -235,10 +235,8 @@ void X3DImporter::ParseFile(const std::string &file, IOSystem *pIOHandler) {
 
 bool X3DImporter::CanRead(const std::string &pFile, IOSystem * /*pIOHandler*/, bool checkSig) const {
     if (checkSig) {
-        std::string::size_type pos = pFile.find_last_of(".x3d");
-        if (pos != std::string::npos) {
+        if (GetExtension(pFile) == "x3d")
             return true;
-        }
     }
 
     return false;

--- a/code/AssetLib/X3D/X3DImporter_Group.cpp
+++ b/code/AssetLib/X3D/X3DImporter_Group.cpp
@@ -226,8 +226,13 @@ void X3DImporter::startReadTransform(XmlNode &node) {
     // if "USE" defined then find already defined element.
     if (!use.empty()) {
         X3DNodeElementBase *ne(nullptr);
-
+        bool newgroup = (nullptr == mNodeElementCur);
+        if(newgroup)
+            ParseHelper_Group_Begin();
         ne = MACRO_USE_CHECKANDAPPLY(node, def, use, ENET_Group, ne);
+        if (newgroup && isNodeEmpty(node)) {
+            ParseHelper_Node_Exit();
+        }
     } else {
         ParseHelper_Group_Begin(); // create new grouping element and go deeper if node has children.
         // at this place new group mode created and made current, so we can name it.

--- a/code/AssetLib/X3D/X3DImporter_Group.cpp
+++ b/code/AssetLib/X3D/X3DImporter_Group.cpp
@@ -72,7 +72,7 @@ void X3DImporter::startReadGroup(XmlNode &node) {
 
     // if "USE" defined then find already defined element.
     if (!use.empty()) {
-        X3DNodeElementBase *ne = nullptr;
+        X3DNodeElementBase *ne(nullptr);
         ne = MACRO_USE_CHECKANDAPPLY(node, def, use, ENET_Group, ne);
     } else {
         ParseHelper_Group_Begin(); // create new grouping element and go deeper if node has children.
@@ -110,7 +110,7 @@ void X3DImporter::startReadStaticGroup(XmlNode &node) {
 
     // if "USE" defined then find already defined element.
     if (!use.empty()) {
-        X3DNodeElementBase *ne = nullptr;
+        X3DNodeElementBase *ne(nullptr);
 
         ne = MACRO_USE_CHECKANDAPPLY(node, def, use, ENET_Group, ne);
     } else {
@@ -153,7 +153,7 @@ void X3DImporter::startReadSwitch(XmlNode &node) {
 
     // if "USE" defined then find already defined element.
     if (!use.empty()) {
-        X3DNodeElementBase *ne=nullptr;
+        X3DNodeElementBase *ne(nullptr);
 
         ne = MACRO_USE_CHECKANDAPPLY(node, def, use, ENET_Group, ne);
     } else {

--- a/code/AssetLib/X3D/X3DImporter_Macro.hpp
+++ b/code/AssetLib/X3D/X3DImporter_Macro.hpp
@@ -60,14 +60,12 @@ namespace Assimp {
 /// \param [in] pType - type of element to find.
 /// \param [out] pNE - pointer to found node element.
 inline X3DNodeElementBase *X3DImporter::MACRO_USE_CHECKANDAPPLY(XmlNode &node, std::string pDEF, std::string pUSE, X3DElemType pType, X3DNodeElementBase *pNE) {
-    if (nullptr == mNodeElementCur) {
-        printf("here\n");
-    }
     checkNodeMustBeEmpty(node);
     if (!pDEF.empty())
         Assimp::Throw_DEF_And_USE(node.name());
     if (!FindNodeElement(pUSE, pType, &pNE))
         Assimp::Throw_USE_NotFound(node.name(), pUSE);
+    ai_assert(nullptr != mNodeElementCur);
     mNodeElementCur->Children.push_back(pNE); /* add found object as child to current element */
 
     return pNE;


### PR DESCRIPTION
using the pre-existing and well-tested GetExtension() (which happens to also normalize the extension), rather than attempting a new buggy implementation of the same thing...

Closes: https://github.com/assimp/assimp/issues/4177