### PR TITLE
ASE: Fix material parsing

### DIFF
--- a/code/AssetLib/ASE/ASEParser.cpp
+++ b/code/AssetLib/ASE/ASEParser.cpp
@@ -486,8 +486,9 @@ void Parser::ParseLV1MaterialListBlock() {
                 ParseLV4MeshLong(iIndex);
 
                 if (iIndex >= iMaterialCount) {
-                    LogWarning("Out of range: material index is too large");
+                    LogError("Out of range: material index is too large");
                     iIndex = iMaterialCount - 1;
+                    return;
                 }
 
                 // get a reference to the material


### PR DESCRIPTION
- Fuzzer error found when material access get's an out-of-bound access.
- Break parsing when material index gets out of range.
- closes https://github.com/assimp/assimp/issues/4232