### PR TITLE
Remove exception on glTF 2.0 loading

### DIFF
--- a/code/AssetLib/glTF/glTFAsset.h
+++ b/code/AssetLib/glTF/glTFAsset.h
@@ -903,8 +903,10 @@ struct AssetMetadata {
     void Read(Document &doc);
 
     AssetMetadata() :
-            premultipliedAlpha(false), version() {
+            premultipliedAlpha(false) {
     }
+
+    operator bool() const { return version.size() && version[0] == '1'; }
 };
 
 //

--- a/code/AssetLib/glTF/glTFAsset.inl
+++ b/code/AssetLib/glTF/glTFAsset.inl
@@ -1114,10 +1114,6 @@ inline void AssetMetadata::Read(Document &doc) {
             ReadMember(*curProfile, "version", this->profile.version);
         }
     }
-
-    if (version.empty() || version[0] != '1') {
-        throw DeadlyImportError("GLTF: Unsupported glTF version: ", version);
-    }
 }
 
 //
@@ -1222,6 +1218,10 @@ inline void Asset::Load(const std::string &pFile, bool isBinary) {
 
     // Load the metadata
     asset.Read(doc);
+    if (!asset) {
+        return;
+    }
+
     ReadExtensionsUsed(doc);
 
     // Prepare the dictionaries

--- a/code/AssetLib/glTF/glTFImporter.cpp
+++ b/code/AssetLib/glTF/glTFImporter.cpp
@@ -96,8 +96,7 @@ bool glTFImporter::CanRead(const std::string &pFile, IOSystem *pIOHandler, bool 
     glTF::Asset asset(pIOHandler);
     try {
         asset.Load(pFile, GetExtension(pFile) == "glb");
-        std::string version = asset.asset.version;
-        return !version.empty() && version[0] == '1';
+        return asset.asset;
     } catch (...) {
         return false;
     }


### PR DESCRIPTION
The reason for this PR is that when loading glTF 2.0 scenes, first the glTF importer will be chosen by default and exception will be thrown, which is later resolved in the glTF2 importer.

Example file: https://sketchfab.com/3d-models/griffin-animated-a8852f113416426bb06e6bba49a525a9#download
