### PR TITLE
Add USE_STATIC_CRT option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,27 @@ IF (WIN32)
       # Multibyte character set is deprecated since at least MSVC2015 (possibly earlier)
       ADD_DEFINITIONS( -DUNICODE -D_UNICODE )
     ENDIF()
+
+    # Link statically against c/c++ lib to avoid missing redistriburable such as
+    # "VCRUNTIME140.dll not found. Try reinstalling the app.", but give users
+    # a choice to opt for the shared runtime if they want.
+    option(USE_STATIC_CRT "Link against the static runtime libraries." OFF)
+
+    # The CMAKE_CXX_FLAGS vars can be overriden by some Visual Studio generators, so we use an alternative
+    # global method here:
+    if (${USE_STATIC_CRT})
+      add_compile_options(
+          $<$<CONFIG:>:/MT>
+          $<$<CONFIG:Debug>:/MTd>
+          $<$<CONFIG:Release>:/MT>
+      )
+    else()
+      add_compile_options(
+          $<$<CONFIG:>:/MD>
+          $<$<CONFIG:Debug>:/MDd>
+          $<$<CONFIG:Release>:/MD>
+      )
+    endif()
   ENDIF()
 ENDIF()
 


### PR DESCRIPTION
Allow user to choose C runtime library version, on Windows

This PR adds an option to cmake, `USE_STATIC_CRT`.

The default is OFF, which has no changes to the current build.