### PR TITLE
Fix typo in installation instructions for ubuntu.

### DIFF
--- a/Build.md
+++ b/Build.md
@@ -14,7 +14,7 @@ The assimp port in vcpkg is kept up to date by Microsoft team members and commun
 ## Install on Ubuntu
 You can install the Asset-Importer-Lib via apt:
 ```
-sudp apt-get update
+sudo apt-get update
 sudo apt-get install libassimp-dev
 ```
 


### PR DESCRIPTION
Replace `sudp` by `sudo`.  