### PR TITLE
fix missing include for size_t

### DIFF
--- a/code/Common/Compression.h
+++ b/code/Common/Compression.h
@@ -42,6 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 #include <vector>
+#include <cstddef> // size_t
 
 namespace Assimp {
 


### PR DESCRIPTION
gcc11 seems to have changed some internal includes:

```
[ 10%] Building CXX object externals/assimp/assimp/code/CMakeFiles/assimp.dir/Common/Compression.cpp.o
In file included from /home/runner/work/cage/cage/externals/assimp/assimp/code/Common/Compression.cpp:42:
/home/runner/work/cage/cage/externals/assimp/assimp/code/Common/Compression.h:73:5: error: ‘size_t’ does not name a type
   73 |     size_t decompress(unsigned char *data, size_t in, std::vector<unsigned char> &uncompressed);
      |     ^~~~~~
/home/runner/work/cage/cage/externals/assimp/assimp/code/Common/Compression.h:45:1: note: ‘size_t’ is defined in header ‘<cstddef>’; did you forget to ‘#include <cstddef>’?
   44 | #include <vector>
  +++ |+#include <cstddef>
   45 | 
```

