### PR TITLE
Bug: Export crashes when any of the meshes contains texture coordinate names #4243

### DIFF
--- a/code/Common/SceneCombiner.cpp
+++ b/code/Common/SceneCombiner.cpp
@@ -1101,6 +1101,14 @@ void SceneCombiner::Copy(aiMesh **_dest, const aiMesh *src) {
 
     // make a deep copy of all blend shapes
     CopyPtrArray(dest->mAnimMeshes, dest->mAnimMeshes, dest->mNumAnimMeshes);
+
+    // make a deep copy of all texture coordinate names
+    if (src->mTextureCoordsNames != nullptr) {
+        dest->mTextureCoordsNames = new aiString *[AI_MAX_NUMBER_OF_TEXTURECOORDS] {};
+        for (unsigned int i = 0; i < AI_MAX_NUMBER_OF_TEXTURECOORDS; ++i) {
+            Copy(&dest->mTextureCoordsNames[i], src->mTextureCoordsNames[i]);
+        }
+    }
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -1346,6 +1354,18 @@ void SceneCombiner::Copy(aiMetadata **_dest, const aiMetadata *src) {
             break;
         }
     }
+}
+
+// ------------------------------------------------------------------------------------------------
+void SceneCombiner::Copy(aiString **_dest, const aiString *src) {
+    if (nullptr == _dest || nullptr == src) {
+        return;
+    }
+
+    aiString *dest = *_dest = new aiString();
+
+    // get a flat copy
+    *dest = *src;
 }
 
 #if (__GNUC__ >= 8 && __GNUC_MINOR__ >= 0)

--- a/include/assimp/SceneCombiner.h
+++ b/include/assimp/SceneCombiner.h
@@ -361,6 +361,7 @@ public:
     static void Copy(aiNodeAnim **dest, const aiNodeAnim *src);
     static void Copy(aiMeshMorphAnim **dest, const aiMeshMorphAnim *src);
     static void Copy(aiMetadata **dest, const aiMetadata *src);
+    static void Copy(aiString **dest, const aiString *src);
 
     // recursive, of course
     static void Copy(aiNode **dest, const aiNode *src);

--- a/test/unit/Common/uiScene.cpp
+++ b/test/unit/Common/uiScene.cpp
@@ -42,6 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "UnitTestPCH.h"
 
 #include <assimp/scene.h>
+#include <assimp/SceneCombiner.h>
 
 using namespace Assimp;
 
@@ -86,6 +87,22 @@ TEST_F(utScene, getShortFilenameTest) {
     std::string long_filename2 = "foo_bar\\name";
     const char *name2 = scene->GetShortFilename(long_filename2.c_str());
 	EXPECT_NE(nullptr, name2);
+}
+
+TEST_F(utScene, deepCopyTest) {
+    scene->mRootNode = new aiNode();
+    
+    scene->mNumMeshes = 1;
+    scene->mMeshes = new aiMesh *[scene->mNumMeshes] ();
+    scene->mMeshes[0] = new aiMesh ();
+
+    scene->mMeshes[0]->SetTextureCoordsName (0, aiString ("test"));
+
+    {
+        aiScene* copied = nullptr;
+        SceneCombiner::CopyScene(&copied,scene);
+        delete copied;
+    }
 }
 
 TEST_F(utScene, getEmbeddedTextureTest) {


### PR DESCRIPTION
Copy `mTextureCoordsNames` when copying a mesh.