### PR TITLE
Add support for _WIN32

### DIFF
--- a/code/Common/DefaultIOStream.cpp
+++ b/code/Common/DefaultIOStream.cpp
@@ -156,7 +156,7 @@ size_t DefaultIOStream::FileSize() const {
         if (0 != err)
             return 0;
         mCachedSize = (size_t)(fileStat.st_size);
-#elif defined __GNUC__ || defined __APPLE__ || defined __MACH__ || defined __FreeBSD__
+#elif defined __GNUC__ || defined __APPLE__ || defined __MACH__ || defined __FreeBSD__ || defined _WIN32
         struct stat fileStat;
         int err = stat(mFilename.c_str(), &fileStat);
         if (0 != err)


### PR DESCRIPTION
My machine failed to compile this project with the MSVC, but does succeed with MinGW. I edited this pragma to add a check for _WIN32 to the 32-bit variant of the code. My computer then compiled the project successfully under both the MSVC and MinGW. MinGW seemed to use the 64-bit variant while the MSVC used the 32-bit variant. Perhaps I am fixing this in a way that makes it bad, but this fix does make it functional, at least on my machine.