### PR TITLE
use fully qualified namespace in byteswap macros

### DIFF
--- a/include/assimp/ByteSwapper.h
+++ b/include/assimp/ByteSwapper.h
@@ -211,7 +211,7 @@ template <typename T> struct ByteSwap::_swapper<T,8> {
 // --------------------------------------------------------------------------------------
 #if (defined AI_BUILD_BIG_ENDIAN)
 #   define AI_LE(t) (t)
-#   define AI_BE(t) ByteSwap::Swapped(t)
+#   define AI_BE(t) Assimp::ByteSwap::Swapped(t)
 #   define AI_LSWAP2(p)
 #   define AI_LSWAP4(p)
 #   define AI_LSWAP8(p)
@@ -219,16 +219,16 @@ template <typename T> struct ByteSwap::_swapper<T,8> {
 #   define AI_LSWAP4P(p)
 #   define AI_LSWAP8P(p)
 #   define LE_NCONST const
-#   define AI_SWAP2(p) ByteSwap::Swap2(&(p))
-#   define AI_SWAP4(p) ByteSwap::Swap4(&(p))
-#   define AI_SWAP8(p) ByteSwap::Swap8(&(p))
-#   define AI_SWAP2P(p) ByteSwap::Swap2((p))
-#   define AI_SWAP4P(p) ByteSwap::Swap4((p))
-#   define AI_SWAP8P(p) ByteSwap::Swap8((p))
+#   define AI_SWAP2(p) Assimp::ByteSwap::Swap2(&(p))
+#   define AI_SWAP4(p) Assimp::ByteSwap::Swap4(&(p))
+#   define AI_SWAP8(p) Assimp::ByteSwap::Swap8(&(p))
+#   define AI_SWAP2P(p) Assimp::ByteSwap::Swap2((p))
+#   define AI_SWAP4P(p) Assimp::ByteSwap::Swap4((p))
+#   define AI_SWAP8P(p) Assimp::ByteSwap::Swap8((p))
 #   define BE_NCONST
 #else
 #   define AI_BE(t) (t)
-#   define AI_LE(t) ByteSwap::Swapped(t)
+#   define AI_LE(t) Assimp::ByteSwap::Swapped(t)
 #   define AI_SWAP2(p)
 #   define AI_SWAP4(p)
 #   define AI_SWAP8(p)
@@ -236,12 +236,12 @@ template <typename T> struct ByteSwap::_swapper<T,8> {
 #   define AI_SWAP4P(p)
 #   define AI_SWAP8P(p)
 #   define BE_NCONST const
-#   define AI_LSWAP2(p)     ByteSwap::Swap2(&(p))
-#   define AI_LSWAP4(p)     ByteSwap::Swap4(&(p))
-#   define AI_LSWAP8(p)     ByteSwap::Swap8(&(p))
-#   define AI_LSWAP2P(p)    ByteSwap::Swap2((p))
-#   define AI_LSWAP4P(p)    ByteSwap::Swap4((p))
-#   define AI_LSWAP8P(p)    ByteSwap::Swap8((p))
+#   define AI_LSWAP2(p)     Assimp::ByteSwap::Swap2(&(p))
+#   define AI_LSWAP4(p)     Assimp::ByteSwap::Swap4(&(p))
+#   define AI_LSWAP8(p)     Assimp::ByteSwap::Swap8(&(p))
+#   define AI_LSWAP2P(p)    Assimp::ByteSwap::Swap2((p))
+#   define AI_LSWAP4P(p)    Assimp::ByteSwap::Swap4((p))
+#   define AI_LSWAP8P(p)    Assimp::ByteSwap::Swap8((p))
 #   define LE_NCONST
 #endif
 


### PR DESCRIPTION
the `AI_SWAP4` macros and friends assume that they are called in a context that resolves the `Assimp` namespace.

rather than adding an explicit namespace to the macro-invocation whereever it is used (as suggested in #4360), this PR modifies the macros themselves so they are expanded with the full namespace.


Closes: https://github.com/assimp/assimp/issues/4358