### PR TITLE
Fix duplicate call to Export function

### DIFF
--- a/code/Common/Exporter.cpp
+++ b/code/Common/Exporter.cpp
@@ -445,8 +445,7 @@ aiReturn Exporter::Export( const aiScene* pScene, const char* pFormatId, const c
 
                 ExportProperties emptyProperties;  // Never pass NULL ExportProperties so Exporters don't have to worry.
                 ExportProperties* pProp = pProperties ? (ExportProperties*)pProperties : &emptyProperties;
-                                pProp->SetPropertyBool("bJoinIdenticalVertices", must_join_again);
-                                exp.mExportFunction(pPath,pimpl->mIOSystem.get(),scenecopy.get(), pProp);
+                pProp->SetPropertyBool("bJoinIdenticalVertices", must_join_again);
                 exp.mExportFunction(pPath,pimpl->mIOSystem.get(),scenecopy.get(), pProp);
 
                 pimpl->mProgressHandler->UpdateFileWrite(4, 4);


### PR DESCRIPTION
In the exporter the `exp.mExportFunction` is called twice, the indentation it's also broken