### PR TITLE
Fixes Heap-use-after-free in Assimp::DXFImporter::ExpandBlockReferences

### DIFF
--- a/code/AssetLib/DXF/DXFLoader.cpp
+++ b/code/AssetLib/DXF/DXFLoader.cpp
@@ -368,7 +368,9 @@ void DXFImporter::ExpandBlockReferences(DXF::Block& bl,const DXF::BlockMap& bloc
         // XXX this would be the place to implement recursive expansion if needed.
         const DXF::Block& bl_src = *(*it).second;
 
-        for (std::shared_ptr<const DXF::PolyLine> pl_in : bl_src.lines) {
+        const size_t size = bl_src.lines.size(); // the size may increase in the loop
+        for (size_t i = 0; i < size; ++i) {
+            std::shared_ptr<const DXF::PolyLine> pl_in = bl_src.lines[i];
             if (!pl_in) {
                 ASSIMP_LOG_ERROR("DXF: PolyLine instance is nullptr, skipping.");
                 continue;


### PR DESCRIPTION
Fixes Heap-use-after-free in Assimp::DXFImporter::ExpandBlockReferences revealed by fuzzing:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=42899

The root cause is that `bl_src.lines` and `bl.lines` in `DXFImporter::ExpandBlockReferences` may be the same vector. Iterator may become invalid when new objects are pushed into the same vector.
