### PR TITLE
Fixes Heap-buffer-overflow in Assimp::ObjFileParser::getFace

### DIFF
--- a/code/AssetLib/Obj/ObjFileParser.cpp
+++ b/code/AssetLib/Obj/ObjFileParser.cpp
@@ -458,7 +458,8 @@ void ObjFileParser::getFace(aiPrimitiveType type) {
             iPos = 0;
         } else {
             //OBJ USES 1 Base ARRAYS!!!!
-            const int iVal(::atoi(&(*m_DataIt)));
+            std::string number(&(*m_DataIt), m_DataItEnd - m_DataIt);
+            const int iVal(::atoi(number.c_str()));
 
             // increment iStep position based off of the sign and # of digits
             int tmp = iVal;


### PR DESCRIPTION
Fixes Heap-buffer-overflow in Assimp::ObjFileParser::getFace revealed by fuzzing:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=40589

The root cause is that `const int iVal(::atoi(&(*m_DataIt)));` reads beyond of `m_DataItEnd` if the string is not null terminated.