### PR TITLE
Fixes Heap-buffer-overflow in std::__1::basic_string<char, std::__1::…

### DIFF
--- a/code/AssetLib/NDO/NDOLoader.cpp
+++ b/code/AssetLib/NDO/NDOLoader.cpp
@@ -136,7 +136,9 @@ void NDOImporter::InternReadFile( const std::string& pFile,
         ASSIMP_LOG_INFO("NDO file format is 1.2");
     }
     else {
-        ASSIMP_LOG_WARN( "Unrecognized nendo file format version, continuing happily ... :", (head+6));
+        char buff[4] = {0};
+        memcpy(buff, head+6, 3);
+        ASSIMP_LOG_WARN( "Unrecognized nendo file format version, continuing happily ... :", buff);
     }
 
     reader.IncPtr(2); /* skip flags */


### PR DESCRIPTION
Fixes Heap-buffer-overflow in std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<ch revealed by fuzzing:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=41582

The root cause is that it fails to parse the version of an arbitrary file without extension but the header `nendo ****garbage***` in `NDOImporter::InternReadFile`. Then it tries to log the non null terminated garbage string in `ASSIMP_LOG_WARN( "Unrecognized nendo file format version, continuing happily ... :", (head+6));`. It leads to out of bounds read access. 
