### PR TITLE
Pragma warnings cause build fail with MinGW

### DIFF
--- a/contrib/unzip/crypt.c
+++ b/contrib/unzip/crypt.c
@@ -43,10 +43,10 @@
 
 #include "crypt.h"
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #   pragma warning(push)
 #   pragma warning(disable : 4244)
-#endif // _WIN32
+#endif // _MSC_VER
 
 /***************************************************************************/
 
@@ -164,8 +164,8 @@ int crypthead(const char *passwd, uint8_t *buf, int buf_size, uint32_t *pkeys,
     return n;
 }
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #   pragma warning(pop)
-#endif // _WIN32
+#endif // _MSC_VER
 
 /***************************************************************************/

--- a/contrib/unzip/crypt.c
+++ b/contrib/unzip/crypt.c
@@ -43,6 +43,11 @@
 
 #include "crypt.h"
 
+#ifdef _WIN32
+#   pragma warning(push)
+#   pragma warning(disable : 4244)
+#endif // _WIN32
+
 /***************************************************************************/
 
 #define CRC32(c, b) ((*(pcrc_32_tab+(((uint32_t)(c) ^ (b)) & 0xff))) ^ ((c) >> 8))
@@ -158,5 +163,9 @@ int crypthead(const char *passwd, uint8_t *buf, int buf_size, uint32_t *pkeys,
     buf[n++] = (uint8_t)zencode(pkeys, pcrc_32_tab, verify2, t);
     return n;
 }
+
+#ifdef _WIN32
+#   pragma warning(pop)
+#endif // _WIN32
 
 /***************************************************************************/

--- a/contrib/unzip/crypt.c
+++ b/contrib/unzip/crypt.c
@@ -43,11 +43,6 @@
 
 #include "crypt.h"
 
-#ifdef _WIN32
-#   pragma warning(push)
-#   pragma warning(disable : 4244)
-#endif // _WIN32
-
 /***************************************************************************/
 
 #define CRC32(c, b) ((*(pcrc_32_tab+(((uint32_t)(c) ^ (b)) & 0xff))) ^ ((c) >> 8))
@@ -163,9 +158,5 @@ int crypthead(const char *passwd, uint8_t *buf, int buf_size, uint32_t *pkeys,
     buf[n++] = (uint8_t)zencode(pkeys, pcrc_32_tab, verify2, t);
     return n;
 }
-
-#ifdef _WIN32
-#   pragma warning(pop)
-#endif // _WIN32
 
 /***************************************************************************/

--- a/contrib/unzip/ioapi.c
+++ b/contrib/unzip/ioapi.c
@@ -23,8 +23,10 @@
 
 #ifdef _WIN32
 #   define snprintf _snprintf
+#ifdef _MSC_VER
 #   pragma warning(push)
 #   pragma warning(disable : 4131 4100)
+#endif
 #   ifdef __clang__
 #       pragma clang diagnostic push
 #       pragma clang diagnostic ignored "-Wunused-parameter"
@@ -357,9 +359,9 @@ void fill_fopen64_filefunc(zlib_filefunc64_def *pzlib_filefunc_def)
     pzlib_filefunc_def->opaque = NULL;
 }
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #   pragma warning(pop)
 #   ifdef __clang__
 #       pragma clang diagnostic pop
 #   endif
-#endif // _WIN32
+#endif // _MSC_VER

--- a/contrib/unzip/ioapi.c
+++ b/contrib/unzip/ioapi.c
@@ -23,6 +23,8 @@
 
 #ifdef _WIN32
 #   define snprintf _snprintf
+#   pragma warning(push)
+#   pragma warning(disable : 4131 4100)
 #   ifdef __clang__
 #       pragma clang diagnostic push
 #       pragma clang diagnostic ignored "-Wunused-parameter"
@@ -356,6 +358,7 @@ void fill_fopen64_filefunc(zlib_filefunc64_def *pzlib_filefunc_def)
 }
 
 #ifdef _WIN32
+#   pragma warning(pop)
 #   ifdef __clang__
 #       pragma clang diagnostic pop
 #   endif

--- a/contrib/unzip/ioapi.c
+++ b/contrib/unzip/ioapi.c
@@ -23,8 +23,6 @@
 
 #ifdef _WIN32
 #   define snprintf _snprintf
-#   pragma warning(push)
-#   pragma warning(disable : 4131 4100)
 #   ifdef __clang__
 #       pragma clang diagnostic push
 #       pragma clang diagnostic ignored "-Wunused-parameter"
@@ -358,7 +356,6 @@ void fill_fopen64_filefunc(zlib_filefunc64_def *pzlib_filefunc_def)
 }
 
 #ifdef _WIN32
-#   pragma warning(pop)
 #   ifdef __clang__
 #       pragma clang diagnostic pop
 #   endif

--- a/contrib/unzip/unzip.c
+++ b/contrib/unzip/unzip.c
@@ -73,10 +73,10 @@
 #  define TRYFREE(p) {if (p) free(p);}
 #endif
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #   pragma warning(push)
 #   pragma warning(disable : 4131 4244 4189 4245)
-#endif // _WIN32
+#endif // _MSC_VER
 
 const char unz_copyright[] =
    " unzip 1.01 Copyright 1998-2004 Gilles Vollant - http://www.winimage.com/zLibDll";
@@ -1995,6 +1995,6 @@ extern int ZEXPORT unzEndOfFile(unzFile file)
     return 0;
 }
 
-#ifdef _WIN32
+#ifdef _MSC_VER
 #   pragma warning(pop)
-#endif // _WIN32
+#endif // _MSC_VER

--- a/contrib/unzip/unzip.c
+++ b/contrib/unzip/unzip.c
@@ -73,6 +73,11 @@
 #  define TRYFREE(p) {if (p) free(p);}
 #endif
 
+#ifdef _WIN32
+#   pragma warning(push)
+#   pragma warning(disable : 4131 4244 4189 4245)
+#endif // _WIN32
+
 const char unz_copyright[] =
    " unzip 1.01 Copyright 1998-2004 Gilles Vollant - http://www.winimage.com/zLibDll";
 
@@ -1989,3 +1994,7 @@ extern int ZEXPORT unzEndOfFile(unzFile file)
         return 1;
     return 0;
 }
+
+#ifdef _WIN32
+#   pragma warning(pop)
+#endif // _WIN32

--- a/contrib/unzip/unzip.c
+++ b/contrib/unzip/unzip.c
@@ -73,11 +73,6 @@
 #  define TRYFREE(p) {if (p) free(p);}
 #endif
 
-#ifdef _WIN32
-#   pragma warning(push)
-#   pragma warning(disable : 4131 4244 4189 4245)
-#endif // _WIN32
-
 const char unz_copyright[] =
    " unzip 1.01 Copyright 1998-2004 Gilles Vollant - http://www.winimage.com/zLibDll";
 
@@ -1994,7 +1989,3 @@ extern int ZEXPORT unzEndOfFile(unzFile file)
         return 1;
     return 0;
 }
-
-#ifdef _WIN32
-#   pragma warning(pop)
-#endif // _WIN32


### PR DESCRIPTION
Using pragma warning caused builds using MinGW bundled with the latest version of CLion (2022.1.2). Removing it seems to build correctly and fix the problem.