### PR TITLE
Bugfix/import crashes

### DIFF
--- a/code/AssetLib/LWO/LWOLoader.cpp
+++ b/code/AssetLib/LWO/LWOLoader.cpp
@@ -393,7 +393,7 @@ void LWOImporter::InternReadFile(const std::string &pFile,
 
                             // If a RGB color map is explicitly requested delete the
                             // alpha channel - it could theoretically be != 1.
-                            if (_mSurfaces[i].mVCMapType == AI_LWO_RGB)
+                            if (_mSurfaces[j].mVCMapType == AI_LWO_RGB)
                                 pvVC[w]->a = 1.f;
 
                             pvVC[w]++;

--- a/code/PostProcessing/RemoveRedundantMaterials.cpp
+++ b/code/PostProcessing/RemoveRedundantMaterials.cpp
@@ -50,6 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/ParsingUtils.h>
 #include "ProcessHelper.h"
 #include "Material/MaterialSystem.h"
+#include <assimp/Exceptional.h>
 #include <stdio.h>
 
 using namespace Assimp;
@@ -171,6 +172,8 @@ void RemoveRedundantMatsProcess::Execute( aiScene* pScene)
         }
         // If the new material count differs from the original,
         // we need to rebuild the material list and remap mesh material indexes.
+        if(iNewNum < 1)
+          throw DeadlyImportError("No materials remaining");
         if (iNewNum != pScene->mNumMaterials) {
             ai_assert(iNewNum > 0);
             aiMaterial** ppcMaterials = new aiMaterial*[iNewNum];


### PR DESCRIPTION
this fixes a few crashes when running `assimp info` on the test-models.

notably:
- `LWOImporter`: it seems there was a typo, swapping `j` for `i` (loop-vars rock!), which would create an out-of-bounds access on a vector
  - Closes: #4209 
- `RemoveRedundantMatsProcess`: this crashed on an assertion (that there are actually materials left after removing all the redundant ones). i replaced the assertion by a throwing a `DeadlyImportError`
  - the documentation of BaseProcess says that the *process()* method should raise an `ImportErrorException`: https://github.com/assimp/assimp/blob/70f5cca9c3ebd84b89c5775852ac9aa2449f6c5b/code/Common/BaseProcess.h#L217-L224
    however, there is no such exception and other postprocessors used the `DeadlyImportError`, so i used that one as well (probably the docs should be updated)
    - Closes: #4224 
    - Closes: #4225 