### PR TITLE
Fix 'i >= 0' always true bug

### DIFF
--- a/code/Common/ZipArchiveIOSystem.cpp
+++ b/code/Common/ZipArchiveIOSystem.cpp
@@ -126,7 +126,7 @@ voidpf IOSystem2Unzip::opendisk(voidpf opaque, voidpf stream, uint32_t number_di
 
     char *disk_filename = (char*)malloc(io_stream->m_Filename.length() + 1);
     strncpy(disk_filename, io_stream->m_Filename.c_str(), io_stream->m_Filename.length() + 1);
-    for (i = io_stream->m_Filename.length() - 1; i >= 0; i -= 1)
+    for (i = (int)io_stream->m_Filename.length() - 1; i >= 0; i -= 1)
     {
         if (disk_filename[i] != '.')
             continue;

--- a/code/Common/ZipArchiveIOSystem.cpp
+++ b/code/Common/ZipArchiveIOSystem.cpp
@@ -122,7 +122,7 @@ voidpf IOSystem2Unzip::open(voidpf opaque, const char *filename, int mode) {
 voidpf IOSystem2Unzip::opendisk(voidpf opaque, voidpf stream, uint32_t number_disk, int mode) {
     ZipFile *io_stream = (ZipFile *)stream;
     voidpf ret = NULL;
-    size_t i;
+    int i;
 
     char *disk_filename = (char*)malloc(io_stream->m_Filename.length() + 1);
     strncpy(disk_filename, io_stream->m_Filename.c_str(), io_stream->m_Filename.length() + 1);
@@ -130,7 +130,7 @@ voidpf IOSystem2Unzip::opendisk(voidpf opaque, voidpf stream, uint32_t number_di
     {
         if (disk_filename[i] != '.')
             continue;
-        snprintf(&disk_filename[i], io_stream->m_Filename.length() - i, ".z%02u", number_disk + 1);
+        snprintf(&disk_filename[i], io_stream->m_Filename.length() - size_t(i), ".z%02u", number_disk + 1);
         break;
     }
 


### PR DESCRIPTION
If 'disk_filename' does not contain a dot (.) then 'i' would overflow.
Making 'i' an int makes sure the for loop works as intended.