### PR TITLE
Improvements and optimizations for the obj-parsers.

### DIFF
--- a/code/AssetLib/Obj/ObjFileData.h
+++ b/code/AssetLib/Obj/ObjFileData.h
@@ -271,65 +271,65 @@ struct Model {
     using ConstGroupMapIt = std::map<std::string, std::vector<unsigned int> *>::const_iterator;
 
     //! Model name
-    std::string m_ModelName;
+    std::string mModelName;
     //! List ob assigned objects
-    std::vector<Object *> m_Objects;
+    std::vector<Object *> mObjects;
     //! Pointer to current object
-    ObjFile::Object *m_pCurrent;
+    ObjFile::Object *mCurrentObject;
     //! Pointer to current material
-    ObjFile::Material *m_pCurrentMaterial;
+    ObjFile::Material *mCurrentMaterial;
     //! Pointer to default material
-    ObjFile::Material *m_pDefaultMaterial;
+    ObjFile::Material *mDefaultMaterial;
     //! Vector with all generated materials
-    std::vector<std::string> m_MaterialLib;
+    std::vector<std::string> mMaterialLib;
     //! Vector with all generated vertices
-    std::vector<aiVector3D> m_Vertices;
+    std::vector<aiVector3D> mVertices;
     //! vector with all generated normals
-    std::vector<aiVector3D> m_Normals;
+    std::vector<aiVector3D> mNormals;
     //! vector with all vertex colors
-    std::vector<aiVector3D> m_VertexColors;
+    std::vector<aiVector3D> mVertexColors;
     //! Group map
-    GroupMap m_Groups;
+    GroupMap mGroups;
     //! Group to face id assignment
-    std::vector<unsigned int> *m_pGroupFaceIDs;
+    std::vector<unsigned int> *mGroupFaceIDs;
     //! Active group
-    std::string m_strActiveGroup;
+    std::string mActiveGroup;
     //! Vector with generated texture coordinates
-    std::vector<aiVector3D> m_TextureCoord;
+    std::vector<aiVector3D> mTextureCoord;
     //! Maximum dimension of texture coordinates
-    unsigned int m_TextureCoordDim;
+    unsigned int mTextureCoordDim;
     //! Current mesh instance
-    Mesh *m_pCurrentMesh;
+    Mesh *mCurrentMesh;
     //! Vector with stored meshes
-    std::vector<Mesh *> m_Meshes;
+    std::vector<Mesh *> mMeshes;
     //! Material map
-    std::map<std::string, Material *> m_MaterialMap;
+    std::map<std::string, Material*> mMaterialMap;
 
     //! \brief  The default class constructor
     Model() :
-            m_ModelName(),
-            m_pCurrent(nullptr),
-            m_pCurrentMaterial(nullptr),
-            m_pDefaultMaterial(nullptr),
-            m_pGroupFaceIDs(nullptr),
-            m_strActiveGroup(),
-            m_TextureCoordDim(0),
-            m_pCurrentMesh(nullptr) {
+            mModelName(),
+            mCurrentObject(nullptr),
+            mCurrentMaterial(nullptr),
+            mDefaultMaterial(nullptr),
+            mGroupFaceIDs(nullptr),
+            mActiveGroup(),
+            mTextureCoordDim(0),
+            mCurrentMesh(nullptr) {
         // empty
     }
 
     //! \brief  The class destructor
     ~Model() {
-        for (auto & it : m_Objects) {
+        for (auto & it : mObjects) {
             delete it;
         }
-        for (auto & Meshe : m_Meshes) {
+        for (auto & Meshe : mMeshes) {
             delete Meshe;
         }
-        for (auto & Group : m_Groups) {
+        for (auto & Group : mGroups) {
             delete Group.second;
         }
-        for (auto & it : m_MaterialMap) {
+        for (auto & it : mMaterialMap) {
             delete it.second;
         }
     }

--- a/code/AssetLib/Obj/ObjFileData.h
+++ b/code/AssetLib/Obj/ObjFileData.h
@@ -64,7 +64,7 @@ struct Face {
     using IndexArray = std::vector<unsigned int>;
 
     //! Primitive type
-    aiPrimitiveType m_PrimitiveType;
+    aiPrimitiveType mPrimitiveType;
     //! Vertex indices
     IndexArray m_vertices;
     //! Normal indices
@@ -76,7 +76,7 @@ struct Face {
 
     //! \brief  Default constructor
     Face(aiPrimitiveType pt = aiPrimitiveType_POLYGON) :
-            m_PrimitiveType(pt), m_vertices(), m_normals(), m_texturCoords(), m_pMaterial(0L) {
+            mPrimitiveType(pt), m_vertices(), m_normals(), m_texturCoords(), m_pMaterial(nullptr) {
         // empty
     }
 
@@ -228,7 +228,7 @@ struct Mesh {
     /// The name for the mesh
     std::string m_name;
     /// Array with pointer to all stored faces
-    std::vector<Face> m_Faces;
+    std::vector<Face*> m_Faces;
     /// Assigned material
     Material *m_pMaterial;
     /// Number of stored indices.

--- a/code/AssetLib/Obj/ObjFileData.h
+++ b/code/AssetLib/Obj/ObjFileData.h
@@ -2,7 +2,7 @@
 Open Asset Import Library (assimp)
 ----------------------------------------------------------------------
 
-Copyright (c) 2006-2020, assimp team
+Copyright (c) 2006-2022, assimp team
 
 All rights reserved.
 
@@ -81,9 +81,7 @@ struct Face {
     }
 
     //! \brief  Destructor
-    ~Face() {
-        // empty
-    }
+    ~Face() = default;
 };
 
 // ------------------------------------------------------------------------------------------------
@@ -230,7 +228,7 @@ struct Mesh {
     /// The name for the mesh
     std::string m_name;
     /// Array with pointer to all stored faces
-    std::vector<Face *> m_Faces;
+    std::vector<Face> m_Faces;
     /// Assigned material
     Material *m_pMaterial;
     /// Number of stored indices.
@@ -256,10 +254,10 @@ struct Mesh {
 
     /// Destructor
     ~Mesh() {
-        for (std::vector<Face *>::iterator it = m_Faces.begin();
+        /* for (std::vector<Face *>::iterator it = m_Faces.begin();
                 it != m_Faces.end(); ++it) {
             delete *it;
-        }
+        }*/
     }
 };
 

--- a/code/AssetLib/Obj/ObjFileData.h
+++ b/code/AssetLib/Obj/ObjFileData.h
@@ -254,10 +254,10 @@ struct Mesh {
 
     /// Destructor
     ~Mesh() {
-        /* for (std::vector<Face *>::iterator it = m_Faces.begin();
+        for (std::vector<Face *>::iterator it = m_Faces.begin();
                 it != m_Faces.end(); ++it) {
             delete *it;
-        }*/
+        }
     }
 };
 

--- a/code/AssetLib/Obj/ObjFileImporter.cpp
+++ b/code/AssetLib/Obj/ObjFileImporter.cpp
@@ -330,18 +330,18 @@ aiMesh *ObjFileImporter::createTopology(const ObjFile::Model *pModel, const ObjF
     }
 
     for (size_t index = 0; index < pObjMesh->m_Faces.size(); index++) {
-        ObjFile::Face *const inp = pObjMesh->m_Faces[index];
-        ai_assert(nullptr != inp);
+        const ObjFile::Face &inp = pObjMesh->m_Faces[index];
+        //ai_assert(nullptr != inp);
 
-        if (inp->m_PrimitiveType == aiPrimitiveType_LINE) {
-            pMesh->mNumFaces += static_cast<unsigned int>(inp->m_vertices.size() - 1);
+        if (inp.m_PrimitiveType == aiPrimitiveType_LINE) {
+            pMesh->mNumFaces += static_cast<unsigned int>(inp.m_vertices.size() - 1);
             pMesh->mPrimitiveTypes |= aiPrimitiveType_LINE;
-        } else if (inp->m_PrimitiveType == aiPrimitiveType_POINT) {
-            pMesh->mNumFaces += static_cast<unsigned int>(inp->m_vertices.size());
+        } else if (inp.m_PrimitiveType == aiPrimitiveType_POINT) {
+            pMesh->mNumFaces += static_cast<unsigned int>(inp.m_vertices.size());
             pMesh->mPrimitiveTypes |= aiPrimitiveType_POINT;
         } else {
             ++pMesh->mNumFaces;
-            if (inp->m_vertices.size() > 3) {
+            if (inp.m_vertices.size() > 3) {
                 pMesh->mPrimitiveTypes |= aiPrimitiveType_POLYGON;
             } else {
                 pMesh->mPrimitiveTypes |= aiPrimitiveType_TRIANGLE;
@@ -360,16 +360,16 @@ aiMesh *ObjFileImporter::createTopology(const ObjFile::Model *pModel, const ObjF
 
         // Copy all data from all stored meshes
         for (auto &face : pObjMesh->m_Faces) {
-            ObjFile::Face *const inp = face;
-            if (inp->m_PrimitiveType == aiPrimitiveType_LINE) {
-                for (size_t i = 0; i < inp->m_vertices.size() - 1; ++i) {
+            const ObjFile::Face &inp = face;
+            if (inp.m_PrimitiveType == aiPrimitiveType_LINE) {
+                for (size_t i = 0; i < inp.m_vertices.size() - 1; ++i) {
                     aiFace &f = pMesh->mFaces[outIndex++];
                     uiIdxCount += f.mNumIndices = 2;
                     f.mIndices = new unsigned int[2];
                 }
                 continue;
-            } else if (inp->m_PrimitiveType == aiPrimitiveType_POINT) {
-                for (size_t i = 0; i < inp->m_vertices.size(); ++i) {
+            } else if (inp.m_PrimitiveType == aiPrimitiveType_POINT) {
+                for (size_t i = 0; i < inp.m_vertices.size(); ++i) {
                     aiFace &f = pMesh->mFaces[outIndex++];
                     uiIdxCount += f.mNumIndices = 1;
                     f.mIndices = new unsigned int[1];
@@ -378,7 +378,7 @@ aiMesh *ObjFileImporter::createTopology(const ObjFile::Model *pModel, const ObjF
             }
 
             aiFace *pFace = &pMesh->mFaces[outIndex++];
-            const unsigned int uiNumIndices = (unsigned int)face->m_vertices.size();
+            const unsigned int uiNumIndices = (unsigned int)face.m_vertices.size();
             uiIdxCount += pFace->mNumIndices = (unsigned int)uiNumIndices;
             if (pFace->mNumIndices > 0) {
                 pFace->mIndices = new unsigned int[uiNumIndices];
@@ -438,10 +438,10 @@ void ObjFileImporter::createVertexArray(const ObjFile::Model *pModel,
     // Copy vertices, normals and textures into aiMesh instance
     bool normalsok = true, uvok = true;
     unsigned int newIndex = 0, outIndex = 0;
-    for (auto sourceFace : pObjMesh->m_Faces) {
+    for (auto &sourceFace : pObjMesh->m_Faces) {
         // Copy all index arrays
-        for (size_t vertexIndex = 0, outVertexIndex = 0; vertexIndex < sourceFace->m_vertices.size(); vertexIndex++) {
-            const unsigned int vertex = sourceFace->m_vertices.at(vertexIndex);
+        for (size_t vertexIndex = 0, outVertexIndex = 0; vertexIndex < sourceFace.m_vertices.size(); vertexIndex++) {
+            const unsigned int vertex = sourceFace.m_vertices.at(vertexIndex);
             if (vertex >= pModel->m_Vertices.size()) {
                 throw DeadlyImportError("OBJ: vertex index out of range");
             }
@@ -453,8 +453,8 @@ void ObjFileImporter::createVertexArray(const ObjFile::Model *pModel,
             pMesh->mVertices[newIndex] = pModel->m_Vertices[vertex];
 
             // Copy all normals
-            if (normalsok && !pModel->m_Normals.empty() && vertexIndex < sourceFace->m_normals.size()) {
-                const unsigned int normal = sourceFace->m_normals.at(vertexIndex);
+            if (normalsok && !pModel->m_Normals.empty() && vertexIndex < sourceFace.m_normals.size()) {
+                const unsigned int normal = sourceFace.m_normals.at(vertexIndex);
                 if (normal >= pModel->m_Normals.size()) {
                     normalsok = false;
                 } else {
@@ -469,8 +469,8 @@ void ObjFileImporter::createVertexArray(const ObjFile::Model *pModel,
             }
 
             // Copy all texture coordinates
-            if (uvok && !pModel->m_TextureCoord.empty() && vertexIndex < sourceFace->m_texturCoords.size()) {
-                const unsigned int tex = sourceFace->m_texturCoords.at(vertexIndex);
+            if (uvok && !pModel->m_TextureCoord.empty() && vertexIndex < sourceFace.m_texturCoords.size()) {
+                const unsigned int tex = sourceFace.m_texturCoords.at(vertexIndex);
 
                 if (tex >= pModel->m_TextureCoord.size()) {
                     uvok = false;
@@ -483,16 +483,16 @@ void ObjFileImporter::createVertexArray(const ObjFile::Model *pModel,
             // Get destination face
             aiFace *pDestFace = &pMesh->mFaces[outIndex];
 
-            const bool last = (vertexIndex == sourceFace->m_vertices.size() - 1);
-            if (sourceFace->m_PrimitiveType != aiPrimitiveType_LINE || !last) {
+            const bool last = (vertexIndex == sourceFace.m_vertices.size() - 1);
+            if (sourceFace.m_PrimitiveType != aiPrimitiveType_LINE || !last) {
                 pDestFace->mIndices[outVertexIndex] = newIndex;
                 outVertexIndex++;
             }
 
-            if (sourceFace->m_PrimitiveType == aiPrimitiveType_POINT) {
+            if (sourceFace.m_PrimitiveType == aiPrimitiveType_POINT) {
                 outIndex++;
                 outVertexIndex = 0;
-            } else if (sourceFace->m_PrimitiveType == aiPrimitiveType_LINE) {
+            } else if (sourceFace.m_PrimitiveType == aiPrimitiveType_LINE) {
                 outVertexIndex = 0;
 
                 if (!last)
@@ -501,7 +501,7 @@ void ObjFileImporter::createVertexArray(const ObjFile::Model *pModel,
                 if (vertexIndex) {
                     if (!last) {
                         pMesh->mVertices[newIndex + 1] = pMesh->mVertices[newIndex];
-                        if (!sourceFace->m_normals.empty() && !pModel->m_Normals.empty()) {
+                        if (!sourceFace.m_normals.empty() && !pModel->m_Normals.empty()) {
                             pMesh->mNormals[newIndex + 1] = pMesh->mNormals[newIndex];
                         }
                         if (!pModel->m_TextureCoord.empty()) {

--- a/code/AssetLib/Obj/ObjFileImporter.cpp
+++ b/code/AssetLib/Obj/ObjFileImporter.cpp
@@ -330,18 +330,18 @@ aiMesh *ObjFileImporter::createTopology(const ObjFile::Model *pModel, const ObjF
     }
 
     for (size_t index = 0; index < pObjMesh->m_Faces.size(); index++) {
-        const ObjFile::Face &inp = pObjMesh->m_Faces[index];
+        const ObjFile::Face *inp = pObjMesh->m_Faces[index];
         //ai_assert(nullptr != inp);
 
-        if (inp.m_PrimitiveType == aiPrimitiveType_LINE) {
-            pMesh->mNumFaces += static_cast<unsigned int>(inp.m_vertices.size() - 1);
+        if (inp->mPrimitiveType == aiPrimitiveType_LINE) {
+            pMesh->mNumFaces += static_cast<unsigned int>(inp->m_vertices.size() - 1);
             pMesh->mPrimitiveTypes |= aiPrimitiveType_LINE;
-        } else if (inp.m_PrimitiveType == aiPrimitiveType_POINT) {
-            pMesh->mNumFaces += static_cast<unsigned int>(inp.m_vertices.size());
+        } else if (inp->mPrimitiveType == aiPrimitiveType_POINT) {
+            pMesh->mNumFaces += static_cast<unsigned int>(inp->m_vertices.size());
             pMesh->mPrimitiveTypes |= aiPrimitiveType_POINT;
         } else {
             ++pMesh->mNumFaces;
-            if (inp.m_vertices.size() > 3) {
+            if (inp->m_vertices.size() > 3) {
                 pMesh->mPrimitiveTypes |= aiPrimitiveType_POLYGON;
             } else {
                 pMesh->mPrimitiveTypes |= aiPrimitiveType_TRIANGLE;
@@ -360,16 +360,16 @@ aiMesh *ObjFileImporter::createTopology(const ObjFile::Model *pModel, const ObjF
 
         // Copy all data from all stored meshes
         for (auto &face : pObjMesh->m_Faces) {
-            const ObjFile::Face &inp = face;
-            if (inp.m_PrimitiveType == aiPrimitiveType_LINE) {
-                for (size_t i = 0; i < inp.m_vertices.size() - 1; ++i) {
+            const ObjFile::Face *inp = face;
+            if (inp->mPrimitiveType == aiPrimitiveType_LINE) {
+                for (size_t i = 0; i < inp->m_vertices.size() - 1; ++i) {
                     aiFace &f = pMesh->mFaces[outIndex++];
                     uiIdxCount += f.mNumIndices = 2;
                     f.mIndices = new unsigned int[2];
                 }
                 continue;
-            } else if (inp.m_PrimitiveType == aiPrimitiveType_POINT) {
-                for (size_t i = 0; i < inp.m_vertices.size(); ++i) {
+            } else if (inp->mPrimitiveType == aiPrimitiveType_POINT) {
+                for (size_t i = 0; i < inp->m_vertices.size(); ++i) {
                     aiFace &f = pMesh->mFaces[outIndex++];
                     uiIdxCount += f.mNumIndices = 1;
                     f.mIndices = new unsigned int[1];
@@ -378,7 +378,7 @@ aiMesh *ObjFileImporter::createTopology(const ObjFile::Model *pModel, const ObjF
             }
 
             aiFace *pFace = &pMesh->mFaces[outIndex++];
-            const unsigned int uiNumIndices = (unsigned int)face.m_vertices.size();
+            const unsigned int uiNumIndices = (unsigned int)face->m_vertices.size();
             uiIdxCount += pFace->mNumIndices = (unsigned int)uiNumIndices;
             if (pFace->mNumIndices > 0) {
                 pFace->mIndices = new unsigned int[uiNumIndices];
@@ -438,10 +438,10 @@ void ObjFileImporter::createVertexArray(const ObjFile::Model *pModel,
     // Copy vertices, normals and textures into aiMesh instance
     bool normalsok = true, uvok = true;
     unsigned int newIndex = 0, outIndex = 0;
-    for (auto &sourceFace : pObjMesh->m_Faces) {
+    for (auto sourceFace : pObjMesh->m_Faces) {
         // Copy all index arrays
-        for (size_t vertexIndex = 0, outVertexIndex = 0; vertexIndex < sourceFace.m_vertices.size(); vertexIndex++) {
-            const unsigned int vertex = sourceFace.m_vertices.at(vertexIndex);
+        for (size_t vertexIndex = 0, outVertexIndex = 0; vertexIndex < sourceFace->m_vertices.size(); vertexIndex++) {
+            const unsigned int vertex = sourceFace->m_vertices.at(vertexIndex);
             if (vertex >= pModel->m_Vertices.size()) {
                 throw DeadlyImportError("OBJ: vertex index out of range");
             }
@@ -453,8 +453,8 @@ void ObjFileImporter::createVertexArray(const ObjFile::Model *pModel,
             pMesh->mVertices[newIndex] = pModel->m_Vertices[vertex];
 
             // Copy all normals
-            if (normalsok && !pModel->m_Normals.empty() && vertexIndex < sourceFace.m_normals.size()) {
-                const unsigned int normal = sourceFace.m_normals.at(vertexIndex);
+            if (normalsok && !pModel->m_Normals.empty() && vertexIndex < sourceFace->m_normals.size()) {
+                const unsigned int normal = sourceFace->m_normals.at(vertexIndex);
                 if (normal >= pModel->m_Normals.size()) {
                     normalsok = false;
                 } else {
@@ -469,8 +469,8 @@ void ObjFileImporter::createVertexArray(const ObjFile::Model *pModel,
             }
 
             // Copy all texture coordinates
-            if (uvok && !pModel->m_TextureCoord.empty() && vertexIndex < sourceFace.m_texturCoords.size()) {
-                const unsigned int tex = sourceFace.m_texturCoords.at(vertexIndex);
+            if (uvok && !pModel->m_TextureCoord.empty() && vertexIndex < sourceFace->m_texturCoords.size()) {
+                const unsigned int tex = sourceFace->m_texturCoords.at(vertexIndex);
 
                 if (tex >= pModel->m_TextureCoord.size()) {
                     uvok = false;
@@ -483,16 +483,16 @@ void ObjFileImporter::createVertexArray(const ObjFile::Model *pModel,
             // Get destination face
             aiFace *pDestFace = &pMesh->mFaces[outIndex];
 
-            const bool last = (vertexIndex == sourceFace.m_vertices.size() - 1);
-            if (sourceFace.m_PrimitiveType != aiPrimitiveType_LINE || !last) {
+            const bool last = (vertexIndex == sourceFace->m_vertices.size() - 1);
+            if (sourceFace->mPrimitiveType != aiPrimitiveType_LINE || !last) {
                 pDestFace->mIndices[outVertexIndex] = newIndex;
                 outVertexIndex++;
             }
 
-            if (sourceFace.m_PrimitiveType == aiPrimitiveType_POINT) {
+            if (sourceFace->mPrimitiveType == aiPrimitiveType_POINT) {
                 outIndex++;
                 outVertexIndex = 0;
-            } else if (sourceFace.m_PrimitiveType == aiPrimitiveType_LINE) {
+            } else if (sourceFace->mPrimitiveType == aiPrimitiveType_LINE) {
                 outVertexIndex = 0;
 
                 if (!last)
@@ -501,7 +501,7 @@ void ObjFileImporter::createVertexArray(const ObjFile::Model *pModel,
                 if (vertexIndex) {
                     if (!last) {
                         pMesh->mVertices[newIndex + 1] = pMesh->mVertices[newIndex];
-                        if (!sourceFace.m_normals.empty() && !pModel->m_Normals.empty()) {
+                        if (!sourceFace->m_normals.empty() && !pModel->m_Normals.empty()) {
                             pMesh->mNormals[newIndex + 1] = pMesh->mNormals[newIndex];
                         }
                         if (!pModel->m_TextureCoord.empty()) {

--- a/code/AssetLib/Obj/ObjFileImporter.cpp
+++ b/code/AssetLib/Obj/ObjFileImporter.cpp
@@ -163,20 +163,20 @@ void ObjFileImporter::CreateDataFromImport(const ObjFile::Model *pModel, aiScene
 
     // Create the root node of the scene
     pScene->mRootNode = new aiNode;
-    if (!pModel->m_ModelName.empty()) {
+    if (!pModel->mModelName.empty()) {
         // Set the name of the scene
-        pScene->mRootNode->mName.Set(pModel->m_ModelName);
+        pScene->mRootNode->mName.Set(pModel->mModelName);
     } else {
         // This is a fatal error, so break down the application
         ai_assert(false);
     }
 
-    if (!pModel->m_Objects.empty()) {
+    if (!pModel->mObjects.empty()) {
 
         unsigned int meshCount = 0;
         unsigned int childCount = 0;
 
-        for (auto object : pModel->m_Objects) {
+        for (auto object : pModel->mObjects) {
             if (object) {
                 ++childCount;
                 meshCount += (unsigned int)object->m_Meshes.size();
@@ -189,8 +189,8 @@ void ObjFileImporter::CreateDataFromImport(const ObjFile::Model *pModel, aiScene
         // Create nodes for the whole scene
         std::vector<aiMesh *> MeshArray;
         MeshArray.reserve(meshCount);
-        for (size_t index = 0; index < pModel->m_Objects.size(); ++index) {
-            createNodes(pModel, pModel->m_Objects[index], pScene->mRootNode, pScene, MeshArray);
+        for (size_t index = 0; index < pModel->mObjects.size(); ++index) {
+            createNodes(pModel, pModel->mObjects[index], pScene->mRootNode, pScene, MeshArray);
         }
 
         ai_assert(pScene->mRootNode->mNumChildren == childCount);
@@ -206,31 +206,31 @@ void ObjFileImporter::CreateDataFromImport(const ObjFile::Model *pModel, aiScene
         // Create all materials
         createMaterials(pModel, pScene);
     } else {
-        if (pModel->m_Vertices.empty()) {
+        if (pModel->mVertices.empty()) {
             return;
         }
 
         std::unique_ptr<aiMesh> mesh(new aiMesh);
         mesh->mPrimitiveTypes = aiPrimitiveType_POINT;
-        unsigned int n = (unsigned int)pModel->m_Vertices.size();
+        unsigned int n = (unsigned int)pModel->mVertices.size();
         mesh->mNumVertices = n;
 
         mesh->mVertices = new aiVector3D[n];
-        memcpy(mesh->mVertices, pModel->m_Vertices.data(), n * sizeof(aiVector3D));
+        memcpy(mesh->mVertices, pModel->mVertices.data(), n * sizeof(aiVector3D));
 
-        if (!pModel->m_Normals.empty()) {
+        if (!pModel->mNormals.empty()) {
             mesh->mNormals = new aiVector3D[n];
-            if (pModel->m_Normals.size() < n) {
+            if (pModel->mNormals.size() < n) {
                 throw DeadlyImportError("OBJ: vertex normal index out of range");
             }
-            memcpy(mesh->mNormals, pModel->m_Normals.data(), n * sizeof(aiVector3D));
+            memcpy(mesh->mNormals, pModel->mNormals.data(), n * sizeof(aiVector3D));
         }
 
-        if (!pModel->m_VertexColors.empty()) {
+        if (!pModel->mVertexColors.empty()) {
             mesh->mColors[0] = new aiColor4D[mesh->mNumVertices];
             for (unsigned int i = 0; i < n; ++i) {
-                if (i < pModel->m_VertexColors.size()) {
-                    const aiVector3D &color = pModel->m_VertexColors[i];
+                if (i < pModel->mVertexColors.size()) {
+                    const aiVector3D &color = pModel->mVertexColors[i];
                     mesh->mColors[0][i] = aiColor4D(color.x, color.y, color.z, 1.0);
                 } else {
                     throw DeadlyImportError("OBJ: vertex color index out of range");
@@ -315,7 +315,7 @@ aiMesh *ObjFileImporter::createTopology(const ObjFile::Model *pModel, const ObjF
     }
 
     // Create faces
-    ObjFile::Mesh *pObjMesh = pModel->m_Meshes[meshIndex];
+    ObjFile::Mesh *pObjMesh = pModel->mMeshes[meshIndex];
     if (!pObjMesh) {
         return nullptr;
     }
@@ -407,7 +407,7 @@ void ObjFileImporter::createVertexArray(const ObjFile::Model *pModel,
         return;
 
     // Get current mesh
-    ObjFile::Mesh *pObjMesh = pModel->m_Meshes[uiMeshIndex];
+    ObjFile::Mesh *pObjMesh = pModel->mMeshes[uiMeshIndex];
     if (nullptr == pObjMesh || pObjMesh->m_uiNumIndices < 1) {
         return;
     }
@@ -422,16 +422,16 @@ void ObjFileImporter::createVertexArray(const ObjFile::Model *pModel,
     pMesh->mVertices = new aiVector3D[pMesh->mNumVertices];
 
     // Allocate buffer for normal vectors
-    if (!pModel->m_Normals.empty() && pObjMesh->m_hasNormals)
+    if (!pModel->mNormals.empty() && pObjMesh->m_hasNormals)
         pMesh->mNormals = new aiVector3D[pMesh->mNumVertices];
 
     // Allocate buffer for vertex-color vectors
-    if (!pModel->m_VertexColors.empty())
+    if (!pModel->mVertexColors.empty())
         pMesh->mColors[0] = new aiColor4D[pMesh->mNumVertices];
 
     // Allocate buffer for texture coordinates
-    if (!pModel->m_TextureCoord.empty() && pObjMesh->m_uiUVCoordinates[0]) {
-        pMesh->mNumUVComponents[0] = pModel->m_TextureCoordDim;
+    if (!pModel->mTextureCoord.empty() && pObjMesh->m_uiUVCoordinates[0]) {
+        pMesh->mNumUVComponents[0] = pModel->mTextureCoordDim;
         pMesh->mTextureCoords[0] = new aiVector3D[pMesh->mNumVertices];
     }
 
@@ -442,7 +442,7 @@ void ObjFileImporter::createVertexArray(const ObjFile::Model *pModel,
         // Copy all index arrays
         for (size_t vertexIndex = 0, outVertexIndex = 0; vertexIndex < sourceFace->m_vertices.size(); vertexIndex++) {
             const unsigned int vertex = sourceFace->m_vertices.at(vertexIndex);
-            if (vertex >= pModel->m_Vertices.size()) {
+            if (vertex >= pModel->mVertices.size()) {
                 throw DeadlyImportError("OBJ: vertex index out of range");
             }
 
@@ -450,32 +450,32 @@ void ObjFileImporter::createVertexArray(const ObjFile::Model *pModel,
                 throw DeadlyImportError("OBJ: bad vertex index");
             }
 
-            pMesh->mVertices[newIndex] = pModel->m_Vertices[vertex];
+            pMesh->mVertices[newIndex] = pModel->mVertices[vertex];
 
             // Copy all normals
-            if (normalsok && !pModel->m_Normals.empty() && vertexIndex < sourceFace->m_normals.size()) {
+            if (normalsok && !pModel->mNormals.empty() && vertexIndex < sourceFace->m_normals.size()) {
                 const unsigned int normal = sourceFace->m_normals.at(vertexIndex);
-                if (normal >= pModel->m_Normals.size()) {
+                if (normal >= pModel->mNormals.size()) {
                     normalsok = false;
                 } else {
-                    pMesh->mNormals[newIndex] = pModel->m_Normals[normal];
+                    pMesh->mNormals[newIndex] = pModel->mNormals[normal];
                 }
             }
 
             // Copy all vertex colors
-            if (vertex < pModel->m_VertexColors.size()) {
-                const aiVector3D &color = pModel->m_VertexColors[vertex];
+            if (vertex < pModel->mVertexColors.size()) {
+                const aiVector3D &color = pModel->mVertexColors[vertex];
                 pMesh->mColors[0][newIndex] = aiColor4D(color.x, color.y, color.z, 1.0);
             }
 
             // Copy all texture coordinates
-            if (uvok && !pModel->m_TextureCoord.empty() && vertexIndex < sourceFace->m_texturCoords.size()) {
+            if (uvok && !pModel->mTextureCoord.empty() && vertexIndex < sourceFace->m_texturCoords.size()) {
                 const unsigned int tex = sourceFace->m_texturCoords.at(vertexIndex);
 
-                if (tex >= pModel->m_TextureCoord.size()) {
+                if (tex >= pModel->mTextureCoord.size()) {
                     uvok = false;
                 } else {
-                    const aiVector3D &coord3d = pModel->m_TextureCoord[tex];
+                    const aiVector3D &coord3d = pModel->mTextureCoord[tex];
                     pMesh->mTextureCoords[0][newIndex] = aiVector3D(coord3d.x, coord3d.y, coord3d.z);
                 }
             }
@@ -501,10 +501,10 @@ void ObjFileImporter::createVertexArray(const ObjFile::Model *pModel,
                 if (vertexIndex) {
                     if (!last) {
                         pMesh->mVertices[newIndex + 1] = pMesh->mVertices[newIndex];
-                        if (!sourceFace->m_normals.empty() && !pModel->m_Normals.empty()) {
+                        if (!sourceFace->m_normals.empty() && !pModel->mNormals.empty()) {
                             pMesh->mNormals[newIndex + 1] = pMesh->mNormals[newIndex];
                         }
-                        if (!pModel->m_TextureCoord.empty()) {
+                        if (!pModel->mTextureCoord.empty()) {
                             for (size_t i = 0; i < pMesh->GetNumUVChannels(); i++) {
                                 pMesh->mTextureCoords[i][newIndex + 1] = pMesh->mTextureCoords[i][newIndex];
                             }
@@ -565,9 +565,9 @@ void ObjFileImporter::createMaterials(const ObjFile::Model *pModel, aiScene *pSc
         return;
     }
 
-    const unsigned int numMaterials = (unsigned int)pModel->m_MaterialLib.size();
+    const unsigned int numMaterials = (unsigned int)pModel->mMaterialLib.size();
     pScene->mNumMaterials = 0;
-    if (pModel->m_MaterialLib.empty()) {
+    if (pModel->mMaterialLib.empty()) {
         ASSIMP_LOG_DEBUG("OBJ: no materials specified");
         return;
     }
@@ -576,10 +576,10 @@ void ObjFileImporter::createMaterials(const ObjFile::Model *pModel, aiScene *pSc
     for (unsigned int matIndex = 0; matIndex < numMaterials; matIndex++) {
         // Store material name
         std::map<std::string, ObjFile::Material *>::const_iterator it;
-        it = pModel->m_MaterialMap.find(pModel->m_MaterialLib[matIndex]);
+        it = pModel->mMaterialMap.find(pModel->mMaterialLib[matIndex]);
 
         // No material found, use the default material
-        if (pModel->m_MaterialMap.end() == it)
+        if (pModel->mMaterialMap.end() == it)
             continue;
 
         aiMaterial *mat = new aiMaterial;

--- a/code/AssetLib/Obj/ObjFileMtlImporter.cpp
+++ b/code/AssetLib/Obj/ObjFileMtlImporter.cpp
@@ -99,9 +99,9 @@ ObjFileMtlImporter::ObjFileMtlImporter(std::vector<char> &buffer,
     ai_assert(nullptr != m_pModel);
     m_buffer.resize(BUFFERSIZE);
     std::fill(m_buffer.begin(), m_buffer.end(), '\0');
-    if (nullptr == m_pModel->m_pDefaultMaterial) {
-        m_pModel->m_pDefaultMaterial = new ObjFile::Material;
-        m_pModel->m_pDefaultMaterial->MaterialName.Set("default");
+    if (nullptr == m_pModel->mDefaultMaterial) {
+        m_pModel->mDefaultMaterial = new ObjFile::Material;
+        m_pModel->mDefaultMaterial->MaterialName.Set("default");
     }
     load();
 }
@@ -126,21 +126,21 @@ void ObjFileMtlImporter::load() {
                 if (*m_DataIt == 'a') // Ambient color
                 {
                     ++m_DataIt;
-                    if (m_pModel->m_pCurrentMaterial != nullptr)
-                        getColorRGBA(&m_pModel->m_pCurrentMaterial->ambient);
+                    if (m_pModel->mCurrentMaterial != nullptr)
+                        getColorRGBA(&m_pModel->mCurrentMaterial->ambient);
                 } else if (*m_DataIt == 'd') {
                     // Diffuse color
                     ++m_DataIt;
-                    if (m_pModel->m_pCurrentMaterial != nullptr)
-                        getColorRGBA(&m_pModel->m_pCurrentMaterial->diffuse);
+                    if (m_pModel->mCurrentMaterial != nullptr)
+                        getColorRGBA(&m_pModel->mCurrentMaterial->diffuse);
                 } else if (*m_DataIt == 's') {
                     ++m_DataIt;
-                    if (m_pModel->m_pCurrentMaterial != nullptr)
-                        getColorRGBA(&m_pModel->m_pCurrentMaterial->specular);
+                    if (m_pModel->mCurrentMaterial != nullptr)
+                        getColorRGBA(&m_pModel->mCurrentMaterial->specular);
                 } else if (*m_DataIt == 'e') {
                     ++m_DataIt;
-                    if (m_pModel->m_pCurrentMaterial != nullptr)
-                        getColorRGBA(&m_pModel->m_pCurrentMaterial->emissive);
+                    if (m_pModel->mCurrentMaterial != nullptr)
+                        getColorRGBA(&m_pModel->mCurrentMaterial->emissive);
                 }
                 m_DataIt = skipLine<DataArrayIt>(m_DataIt, m_DataItEnd, m_uiLine);
             } break;
@@ -149,15 +149,15 @@ void ObjFileMtlImporter::load() {
                 // Material transmission color
                 if (*m_DataIt == 'f')  {
                     ++m_DataIt;
-                    if (m_pModel->m_pCurrentMaterial != nullptr)
-                        getColorRGBA(&m_pModel->m_pCurrentMaterial->transparent);
+                    if (m_pModel->mCurrentMaterial != nullptr)
+                        getColorRGBA(&m_pModel->mCurrentMaterial->transparent);
                 } else if (*m_DataIt == 'r')  {
                     // Material transmission alpha value
                     ++m_DataIt;
                     ai_real d;
                     getFloatValue(d);
-                    if (m_pModel->m_pCurrentMaterial != nullptr)
-                        m_pModel->m_pCurrentMaterial->alpha = static_cast<ai_real>(1.0) - d;
+                    if (m_pModel->mCurrentMaterial != nullptr)
+                        m_pModel->mCurrentMaterial->alpha = static_cast<ai_real>(1.0) - d;
                 }
                 m_DataIt = skipLine<DataArrayIt>(m_DataIt, m_DataItEnd, m_uiLine);
             } break;
@@ -168,8 +168,8 @@ void ObjFileMtlImporter::load() {
                 } else {
                     // Alpha value
                     ++m_DataIt;
-                    if (m_pModel->m_pCurrentMaterial != nullptr)
-                        getFloatValue(m_pModel->m_pCurrentMaterial->alpha);
+                    if (m_pModel->mCurrentMaterial != nullptr)
+                        getFloatValue(m_pModel->mCurrentMaterial->alpha);
                     m_DataIt = skipLine<DataArrayIt>(m_DataIt, m_DataItEnd, m_uiLine);
                 }
             } break;
@@ -180,13 +180,13 @@ void ObjFileMtlImporter::load() {
                 switch (*m_DataIt) {
                     case 's': // Specular exponent
                         ++m_DataIt;
-                        if (m_pModel->m_pCurrentMaterial != nullptr)
-                            getFloatValue(m_pModel->m_pCurrentMaterial->shineness);
+                        if (m_pModel->mCurrentMaterial != nullptr)
+                            getFloatValue(m_pModel->mCurrentMaterial->shineness);
                         break;
                     case 'i': // Index Of refraction
                         ++m_DataIt;
-                        if (m_pModel->m_pCurrentMaterial != nullptr)
-                            getFloatValue(m_pModel->m_pCurrentMaterial->ior);
+                        if (m_pModel->mCurrentMaterial != nullptr)
+                            getFloatValue(m_pModel->mCurrentMaterial->ior);
                         break;
                     case 'e': // New material
                         createMaterial();
@@ -206,28 +206,28 @@ void ObjFileMtlImporter::load() {
                     {
                     case 'r':
                         ++m_DataIt;
-                        if (m_pModel->m_pCurrentMaterial != nullptr)
-                            getFloatValue(m_pModel->m_pCurrentMaterial->roughness);
+                        if (m_pModel->mCurrentMaterial != nullptr)
+                            getFloatValue(m_pModel->mCurrentMaterial->roughness);
                         break;
                     case 'm':
                         ++m_DataIt;
-                        if (m_pModel->m_pCurrentMaterial != nullptr)
-                            getFloatValue(m_pModel->m_pCurrentMaterial->metallic);
+                        if (m_pModel->mCurrentMaterial != nullptr)
+                            getFloatValue(m_pModel->mCurrentMaterial->metallic);
                         break;
                     case 's':
                         ++m_DataIt;
-                        if (m_pModel->m_pCurrentMaterial != nullptr)
-                            getColorRGBA(m_pModel->m_pCurrentMaterial->sheen);
+                        if (m_pModel->mCurrentMaterial != nullptr)
+                            getColorRGBA(m_pModel->mCurrentMaterial->sheen);
                         break;
                     case 'c':
                         ++m_DataIt;
                         if (*m_DataIt == 'r') {
                             ++m_DataIt;
-                            if (m_pModel->m_pCurrentMaterial != nullptr)
-                                getFloatValue(m_pModel->m_pCurrentMaterial->clearcoat_roughness);
+                            if (m_pModel->mCurrentMaterial != nullptr)
+                                getFloatValue(m_pModel->mCurrentMaterial->clearcoat_roughness);
                         } else {
-                            if (m_pModel->m_pCurrentMaterial != nullptr)
-                                getFloatValue(m_pModel->m_pCurrentMaterial->clearcoat_thickness);
+                            if (m_pModel->mCurrentMaterial != nullptr)
+                                getFloatValue(m_pModel->mCurrentMaterial->clearcoat_thickness);
                         }
                         break;
                     }
@@ -246,16 +246,16 @@ void ObjFileMtlImporter::load() {
             case 'i': // Illumination model
             {
                 m_DataIt = getNextToken<DataArrayIt>(m_DataIt, m_DataItEnd);
-                if (m_pModel->m_pCurrentMaterial != nullptr)
-                    getIlluminationModel(m_pModel->m_pCurrentMaterial->illumination_model);
+                if (m_pModel->mCurrentMaterial != nullptr)
+                    getIlluminationModel(m_pModel->mCurrentMaterial->illumination_model);
                 m_DataIt = skipLine<DataArrayIt>(m_DataIt, m_DataItEnd, m_uiLine);
             } break;
 
             case 'a': // Anisotropy
             {
                 ++m_DataIt;
-                getFloatValue(m_pModel->m_pCurrentMaterial->anisotropy);
-                if (m_pModel->m_pCurrentMaterial != nullptr)
+                getFloatValue(m_pModel->mCurrentMaterial->anisotropy);
+                if (m_pModel->mCurrentMaterial != nullptr)
                     m_DataIt = skipLine<DataArrayIt>(m_DataIt, m_DataItEnd, m_uiLine);
             } break;
 
@@ -345,20 +345,20 @@ void ObjFileMtlImporter::createMaterial() {
 
     name = trim_whitespaces(name);
 
-    std::map<std::string, ObjFile::Material *>::iterator it = m_pModel->m_MaterialMap.find(name);
-    if (m_pModel->m_MaterialMap.end() == it) {
+    std::map<std::string, ObjFile::Material *>::iterator it = m_pModel->mMaterialMap.find(name);
+    if (m_pModel->mMaterialMap.end() == it) {
         // New Material created
-        m_pModel->m_pCurrentMaterial = new ObjFile::Material();
-        m_pModel->m_pCurrentMaterial->MaterialName.Set(name);
-        m_pModel->m_MaterialLib.push_back(name);
-        m_pModel->m_MaterialMap[name] = m_pModel->m_pCurrentMaterial;
+        m_pModel->mCurrentMaterial = new ObjFile::Material();
+        m_pModel->mCurrentMaterial->MaterialName.Set(name);
+        m_pModel->mMaterialLib.push_back(name);
+        m_pModel->mMaterialMap[name] = m_pModel->mCurrentMaterial;
 
-        if (m_pModel->m_pCurrentMesh) {
-            m_pModel->m_pCurrentMesh->m_uiMaterialIndex = static_cast<unsigned int>(m_pModel->m_MaterialLib.size() - 1);
+        if (m_pModel->mCurrentMesh) {
+            m_pModel->mCurrentMesh->m_uiMaterialIndex = static_cast<unsigned int>(m_pModel->mMaterialLib.size() - 1);
         }
     } else {
         // Use older material
-        m_pModel->m_pCurrentMaterial = (*it).second;
+        m_pModel->mCurrentMaterial = (*it).second;
     }
 }
 
@@ -371,38 +371,38 @@ void ObjFileMtlImporter::getTexture() {
     const char *pPtr(&(*m_DataIt));
     if (!ASSIMP_strincmp(pPtr, DiffuseTexture.c_str(), static_cast<unsigned int>(DiffuseTexture.size()))) {
         // Diffuse texture
-        out = &m_pModel->m_pCurrentMaterial->texture;
+        out = &m_pModel->mCurrentMaterial->texture;
         clampIndex = ObjFile::Material::TextureDiffuseType;
     } else if (!ASSIMP_strincmp(pPtr, AmbientTexture.c_str(), static_cast<unsigned int>(AmbientTexture.size()))) {
         // Ambient texture
-        out = &m_pModel->m_pCurrentMaterial->textureAmbient;
+        out = &m_pModel->mCurrentMaterial->textureAmbient;
         clampIndex = ObjFile::Material::TextureAmbientType;
     } else if (!ASSIMP_strincmp(pPtr, SpecularTexture.c_str(), static_cast<unsigned int>(SpecularTexture.size()))) {
         // Specular texture
-        out = &m_pModel->m_pCurrentMaterial->textureSpecular;
+        out = &m_pModel->mCurrentMaterial->textureSpecular;
         clampIndex = ObjFile::Material::TextureSpecularType;
     } else if (!ASSIMP_strincmp(pPtr, DisplacementTexture1.c_str(), static_cast<unsigned int>(DisplacementTexture1.size())) ||
                !ASSIMP_strincmp(pPtr, DisplacementTexture2.c_str(), static_cast<unsigned int>(DisplacementTexture2.size()))) {
         // Displacement texture
-        out = &m_pModel->m_pCurrentMaterial->textureDisp;
+        out = &m_pModel->mCurrentMaterial->textureDisp;
         clampIndex = ObjFile::Material::TextureDispType;
     } else if (!ASSIMP_strincmp(pPtr, OpacityTexture.c_str(), static_cast<unsigned int>(OpacityTexture.size()))) {
         // Opacity texture
-        out = &m_pModel->m_pCurrentMaterial->textureOpacity;
+        out = &m_pModel->mCurrentMaterial->textureOpacity;
         clampIndex = ObjFile::Material::TextureOpacityType;
     } else if (!ASSIMP_strincmp(pPtr, EmissiveTexture1.c_str(), static_cast<unsigned int>(EmissiveTexture1.size())) ||
                !ASSIMP_strincmp(pPtr, EmissiveTexture2.c_str(), static_cast<unsigned int>(EmissiveTexture2.size()))) {
         // Emissive texture
-        out = &m_pModel->m_pCurrentMaterial->textureEmissive;
+        out = &m_pModel->mCurrentMaterial->textureEmissive;
         clampIndex = ObjFile::Material::TextureEmissiveType;
     } else if (!ASSIMP_strincmp(pPtr, BumpTexture1.c_str(), static_cast<unsigned int>(BumpTexture1.size())) ||
                !ASSIMP_strincmp(pPtr, BumpTexture2.c_str(), static_cast<unsigned int>(BumpTexture2.size()))) {
         // Bump texture
-        out = &m_pModel->m_pCurrentMaterial->textureBump;
+        out = &m_pModel->mCurrentMaterial->textureBump;
         clampIndex = ObjFile::Material::TextureBumpType;
     } else if (!ASSIMP_strincmp(pPtr, NormalTextureV1.c_str(), static_cast<unsigned int>(NormalTextureV1.size())) || !ASSIMP_strincmp(pPtr, NormalTextureV2.c_str(), static_cast<unsigned int>(NormalTextureV2.size()))) {
         // Normal map
-        out = &m_pModel->m_pCurrentMaterial->textureNormal;
+        out = &m_pModel->mCurrentMaterial->textureNormal;
         clampIndex = ObjFile::Material::TextureNormalType;
     } else if (!ASSIMP_strincmp(pPtr, ReflectionTexture.c_str(), static_cast<unsigned int>(ReflectionTexture.size()))) {
         // Reflection texture(s)
@@ -410,23 +410,23 @@ void ObjFileMtlImporter::getTexture() {
         return;
     } else if (!ASSIMP_strincmp(pPtr, SpecularityTexture.c_str(), static_cast<unsigned int>(SpecularityTexture.size()))) {
         // Specularity scaling (glossiness)
-        out = &m_pModel->m_pCurrentMaterial->textureSpecularity;
+        out = &m_pModel->mCurrentMaterial->textureSpecularity;
         clampIndex = ObjFile::Material::TextureSpecularityType;
     } else if ( !ASSIMP_strincmp( pPtr, RoughnessTexture.c_str(), static_cast<unsigned int>(RoughnessTexture.size()))) {
         // PBR Roughness texture
-        out = & m_pModel->m_pCurrentMaterial->textureRoughness;
+        out = & m_pModel->mCurrentMaterial->textureRoughness;
         clampIndex = ObjFile::Material::TextureRoughnessType;
     } else if ( !ASSIMP_strincmp( pPtr, MetallicTexture.c_str(), static_cast<unsigned int>(MetallicTexture.size()))) {
         // PBR Metallic texture
-        out = & m_pModel->m_pCurrentMaterial->textureMetallic;
+        out = & m_pModel->mCurrentMaterial->textureMetallic;
         clampIndex = ObjFile::Material::TextureMetallicType;
     } else if (!ASSIMP_strincmp( pPtr, SheenTexture.c_str(), static_cast<unsigned int>(SheenTexture.size()))) {
         // PBR Sheen (reflectance) texture
-        out = & m_pModel->m_pCurrentMaterial->textureSheen;
+        out = & m_pModel->mCurrentMaterial->textureSheen;
         clampIndex = ObjFile::Material::TextureSheenType;
     } else if (!ASSIMP_strincmp( pPtr, RMATexture.c_str(), static_cast<unsigned int>(RMATexture.size()))) {
         // PBR Rough/Metal/AO texture
-        out = & m_pModel->m_pCurrentMaterial->textureRMA;
+        out = & m_pModel->mCurrentMaterial->textureRMA;
         clampIndex = ObjFile::Material::TextureRMAType;
     } else {
         ASSIMP_LOG_ERROR("OBJ/MTL: Encountered unknown texture type");
@@ -435,7 +435,7 @@ void ObjFileMtlImporter::getTexture() {
 
     bool clamp = false;
     getTextureOption(clamp, clampIndex, out);
-    m_pModel->m_pCurrentMaterial->clamp[clampIndex] = clamp;
+    m_pModel->mCurrentMaterial->clamp[clampIndex] = clamp;
 
     std::string texture;
     m_DataIt = getName<DataArrayIt>(m_DataIt, m_DataItEnd, texture);
@@ -483,31 +483,31 @@ void ObjFileMtlImporter::getTextureOption(bool &clamp, int &clampIndex, aiString
             CopyNextWord(it, m_DataItEnd, value, sizeof(value) / sizeof(*value));
             if (!ASSIMP_strincmp(value, "cube_top", 8)) {
                 clampIndex = ObjFile::Material::TextureReflectionCubeTopType;
-                out = &m_pModel->m_pCurrentMaterial->textureReflection[0];
+                out = &m_pModel->mCurrentMaterial->textureReflection[0];
             } else if (!ASSIMP_strincmp(value, "cube_bottom", 11)) {
                 clampIndex = ObjFile::Material::TextureReflectionCubeBottomType;
-                out = &m_pModel->m_pCurrentMaterial->textureReflection[1];
+                out = &m_pModel->mCurrentMaterial->textureReflection[1];
             } else if (!ASSIMP_strincmp(value, "cube_front", 10)) {
                 clampIndex = ObjFile::Material::TextureReflectionCubeFrontType;
-                out = &m_pModel->m_pCurrentMaterial->textureReflection[2];
+                out = &m_pModel->mCurrentMaterial->textureReflection[2];
             } else if (!ASSIMP_strincmp(value, "cube_back", 9)) {
                 clampIndex = ObjFile::Material::TextureReflectionCubeBackType;
-                out = &m_pModel->m_pCurrentMaterial->textureReflection[3];
+                out = &m_pModel->mCurrentMaterial->textureReflection[3];
             } else if (!ASSIMP_strincmp(value, "cube_left", 9)) {
                 clampIndex = ObjFile::Material::TextureReflectionCubeLeftType;
-                out = &m_pModel->m_pCurrentMaterial->textureReflection[4];
+                out = &m_pModel->mCurrentMaterial->textureReflection[4];
             } else if (!ASSIMP_strincmp(value, "cube_right", 10)) {
                 clampIndex = ObjFile::Material::TextureReflectionCubeRightType;
-                out = &m_pModel->m_pCurrentMaterial->textureReflection[5];
+                out = &m_pModel->mCurrentMaterial->textureReflection[5];
             } else if (!ASSIMP_strincmp(value, "sphere", 6)) {
                 clampIndex = ObjFile::Material::TextureReflectionSphereType;
-                out = &m_pModel->m_pCurrentMaterial->textureReflection[0];
+                out = &m_pModel->mCurrentMaterial->textureReflection[0];
             }
 
             skipToken = 2;
         } else if (!ASSIMP_strincmp(pPtr, BumpOption.c_str(), static_cast<unsigned int>(BumpOption.size()))) {
             DataArrayIt it = getNextToken<DataArrayIt>(m_DataIt, m_DataItEnd);
-            getFloat(it, m_DataItEnd, m_pModel->m_pCurrentMaterial->bump_multiplier);
+            getFloat(it, m_DataItEnd, m_pModel->mCurrentMaterial->bump_multiplier);
             skipToken = 2;
         } else if (!ASSIMP_strincmp(pPtr, BlendUOption.c_str(), static_cast<unsigned int>(BlendUOption.size())) || !ASSIMP_strincmp(pPtr, BlendVOption.c_str(), static_cast<unsigned int>(BlendVOption.size())) || !ASSIMP_strincmp(pPtr, BoostOption.c_str(), static_cast<unsigned int>(BoostOption.size())) || !ASSIMP_strincmp(pPtr, ResolutionOption.c_str(), static_cast<unsigned int>(ResolutionOption.size())) || !ASSIMP_strincmp(pPtr, ChannelOption.c_str(), static_cast<unsigned int>(ChannelOption.size()))) {
             skipToken = 2;

--- a/code/AssetLib/Obj/ObjFileParser.cpp
+++ b/code/AssetLib/Obj/ObjFileParser.cpp
@@ -85,13 +85,13 @@ ObjFileParser::ObjFileParser(IOStreamBuffer<char> &streamBuffer, const std::stri
 
     // Create the model instance to store all the data
     m_pModel.reset(new ObjFile::Model());
-    m_pModel->m_ModelName = modelName;
+    m_pModel->mModelName = modelName;
 
     // create default material and store it
-    m_pModel->m_pDefaultMaterial = new ObjFile::Material;
-    m_pModel->m_pDefaultMaterial->MaterialName.Set(DEFAULT_MATERIAL);
-    m_pModel->m_MaterialLib.push_back(DEFAULT_MATERIAL);
-    m_pModel->m_MaterialMap[DEFAULT_MATERIAL] = m_pModel->m_pDefaultMaterial;
+    m_pModel->mDefaultMaterial = new ObjFile::Material;
+    m_pModel->mDefaultMaterial->MaterialName.Set(DEFAULT_MATERIAL);
+    m_pModel->mMaterialLib.push_back(DEFAULT_MATERIAL);
+    m_pModel->mMaterialMap[DEFAULT_MATERIAL] = m_pModel->mDefaultMaterial;
 
     // Start parsing the file
     parseFile(streamBuffer);
@@ -154,23 +154,23 @@ void ObjFileParser::parseFile(IOStreamBuffer<char> &streamBuffer) {
                 size_t numComponents = getNumComponentsInDataDefinition();
                 if (numComponents == 3) {
                     // read in vertex definition
-                    getVector3(m_pModel->m_Vertices);
+                    getVector3(m_pModel->mVertices);
                 } else if (numComponents == 4) {
                     // read in vertex definition (homogeneous coords)
-                    getHomogeneousVector3(m_pModel->m_Vertices);
+                    getHomogeneousVector3(m_pModel->mVertices);
                 } else if (numComponents == 6) {
                     // read vertex and vertex-color
-                    getTwoVectors3(m_pModel->m_Vertices, m_pModel->m_VertexColors);
+                    getTwoVectors3(m_pModel->mVertices, m_pModel->mVertexColors);
                 }
             } else if (*m_DataIt == 't') {
                 // read in texture coordinate ( 2D or 3D )
                 ++m_DataIt;
-                size_t dim = getTexCoordVector(m_pModel->m_TextureCoord);
-                m_pModel->m_TextureCoordDim = std::max(m_pModel->m_TextureCoordDim, (unsigned int)dim);
+                size_t dim = getTexCoordVector(m_pModel->mTextureCoord);
+                m_pModel->mTextureCoordDim = std::max(m_pModel->mTextureCoordDim, (unsigned int)dim);
             } else if (*m_DataIt == 'n') {
                 // Read in normal vector definition
                 ++m_DataIt;
-                getVector3(m_pModel->m_Normals);
+                getVector3(m_pModel->mNormals);
             }
         } break;
 
@@ -436,12 +436,12 @@ void ObjFileParser::getFace(aiPrimitiveType type) {
     ObjFile::Face *face = new ObjFile::Face(type);
     bool hasNormal = false;
 
-    const int vSize = static_cast<unsigned int>(m_pModel->m_Vertices.size());
-    const int vtSize = static_cast<unsigned int>(m_pModel->m_TextureCoord.size());
-    const int vnSize = static_cast<unsigned int>(m_pModel->m_Normals.size());
+    const int vSize = static_cast<unsigned int>(m_pModel->mVertices.size());
+    const int vtSize = static_cast<unsigned int>(m_pModel->mTextureCoord.size());
+    const int vnSize = static_cast<unsigned int>(m_pModel->mNormals.size());
 
-    const bool vt = (!m_pModel->m_TextureCoord.empty());
-    const bool vn = (!m_pModel->m_Normals.empty());
+    const bool vt = (!m_pModel->mTextureCoord.empty());
+    const bool vn = (!m_pModel->mNormals.empty());
     int iPos = 0;
     while (m_DataIt != m_DataItEnd) {
         int iStep = 1;
@@ -516,28 +516,28 @@ void ObjFileParser::getFace(aiPrimitiveType type) {
     }
 
     // Set active material, if one set
-    if (nullptr != m_pModel->m_pCurrentMaterial) {
-        face->m_pMaterial = m_pModel->m_pCurrentMaterial;
+    if (nullptr != m_pModel->mCurrentMaterial) {
+        face->m_pMaterial = m_pModel->mCurrentMaterial;
     } else {
-        face->m_pMaterial = m_pModel->m_pDefaultMaterial;
+        face->m_pMaterial = m_pModel->mDefaultMaterial;
     }
 
     // Create a default object, if nothing is there
-    if (nullptr == m_pModel->m_pCurrent) {
+    if (nullptr == m_pModel->mCurrentObject) {
         createObject(DefaultObjName);
     }
 
     // Assign face to mesh
-    if (nullptr == m_pModel->m_pCurrentMesh) {
+    if (nullptr == m_pModel->mCurrentMesh) {
         createMesh(DefaultObjName);
     }
 
     // Store the face
-    m_pModel->m_pCurrentMesh->m_Faces.emplace_back(face);
-    m_pModel->m_pCurrentMesh->m_uiNumIndices += static_cast<unsigned int>(face->m_vertices.size());
-    m_pModel->m_pCurrentMesh->m_uiUVCoordinates[0] += static_cast<unsigned int>(face->m_texturCoords.size());
-    if (!m_pModel->m_pCurrentMesh->m_hasNormals && hasNormal) {
-        m_pModel->m_pCurrentMesh->m_hasNormals = true;
+    m_pModel->mCurrentMesh->m_Faces.emplace_back(face);
+    m_pModel->mCurrentMesh->m_uiNumIndices += static_cast<unsigned int>(face->m_vertices.size());
+    m_pModel->mCurrentMesh->m_uiUVCoordinates[0] += static_cast<unsigned int>(face->m_texturCoords.size());
+    if (!m_pModel->mCurrentMesh->m_hasNormals && hasNormal) {
+        m_pModel->mCurrentMesh->m_hasNormals = true;
     }
     // Skip the rest of the line
     m_DataIt = skipLine<DataArrayIt>(m_DataIt, m_DataItEnd, m_uiLine);
@@ -566,33 +566,33 @@ void ObjFileParser::getMaterialDesc() {
 
     // If the current mesh has the same material, we simply ignore that 'usemtl' command
     // There is no need to create another object or even mesh here
-    if (m_pModel->m_pCurrentMaterial && m_pModel->m_pCurrentMaterial->MaterialName == aiString(strName)) {
+    if (m_pModel->mCurrentMaterial && m_pModel->mCurrentMaterial->MaterialName == aiString(strName)) {
         skip = true;
     }
 
     if (!skip) {
         // Search for material
-        std::map<std::string, ObjFile::Material *>::iterator it = m_pModel->m_MaterialMap.find(strName);
-        if (it == m_pModel->m_MaterialMap.end()) {
+        std::map<std::string, ObjFile::Material *>::iterator it = m_pModel->mMaterialMap.find(strName);
+        if (it == m_pModel->mMaterialMap.end()) {
             // Not found, so we don't know anything about the material except for its name.
             // This may be the case if the material library is missing. We don't want to lose all
             // materials if that happens, so create a new named material instead of discarding it
             // completely.
             ASSIMP_LOG_ERROR("OBJ: failed to locate material ", strName, ", creating new material");
-            m_pModel->m_pCurrentMaterial = new ObjFile::Material();
-            m_pModel->m_pCurrentMaterial->MaterialName.Set(strName);
-            m_pModel->m_MaterialLib.push_back(strName);
-            m_pModel->m_MaterialMap[strName] = m_pModel->m_pCurrentMaterial;
+            m_pModel->mCurrentMaterial = new ObjFile::Material();
+            m_pModel->mCurrentMaterial->MaterialName.Set(strName);
+            m_pModel->mMaterialLib.push_back(strName);
+            m_pModel->mMaterialMap[strName] = m_pModel->mCurrentMaterial;
         } else {
             // Found, using detected material
-            m_pModel->m_pCurrentMaterial = (*it).second;
+            m_pModel->mCurrentMaterial = (*it).second;
         }
 
         if (needsNewMesh(strName)) {
             createMesh(strName);
         }
 
-        m_pModel->m_pCurrentMesh->m_uiMaterialIndex = getMaterialIndex(strName);
+        m_pModel->mCurrentMesh->m_uiMaterialIndex = getMaterialIndex(strName);
     }
 
     // Skip rest of line
@@ -679,17 +679,17 @@ void ObjFileParser::getNewMaterial() {
     while (m_DataIt != m_DataItEnd && IsSpaceOrNewLine(*m_DataIt)) {
         ++m_DataIt;
     }
-    std::map<std::string, ObjFile::Material *>::iterator it = m_pModel->m_MaterialMap.find(strMat);
-    if (it == m_pModel->m_MaterialMap.end()) {
+    std::map<std::string, ObjFile::Material *>::iterator it = m_pModel->mMaterialMap.find(strMat);
+    if (it == m_pModel->mMaterialMap.end()) {
         // Show a warning, if material was not found
         ASSIMP_LOG_WARN("OBJ: Unsupported material requested: ", strMat);
-        m_pModel->m_pCurrentMaterial = m_pModel->m_pDefaultMaterial;
+        m_pModel->mCurrentMaterial = m_pModel->mDefaultMaterial;
     } else {
         // Set new material
         if (needsNewMesh(strMat)) {
             createMesh(strMat);
         }
-        m_pModel->m_pCurrentMesh->m_uiMaterialIndex = getMaterialIndex(strMat);
+        m_pModel->mCurrentMesh->m_uiMaterialIndex = getMaterialIndex(strMat);
     }
 
     m_DataIt = skipLine<DataArrayIt>(m_DataIt, m_DataItEnd, m_uiLine);
@@ -701,8 +701,8 @@ int ObjFileParser::getMaterialIndex(const std::string &strMaterialName) {
     if (strMaterialName.empty()) {
         return mat_index;
     }
-    for (size_t index = 0; index < m_pModel->m_MaterialLib.size(); ++index) {
-        if (strMaterialName == m_pModel->m_MaterialLib[index]) {
+    for (size_t index = 0; index < m_pModel->mMaterialLib.size(); ++index) {
+        if (strMaterialName == m_pModel->mMaterialLib[index]) {
             mat_index = (int)index;
             break;
         }
@@ -723,22 +723,22 @@ void ObjFileParser::getGroupName() {
     }
 
     // Change active group, if necessary
-    if (m_pModel->m_strActiveGroup != groupName) {
+    if (m_pModel->mActiveGroup != groupName) {
         // Search for already existing entry
-        ObjFile::Model::ConstGroupMapIt it = m_pModel->m_Groups.find(groupName);
+        ObjFile::Model::ConstGroupMapIt it = m_pModel->mGroups.find(groupName);
 
         // We are mapping groups into the object structure
         createObject(groupName);
 
         // New group name, creating a new entry
-        if (it == m_pModel->m_Groups.end()) {
+        if (it == m_pModel->mGroups.end()) {
             std::vector<unsigned int> *pFaceIDArray = new std::vector<unsigned int>;
-            m_pModel->m_Groups[groupName] = pFaceIDArray;
-            m_pModel->m_pGroupFaceIDs = (pFaceIDArray);
+            m_pModel->mGroups[groupName] = pFaceIDArray;
+            m_pModel->mGroupFaceIDs = (pFaceIDArray);
         } else {
-            m_pModel->m_pGroupFaceIDs = (*it).second;
+            m_pModel->mGroupFaceIDs = (*it).second;
         }
-        m_pModel->m_strActiveGroup = groupName;
+        m_pModel->mActiveGroup = groupName;
     }
     m_DataIt = skipLine<DataArrayIt>(m_DataIt, m_DataItEnd, m_uiLine);
 }
@@ -775,20 +775,20 @@ void ObjFileParser::getObjectName() {
     std::string strObjectName(pStart, &(*m_DataIt));
     if (!strObjectName.empty()) {
         // Reset current object
-        m_pModel->m_pCurrent = nullptr;
+        m_pModel->mCurrentObject = nullptr;
 
         // Search for actual object
-        for (std::vector<ObjFile::Object *>::const_iterator it = m_pModel->m_Objects.begin();
-                it != m_pModel->m_Objects.end();
+        for (std::vector<ObjFile::Object *>::const_iterator it = m_pModel->mObjects.begin();
+                it != m_pModel->mObjects.end();
                 ++it) {
             if ((*it)->m_strObjName == strObjectName) {
-                m_pModel->m_pCurrent = *it;
+                m_pModel->mCurrentObject = *it;
                 break;
             }
         }
 
         // Allocate a new object, if current one was not found before
-        if (nullptr == m_pModel->m_pCurrent) {
+        if (nullptr == m_pModel->mCurrentObject) {
             createObject(strObjectName);
         }
     }
@@ -799,16 +799,16 @@ void ObjFileParser::getObjectName() {
 void ObjFileParser::createObject(const std::string &objName) {
     ai_assert(nullptr != m_pModel);
 
-    m_pModel->m_pCurrent = new ObjFile::Object;
-    m_pModel->m_pCurrent->m_strObjName = objName;
-    m_pModel->m_Objects.push_back(m_pModel->m_pCurrent);
+    m_pModel->mCurrentObject = new ObjFile::Object;
+    m_pModel->mCurrentObject->m_strObjName = objName;
+    m_pModel->mObjects.push_back(m_pModel->mCurrentObject);
 
     createMesh(objName);
 
-    if (m_pModel->m_pCurrentMaterial) {
-        m_pModel->m_pCurrentMesh->m_uiMaterialIndex =
-                getMaterialIndex(m_pModel->m_pCurrentMaterial->MaterialName.data);
-        m_pModel->m_pCurrentMesh->m_pMaterial = m_pModel->m_pCurrentMaterial;
+    if (m_pModel->mCurrentMaterial) {
+        m_pModel->mCurrentMesh->m_uiMaterialIndex =
+                getMaterialIndex(m_pModel->mCurrentMaterial->MaterialName.data);
+        m_pModel->mCurrentMesh->m_pMaterial = m_pModel->mCurrentMaterial;
     }
 }
 // -------------------------------------------------------------------
@@ -816,11 +816,11 @@ void ObjFileParser::createObject(const std::string &objName) {
 void ObjFileParser::createMesh(const std::string &meshName) {
     ai_assert(nullptr != m_pModel);
 
-    m_pModel->m_pCurrentMesh = new ObjFile::Mesh(meshName);
-    m_pModel->m_Meshes.push_back(m_pModel->m_pCurrentMesh);
-    unsigned int meshId = static_cast<unsigned int>(m_pModel->m_Meshes.size() - 1);
-    if (nullptr != m_pModel->m_pCurrent) {
-        m_pModel->m_pCurrent->m_Meshes.push_back(meshId);
+    m_pModel->mCurrentMesh = new ObjFile::Mesh(meshName);
+    m_pModel->mMeshes.push_back(m_pModel->mCurrentMesh);
+    unsigned int meshId = static_cast<unsigned int>(m_pModel->mMeshes.size() - 1);
+    if (nullptr != m_pModel->mCurrentObject) {
+        m_pModel->mCurrentObject->m_Meshes.push_back(meshId);
     } else {
         ASSIMP_LOG_ERROR("OBJ: No object detected to attach a new mesh instance.");
     }
@@ -830,16 +830,16 @@ void ObjFileParser::createMesh(const std::string &meshName) {
 //  Returns true, if a new mesh must be created.
 bool ObjFileParser::needsNewMesh(const std::string &materialName) {
     // If no mesh data yet
-    if (m_pModel->m_pCurrentMesh == nullptr) {
+    if (m_pModel->mCurrentMesh == nullptr) {
         return true;
     }
     bool newMat = false;
     int matIdx = getMaterialIndex(materialName);
-    int curMatIdx = m_pModel->m_pCurrentMesh->m_uiMaterialIndex;
+    int curMatIdx = m_pModel->mCurrentMesh->m_uiMaterialIndex;
     if (curMatIdx != int(ObjFile::Mesh::NoMaterial) && curMatIdx != matIdx
             // no need create a new mesh if no faces in current
             // lets say 'usemtl' goes straight after 'g'
-            && !m_pModel->m_pCurrentMesh->m_Faces.empty()) {
+            && !m_pModel->mCurrentMesh->m_Faces.empty()) {
         // New material -> only one material per mesh, so we need to create a new
         // material
         newMat = true;

--- a/code/AssetLib/Obj/ObjFileParser.cpp
+++ b/code/AssetLib/Obj/ObjFileParser.cpp
@@ -433,7 +433,6 @@ void ObjFileParser::getFace(aiPrimitiveType type) {
         return;
     }
 
-    //ObjFile::Face *face = new ObjFile::Face(type);
     ObjFile::Face *face = new ObjFile::Face(type);
     bool hasNormal = false;
 
@@ -501,7 +500,7 @@ void ObjFileParser::getFace(aiPrimitiveType type) {
                 }
             } else {
                 //On error, std::atoi will return 0 which is not a valid value
-                //delete face;
+                delete face;
                 throw DeadlyImportError("OBJ: Invalid face index.");
             }
         }
@@ -512,7 +511,7 @@ void ObjFileParser::getFace(aiPrimitiveType type) {
         ASSIMP_LOG_ERROR("Obj: Ignoring empty face");
         // skip line and clean up
         m_DataIt = skipLine<DataArrayIt>(m_DataIt, m_DataItEnd, m_uiLine);
-        //delete face;
+        delete face;
         return;
     }
 

--- a/code/AssetLib/Obj/ObjFileParser.cpp
+++ b/code/AssetLib/Obj/ObjFileParser.cpp
@@ -434,7 +434,7 @@ void ObjFileParser::getFace(aiPrimitiveType type) {
     }
 
     //ObjFile::Face *face = new ObjFile::Face(type);
-    ObjFile::Face face(type);
+    ObjFile::Face *face = new ObjFile::Face(type);
     bool hasNormal = false;
 
     const int vSize = static_cast<unsigned int>(m_pModel->m_Vertices.size());
@@ -478,11 +478,11 @@ void ObjFileParser::getFace(aiPrimitiveType type) {
             if (iVal > 0) {
                 // Store parsed index
                 if (0 == iPos) {
-                    face.m_vertices.push_back(iVal - 1);
+                    face->m_vertices.push_back(iVal - 1);
                 } else if (1 == iPos) {
-                    face.m_texturCoords.push_back(iVal - 1);
+                    face->m_texturCoords.push_back(iVal - 1);
                 } else if (2 == iPos) {
-                    face.m_normals.push_back(iVal - 1);
+                    face->m_normals.push_back(iVal - 1);
                     hasNormal = true;
                 } else {
                     reportErrorTokenInFace();
@@ -490,11 +490,11 @@ void ObjFileParser::getFace(aiPrimitiveType type) {
             } else if (iVal < 0) {
                 // Store relatively index
                 if (0 == iPos) {
-                    face.m_vertices.push_back(vSize + iVal);
+                    face->m_vertices.push_back(vSize + iVal);
                 } else if (1 == iPos) {
-                    face.m_texturCoords.push_back(vtSize + iVal);
+                    face->m_texturCoords.push_back(vtSize + iVal);
                 } else if (2 == iPos) {
-                    face.m_normals.push_back(vnSize + iVal);
+                    face->m_normals.push_back(vnSize + iVal);
                     hasNormal = true;
                 } else {
                     reportErrorTokenInFace();
@@ -508,7 +508,7 @@ void ObjFileParser::getFace(aiPrimitiveType type) {
         m_DataIt += iStep;
     }
 
-    if (face.m_vertices.empty()) {
+    if (face->m_vertices.empty()) {
         ASSIMP_LOG_ERROR("Obj: Ignoring empty face");
         // skip line and clean up
         m_DataIt = skipLine<DataArrayIt>(m_DataIt, m_DataItEnd, m_uiLine);
@@ -518,9 +518,9 @@ void ObjFileParser::getFace(aiPrimitiveType type) {
 
     // Set active material, if one set
     if (nullptr != m_pModel->m_pCurrentMaterial) {
-        face.m_pMaterial = m_pModel->m_pCurrentMaterial;
+        face->m_pMaterial = m_pModel->m_pCurrentMaterial;
     } else {
-        face.m_pMaterial = m_pModel->m_pDefaultMaterial;
+        face->m_pMaterial = m_pModel->m_pDefaultMaterial;
     }
 
     // Create a default object, if nothing is there
@@ -534,9 +534,9 @@ void ObjFileParser::getFace(aiPrimitiveType type) {
     }
 
     // Store the face
-    m_pModel->m_pCurrentMesh->m_Faces.push_back(face);
-    m_pModel->m_pCurrentMesh->m_uiNumIndices += (unsigned int)face.m_vertices.size();
-    m_pModel->m_pCurrentMesh->m_uiUVCoordinates[0] += (unsigned int)face.m_texturCoords.size();
+    m_pModel->m_pCurrentMesh->m_Faces.emplace_back(face);
+    m_pModel->m_pCurrentMesh->m_uiNumIndices += static_cast<unsigned int>(face->m_vertices.size());
+    m_pModel->m_pCurrentMesh->m_uiUVCoordinates[0] += static_cast<unsigned int>(face->m_texturCoords.size());
     if (!m_pModel->m_pCurrentMesh->m_hasNormals && hasNormal) {
         m_pModel->m_pCurrentMesh->m_hasNormals = true;
     }

--- a/code/AssetLib/Obj/ObjFileParser.h
+++ b/code/AssetLib/Obj/ObjFileParser.h
@@ -137,9 +137,6 @@ protected:
     void reportErrorTokenInFace();
 
 private:
-    // Copy and assignment constructor should be private
-    // because the class contains pointer to allocated memory
-
     /// Default material name
     static constexpr const char DEFAULT_MATERIAL[] = AI_DEFAULT_MATERIAL_NAME;
     //! Iterator to current position in buffer

--- a/code/AssetLib/Obj/ObjTools.h
+++ b/code/AssetLib/Obj/ObjTools.h
@@ -236,7 +236,7 @@ inline char_t CopyNextWord(char_t it, char_t end, char *pBuffer, size_t length) 
 template <class char_t>
 inline char_t getFloat(char_t it, char_t end, ai_real &value) {
     static const size_t BUFFERSIZE = 1024;
-    char buffer[BUFFERSIZE];
+    char buffer[BUFFERSIZE] = {};
     it = CopyNextWord<char_t>(it, end, buffer, BUFFERSIZE);
     value = (ai_real)fast_atof(buffer);
 


### PR DESCRIPTION
- Avoid creation of std::string to parse integer number from face declaration
- Replace one std::string constant with a character array
- Use std::vector to store pod face types instead of storing pointers to each face