### PR TITLE
Fix stat for 32-biut linuxes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,6 +243,13 @@ SET(ASSIMP_LIBRARY_SUFFIX "" CACHE STRING "Suffix to append to library names")
 IF( UNIX )
   # Use GNUInstallDirs for Unix predefined directories
   INCLUDE(GNUInstallDirs)
+  # Ensure that we do not run into issues like http://www.tcm.phy.cam.ac.uk/sw/inodes64.html on 32 bit linux
+  IF( ${OPERATING_SYSTEM} MATCHES "Android")
+  ELSE()
+    IF ( CMAKE_SIZEOF_VOID_P EQUAL 4) # only necessary for 32-bit linux
+      #ADD_DEFINITIONS(-D_FILE_OFFSET_BITS=64 )
+    ENDIF()
+  ENDIF()
 ENDIF()
 
 # Grouped compiler settings ########################################


### PR DESCRIPTION
- Reenable fix to ensure that stat works correctly on 32-bit linuxes again
  - stat will return 32-bit inodes when checking a file. So when this call will be used on a 64-bit linux this will cause errors like:
Error writing to foo: Value too large for defined data type
File I/O error: foo
- closes https://github.com/assimp/assimp/issues/4390