### PR TITLE
Fix bone fitted check in gltf2 exporter

### DIFF
--- a/code/AssetLib/glTF2/glTF2Exporter.cpp
+++ b/code/AssetLib/glTF2/glTF2Exporter.cpp
@@ -972,7 +972,7 @@ void ExportSkin(Asset &mAsset, const aiMesh *aimesh, Ref<Mesh> &meshRef, Ref<Buf
             }
             if (jointsPerVertex[vertexId] > 3) {
                 int boneIndexFitted = FitBoneWeight(vertexWeightData[vertexId], vertWeight);
-                if (boneIndexFitted) {
+                if (boneIndexFitted != -1) {
                     vertexJointData[vertexId][boneIndexFitted] = static_cast<float>(jointNamesIndex);
                 }
             }else {


### PR DESCRIPTION
I'm not entirely sure what's going on here but this seems to fix a crash I encountered with some models