### PR TITLE
Fixes Heap-buffer-overflow READ in Assimp::ASE::Parser::ParseLV1SoftSkinBlock

### DIFF
--- a/code/AssetLib/ASE/ASEParser.cpp
+++ b/code/AssetLib/ASE/ASEParser.cpp
@@ -74,7 +74,7 @@ using namespace Assimp::ASE;
             return;                                \
         }                                          \
     }                                              \
-    else if ('\0' == *filePtr) {                   \
+    if ('\0' == *filePtr) {                        \
         return;                                    \
     }                                              \
     if (IsLineEnd(*filePtr) && !bLastWasEndLine) { \
@@ -420,6 +420,8 @@ void Parser::ParseLV1SoftSkinBlock() {
                 }
             }
         }
+        if (*filePtr == '\0')
+            return;
         ++filePtr;
         SkipSpacesAndLineEnd(&filePtr);
     }


### PR DESCRIPTION
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=47392

If parsing mesh in `Parser::ParseLV1SoftSkinBlock` reaches a line end in `filePtr`, the `++filePtr;` advances the `filePtr` past the termination `\0` and the follwing call to `SkipSpacesAndLineEnd` attempts to read one byte past the allocated buffer.