### PR TITLE
Fix warning C4702 (unreacheable code) treated as error in win build

### DIFF
--- a/code/AssetLib/ASE/ASEParser.cpp
+++ b/code/AssetLib/ASE/ASEParser.cpp
@@ -487,8 +487,6 @@ void Parser::ParseLV1MaterialListBlock() {
 
                 if (iIndex >= iMaterialCount) {
                     LogError("Out of range: material index is too large");
-                    iIndex = iMaterialCount - 1;
-                    return;
                 }
 
                 // get a reference to the material


### PR DESCRIPTION
Hello! Faced such a problem: I could not build assimp with default cmake flags (i just did `cmake .\CMakeLists.txt` in main dir):
```
C:\assimp\code\AssetLib\ASE\ASEParser.cpp(490): error C2220: the following warning is treated as an error [C:\assimp\code\assimp.vcxproj]
C:\assimp\code\AssetLib\ASE\ASEParser.cpp(490): warning C4702: unreachable code [C:\assimp\code\assimp.vc
xproj]
```
Environment: Windows 10, build 21H1, x64
Compiler: MSVC Version 19.29.30139

I looked at the code and made a possible fix: since `Parser::LogError` throw exception, no matter what will be in the scope after condition. 

I don’t know why your builds work on Github Actions CI, but my local one doesn't work without this fix.