### PR TITLE
Build fix for compiling against minizip.

### DIFF
--- a/code/Common/ZipArchiveIOSystem.cpp
+++ b/code/Common/ZipArchiveIOSystem.cpp
@@ -196,7 +196,9 @@ zlib_filefunc_def IOSystem2Unzip::get(IOSystem *pIOHandler) {
     zlib_filefunc_def mapping;
 
     mapping.zopen_file = (open_file_func)open;
+#ifdef _UNZ_H
     mapping.zopendisk_file = (opendisk_file_func)opendisk;
+#endif
     mapping.zread_file = (read_file_func)read;
     mapping.zwrite_file = (write_file_func)write;
     mapping.ztell_file = (tell_file_func)tell;


### PR DESCRIPTION
From v5.1.6 onwards Assimp fails to build on my Ubuntu 21.10 system's default minizip install.  Looking at Issues tracker, #4334, others have the same build problem on a range of Linux distos.   I've added a #ifdef check around the problematic line to keep things compiling.

Unfortunately this #ifdef approach looks like it'll disable the functionality that caused this break in the build - I don't know how intrusive this would be as I'm not familiar with the wider code, there may well be more changes that would need disabling or handling to more elegantly handle these features that can't be implemented against minizip.

I provide this build fix so that others who are hitting up against the same problem can at least get Assimp built.