### PR TITLE
GLTF2 attribute name/parse bug fix

### DIFF
--- a/code/AssetLib/glTF2/glTF2Asset.inl
+++ b/code/AssetLib/glTF2/glTF2Asset.inl
@@ -179,11 +179,11 @@ inline bool GetAttribVector(Mesh::Primitive &p, const char *attr, Mesh::Accessor
         v = &(p.attributes.texcoord);
     } else if ((pos = Compare(attr, "COLOR"))) {
         v = &(p.attributes.color);
-    } else if ((pos = Compare(attr, "JOINT"))) {
+    } else if ((pos = Compare(attr, "JOINTS"))) {
         v = &(p.attributes.joint);
     } else if ((pos = Compare(attr, "JOINTMATRIX"))) {
         v = &(p.attributes.jointmatrix);
-    } else if ((pos = Compare(attr, "WEIGHT"))) {
+    } else if ((pos = Compare(attr, "WEIGHTS"))) {
         v = &(p.attributes.weight);
     } else
         return false;


### PR DESCRIPTION
Fixing mistakes in attribute names for GLTF. This causes attribute index to not be parsed out correctly (e.g. JOINTS_1) and fails the scene load. See https://github.com/assimp/assimp/blob/a916a0eda5dfa5c9d1a6f0c4657af6d40886f0a8/code/AssetLib/glTF2/glTF2Asset.inl#L1380 for where the parsing breaks.