### PR TITLE
Add link to used enum for a better understandability

### DIFF
--- a/include/assimp/mesh.h
+++ b/include/assimp/mesh.h
@@ -740,6 +740,7 @@ struct aiMesh {
 
     /**
      *  Method of morphing when anim-meshes are specified.
+     *  @see aiMorphingMethod to learn more about the provided morphing targets.
      */
     unsigned int mMethod;
 


### PR DESCRIPTION
- Add link to enum which describes the used morphing method in an instance of an aiMesh for the case, that this instance will be used as an AnimMesh-instance.
- closes https://github.com/assimp/assimp/issues/4320