### PR TITLE
Fixes "too many sections" error with MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -295,6 +295,7 @@ ELSEIF( CMAKE_COMPILER_IS_MINGW )
   ENDIF()
   SET(CMAKE_CXX_FLAGS "-fvisibility=hidden -fno-strict-aliasing -Wall -Wno-long-long -Wa,-mbig-obj -O3 ${CMAKE_CXX_FLAGS}")
   SET(CMAKE_C_FLAGS "-fno-strict-aliasing ${CMAKE_C_FLAGS}")
+  ADD_COMPILE_OPTIONS(-Wa,-mbig-obj)
 ENDIF()
 
 IF ( IOS AND NOT ASSIMP_HUNTER_ENABLED)


### PR DESCRIPTION
Hi.

I've been encountering the same issue as #1708 but with MinGW ([see compilation log](https://github.com/DigitalPulseSoftware/NazaraEngine/runs/4631331502?check_suite_focus=true#step:9:3588)):
```
D:/a/_temp/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/11.2.0/../../../../x86_64-w64-mingw32/bin/as.exe: CMakeFiles/assimp.dir/Importer/IFC/IFCReaderGen1_2x3.cpp.obj: too many sections (65884)
C:\Users\RUNNER~1\AppData\Local\Temp\ccw1ZPdq.s: Assembler messages:
C:\Users\RUNNER~1\AppData\Local\Temp\ccw1ZPdq.s: Fatal error: can't write 180 bytes to section .text of CMakeFiles/assimp.dir/Importer/IFC/IFCReaderGen1_2x3.cpp.obj: 'file too big'
D:/a/_temp/msys64/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/11.2.0/../../../../x86_64-w64-mingw32/bin/as.exe: CMakeFiles/assimp.dir/Importer/IFC/IFCReaderGen1_2x3.cpp.obj: too many sections (65884)
```

This can be fixed by adding [MinGW equivalent of /bigobj option](https://stackoverflow.com/questions/16596876/gcc-equivalent-of-mss-bigobj)