### PR TITLE
Use mingw.include

### DIFF
--- a/code/res/assimp.rc
+++ b/code/res/assimp.rc
@@ -1,5 +1,9 @@
 #include "revision.h"
+#ifdef __GNUC__
+#include "winresrc.h"
+#else
 #include "winres.h"
+#endif
 
 LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
 #pragma code_page(1252)


### PR DESCRIPTION
- mingw is using a different include to win32-specific resource files.
- closes https://github.com/assimp/assimp/issues/4586