### PR TITLE
Expose the original OBJ "illum" value

### DIFF
--- a/code/AssetLib/Obj/ObjFileImporter.cpp
+++ b/code/AssetLib/Obj/ObjFileImporter.cpp
@@ -605,6 +605,9 @@ void ObjFileImporter::createMaterials(const ObjFile::Model *pModel, aiScene *pSc
 
         mat->AddProperty<int>(&sm, 1, AI_MATKEY_SHADING_MODEL);
 
+        // Preserve the original illum value
+        mat->AddProperty<int>(&pCurrentMaterial->illumination_model, 1, AI_MATKEY_OBJ_ILLUM);
+
         // Adding material colors
         mat->AddProperty(&pCurrentMaterial->ambient, 1, AI_MATKEY_COLOR_AMBIENT);
         mat->AddProperty(&pCurrentMaterial->diffuse, 1, AI_MATKEY_COLOR_DIFFUSE);

--- a/include/assimp/ObjMaterial.h
+++ b/include/assimp/ObjMaterial.h
@@ -54,6 +54,13 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/material.h>
 
 // ---------------------------------------------------------------------------
+
+// the original illum property
+#define AI_MATKEY_OBJ_ILLUM "$mat.illum", 0, 0
+
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
 // Pure key names for all obj texture-related properties
 //! @cond MATS_DOC_FULL
 


### PR DESCRIPTION
This commit exposes the original Obj model  `illum` value (illumination_model) as a material property. 

The `illum` value is defined in a .mtl material file like so:
`illum 3`

Background:
`ObjFileImporter::createMaterials` in `ObjFileImporter.cpp` partially interprets the illum value as an `aiShadingMode` enum and stores it in the `AI_MATKEY_SHADING_MODEL` material property. Illumination model values 3 thru 10 are lost in the interpretation. Exposing the original illum value allows user interpretation of the intended model.

Example accessor usage:
`    aiScene* scene = ...`
`    int illum = 1;`
`    aiMaterial* mtl = scene->mMaterials[m];`
`    aiGetMaterialInteger(mtl, AI_MATKEY_OBJ_ILLUM, &illum);`
