### PR TITLE
Make sure no overflow can happen

### DIFF
--- a/code/Common/BaseImporter.cpp
+++ b/code/Common/BaseImporter.cpp
@@ -377,7 +377,7 @@ void BaseImporter::ConvertToUTF8(std::vector<char> &data) {
         // swap the endianness ..
         for (uint16_t *p = (uint16_t *)&data.front(), *end = (uint16_t *)&data.back(); p <= end; ++p) {
             // Check to ensure no overflow can happen
-            if ((index+2) < data.Size()) {
+            if ((index+2) < data.size()) {
                 // Swap the data
                 ByteSwap::Swap2(p);
                 index += 2;

--- a/code/Common/BaseImporter.cpp
+++ b/code/Common/BaseImporter.cpp
@@ -372,16 +372,14 @@ void BaseImporter::ConvertToUTF8(std::vector<char> &data) {
     }
 
     // UTF 16 BE with BOM
-    size_t index = 0;
     if (*((uint16_t *)&data.front()) == 0xFFFE) {
+        // Check to ensure no overflow can happen
+        if(data.size() % 2 != 0) {
+            return;
+        }
         // swap the endianness ..
         for (uint16_t *p = (uint16_t *)&data.front(), *end = (uint16_t *)&data.back(); p <= end; ++p) {
-            // Check to ensure no overflow can happen
-            if ((index+2) < data.size()) {
-                // Swap the data
-                ByteSwap::Swap2(p);
-                index += 2;
-            }
+            ByteSwap::Swap2(p);
         }
     }
 

--- a/code/Common/BaseImporter.cpp
+++ b/code/Common/BaseImporter.cpp
@@ -65,6 +65,7 @@ using namespace Assimp;
 // Constructor to be privately used by Importer
 BaseImporter::BaseImporter() AI_NO_EXCEPT
         : m_progress() {
+    // empty
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -371,11 +372,16 @@ void BaseImporter::ConvertToUTF8(std::vector<char> &data) {
     }
 
     // UTF 16 BE with BOM
+    size_t index = 0;
     if (*((uint16_t *)&data.front()) == 0xFFFE) {
-
         // swap the endianness ..
         for (uint16_t *p = (uint16_t *)&data.front(), *end = (uint16_t *)&data.back(); p <= end; ++p) {
-            ByteSwap::Swap2(p);
+            // Check to ensure no overflow can happen
+            if ((index+2) < data.Size()) {
+                // Swap the data
+                ByteSwap::Swap2(p);
+                index += 2;
+            }
         }
     }
 


### PR DESCRIPTION
- During UTF32 LE with BOM make sure that the byteswap operation will have enough space when iterating through the text buffer, which shall get encoded.
- closes https://github.com/assimp/assimp/issues/4230