### PR TITLE
Fixes Heap-buffer-overflow in SuperFastHash

### DIFF
--- a/code/AssetLib/LWS/LWSLoader.cpp
+++ b/code/AssetLib/LWS/LWSLoader.cpp
@@ -313,6 +313,9 @@ void LWSImporter::SetupNodeName(aiNode *nd, LWS::NodeDesc &src) {
             std::string::size_type t = src.path.substr(s).find_last_of('.');
 
             nd->mName.length = ::ai_snprintf(nd->mName.data, MAXLEN, "%s_(%08X)", src.path.substr(s).substr(0, t).c_str(), combined);
+            if (nd->mName.length > MAXLEN) {
+                nd->mName.length = MAXLEN;
+            }
             return;
         }
     }


### PR DESCRIPTION
Fixes Heap-buffer-overflow in SuperFastHash revealed by fuzzing:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=44964

The root cause is that a call to `ai_snprintf` in `LWSImporter::SetupNodeName` returns the number of characters that would have been written if the buffer had been sufficiently large.
It leads to creation of `aiString` object with incorrect length that causes out of bounds buffer read in `SuperFastHash` later.