### PR TITLE
Fix problems setting DirectX_LIBRARY

### DIFF
--- a/cmake-modules/FindPkgMacros.cmake
+++ b/cmake-modules/FindPkgMacros.cmake
@@ -54,7 +54,7 @@ macro(clear_if_changed TESTVAR)
       set(${var} "NOTFOUND" CACHE STRING "x" FORCE)
     endforeach(var)
   endif ()
-  set(${TESTVAR}_INT_CHECK ${${TESTVAR}} CACHE INTERNAL "x" FORCE)
+  set(${TESTVAR}_INT_CHECK "${${TESTVAR}}" CACHE INTERNAL "x" FORCE)
 endmacro(clear_if_changed)
 
 # Try to get some hints from pkg-config, if available


### PR DESCRIPTION
`DirectX_LIBRARY` was always clearing, though `DirectX_PREFIX_PATH` was not changed. This is because I had some extra semicolons at begin of `DirectX_PREFIX_PATH` and the macro `clear_if_changed` discarded them. Now it saves all extra semicolons and check passes.