### PR TITLE
MDL: Do not try to copy empty embedded texture

### DIFF
--- a/code/AssetLib/MDL/MDLMaterialLoader.cpp
+++ b/code/AssetLib/MDL/MDLMaterialLoader.cpp
@@ -463,8 +463,12 @@ void MDLImporter::ParseSkinLump_3DGS_MDL7(
             ASSIMP_LOG_WARN("Found a reference to an embedded DDS texture, "
                             "but texture height is not equal to 1, which is not supported by MED");
         }
-
-        pcNew.reset(new aiTexture());
+        if (iWidth == 0) {
+            ASSIMP_LOG_ERROR("Found a reference to an embedded DDS texture, but texture width is zero, aborting import.");
+            return;
+        }
+        
+        pcNew.reset(new aiTexture);
         pcNew->mHeight = 0;
         pcNew->mWidth = iWidth;
 


### PR DESCRIPTION
- When an embedded texture is empty, skip it instead of trying to copy it. This must fail.
- closes https://github.com/assimp/assimp/issues/4238
- Found from the Google fuzzer.