### PR TITLE
Apply modernize-use-emplace clang-tidy rule

### DIFF
--- a/code/AssetLib/3DS/3DSLoader.cpp
+++ b/code/AssetLib/3DS/3DSLoader.cpp
@@ -319,7 +319,7 @@ void Discreet3DSImporter::ParseObjectChunk() {
     case Discreet3DS::CHUNK_MAT_MATERIAL:
 
         // Add a new material to the list
-        mScene->mMaterials.push_back(D3DS::Material(std::string("UNNAMED_" + ai_to_string(mScene->mMaterials.size()))));
+        mScene->mMaterials.emplace_back(std::string("UNNAMED_" + ai_to_string(mScene->mMaterials.size())));
         ParseMaterialChunk();
         break;
 
@@ -370,7 +370,7 @@ void Discreet3DSImporter::ParseChunk(const char *name, unsigned int num) {
     switch (chunk.Flag) {
     case Discreet3DS::CHUNK_TRIMESH: {
         // this starts a new triangle mesh
-        mScene->mMeshes.push_back(D3DS::Mesh(std::string(name, num)));
+        mScene->mMeshes.emplace_back(std::string(name, num));
 
         // Read mesh chunks
         ParseMeshChunk();
@@ -999,7 +999,7 @@ void Discreet3DSImporter::ParseMeshChunk() {
         mMesh.mFaces.reserve(num);
         while (num-- > 0) {
             // 3DS faces are ALWAYS triangles
-            mMesh.mFaces.push_back(D3DS::Face());
+            mMesh.mFaces.emplace_back();
             D3DS::Face &sFace = mMesh.mFaces.back();
 
             sFace.mIndices[0] = (uint16_t)stream->GetI2();

--- a/code/AssetLib/AC/ACLoader.cpp
+++ b/code/AssetLib/AC/ACLoader.cpp
@@ -180,7 +180,7 @@ void AC3DImporter::LoadObjectSection(std::vector<Object> &objects) {
 
     ++mNumMeshes;
 
-    objects.push_back(Object());
+    objects.emplace_back();
     Object &obj = objects.back();
 
     aiLight *light = nullptr;
@@ -267,7 +267,7 @@ void AC3DImporter::LoadObjectSection(std::vector<Object> &objects) {
                     --buffer; // make sure the line is processed a second time
                     break;
                 }
-                obj.vertices.push_back(aiVector3D());
+                obj.vertices.emplace_back();
                 aiVector3D &v = obj.vertices.back();
                 buffer = TAcCheckedLoadFloatArray(buffer, "", 0, 3, &v.x);
             }
@@ -293,7 +293,7 @@ void AC3DImporter::LoadObjectSection(std::vector<Object> &objects) {
                     Q3DWorkAround = true;
                 }
                 SkipSpaces(&buffer);
-                obj.surfaces.push_back(Surface());
+                obj.surfaces.emplace_back();
                 Surface &surf = obj.surfaces.back();
                 surf.flags = strtoul_cppstyle(buffer);
 
@@ -324,7 +324,7 @@ void AC3DImporter::LoadObjectSection(std::vector<Object> &objects) {
                                 ASSIMP_LOG_ERROR("AC3D: Unexpected EOF: surface references are incomplete");
                                 break;
                             }
-                            surf.entries.push_back(Surface::SurfaceEntry());
+                            surf.entries.emplace_back();
                             Surface::SurfaceEntry &entry = surf.entries.back();
 
                             entry.first = strtoul10(buffer, &buffer);
@@ -786,7 +786,7 @@ void AC3DImporter::InternReadFile(const std::string &pFile,
 
     while (GetNextLine()) {
         if (TokenMatch(buffer, "MATERIAL", 8)) {
-            materials.push_back(Material());
+            materials.emplace_back();
             Material &mat = materials.back();
 
             // manually parse the material ... sscanf would use the buldin atof ...
@@ -813,7 +813,7 @@ void AC3DImporter::InternReadFile(const std::string &pFile,
     }
     if (materials.empty()) {
         ASSIMP_LOG_WARN("AC3D: No material has been found");
-        materials.push_back(Material());
+        materials.emplace_back();
     }
 
     mNumMeshes += (mNumMeshes >> 2u) + 1;

--- a/code/AssetLib/ASE/ASELoader.cpp
+++ b/code/AssetLib/ASE/ASELoader.cpp
@@ -265,7 +265,7 @@ void ASEImporter::GenerateDefaultMaterial() {
     }
     if (bHas || mParser->m_vMaterials.empty()) {
         // add a simple material without submaterials to the parser's list
-        mParser->m_vMaterials.push_back(ASE::Material(AI_DEFAULT_MATERIAL_NAME));
+        mParser->m_vMaterials.emplace_back(AI_DEFAULT_MATERIAL_NAME);
         ASE::Material &mat = mParser->m_vMaterials.back();
 
         mat.mDiffuse = aiColor3D(0.6f, 0.6f, 0.6f);
@@ -1005,8 +1005,8 @@ void ASEImporter::ConvertMeshes(ASE::Mesh &mesh, std::vector<aiMesh *> &avOutMes
                                             blubb != mesh.mBoneVertices[iIndex2].mBoneWeights.end(); ++blubb) {
 
                                         // NOTE: illegal cases have already been filtered out
-                                        avOutputBones[(*blubb).first].push_back(std::pair<unsigned int, float>(
-                                                iBase, (*blubb).second));
+                                        avOutputBones[(*blubb).first].emplace_back(
+                                                iBase, (*blubb).second);
                                     }
                                 }
                             }

--- a/code/AssetLib/ASE/ASEParser.cpp
+++ b/code/AssetLib/ASE/ASEParser.cpp
@@ -264,7 +264,7 @@ void Parser::Parse() {
             if (TokenMatch(filePtr, "GEOMOBJECT", 10))
 
             {
-                m_vMeshes.push_back(Mesh("UNNAMED"));
+                m_vMeshes.emplace_back("UNNAMED");
                 ParseLV1ObjectBlock(m_vMeshes.back());
                 continue;
             }
@@ -272,7 +272,7 @@ void Parser::Parse() {
             if (TokenMatch(filePtr, "HELPEROBJECT", 12))
 
             {
-                m_vDummies.push_back(Dummy());
+                m_vDummies.emplace_back();
                 ParseLV1ObjectBlock(m_vDummies.back());
                 continue;
             }
@@ -280,13 +280,13 @@ void Parser::Parse() {
             if (TokenMatch(filePtr, "LIGHTOBJECT", 11))
 
             {
-                m_vLights.push_back(Light("UNNAMED"));
+                m_vLights.emplace_back("UNNAMED");
                 ParseLV1ObjectBlock(m_vLights.back());
                 continue;
             }
             // camera object
             if (TokenMatch(filePtr, "CAMERAOBJECT", 12)) {
-                m_vCameras.push_back(Camera("UNNAMED"));
+                m_vCameras.emplace_back("UNNAMED");
                 ParseLV1ObjectBlock(m_vCameras.back());
                 continue;
             }
@@ -385,7 +385,7 @@ void Parser::ParseLV1SoftSkinBlock() {
                         unsigned int numWeights;
                         ParseLV4MeshLong(numWeights);
 
-                        curMesh->mBoneVertices.push_back(ASE::BoneVertex());
+                        curMesh->mBoneVertices.emplace_back();
                         ASE::BoneVertex &vert = curMesh->mBoneVertices.back();
 
                         // Reserve enough storage
@@ -409,7 +409,7 @@ void Parser::ParseLV1SoftSkinBlock() {
                             if (-1 == me.first) {
                                 // We don't have this bone yet, so add it to the list
                                 me.first = static_cast<int>(curMesh->mBones.size());
-                                curMesh->mBones.push_back(ASE::Bone(bone));
+                                curMesh->mBones.emplace_back(bone);
                             }
                             ParseLV4MeshFloat(me.second);
 
@@ -1011,7 +1011,7 @@ void Parser::ParseLV3ScaleAnimationBlock(ASE::Animation &anim) {
                 anim.mScalingType = ASE::Animation::TCB;
             }
             if (b) {
-                anim.akeyScaling.push_back(aiVectorKey());
+                anim.akeyScaling.emplace_back();
                 aiVectorKey &key = anim.akeyScaling.back();
                 ParseLV4MeshFloatTriple(&key.mValue.x, iIndex);
                 key.mTime = (double)iIndex;
@@ -1050,7 +1050,7 @@ void Parser::ParseLV3PosAnimationBlock(ASE::Animation &anim) {
                 anim.mPositionType = ASE::Animation::TCB;
             }
             if (b) {
-                anim.akeyPositions.push_back(aiVectorKey());
+                anim.akeyPositions.emplace_back();
                 aiVectorKey &key = anim.akeyPositions.back();
                 ParseLV4MeshFloatTriple(&key.mValue.x, iIndex);
                 key.mTime = (double)iIndex;
@@ -1089,7 +1089,7 @@ void Parser::ParseLV3RotAnimationBlock(ASE::Animation &anim) {
                 anim.mRotationType = ASE::Animation::TCB;
             }
             if (b) {
-                anim.akeyRotations.push_back(aiQuatKey());
+                anim.akeyRotations.emplace_back();
                 aiQuatKey &key = anim.akeyRotations.back();
                 aiVector3D v;
                 ai_real f;

--- a/code/AssetLib/Assjson/mesh_splitter.cpp
+++ b/code/AssetLib/Assjson/mesh_splitter.cpp
@@ -304,7 +304,7 @@ void MeshSplitter :: SplitMesh(unsigned int a, aiMesh* in_mesh, std::vector<std:
 		}
 
 		// add the newly created mesh to the list
-		source_mesh_map.push_back(std::make_pair(out_mesh,a));
+		source_mesh_map.emplace_back(out_mesh,a);
 
 		if (base == in_mesh->mNumFaces) {
 			break;

--- a/code/AssetLib/B3D/B3DImporter.cpp
+++ b/code/AssetLib/B3D/B3DImporter.cpp
@@ -479,13 +479,13 @@ void B3DImporter::ReadKEYS(aiNodeAnim *nodeAnim) {
     while (ChunkSize()) {
         int frame = ReadInt();
         if (flags & 1) {
-            trans.push_back(aiVectorKey(frame, ReadVec3()));
+            trans.emplace_back(frame, ReadVec3());
         }
         if (flags & 2) {
-            scale.push_back(aiVectorKey(frame, ReadVec3()));
+            scale.emplace_back(frame, ReadVec3());
         }
         if (flags & 4) {
-            rot.push_back(aiQuatKey(frame, ReadQuat()));
+            rot.emplace_back(frame, ReadQuat());
         }
     }
 

--- a/code/AssetLib/BVH/BVHLoader.cpp
+++ b/code/AssetLib/BVH/BVHLoader.cpp
@@ -186,7 +186,7 @@ aiNode *BVHLoader::ReadNode() {
     std::vector<aiNode *> childNodes;
 
     // and create an bone entry for it
-    mNodes.push_back(Node(node));
+    mNodes.emplace_back(node);
     Node &internNode = mNodes.back();
 
     // now read the node's contents

--- a/code/AssetLib/COB/COBLoader.cpp
+++ b/code/AssetLib/COB/COBLoader.cpp
@@ -753,7 +753,7 @@ void COBImporter::ReadPolH_Ascii(Scene &out, LineSplitter &splitter, const Chunk
                     ThrowException("Expected Face line");
                 }
 
-                msh.faces.push_back(Face());
+                msh.faces.emplace_back();
                 Face &face = msh.faces.back();
 
                 face.indices.resize(strtoul10(splitter[2]));
@@ -956,7 +956,7 @@ void COBImporter::ReadPolH_Binary(COB::Scene &out, StreamReaderLE &reader, const
                 ThrowException(format("A hole is the first entity in the `PolH` chunk with id ") << nfo.id);
             }
         } else
-            msh.faces.push_back(Face());
+            msh.faces.emplace_back();
         Face &f = msh.faces.back();
 
         const size_t num = reader.GetI2();
@@ -968,7 +968,7 @@ void COBImporter::ReadPolH_Binary(COB::Scene &out, StreamReaderLE &reader, const
         }
 
         for (size_t x = 0; x < num; ++x) {
-            f.indices.push_back(VertexIndex());
+            f.indices.emplace_back();
 
             VertexIndex &v = f.indices.back();
             v.pos_idx = reader.GetI4();

--- a/code/AssetLib/Collada/ColladaExporter.cpp
+++ b/code/AssetLib/Collada/ColladaExporter.cpp
@@ -1330,9 +1330,9 @@ void ColladaExporter::WriteAnimationLibrary(size_t pIndex) {
             std::vector<std::string> names;
             for (size_t i = 0; i < nodeAnim->mNumPositionKeys; ++i) {
                 if (nodeAnim->mPreState == aiAnimBehaviour_DEFAULT || nodeAnim->mPreState == aiAnimBehaviour_LINEAR || nodeAnim->mPreState == aiAnimBehaviour_REPEAT) {
-                    names.push_back("LINEAR");
+                    names.emplace_back("LINEAR");
                 } else if (nodeAnim->mPostState == aiAnimBehaviour_CONSTANT) {
-                    names.push_back("STEP");
+                    names.emplace_back("STEP");
                 }
             }
 

--- a/code/AssetLib/Collada/ColladaParser.cpp
+++ b/code/AssetLib/Collada/ColladaParser.cpp
@@ -1929,7 +1929,7 @@ void ColladaParser::ExtractDataObjectFromChannel(const InputChannel &pInput, siz
     switch (pInput.mType) {
     case IT_Position: // ignore all position streams except 0 - there can be only one position
         if (pInput.mIndex == 0) {
-            pMesh.mPositions.push_back(aiVector3D(obj[0], obj[1], obj[2]));
+            pMesh.mPositions.emplace_back(obj[0], obj[1], obj[2]);
         } else {
             ASSIMP_LOG_ERROR("Collada: just one vertex position stream supported");
         }
@@ -1941,7 +1941,7 @@ void ColladaParser::ExtractDataObjectFromChannel(const InputChannel &pInput, siz
 
         // ignore all normal streams except 0 - there can be only one normal
         if (pInput.mIndex == 0) {
-            pMesh.mNormals.push_back(aiVector3D(obj[0], obj[1], obj[2]));
+            pMesh.mNormals.emplace_back(obj[0], obj[1], obj[2]);
         } else {
             ASSIMP_LOG_ERROR("Collada: just one vertex normal stream supported");
         }
@@ -1953,7 +1953,7 @@ void ColladaParser::ExtractDataObjectFromChannel(const InputChannel &pInput, siz
 
         // ignore all tangent streams except 0 - there can be only one tangent
         if (pInput.mIndex == 0) {
-            pMesh.mTangents.push_back(aiVector3D(obj[0], obj[1], obj[2]));
+            pMesh.mTangents.emplace_back(obj[0], obj[1], obj[2]);
         } else {
             ASSIMP_LOG_ERROR("Collada: just one vertex tangent stream supported");
         }
@@ -1966,7 +1966,7 @@ void ColladaParser::ExtractDataObjectFromChannel(const InputChannel &pInput, siz
 
         // ignore all bitangent streams except 0 - there can be only one bitangent
         if (pInput.mIndex == 0) {
-            pMesh.mBitangents.push_back(aiVector3D(obj[0], obj[1], obj[2]));
+            pMesh.mBitangents.emplace_back(obj[0], obj[1], obj[2]);
         } else {
             ASSIMP_LOG_ERROR("Collada: just one vertex bitangent stream supported");
         }
@@ -1979,7 +1979,7 @@ void ColladaParser::ExtractDataObjectFromChannel(const InputChannel &pInput, siz
                 pMesh.mTexCoords[pInput.mIndex].insert(pMesh.mTexCoords[pInput.mIndex].end(),
                         pMesh.mPositions.size() - pMesh.mTexCoords[pInput.mIndex].size() - 1, aiVector3D(0, 0, 0));
 
-            pMesh.mTexCoords[pInput.mIndex].push_back(aiVector3D(obj[0], obj[1], obj[2]));
+            pMesh.mTexCoords[pInput.mIndex].emplace_back(obj[0], obj[1], obj[2]);
             if (0 != acc.mSubOffset[2] || 0 != acc.mSubOffset[3]) {
                 pMesh.mNumUVComponents[pInput.mIndex] = 3;
             }
@@ -2113,7 +2113,7 @@ void ColladaParser::ReadSceneNode(XmlNode &node, Node *pNode) {
                 if (s[0] != '#') {
                     ASSIMP_LOG_ERROR("Collada: Unresolved reference format of node");
                 } else {
-                    pNode->mNodeInstances.push_back(NodeInstance());
+                    pNode->mNodeInstances.emplace_back();
                     pNode->mNodeInstances.back().mNode = s.c_str() + 1;
                 }
             }
@@ -2129,7 +2129,7 @@ void ColladaParser::ReadSceneNode(XmlNode &node, Node *pNode) {
                     throw DeadlyImportError("Unknown reference format in <instance_light> element");
                 }
 
-                pNode->mLights.push_back(LightInstance());
+                pNode->mLights.emplace_back();
                 pNode->mLights.back().mLight = url.c_str() + 1;
             }
         } else if (currentName == "instance_camera") {
@@ -2140,7 +2140,7 @@ void ColladaParser::ReadSceneNode(XmlNode &node, Node *pNode) {
                 if (url[0] != '#') {
                     throw DeadlyImportError("Unknown reference format in <instance_camera> element");
                 }
-                pNode->mCameras.push_back(CameraInstance());
+                pNode->mCameras.emplace_back();
                 pNode->mCameras.back().mCamera = url.c_str() + 1;
             }
         }

--- a/code/AssetLib/DXF/DXFLoader.cpp
+++ b/code/AssetLib/DXF/DXFLoader.cpp
@@ -475,7 +475,7 @@ void DXFImporter::ParseBlocks(DXF::LineReader& reader, DXF::FileData& output) {
 // ------------------------------------------------------------------------------------------------
 void DXFImporter::ParseBlock(DXF::LineReader& reader, DXF::FileData& output) {
     // push a new block onto the stack.
-    output.blocks.emplace_back( );
+    output.blocks.emplace_back();
     DXF::Block& block = output.blocks.back();
 
     while( !reader.End() && !reader.Is(0,"ENDBLK")) {
@@ -520,7 +520,7 @@ void DXFImporter::ParseBlock(DXF::LineReader& reader, DXF::FileData& output) {
 // ------------------------------------------------------------------------------------------------
 void DXFImporter::ParseEntities(DXF::LineReader& reader, DXF::FileData& output) {
     // Push a new block onto the stack.
-    output.blocks.emplace_back( );
+    output.blocks.emplace_back();
     DXF::Block& block = output.blocks.back();
 
     block.name = AI_DXF_ENTITIES_MAGIC_BLOCK;
@@ -550,7 +550,7 @@ void DXFImporter::ParseEntities(DXF::LineReader& reader, DXF::FileData& output) 
 }
 
 void DXFImporter::ParseInsertion(DXF::LineReader& reader, DXF::FileData& output) {
-    output.blocks.back().insertions.emplace_back( );
+    output.blocks.back().insertions.emplace_back();
     DXF::InsertBlock& bl = output.blocks.back().insertions.back();
 
     while( !reader.End() && !reader.Is(0)) {

--- a/code/AssetLib/DXF/DXFLoader.cpp
+++ b/code/AssetLib/DXF/DXFLoader.cpp
@@ -475,7 +475,7 @@ void DXFImporter::ParseBlocks(DXF::LineReader& reader, DXF::FileData& output) {
 // ------------------------------------------------------------------------------------------------
 void DXFImporter::ParseBlock(DXF::LineReader& reader, DXF::FileData& output) {
     // push a new block onto the stack.
-    output.blocks.push_back( DXF::Block() );
+    output.blocks.emplace_back( );
     DXF::Block& block = output.blocks.back();
 
     while( !reader.End() && !reader.Is(0,"ENDBLK")) {
@@ -520,7 +520,7 @@ void DXFImporter::ParseBlock(DXF::LineReader& reader, DXF::FileData& output) {
 // ------------------------------------------------------------------------------------------------
 void DXFImporter::ParseEntities(DXF::LineReader& reader, DXF::FileData& output) {
     // Push a new block onto the stack.
-    output.blocks.push_back( DXF::Block() );
+    output.blocks.emplace_back( );
     DXF::Block& block = output.blocks.back();
 
     block.name = AI_DXF_ENTITIES_MAGIC_BLOCK;
@@ -550,7 +550,7 @@ void DXFImporter::ParseEntities(DXF::LineReader& reader, DXF::FileData& output) 
 }
 
 void DXFImporter::ParseInsertion(DXF::LineReader& reader, DXF::FileData& output) {
-    output.blocks.back().insertions.push_back( DXF::InsertBlock() );
+    output.blocks.back().insertions.emplace_back( );
     DXF::InsertBlock& bl = output.blocks.back().insertions.back();
 
     while( !reader.End() && !reader.Is(0)) {

--- a/code/AssetLib/FBX/FBXConverter.cpp
+++ b/code/AssetLib/FBX/FBXConverter.cpp
@@ -242,7 +242,7 @@ void FBXConverter::ConvertNodes(uint64_t id, aiNode *parent, aiNode *root_node) 
             ai_assert(nodes_chain.size());
 
             if (need_additional_node) {
-                nodes_chain.emplace_back(PotentialNode(node_name));
+                nodes_chain.emplace_back(node_name);
             }
 
             //setup metadata on newest node

--- a/code/AssetLib/FBX/FBXParser.cpp
+++ b/code/AssetLib/FBX/FBXParser.cpp
@@ -619,9 +619,9 @@ void ParseVectorDataArray(std::vector<aiVector3D>& out, const Element& el)
         if (type == 'd') {
             const double* d = reinterpret_cast<const double*>(&buff[0]);
             for (unsigned int i = 0; i < count3; ++i, d += 3) {
-                out.push_back(aiVector3D(static_cast<ai_real>(d[0]),
+                out.emplace_back(static_cast<ai_real>(d[0]),
                     static_cast<ai_real>(d[1]),
-                    static_cast<ai_real>(d[2])));
+                    static_cast<ai_real>(d[2]));
             }
             // for debugging
             /*for ( size_t i = 0; i < out.size(); i++ ) {
@@ -634,7 +634,7 @@ void ParseVectorDataArray(std::vector<aiVector3D>& out, const Element& el)
         else if (type == 'f') {
             const float* f = reinterpret_cast<const float*>(&buff[0]);
             for (unsigned int i = 0; i < count3; ++i, f += 3) {
-                out.push_back(aiVector3D(f[0],f[1],f[2]));
+                out.emplace_back(f[0],f[1],f[2]);
             }
         }
 
@@ -708,16 +708,16 @@ void ParseVectorDataArray(std::vector<aiColor4D>& out, const Element& el)
         if (type == 'd') {
             const double* d = reinterpret_cast<const double*>(&buff[0]);
             for (unsigned int i = 0; i < count4; ++i, d += 4) {
-                out.push_back(aiColor4D(static_cast<float>(d[0]),
+                out.emplace_back(static_cast<float>(d[0]),
                     static_cast<float>(d[1]),
                     static_cast<float>(d[2]),
-                    static_cast<float>(d[3])));
+                    static_cast<float>(d[3]));
             }
         }
         else if (type == 'f') {
             const float* f = reinterpret_cast<const float*>(&buff[0]);
             for (unsigned int i = 0; i < count4; ++i, f += 4) {
-                out.push_back(aiColor4D(f[0],f[1],f[2],f[3]));
+                out.emplace_back(f[0],f[1],f[2],f[3]);
             }
         }
         return;
@@ -789,13 +789,13 @@ void ParseVectorDataArray(std::vector<aiVector2D>& out, const Element& el) {
         if (type == 'd') {
             const double* d = reinterpret_cast<const double*>(&buff[0]);
             for (unsigned int i = 0; i < count2; ++i, d += 2) {
-                out.push_back(aiVector2D(static_cast<float>(d[0]),
-                    static_cast<float>(d[1])));
+                out.emplace_back(static_cast<float>(d[0]),
+                    static_cast<float>(d[1]));
             }
         } else if (type == 'f') {
             const float* f = reinterpret_cast<const float*>(&buff[0]);
             for (unsigned int i = 0; i < count2; ++i, f += 2) {
-                out.push_back(aiVector2D(f[0],f[1]));
+                out.emplace_back(f[0],f[1]);
             }
         }
 

--- a/code/AssetLib/IFC/IFCBoolean.cpp
+++ b/code/AssetLib/IFC/IFCBoolean.cpp
@@ -310,7 +310,7 @@ bool IntersectsBoundaryProfile(const IfcVector3 &e0, const IfcVector3 &e1, const
                 if (IfcVector2(diff.x, diff.y).SquareLength() < 1e-10)
                     continue;
             }
-            intersect_results.push_back(std::make_pair(i, e0));
+            intersect_results.emplace_back(i, e0);
             continue;
         }
 
@@ -324,7 +324,7 @@ bool IntersectsBoundaryProfile(const IfcVector3 &e0, const IfcVector3 &e1, const
                 if (IfcVector2(diff.x, diff.y).SquareLength() < 1e-10)
                     continue;
             }
-            intersect_results.push_back(std::make_pair(i, p));
+            intersect_results.emplace_back(i, p);
         }
     }
 
@@ -504,7 +504,7 @@ void ProcessPolygonalBoundedBooleanHalfSpaceDifference(const Schema_2x3::IfcPoly
                 }
                 // now add them to the list of intersections
                 for (size_t b = 0; b < intersected_boundary.size(); ++b)
-                    intersections.push_back(std::make_tuple(a, proj_inv * intersected_boundary[b].second, intersected_boundary[b].first));
+                    intersections.emplace_back(a, proj_inv * intersected_boundary[b].second, intersected_boundary[b].first);
 
                 // and calculate our new inside/outside state
                 if (intersected_boundary.size() & 1)

--- a/code/AssetLib/IFC/IFCCurve.cpp
+++ b/code/AssetLib/IFC/IFCCurve.cpp
@@ -224,7 +224,7 @@ public:
                 IFCImporter::LogVerboseDebug("ignoring transition code on composite curve segment, only continuous transitions are supported");
             }
 
-            curves.push_back( CurveEntry(bc,IsTrue(curveSegment.SameSense)) );
+            curves.emplace_back(bc,IsTrue(curveSegment.SameSense) );
             total += bc->GetParametricRangeDelta();
         }
 

--- a/code/AssetLib/IFC/IFCGeometry.cpp
+++ b/code/AssetLib/IFC/IFCGeometry.cpp
@@ -170,7 +170,7 @@ void ProcessPolygonBoundaries(TempMesh& result, const TempMesh& inmesh, size_t m
             continue;
         }
 
-        fake_openings.push_back(TempOpening());
+        fake_openings.emplace_back();
         TempOpening& opening = fake_openings.back();
 
         opening.extrusionDir = master_normal;
@@ -612,7 +612,7 @@ void ProcessExtrudedArea(const Schema_2x3::IfcExtrudedAreaSolid& solid, const Te
             TempMesh& bounds = *t.profileMesh.get();
 
             if( bounds.mVerts.size() <= 2 ) {
-                nors.push_back(IfcVector3());
+                nors.emplace_back();
                 continue;
             }
             auto nor = ((bounds.mVerts[2] - bounds.mVerts[0]) ^ (bounds.mVerts[1] - bounds.mVerts[0])).Normalize();

--- a/code/AssetLib/IFC/IFCOpenings.cpp
+++ b/code/AssetLib/IFC/IFCOpenings.cpp
@@ -114,9 +114,9 @@ void QuadrifyPart(const IfcVector2& pmin, const IfcVector2& pmax, XYSortedField&
     if (!found) {
         // the rectangle [pmin,pend] is opaque, fill it
         out.push_back(pmin);
-        out.push_back(IfcVector2(pmin.x,pmax.y));
+        out.emplace_back(pmin.x,pmax.y);
         out.push_back(pmax);
-        out.push_back(IfcVector2(pmax.x,pmin.y));
+        out.emplace_back(pmax.x,pmin.y);
         return;
     }
 
@@ -126,9 +126,9 @@ void QuadrifyPart(const IfcVector2& pmin, const IfcVector2& pmax, XYSortedField&
     // see if there's an offset to fill at the top of our quad
     if (xs - pmin.x) {
         out.push_back(pmin);
-        out.push_back(IfcVector2(pmin.x,pmax.y));
-        out.push_back(IfcVector2(xs,pmax.y));
-        out.push_back(IfcVector2(xs,pmin.y));
+        out.emplace_back(pmin.x,pmax.y);
+        out.emplace_back(xs,pmax.y);
+        out.emplace_back(xs,pmin.y);
     }
 
     // search along the y-axis for all openings that overlap xs and our quad
@@ -159,10 +159,10 @@ void QuadrifyPart(const IfcVector2& pmin, const IfcVector2& pmax, XYSortedField&
     }
     if (!found) {
         // the rectangle [pmin,pend] is opaque, fill it
-        out.push_back(IfcVector2(xs,pmin.y));
-        out.push_back(IfcVector2(xs,pmax.y));
-        out.push_back(IfcVector2(xe,pmax.y));
-        out.push_back(IfcVector2(xe,pmin.y));
+        out.emplace_back(xs,pmin.y);
+        out.emplace_back(xs,pmax.y);
+        out.emplace_back(xe,pmax.y);
+        out.emplace_back(xe,pmin.y);
         return;
     }
     if (ylast < pmax.y) {
@@ -342,7 +342,7 @@ void InsertWindowContours(const ContourVector& contours,
                         if ((contour[a] - edge).SquareLength() > diag*diag*0.7) {
                             continue;
                         }
-                        curmesh.mVerts.push_back(IfcVector3(contour[a].x, contour[a].y, 0.0f));
+                        curmesh.mVerts.emplace_back(contour[a].x, contour[a].y, 0.0f);
                     }
 
                     if (edge != contour[last_hit]) {
@@ -363,7 +363,7 @@ void InsertWindowContours(const ContourVector& contours,
                             corner.y = bb.second.y;
                         }
 
-                        curmesh.mVerts.push_back(IfcVector3(corner.x, corner.y, 0.0f));
+                        curmesh.mVerts.emplace_back(corner.x, corner.y, 0.0f);
                     }
                     else if (cnt == 1) {
                         // avoid degenerate polygons (also known as lines or points)
@@ -558,10 +558,10 @@ void CleanupOuterContour(const std::vector<IfcVector2>& contour_flat, TempMesh& 
                 for(const ClipperLib::ExPolygon& ex : clipped) {
                     iold.push_back(static_cast<unsigned int>(ex.outer.size()));
                     for(const ClipperLib::IntPoint& point : ex.outer) {
-                        vold.push_back(IfcVector3(
+                        vold.emplace_back(
                             from_int64(point.X),
                             from_int64(point.Y),
-                            0.0f));
+                            0.0f);
                     }
                 }
 
@@ -1039,7 +1039,7 @@ void Quadrify(const std::vector< BoundingBox >& bbs, TempMesh& curmesh)
     curmesh.mVertcnt.resize(quads.size()/4,4);
     curmesh.mVerts.reserve(quads.size());
     for(const IfcVector2& v2 : quads) {
-        curmesh.mVerts.push_back(IfcVector3(v2.x, v2.y, static_cast<IfcFloat>(0.0)));
+        curmesh.mVerts.emplace_back(v2.x, v2.y, static_cast<IfcFloat>(0.0));
     }
 }
 
@@ -1095,7 +1095,7 @@ IfcMatrix4 ProjectOntoPlane(std::vector<IfcVector2>& out_contour, const TempMesh
         vmin = std::min(vv, vmin);
         vmax = std::max(vv, vmax);
 
-        out_contour.push_back(IfcVector2(vv.x,vv.y));
+        out_contour.emplace_back(vv.x,vv.y);
     }
 
     zcoord /= in_verts.size();
@@ -1128,7 +1128,7 @@ IfcMatrix4 ProjectOntoPlane(std::vector<IfcVector2>& out_contour, const TempMesh
     for(const IfcVector3& x : in_verts) {
         const IfcVector3& vv = m * x;
 
-        out_contour2.push_back(IfcVector2(vv.x,vv.y));
+        out_contour2.emplace_back(vv.x,vv.y);
         ai_assert(std::fabs(vv.z) < vmax.z + 1e-8);
     }
 
@@ -1469,7 +1469,7 @@ std::vector<IfcVector2> GetContourInPlane2D(const std::shared_ptr<TempMesh>& mes
 
         // XXX should not be necessary - but it is. Why? For precision reasons?
         vv = is_extruded_side ? vv_extr : vv;
-        contour.push_back(IfcVector2(vv.x,vv.y));
+        contour.emplace_back(vv.x,vv.y);
     }
     ok = true;
 
@@ -1758,7 +1758,7 @@ bool TryAddOpenings_Poly2Tri(const std::vector<TempOpening>& openings,
         vmin = std::min(IfcVector2(vv.x, vv.y), vmin);
         vmax = std::max(IfcVector2(vv.x, vv.y), vmax);
 
-        contour_flat.push_back(IfcVector2(vv.x,vv.y));
+        contour_flat.emplace_back(vv.x,vv.y);
     }
 
     // With the current code in DerivePlaneCoordinateSpace,
@@ -1891,7 +1891,7 @@ bool TryAddOpenings_Poly2Tri(const std::vector<TempOpening>& openings,
         // Build the poly2tri inner contours for all holes we got from ClipperLib
         for(ClipperLib::Polygon& opening : clip.holes) {
 
-            contours.push_back(std::vector<p2t::Point*>());
+            contours.emplace_back();
             std::vector<p2t::Point*>& contour = contours.back();
 
             for(ClipperLib::IntPoint& point : opening) {

--- a/code/AssetLib/IFC/IFCProfile.cpp
+++ b/code/AssetLib/IFC/IFCProfile.cpp
@@ -108,10 +108,10 @@ void ProcessParametrizedProfile(const Schema_2x3::IfcParameterizedProfileDef& de
         const IfcFloat x = cprofile->XDim*0.5f, y = cprofile->YDim*0.5f;
 
         meshout.mVerts.reserve(meshout.mVerts.size()+4);
-        meshout.mVerts.push_back( IfcVector3( x, y, 0.f ));
-        meshout.mVerts.push_back( IfcVector3(-x, y, 0.f ));
-        meshout.mVerts.push_back( IfcVector3(-x,-y, 0.f ));
-        meshout.mVerts.push_back( IfcVector3( x,-y, 0.f ));
+        meshout.mVerts.emplace_back( x, y, 0.f );
+        meshout.mVerts.emplace_back(-x, y, 0.f );
+        meshout.mVerts.emplace_back(-x,-y, 0.f );
+        meshout.mVerts.emplace_back( x,-y, 0.f );
         meshout.mVertcnt.push_back(4);
     }
     else if( const Schema_2x3::IfcCircleProfileDef* const circle = def.ToPtr<Schema_2x3::IfcCircleProfileDef>()) {
@@ -125,7 +125,7 @@ void ProcessParametrizedProfile(const Schema_2x3::IfcParameterizedProfileDef& de
 
         IfcFloat angle = 0.f;
         for(size_t i = 0; i < segments; ++i, angle += delta) {
-            meshout.mVerts.push_back( IfcVector3( std::cos(angle)*radius, std::sin(angle)*radius, 0.f ));
+            meshout.mVerts.emplace_back( std::cos(angle)*radius, std::sin(angle)*radius, 0.f );
         }
 
         meshout.mVertcnt.push_back(static_cast<unsigned int>(segments));
@@ -136,18 +136,18 @@ void ProcessParametrizedProfile(const Schema_2x3::IfcParameterizedProfileDef& de
         const IfcFloat inner_height = ishape->OverallDepth - ishape->FlangeThickness * 2;
 
         meshout.mVerts.reserve(12);
-        meshout.mVerts.push_back(IfcVector3(0,0,0));
-        meshout.mVerts.push_back(IfcVector3(0,ishape->FlangeThickness,0));
-        meshout.mVerts.push_back(IfcVector3(offset,ishape->FlangeThickness,0));
-        meshout.mVerts.push_back(IfcVector3(offset,ishape->FlangeThickness + inner_height,0));
-        meshout.mVerts.push_back(IfcVector3(0,ishape->FlangeThickness + inner_height,0));
-        meshout.mVerts.push_back(IfcVector3(0,ishape->OverallDepth,0));
-        meshout.mVerts.push_back(IfcVector3(ishape->OverallWidth,ishape->OverallDepth,0));
-        meshout.mVerts.push_back(IfcVector3(ishape->OverallWidth,ishape->FlangeThickness + inner_height,0));
-        meshout.mVerts.push_back(IfcVector3(offset+ishape->WebThickness,ishape->FlangeThickness + inner_height,0));
-        meshout.mVerts.push_back(IfcVector3(offset+ishape->WebThickness,ishape->FlangeThickness,0));
-        meshout.mVerts.push_back(IfcVector3(ishape->OverallWidth,ishape->FlangeThickness,0));
-        meshout.mVerts.push_back(IfcVector3(ishape->OverallWidth,0,0));
+        meshout.mVerts.emplace_back(0,0,0);
+        meshout.mVerts.emplace_back(0,ishape->FlangeThickness,0);
+        meshout.mVerts.emplace_back(offset,ishape->FlangeThickness,0);
+        meshout.mVerts.emplace_back(offset,ishape->FlangeThickness + inner_height,0);
+        meshout.mVerts.emplace_back(0,ishape->FlangeThickness + inner_height,0);
+        meshout.mVerts.emplace_back(0,ishape->OverallDepth,0);
+        meshout.mVerts.emplace_back(ishape->OverallWidth,ishape->OverallDepth,0);
+        meshout.mVerts.emplace_back(ishape->OverallWidth,ishape->FlangeThickness + inner_height,0);
+        meshout.mVerts.emplace_back(offset+ishape->WebThickness,ishape->FlangeThickness + inner_height,0);
+        meshout.mVerts.emplace_back(offset+ishape->WebThickness,ishape->FlangeThickness,0);
+        meshout.mVerts.emplace_back(ishape->OverallWidth,ishape->FlangeThickness,0);
+        meshout.mVerts.emplace_back(ishape->OverallWidth,0,0);
 
         meshout.mVertcnt.push_back(12);
     }

--- a/code/AssetLib/IFC/IFCUtil.cpp
+++ b/code/AssetLib/IFC/IFCUtil.cpp
@@ -201,7 +201,7 @@ void TempMesh::ComputePolygonNormals(std::vector<IfcVector3>& normals,
     size_t vidx = std::accumulate(mVertcnt.begin(),begin,0);
     for(iit = begin; iit != end; vidx += *iit++) {
         if (!*iit) {
-            normals.push_back(IfcVector3());
+            normals.emplace_back();
             continue;
         }
         for(size_t vofs = 0, cnt = 0; vofs < *iit; ++vofs) {
@@ -215,7 +215,7 @@ void TempMesh::ComputePolygonNormals(std::vector<IfcVector3>& normals,
             ++cnt;
         }
 
-        normals.push_back(IfcVector3());
+        normals.emplace_back();
         NewellNormal<4,4,4>(normals.back(),*iit,&temp[0],&temp[1],&temp[2]);
     }
 

--- a/code/AssetLib/Irr/IRRLoader.cpp
+++ b/code/AssetLib/Irr/IRRLoader.cpp
@@ -628,7 +628,7 @@ void IRRImporter::GenerateGraph(Node *root, aiNode *rootOut, aiScene *scene,
 				ASSIMP_LOG_ERROR("IRR: Unable to load external file: ", root->meshPath);
 				break;
 			}
-			attach.push_back(AttachmentInfo(localScene, rootOut));
+			attach.emplace_back(localScene, rootOut);
 
 			// Now combine the material we've loaded for this mesh
 			// with the real materials we got from the file. As we
@@ -979,7 +979,7 @@ void IRRImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
 					// Materials can occur for nearly any type of node
 					if (inMaterials && curNode->type != Node::DUMMY) {
 						//  This is a material description - parse it!
-						curNode->materials.push_back(std::pair<aiMaterial *, unsigned int>());
+						curNode->materials.emplace_back();
 						std::pair<aiMaterial *, unsigned int> &p = curNode->materials.back();
 
 						p.first = ParseMaterial(p.second);
@@ -988,7 +988,7 @@ void IRRImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
 					} else if (inAnimator) {
 						//  This is an animation path - add a new animator
 						//  to the list.
-						curNode->animators.push_back(Animator());
+						curNode->animators.emplace_back();
 						curAnim = &curNode->animators.back();
 
 						++guessedAnimCnt;
@@ -1015,7 +1015,7 @@ void IRRImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
 										// here N is the ONE-based index of the point
 										if (prop.name.length() >= 6 && prop.name.substr(0, 5) == "Point") {
 											// Add a new key to the list
-											curAnim->splineKeys.push_back(aiVectorKey());
+											curAnim->splineKeys.emplace_back();
 											aiVectorKey &key = curAnim->splineKeys.back();
 
 											// and parse its properties

--- a/code/AssetLib/LWO/LWOLoader.cpp
+++ b/code/AssetLib/LWO/LWOLoader.cpp
@@ -1292,7 +1292,7 @@ void LWOImporter::LoadLWO2Envelope(unsigned int length) {
             case AI_LWO_KEY: {
                 AI_LWO_VALIDATE_CHUNK_LENGTH(head.length, KEY, 8);
 
-                envelope.keys.push_back(LWO::Key());
+                envelope.keys.emplace_back();
                 LWO::Key &key = envelope.keys.back();
 
                 key.time = GetF4();
@@ -1390,7 +1390,7 @@ void LWOImporter::LoadLWO3Envelope(unsigned int length) {
             case AI_LWO_KEY: {
                 AI_LWO_VALIDATE_CHUNK_LENGTH(head.length, KEY, 10);
 
-                envelope.keys.push_back(LWO::Key());
+                envelope.keys.emplace_back();
                 LWO::Key &key = envelope.keys.back();
 
                 key.time = GetF4();

--- a/code/AssetLib/LWS/LWSLoader.cpp
+++ b/code/AssetLib/LWS/LWSLoader.cpp
@@ -90,7 +90,7 @@ void LWS::Element::Parse(const char *&buffer) {
         } else if (*buffer == '}')
             return;
 
-        children.push_back(Element());
+        children.emplace_back();
 
         // copy data line - read token per token
 
@@ -199,7 +199,7 @@ void LWSImporter::ReadEnvelope(const LWS::Element &dad, LWO::Envelope &fill) {
         const char *c = (*it).tokens[1].c_str();
 
         if ((*it).tokens[0] == "Key") {
-            fill.keys.push_back(LWO::Key());
+            fill.keys.emplace_back();
             LWO::Key &key = fill.keys.back();
 
             float f;
@@ -262,7 +262,7 @@ void LWSImporter::ReadEnvelope_Old(
     num = strtoul10((*it).tokens[0].c_str());
     for (unsigned int i = 0; i < num; ++i) {
 
-        nodes.channels.push_back(LWO::Envelope());
+        nodes.channels.emplace_back();
         LWO::Envelope &envl = nodes.channels.back();
 
         envl.index = i;
@@ -384,7 +384,7 @@ void LWSImporter::BuildGraph(aiNode *nd, LWS::NodeDesc &src, std::vector<Attachm
 
         //Push attachment, if the object came from an external file
         if (obj) {
-            attach.push_back(AttachmentInfo(obj, nd));
+            attach.emplace_back(obj, nd);
         }
     }
 
@@ -637,7 +637,7 @@ void LWSImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
             }
 
             // important: index of channel
-            nodes.back().channels.push_back(LWO::Envelope());
+            nodes.back().channels.emplace_back();
             LWO::Envelope &env = nodes.back().channels.back();
 
             env.index = strtoul10(c);

--- a/code/AssetLib/MD3/MD3Loader.cpp
+++ b/code/AssetLib/MD3/MD3Loader.cpp
@@ -144,7 +144,7 @@ bool Q3Shader::LoadShader(ShaderData &fill, const std::string &pFile, IOSystem *
                 if (*buff == '{') {
                     ++buff;
                     // add new map section
-                    curData->maps.push_back(Q3Shader::ShaderMapBlock());
+                    curData->maps.emplace_back();
                     curMap = &curData->maps.back();
 
                     for (; SkipSpacesAndLineEnd(&buff); SkipLine(&buff)) {
@@ -209,7 +209,7 @@ bool Q3Shader::LoadShader(ShaderData &fill, const std::string &pFile, IOSystem *
             }
         } else {
             // add new section
-            fill.blocks.push_back(Q3Shader::ShaderDataBlock());
+            fill.blocks.emplace_back();
             curData = &fill.blocks.back();
 
             // get the name of this section
@@ -249,7 +249,7 @@ bool Q3Shader::LoadSkin(SkinData &fill, const std::string &pFile, IOSystem *io) 
         if (!::strncmp(&ss[0], "tag_", std::min((size_t)4, ss.length())))
             continue;
 
-        fill.textures.push_back(SkinData::TextureEntry());
+        fill.textures.emplace_back();
         SkinData::TextureEntry &entry = fill.textures.back();
 
         entry.first = ss;
@@ -584,7 +584,7 @@ bool MD3Importer::ReadMultipartFile() {
 
         // original root
         scene_lower->mRootNode->mName.Set("lower");
-        attach.push_back(AttachmentInfo(scene_lower, nd));
+        attach.emplace_back(scene_lower, nd);
 
         // tag_torso
         tag_torso = scene_lower->mRootNode->FindNode("tag_torso");
@@ -593,7 +593,7 @@ bool MD3Importer::ReadMultipartFile() {
             goto error_cleanup;
         }
         scene_upper->mRootNode->mName.Set("upper");
-        attach.push_back(AttachmentInfo(scene_upper, tag_torso));
+        attach.emplace_back(scene_upper, tag_torso);
 
         // tag_head
         tag_head = scene_upper->mRootNode->FindNode("tag_head");
@@ -602,7 +602,7 @@ bool MD3Importer::ReadMultipartFile() {
             goto error_cleanup;
         }
         scene_head->mRootNode->mName.Set("head");
-        attach.push_back(AttachmentInfo(scene_head, tag_head));
+        attach.emplace_back(scene_head, tag_head);
 
         // Remove tag_head and tag_torso from all other model parts ...
         // this ensures (together with AI_INT_MERGE_SCENE_GEN_UNIQUE_NAMES_IF_NECESSARY)

--- a/code/AssetLib/MDC/MDCLoader.cpp
+++ b/code/AssetLib/MDC/MDCLoader.cpp
@@ -271,13 +271,13 @@ void MDCImporter::InternReadFile(
             pcMesh->mMaterialIndex = (unsigned int)aszShaders.size();
 
             // create a new shader
-            aszShaders.push_back(std::string(pcShader->ucName,
-                    ::strnlen(pcShader->ucName, sizeof(pcShader->ucName))));
+            aszShaders.emplace_back(pcShader->ucName,
+                    ::strnlen(pcShader->ucName, sizeof(pcShader->ucName)));
         }
         // need to create a default material
         else if (UINT_MAX == iDefaultMatIndex) {
             pcMesh->mMaterialIndex = iDefaultMatIndex = (unsigned int)aszShaders.size();
-            aszShaders.push_back(std::string());
+            aszShaders.emplace_back();
         }
         // otherwise assign a reference to the default material
         else

--- a/code/AssetLib/MS3D/MS3DLoader.cpp
+++ b/code/AssetLib/MS3D/MS3DLoader.cpp
@@ -399,7 +399,7 @@ void MS3DImporter::InternReadFile( const std::string& pFile,
         // if one of the groups has no material assigned, but there are other
         // groups with materials, a default material needs to be added (
         // scenepreprocessor adds a default material only if nummat==0).
-        materials.push_back(TempMaterial());
+        materials.emplace_back();
         TempMaterial& m = materials.back();
 
         strcpy(m.name,"<MS3D_DefaultMat>");

--- a/code/AssetLib/NDO/NDOLoader.cpp
+++ b/code/AssetLib/NDO/NDOLoader.cpp
@@ -171,7 +171,7 @@ void NDOImporter::InternReadFile( const std::string& pFile,
         obj.edges.reserve(temp);
         for (unsigned int e = 0; e < temp; ++e) {
 
-            obj.edges.push_back(Edge());
+            obj.edges.emplace_back();
             Edge& edge = obj.edges.back();
 
             for (unsigned int i = 0; i< 8; ++i) {
@@ -188,7 +188,7 @@ void NDOImporter::InternReadFile( const std::string& pFile,
         obj.faces.reserve(temp);
         for (unsigned int e = 0; e < temp; ++e) {
 
-            obj.faces.push_back(Face());
+            obj.faces.emplace_back();
             Face& face = obj.faces.back();
 
             face.elem = file_format >= 12 ? reader.GetU4() : reader.GetU2();
@@ -199,7 +199,7 @@ void NDOImporter::InternReadFile( const std::string& pFile,
         obj.vertices.reserve(temp);
         for (unsigned int e = 0; e < temp; ++e) {
 
-            obj.vertices.push_back(Vertex());
+            obj.vertices.emplace_back();
             Vertex& v = obj.vertices.back();
 
             v.num = file_format >= 12 ? reader.GetU4() : reader.GetU2();

--- a/code/AssetLib/NFF/NFFLoader.cpp
+++ b/code/AssetLib/NFF/NFFLoader.cpp
@@ -167,7 +167,7 @@ void NFFImporter::LoadNFF2MaterialTable(std::vector<ShadingInfo> &output,
         // 'matdef' starts a new material in the file
         else if (TokenMatch(sz, "matdef", 6)) {
             // add a new material to the list
-            output.push_back(ShadingInfo());
+            output.emplace_back();
             curShader = &output.back();
 
             // parse the name of the material
@@ -549,7 +549,7 @@ void NFFImporter::InternReadFile(const std::string &pFile,
                         }
                     }
                     if (!mesh) {
-                        meshes.push_back(MeshInfo(PatchType_Simple, false));
+                        meshes.emplace_back(PatchType_Simple, false);
                         mesh = &meshes.back();
                         mesh->matIndex = matIdx;
 
@@ -614,7 +614,7 @@ void NFFImporter::InternReadFile(const std::string &pFile,
                     }
 
                     if (!currentMeshWithUVCoords) {
-                        meshesWithUVCoords.push_back(MeshInfo(PatchType_UVAndNormals));
+                        meshesWithUVCoords.emplace_back(PatchType_UVAndNormals);
                         currentMeshWithUVCoords = &meshesWithUVCoords.back();
                         currentMeshWithUVCoords->shader = s;
                     }
@@ -631,7 +631,7 @@ void NFFImporter::InternReadFile(const std::string &pFile,
                     }
 
                     if (!currentMeshWithNormals) {
-                        meshesWithNormals.push_back(MeshInfo(PatchType_Normals));
+                        meshesWithNormals.emplace_back(PatchType_Normals);
                         currentMeshWithNormals = &meshesWithNormals.back();
                         currentMeshWithNormals->shader = s;
                     }
@@ -649,7 +649,7 @@ void NFFImporter::InternReadFile(const std::string &pFile,
                     }
 
                     if (!currentMesh) {
-                        meshes.push_back(MeshInfo(PatchType_Simple));
+                        meshes.emplace_back(PatchType_Simple);
                         currentMesh = &meshes.back();
                         currentMesh->shader = s;
                     }
@@ -749,7 +749,7 @@ void NFFImporter::InternReadFile(const std::string &pFile,
             }
             // 'l' - light source
             else if (TokenMatch(sz, "l", 1)) {
-                lights.push_back(Light());
+                lights.emplace_back();
                 Light &light = lights.back();
 
                 AI_NFF_PARSE_TRIPLE(light.position);
@@ -758,7 +758,7 @@ void NFFImporter::InternReadFile(const std::string &pFile,
             }
             // 's' - sphere
             else if (TokenMatch(sz, "s", 1)) {
-                meshesLocked.push_back(MeshInfo(PatchType_Simple, true));
+                meshesLocked.emplace_back(PatchType_Simple, true);
                 MeshInfo &curMesh = meshesLocked.back();
                 curMesh.shader = s;
                 curMesh.shader.mapping = aiTextureMapping_SPHERE;
@@ -774,7 +774,7 @@ void NFFImporter::InternReadFile(const std::string &pFile,
             }
             // 'dod' - dodecahedron
             else if (TokenMatch(sz, "dod", 3)) {
-                meshesLocked.push_back(MeshInfo(PatchType_Simple, true));
+                meshesLocked.emplace_back(PatchType_Simple, true);
                 MeshInfo &curMesh = meshesLocked.back();
                 curMesh.shader = s;
                 curMesh.shader.mapping = aiTextureMapping_SPHERE;
@@ -791,7 +791,7 @@ void NFFImporter::InternReadFile(const std::string &pFile,
 
             // 'oct' - octahedron
             else if (TokenMatch(sz, "oct", 3)) {
-                meshesLocked.push_back(MeshInfo(PatchType_Simple, true));
+                meshesLocked.emplace_back(PatchType_Simple, true);
                 MeshInfo &curMesh = meshesLocked.back();
                 curMesh.shader = s;
                 curMesh.shader.mapping = aiTextureMapping_SPHERE;
@@ -808,7 +808,7 @@ void NFFImporter::InternReadFile(const std::string &pFile,
 
             // 'tet' - tetrahedron
             else if (TokenMatch(sz, "tet", 3)) {
-                meshesLocked.push_back(MeshInfo(PatchType_Simple, true));
+                meshesLocked.emplace_back(PatchType_Simple, true);
                 MeshInfo &curMesh = meshesLocked.back();
                 curMesh.shader = s;
                 curMesh.shader.mapping = aiTextureMapping_SPHERE;
@@ -825,7 +825,7 @@ void NFFImporter::InternReadFile(const std::string &pFile,
 
             // 'hex' - hexahedron
             else if (TokenMatch(sz, "hex", 3)) {
-                meshesLocked.push_back(MeshInfo(PatchType_Simple, true));
+                meshesLocked.emplace_back(PatchType_Simple, true);
                 MeshInfo &curMesh = meshesLocked.back();
                 curMesh.shader = s;
                 curMesh.shader.mapping = aiTextureMapping_BOX;
@@ -841,7 +841,7 @@ void NFFImporter::InternReadFile(const std::string &pFile,
             }
             // 'c' - cone
             else if (TokenMatch(sz, "c", 1)) {
-                meshesLocked.push_back(MeshInfo(PatchType_Simple, true));
+                meshesLocked.emplace_back(PatchType_Simple, true);
                 MeshInfo &curMesh = meshesLocked.back();
                 curMesh.shader = s;
                 curMesh.shader.mapping = aiTextureMapping_CYLINDER;

--- a/code/AssetLib/Obj/ObjExporter.cpp
+++ b/code/AssetLib/Obj/ObjExporter.cpp
@@ -333,7 +333,7 @@ void ObjExporter::WriteGeometryFile(bool noMtl) {
 
 // ------------------------------------------------------------------------------------------------
 void ObjExporter::AddMesh(const aiString& name, const aiMesh* m, const aiMatrix4x4& mat) {
-    mMeshes.push_back(MeshInstance() );
+    mMeshes.emplace_back( );
     MeshInstance& mesh = mMeshes.back();
 
     if ( nullptr != m->mColors[ 0 ] ) {

--- a/code/AssetLib/Obj/ObjExporter.cpp
+++ b/code/AssetLib/Obj/ObjExporter.cpp
@@ -333,7 +333,7 @@ void ObjExporter::WriteGeometryFile(bool noMtl) {
 
 // ------------------------------------------------------------------------------------------------
 void ObjExporter::AddMesh(const aiString& name, const aiMesh* m, const aiMatrix4x4& mat) {
-    mMeshes.emplace_back( );
+    mMeshes.emplace_back();
     MeshInstance& mesh = mMeshes.back();
 
     if ( nullptr != m->mColors[ 0 ] ) {

--- a/code/AssetLib/Obj/ObjFileParser.cpp
+++ b/code/AssetLib/Obj/ObjFileParser.cpp
@@ -90,7 +90,7 @@ ObjFileParser::ObjFileParser(IOStreamBuffer<char> &streamBuffer, const std::stri
     // create default material and store it
     m_pModel->mDefaultMaterial = new ObjFile::Material;
     m_pModel->mDefaultMaterial->MaterialName.Set(DEFAULT_MATERIAL);
-    m_pModel->mMaterialLib.push_back(DEFAULT_MATERIAL);
+    m_pModel->mMaterialLib.emplace_back(DEFAULT_MATERIAL);
     m_pModel->mMaterialMap[DEFAULT_MATERIAL] = m_pModel->mDefaultMaterial;
 
     // Start parsing the file

--- a/code/AssetLib/Ogre/OgreStructs.cpp
+++ b/code/AssetLib/Ogre/OgreStructs.cpp
@@ -256,7 +256,7 @@ AssimpVertexBoneWeightList IVertexData::AssimpBoneWeights(size_t vertices) {
         for (VertexBoneAssignmentList::const_iterator iter = vertexWeights.begin(), end = vertexWeights.end();
                 iter != end; ++iter) {
             std::vector<aiVertexWeight> &boneWeights = weights[iter->boneIndex];
-            boneWeights.push_back(aiVertexWeight(static_cast<unsigned int>(vi), iter->weight));
+            boneWeights.emplace_back(static_cast<unsigned int>(vi), iter->weight);
         }
     }
     return weights;

--- a/code/AssetLib/Q3BSP/Q3BSPFileImporter.cpp
+++ b/code/AssetLib/Q3BSP/Q3BSPFileImporter.cpp
@@ -560,9 +560,9 @@ bool Q3BSPFileImporter::importTextureFromArchive(const Q3BSP::Q3BSPModel *model,
     }
 
     std::vector<std::string> supportedExtensions;
-    supportedExtensions.push_back(".jpg");
-    supportedExtensions.push_back(".png");
-    supportedExtensions.push_back(".tga");
+    supportedExtensions.emplace_back(".jpg");
+    supportedExtensions.emplace_back(".png");
+    supportedExtensions.emplace_back(".tga");
     std::string textureName, ext;
     if (expandFile(archive, pTexture->strName, supportedExtensions, textureName, ext)) {
         IOStream *pTextureStream = archive->Open(textureName.c_str());

--- a/code/AssetLib/Q3D/Q3DLoader.cpp
+++ b/code/AssetLib/Q3D/Q3DLoader.cpp
@@ -157,7 +157,7 @@ void Q3DImporter::InternReadFile(const std::string &pFile,
             // Meshes chunk
         case 'm': {
             for (unsigned int quak = 0; quak < numMeshes; ++quak) {
-                meshes.push_back(Mesh());
+                meshes.emplace_back();
                 Mesh &mesh = meshes.back();
 
                 // read all vertices
@@ -184,7 +184,7 @@ void Q3DImporter::InternReadFile(const std::string &pFile,
 
                 // number of indices
                 for (unsigned int i = 0; i < numVerts; ++i) {
-                    faces.push_back(Face(stream.GetI2()));
+                    faces.emplace_back(stream.GetI2());
                     if (faces.back().indices.empty())
                         throw DeadlyImportError("Quick3D: Found face with zero indices");
                 }
@@ -248,7 +248,7 @@ void Q3DImporter::InternReadFile(const std::string &pFile,
         case 'c':
 
             for (unsigned int i = 0; i < numMats; ++i) {
-                materials.push_back(Material());
+                materials.emplace_back();
                 Material &mat = materials.back();
 
                 // read the material name
@@ -402,7 +402,7 @@ outer:
     // If we have no materials loaded - generate a default mat
     if (materials.empty()) {
         ASSIMP_LOG_INFO("Quick3D: No material found, generating one");
-        materials.push_back(Material());
+        materials.emplace_back();
         materials.back().diffuse = fgColor;
     }
 

--- a/code/AssetLib/Raw/RawLoader.cpp
+++ b/code/AssetLib/Raw/RawLoader.cpp
@@ -138,7 +138,7 @@ void RAWImporter::InternReadFile(const std::string &pFile,
                 }
             }
             if (sz2) {
-                outGroups.push_back(GroupInformation(std::string(sz, length)));
+                outGroups.emplace_back(std::string(sz, length));
                 curGroup = outGroups.end() - 1;
             }
         } else {
@@ -179,7 +179,7 @@ void RAWImporter::InternReadFile(const std::string &pFile,
             }
             // if we don't have the mesh, create it
             if (!output) {
-                (*curGroup).meshes.push_back(MeshInformation(std::string(sz, length)));
+                (*curGroup).meshes.emplace_back(std::string(sz, length));
                 output = &((*curGroup).meshes.back());
             }
             if (12 == num) {
@@ -188,13 +188,13 @@ void RAWImporter::InternReadFile(const std::string &pFile,
                 output->colors.push_back(v);
                 output->colors.push_back(v);
 
-                output->vertices.push_back(aiVector3D(data[3], data[4], data[5]));
-                output->vertices.push_back(aiVector3D(data[6], data[7], data[8]));
-                output->vertices.push_back(aiVector3D(data[9], data[10], data[11]));
+                output->vertices.emplace_back(data[3], data[4], data[5]);
+                output->vertices.emplace_back(data[6], data[7], data[8]);
+                output->vertices.emplace_back(data[9], data[10], data[11]);
             } else {
-                output->vertices.push_back(aiVector3D(data[0], data[1], data[2]));
-                output->vertices.push_back(aiVector3D(data[3], data[4], data[5]));
-                output->vertices.push_back(aiVector3D(data[6], data[7], data[8]));
+                output->vertices.emplace_back(data[0], data[1], data[2]);
+                output->vertices.emplace_back(data[3], data[4], data[5]);
+                output->vertices.emplace_back(data[6], data[7], data[8]);
             }
         }
     }

--- a/code/AssetLib/SMD/SMDLoader.cpp
+++ b/code/AssetLib/SMD/SMDLoader.cpp
@@ -227,7 +227,7 @@ void SMDImporter::FixTimeValues() {
 // create output meshes
 void SMDImporter::CreateOutputMeshes() {
     if (aszTextures.empty()) {
-        aszTextures.push_back(std::string());
+        aszTextures.emplace_back();
     }
 
     // we need to sort all faces by their material index
@@ -589,7 +589,7 @@ void SMDImporter::GetAnimationFileList(const std::string &pFile, IOSystem* pIOHa
                 animPath = p;
                 animName = DefaultIOSystem::completeBaseName(animPath);
             }
-            outList.push_back(std::make_tuple(animName, base + "/" + animPath));
+            outList.emplace_back(animName, base + "/" + animPath);
         }
         tok1 = strtok_s(nullptr, "\r\n", &context1);
     }
@@ -799,7 +799,7 @@ void SMDImporter::ParseVASection(const char* szCurrent, const char** szCurrentOu
             SkipLine(szCurrent,&szCurrent);
         } else {
             if(0 == iCurIndex) {
-                asTriangles.push_back(SMD::Face());
+                asTriangles.emplace_back();
             }
             if (++iCurIndex == 3) {
                 iCurIndex = 0;
@@ -919,7 +919,7 @@ void SMDImporter::ParseSkeletonElement(const char* szCurrent, const char** szCur
     }
     SMD::Bone& bone = asBones[iBone];
 
-    bone.sAnim.asKeys.push_back(SMD::Bone::Animation::MatrixKey());
+    bone.sAnim.asKeys.emplace_back();
     SMD::Bone::Animation::MatrixKey& key = bone.sAnim.asKeys.back();
 
     key.dTime = (double)iTime;
@@ -964,7 +964,7 @@ void SMDImporter::ParseSkeletonElement(const char* szCurrent, const char** szCur
 // ------------------------------------------------------------------------------------------------
 // Parse a triangle
 void SMDImporter::ParseTriangle(const char* szCurrent, const char** szCurrentOut) {
-    asTriangles.push_back(SMD::Face());
+    asTriangles.emplace_back();
     SMD::Face& face = asTriangles.back();
 
     if(!SkipSpaces(szCurrent,&szCurrent)) {

--- a/code/AssetLib/Unreal/UnrealLoader.cpp
+++ b/code/AssetLib/Unreal/UnrealLoader.cpp
@@ -335,7 +335,7 @@ void UnrealImporter::InternReadFile(const std::string &pFile,
                     SkipSpacesAndLineEnd(&data);
 
                     if (TokenMatchI(data, "IMPORT", 6)) {
-                        tempTextures.push_back(std::pair<std::string, std::string>());
+                        tempTextures.emplace_back();
                         std::pair<std::string, std::string> &me = tempTextures.back();
                         for (; !IsLineEnd(*data); ++data) {
                             if (!::ASSIMP_strincmp(data, "NAME=", 5)) {
@@ -361,7 +361,7 @@ void UnrealImporter::InternReadFile(const std::string &pFile,
 
                     if (TokenMatchI(data, "SETTEXTURE", 10)) {
 
-                        textures.push_back(std::pair<unsigned int, std::string>());
+                        textures.emplace_back();
                         std::pair<unsigned int, std::string> &me = textures.back();
 
                         for (; !IsLineEnd(*data); ++data) {

--- a/code/AssetLib/X/XFileImporter.cpp
+++ b/code/AssetLib/X/XFileImporter.cpp
@@ -380,7 +380,7 @@ void XFileImporter::CreateMeshes( aiScene* pScene, aiNode* pNode, const std::vec
                     // does the new vertex stem from an old vertex which was influenced by this bone?
                     ai_real w = oldWeights[orgPoints[d]];
                     if ( w > 0.0 ) {
-                        newWeights.push_back( aiVertexWeight( d, w ) );
+                        newWeights.emplace_back( d, w );
                     }
                 }
 

--- a/code/AssetLib/X/XFileParser.cpp
+++ b/code/AssetLib/X/XFileParser.cpp
@@ -454,7 +454,7 @@ void XFileParser::ParseDataObjectSkinWeights(Mesh *pMesh) {
     std::string transformNodeName;
     GetNextTokenAsString(transformNodeName);
 
-    pMesh->mBones.push_back(Bone());
+    pMesh->mBones.emplace_back();
     Bone &bone = pMesh->mBones.back();
     bone.mName = transformNodeName;
 
@@ -640,7 +640,7 @@ void XFileParser::ParseDataObjectMeshMaterialList(Mesh *pMesh) {
 
             CheckForClosingBrace(); // skip }
         } else if (objectName == "Material") {
-            pMesh->mMaterials.push_back(Material());
+            pMesh->mMaterials.emplace_back();
             ParseDataObjectMaterial(&pMesh->mMaterials.back());
         } else if (objectName == ";") {
             // ignore
@@ -678,12 +678,12 @@ void XFileParser::ParseDataObjectMaterial(Material *pMaterial) {
             // some exporters write "TextureFileName" instead.
             std::string texname;
             ParseDataObjectTextureFilename(texname);
-            pMaterial->mTextures.push_back(TexEntry(texname));
+            pMaterial->mTextures.emplace_back(texname);
         } else if (objectName == "NormalmapFilename" || objectName == "NormalmapFileName") {
             // one exporter writes out the normal map in a separate filename tag
             std::string texname;
             ParseDataObjectTextureFilename(texname);
-            pMaterial->mTextures.push_back(TexEntry(texname, true));
+            pMaterial->mTextures.emplace_back(texname, true);
         } else {
             ASSIMP_LOG_WARN("Unknown data object in material in x file");
             ParseUnknownDataObject();

--- a/code/AssetLib/X3D/X3DExporter.cpp
+++ b/code/AssetLib/X3D/X3DExporter.cpp
@@ -131,7 +131,7 @@ void X3DExporter::AttrHelper_Color3ToAttrList(std::list<SAttribute> &pList, cons
     if (pValue == pDefaultValue) return;
 
     AttrHelper_Col3DArrToString(&pValue, 1, tstr);
-    pList.push_back({ pName, tstr });
+    pList.emplace_back( pName, tstr );
 }
 
 void X3DExporter::AttrHelper_FloatToAttrList(std::list<SAttribute> &pList, const string &pName, const float pValue, const float pDefaultValue) {
@@ -140,7 +140,7 @@ void X3DExporter::AttrHelper_FloatToAttrList(std::list<SAttribute> &pList, const
     if (pValue == pDefaultValue) return;
 
     AttrHelper_FloatToString(pValue, tstr);
-    pList.push_back({ pName, tstr });
+    pList.emplace_back( pName, tstr );
 }
 
 void X3DExporter::NodeHelper_OpenNode(const string &pNodeName, const size_t pTabLevel, const bool pEmptyElement, const list<SAttribute> &pAttrList) {
@@ -186,7 +186,7 @@ void X3DExporter::Export_Node(const aiNode *pNode, const size_t pTabLevel) {
     if (CheckAndExport_Light(*pNode, pTabLevel)) return;
 
     // Check if need DEF.
-    if (pNode->mName.length) attr_list.push_back({ "DEF", pNode->mName.C_Str() });
+    if (pNode->mName.length) attr_list.emplace_back( "DEF", pNode->mName.C_Str() );
 
     // Check if need <Transformation> node against <Group>.
     if (!pNode->mTransformation.IsIdentity()) {
@@ -213,13 +213,13 @@ void X3DExporter::Export_Node(const aiNode *pNode, const size_t pTabLevel) {
         pNode->mTransformation.Decompose(scale, rotate_axis, rotate_angle, translate);
         // Check if values different from default
         if ((rotate_angle != 0) && (rotate_axis.Length() > 0))
-            attr_list.push_back({ "rotation", Rotation2String(rotate_axis, rotate_angle) });
+            attr_list.emplace_back( "rotation", Rotation2String(rotate_axis, rotate_angle) );
 
         if (!scale.Equal({ 1.0, 1.0, 1.0 })) {
-            attr_list.push_back({ "scale", Vector2String(scale) });
+            attr_list.emplace_back( "scale", Vector2String(scale) );
         }
         if (translate.Length() > 0) {
-            attr_list.push_back({ "translation", Vector2String(translate) });
+            attr_list.emplace_back( "translation", Vector2String(translate) );
         }
     }
 
@@ -284,7 +284,7 @@ void X3DExporter::Export_Mesh(const size_t pIdxMesh, const size_t pTabLevel) {
     // Check if mesh already defined early.
     if (mDEF_Map_Mesh.find(pIdxMesh) != mDEF_Map_Mesh.end()) {
         // Mesh already defined, just refer to it
-        attr_list.push_back({ "USE", mDEF_Map_Mesh.at(pIdxMesh) });
+        attr_list.emplace_back( "USE", mDEF_Map_Mesh.at(pIdxMesh) );
         NodeHelper_OpenNode(NodeName_Shape, pTabLevel, true, attr_list);
 
         return;
@@ -293,7 +293,7 @@ void X3DExporter::Export_Mesh(const size_t pIdxMesh, const size_t pTabLevel) {
     string mesh_name(mesh.mName.C_Str() + string("_IDX_") + to_string(pIdxMesh)); // Create mesh name
 
     // Define mesh name.
-    attr_list.push_back({ "DEF", mesh_name });
+    attr_list.emplace_back( "DEF", mesh_name );
     mDEF_Map_Mesh[pIdxMesh] = mesh_name;
 
     //
@@ -327,7 +327,7 @@ void X3DExporter::Export_Mesh(const size_t pIdxMesh, const size_t pTabLevel) {
 
     // remove last space symbol.
     coordIndex.resize(coordIndex.length() - 1);
-    attr_list.push_back({ "coordIndex", coordIndex });
+    attr_list.emplace_back( "coordIndex", coordIndex );
     // create node
     NodeHelper_OpenNode(NodeName_IFS, pTabLevel + 1, false, attr_list);
     attr_list.clear();
@@ -336,14 +336,14 @@ void X3DExporter::Export_Mesh(const size_t pIdxMesh, const size_t pTabLevel) {
 
     // Export <Coordinate>
     AttrHelper_Vec3DArrToString(mesh.mVertices, mesh.mNumVertices, attr_value);
-    attr_list.push_back({ "point", attr_value });
+    attr_list.emplace_back( "point", attr_value );
     NodeHelper_OpenNode("Coordinate", pTabLevel + 2, true, attr_list);
     attr_list.clear();
 
     // Export <ColorRGBA>
     if (mesh.HasVertexColors(0)) {
         AttrHelper_Col4DArrToString(mesh.mColors[0], mesh.mNumVertices, attr_value);
-        attr_list.push_back({ "color", attr_value });
+        attr_list.emplace_back( "color", attr_value );
         NodeHelper_OpenNode("ColorRGBA", pTabLevel + 2, true, attr_list);
         attr_list.clear();
     }
@@ -351,7 +351,7 @@ void X3DExporter::Export_Mesh(const size_t pIdxMesh, const size_t pTabLevel) {
     // Export <TextureCoordinate>
     if (mesh.HasTextureCoords(0)) {
         AttrHelper_Vec3DAsVec2fArrToString(mesh.mTextureCoords[0], mesh.mNumVertices, attr_value);
-        attr_list.push_back({ "point", attr_value });
+        attr_list.emplace_back( "point", attr_value );
         NodeHelper_OpenNode("TextureCoordinate", pTabLevel + 2, true, attr_list);
         attr_list.clear();
     }
@@ -359,7 +359,7 @@ void X3DExporter::Export_Mesh(const size_t pIdxMesh, const size_t pTabLevel) {
     // Export <Normal>
     if (mesh.HasNormals()) {
         AttrHelper_Vec3DArrToString(mesh.mNormals, mesh.mNumVertices, attr_value);
-        attr_list.push_back({ "vector", attr_value });
+        attr_list.emplace_back( "vector", attr_value );
         NodeHelper_OpenNode("Normal", pTabLevel + 2, true, attr_list);
         attr_list.clear();
     }
@@ -380,7 +380,7 @@ void X3DExporter::Export_Material(const size_t pIdxMaterial, const size_t pTabLe
     // Check if material already defined early.
     if (mDEF_Map_Material.find(pIdxMaterial) != mDEF_Map_Material.end()) {
         // Material already defined, just refer to it
-        attr_list.push_back({ "USE", mDEF_Map_Material.at(pIdxMaterial) });
+        attr_list.emplace_back( "USE", mDEF_Map_Material.at(pIdxMaterial) );
         NodeHelper_OpenNode(NodeName_A, pTabLevel, true, attr_list);
 
         return;
@@ -392,7 +392,7 @@ void X3DExporter::Export_Material(const size_t pIdxMaterial, const size_t pTabLe
     if (material.Get(AI_MATKEY_NAME, ai_mat_name) == AI_SUCCESS) material_name.insert(0, ai_mat_name.C_Str());
 
     // Define material name.
-    attr_list.push_back({ "DEF", material_name });
+    attr_list.emplace_back( "DEF", material_name );
     mDEF_Map_Material[pIdxMaterial] = material_name;
 
     //
@@ -410,7 +410,7 @@ void X3DExporter::Export_Material(const size_t pIdxMaterial, const size_t pTabLe
 
             if (aiColor3D(pAttrValue.r, pAttrValue.g, pAttrValue.b) != pAttrDefaultValue) {
                 AttrHelper_Col4DArrToString(&pAttrValue, 1, tstr);
-                attr_list.push_back({ pAttrName, tstr });
+                attr_list.emplace_back( pAttrName, tstr );
             }
         };
 
@@ -462,7 +462,7 @@ void X3DExporter::Export_Material(const size_t pIdxMaterial, const size_t pTabLe
     //
     {
         auto RepeatToAttrList = [&](const string &pAttrName, const bool pAttrValue) {
-            if (!pAttrValue) attr_list.push_back({ pAttrName, "false" });
+            if (!pAttrValue) attr_list.emplace_back( pAttrName, "false" );
         };
 
         bool tvalb;
@@ -473,7 +473,7 @@ void X3DExporter::Export_Material(const size_t pIdxMaterial, const size_t pTabLe
             if (strncmp(tstring.C_Str(), AI_EMBEDDED_TEXNAME_PREFIX, strlen(AI_EMBEDDED_TEXNAME_PREFIX)) == 0)
                 LogError("Embedded texture is not supported");
             else
-                attr_list.push_back({ "url", string("\"") + tstring.C_Str() + "\"" });
+                attr_list.emplace_back( "url", string("\"") + tstring.C_Str() + "\"" );
         }
 
         // repeatS="true" SFBool
@@ -495,7 +495,7 @@ void X3DExporter::Export_Material(const size_t pIdxMaterial, const size_t pTabLe
 
             if (pAttrValue != pAttrDefaultValue) {
                 AttrHelper_Vec2DArrToString(&pAttrValue, 1, tstr);
-                attr_list.push_back({ pAttrName, tstr });
+                attr_list.emplace_back( pAttrName, tstr );
             }
         };
 
@@ -520,40 +520,40 @@ void X3DExporter::Export_Material(const size_t pIdxMaterial, const size_t pTabLe
 void X3DExporter::Export_MetadataBoolean(const aiString &pKey, const bool pValue, const size_t pTabLevel) {
     list<SAttribute> attr_list;
 
-    attr_list.push_back({ "name", pKey.C_Str() });
-    attr_list.push_back({ "value", pValue ? "true" : "false" });
+    attr_list.emplace_back( "name", pKey.C_Str() );
+    attr_list.emplace_back( "value", pValue ? "true" : "false" );
     NodeHelper_OpenNode("MetadataBoolean", pTabLevel, true, attr_list);
 }
 
 void X3DExporter::Export_MetadataDouble(const aiString &pKey, const double pValue, const size_t pTabLevel) {
     list<SAttribute> attr_list;
 
-    attr_list.push_back({ "name", pKey.C_Str() });
-    attr_list.push_back({ "value", to_string(pValue) });
+    attr_list.emplace_back( "name", pKey.C_Str() );
+    attr_list.emplace_back( "value", to_string(pValue) );
     NodeHelper_OpenNode("MetadataDouble", pTabLevel, true, attr_list);
 }
 
 void X3DExporter::Export_MetadataFloat(const aiString &pKey, const float pValue, const size_t pTabLevel) {
     list<SAttribute> attr_list;
 
-    attr_list.push_back({ "name", pKey.C_Str() });
-    attr_list.push_back({ "value", to_string(pValue) });
+    attr_list.emplace_back( "name", pKey.C_Str() );
+    attr_list.emplace_back( "value", to_string(pValue) );
     NodeHelper_OpenNode("MetadataFloat", pTabLevel, true, attr_list);
 }
 
 void X3DExporter::Export_MetadataInteger(const aiString &pKey, const int32_t pValue, const size_t pTabLevel) {
     list<SAttribute> attr_list;
 
-    attr_list.push_back({ "name", pKey.C_Str() });
-    attr_list.push_back({ "value", to_string(pValue) });
+    attr_list.emplace_back( "name", pKey.C_Str() );
+    attr_list.emplace_back( "value", to_string(pValue) );
     NodeHelper_OpenNode("MetadataInteger", pTabLevel, true, attr_list);
 }
 
 void X3DExporter::Export_MetadataString(const aiString &pKey, const aiString &pValue, const size_t pTabLevel) {
     list<SAttribute> attr_list;
 
-    attr_list.push_back({ "name", pKey.C_Str() });
-    attr_list.push_back({ "value", pValue.C_Str() });
+    attr_list.emplace_back( "name", pKey.C_Str() );
+    attr_list.emplace_back( "value", pValue.C_Str() );
     NodeHelper_OpenNode("MetadataString", pTabLevel, true, attr_list);
 }
 
@@ -565,7 +565,7 @@ bool X3DExporter::CheckAndExport_Light(const aiNode &pNode, const size_t pTabLev
 
         if (pAttrValue != pAttrDefaultValue) {
             AttrHelper_Vec3DArrToString(&pAttrValue, 1, tstr);
-            attr_list.push_back({ pAttrName, tstr });
+            attr_list.emplace_back( pAttrName, tstr );
         }
     };
 
@@ -590,8 +590,8 @@ bool X3DExporter::CheckAndExport_Light(const aiNode &pNode, const size_t pTabLev
 
     aiMatrix4x4 trafo_mat = Matrix_GlobalToCurrent(pNode).Inverse();
 
-    attr_list.push_back({ "DEF", light.mName.C_Str() });
-    attr_list.push_back({ "global", "true" }); // "false" is not supported.
+    attr_list.emplace_back( "DEF", light.mName.C_Str() );
+    attr_list.emplace_back( "global", "true" ); // "false" is not supported.
     // ambientIntensity="0" SFFloat [inputOutput]
     AttrHelper_FloatToAttrList(attr_list, "ambientIntensity", aiVector3D(light.mColorAmbient.r, light.mColorAmbient.g, light.mColorAmbient.b).Length(), 0);
     // color="1 1 1"        SFColor [inputOutput]
@@ -648,10 +648,10 @@ X3DExporter::X3DExporter(const char *pFileName, IOSystem *pIOSystem, const aiSce
     XML_Write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
     XML_Write("<!DOCTYPE X3D PUBLIC \"ISO//Web3D//DTD X3D 3.3//EN\" \"http://www.web3d.org/specifications/x3d-3.3.dtd\">\n");
     // Root node
-    attr_list.push_back({ "profile", "Interchange" });
-    attr_list.push_back({ "version", "3.3" });
-    attr_list.push_back({ "xmlns:xsd", "http://www.w3.org/2001/XMLSchema-instance" });
-    attr_list.push_back({ "xsd:noNamespaceSchemaLocation", "http://www.web3d.org/specifications/x3d-3.3.xsd" });
+    attr_list.emplace_back( "profile", "Interchange" );
+    attr_list.emplace_back( "version", "3.3" );
+    attr_list.emplace_back( "xmlns:xsd", "http://www.w3.org/2001/XMLSchema-instance" );
+    attr_list.emplace_back( "xsd:noNamespaceSchemaLocation", "http://www.web3d.org/specifications/x3d-3.3.xsd" );
     NodeHelper_OpenNode("X3D", 0, false, attr_list);
     attr_list.clear();
     // <head>: meta data.

--- a/code/AssetLib/X3D/X3DGeoHelper.cpp
+++ b/code/AssetLib/X3D/X3DGeoHelper.cpp
@@ -193,7 +193,7 @@ void X3DGeoHelper::add_color(aiMesh &pMesh, const std::list<aiColor3D> &pColors,
 
     // create RGBA array from RGB.
     for (std::list<aiColor3D>::const_iterator it = pColors.begin(); it != pColors.end(); ++it)
-        tcol.push_back(aiColor4D((*it).r, (*it).g, (*it).b, 1));
+        tcol.emplace_back((*it).r, (*it).g, (*it).b, 1);
 
     // call existing function for adding RGBA colors
     add_color(pMesh, tcol, pColorPerVertex);
@@ -238,7 +238,7 @@ void X3DGeoHelper::add_color(aiMesh &pMesh, const std::vector<int32_t> &pCoordId
 
     // create RGBA array from RGB.
     for (std::list<aiColor3D>::const_iterator it = pColors.begin(); it != pColors.end(); ++it) {
-        tcol.push_back(aiColor4D((*it).r, (*it).g, (*it).b, 1));
+        tcol.emplace_back((*it).r, (*it).g, (*it).b, 1);
     }
 
     // call existing function for adding RGBA colors
@@ -440,7 +440,7 @@ void X3DGeoHelper::add_tex_coord(aiMesh &pMesh, const std::vector<int32_t> &pCoo
     // copy list to array because we are need indexed access to normals.
     texcoord_arr_copy.reserve(pTexCoords.size());
     for (std::list<aiVector2D>::const_iterator it = pTexCoords.begin(); it != pTexCoords.end(); ++it) {
-        texcoord_arr_copy.push_back(aiVector3D((*it).x, (*it).y, 0));
+        texcoord_arr_copy.emplace_back((*it).x, (*it).y, 0);
     }
 
     if (pTexCoordIdx.size() > 0) {
@@ -480,7 +480,7 @@ void X3DGeoHelper::add_tex_coord(aiMesh &pMesh, const std::list<aiVector2D> &pTe
     // copy list to array because we are need convert aiVector2D to aiVector3D and also get indexed access as a bonus.
     tc_arr_copy.reserve(pTexCoords.size());
     for (std::list<aiVector2D>::const_iterator it = pTexCoords.begin(); it != pTexCoords.end(); ++it) {
-        tc_arr_copy.push_back(aiVector3D((*it).x, (*it).y, 0));
+        tc_arr_copy.emplace_back((*it).x, (*it).y, 0);
     }
 
     // copy texture coordinates to mesh

--- a/code/AssetLib/X3D/X3DImporter_Geometry2D.cpp
+++ b/code/AssetLib/X3D/X3DImporter_Geometry2D.cpp
@@ -152,7 +152,7 @@ void X3DImporter::readArcClose2D(XmlNode &node) {
             std::list<aiVector3D> &vlist = ((X3DNodeElementGeometry2D *)ne)->Vertices; // just short alias.
 
             if ((closureType == "PIE") || (closureType == "\"PIE\""))
-                vlist.push_back(aiVector3D(0, 0, 0)); // center point - first radial line
+                vlist.emplace_back(0, 0, 0); // center point - first radial line
             else if ((closureType != "CHORD") && (closureType != "\"CHORD\""))
                 Throw_IncorrectAttrValue("ArcClose2D", "closureType");
 
@@ -321,7 +321,7 @@ void X3DImporter::readPolyline2D(XmlNode &node) {
 
         // convert vec2 to vec3
         for (std::list<aiVector2D>::iterator it2 = lineSegments.begin(); it2 != lineSegments.end(); ++it2)
-            tlist.push_back(aiVector3D(it2->x, it2->y, 0));
+            tlist.emplace_back(it2->x, it2->y, 0);
 
         // convert point set to line set
         X3DGeoHelper::extend_point_to_line(tlist, ((X3DNodeElementGeometry2D *)ne)->Vertices);
@@ -359,7 +359,7 @@ void X3DImporter::readPolypoint2D(XmlNode &node) {
 
         // convert vec2 to vec3
         for (std::list<aiVector2D>::iterator it2 = point.begin(); it2 != point.end(); ++it2) {
-            ((X3DNodeElementGeometry2D *)ne)->Vertices.push_back(aiVector3D(it2->x, it2->y, 0));
+            ((X3DNodeElementGeometry2D *)ne)->Vertices.emplace_back(it2->x, it2->y, 0);
         }
 
         ((X3DNodeElementGeometry2D *)ne)->NumIndices = 1;
@@ -403,10 +403,10 @@ void X3DImporter::readRectangle2D(XmlNode &node) {
         float y2 = size.y / 2.0f;
         std::list<aiVector3D> &vlist = ((X3DNodeElementGeometry2D *)ne)->Vertices; // just short alias.
 
-        vlist.push_back(aiVector3D(x2, y1, 0)); // 1st point
-        vlist.push_back(aiVector3D(x2, y2, 0)); // 2nd point
-        vlist.push_back(aiVector3D(x1, y2, 0)); // 3rd point
-        vlist.push_back(aiVector3D(x1, y1, 0)); // 4th point
+        vlist.emplace_back(x2, y1, 0); // 1st point
+        vlist.emplace_back(x2, y2, 0); // 2nd point
+        vlist.emplace_back(x1, y2, 0); // 3rd point
+        vlist.emplace_back(x1, y1, 0); // 4th point
         ((X3DNodeElementGeometry2D *)ne)->Solid = solid;
         ((X3DNodeElementGeometry2D *)ne)->NumIndices = 4;
         // check for X3DMetadataObject childs.
@@ -447,7 +447,7 @@ void X3DImporter::readTriangleSet2D(XmlNode &node) {
 
         // convert vec2 to vec3
         for (std::list<aiVector2D>::iterator it2 = vertices.begin(); it2 != vertices.end(); ++it2) {
-            ((X3DNodeElementGeometry2D *)ne)->Vertices.push_back(aiVector3D(it2->x, it2->y, 0));
+            ((X3DNodeElementGeometry2D *)ne)->Vertices.emplace_back(it2->x, it2->y, 0);
         }
 
         ((X3DNodeElementGeometry2D *)ne)->Solid = solid;

--- a/code/Common/Exporter.cpp
+++ b/code/Common/Exporter.cpp
@@ -146,73 +146,73 @@ static void setupExporterArray(std::vector<Exporter::ExportFormatEntry> &exporte
 	(void)exporters;
 
 #ifndef ASSIMP_BUILD_NO_COLLADA_EXPORTER
-	exporters.push_back(Exporter::ExportFormatEntry("collada", "COLLADA - Digital Asset Exchange Schema", "dae", &ExportSceneCollada));
+	exporters.emplace_back("collada", "COLLADA - Digital Asset Exchange Schema", "dae", &ExportSceneCollada);
 #endif
 
 #ifndef ASSIMP_BUILD_NO_X_EXPORTER
-	exporters.push_back(Exporter::ExportFormatEntry("x", "X Files", "x", &ExportSceneXFile,
-			aiProcess_MakeLeftHanded | aiProcess_FlipWindingOrder | aiProcess_FlipUVs));
+	exporters.emplace_back("x", "X Files", "x", &ExportSceneXFile,
+			aiProcess_MakeLeftHanded | aiProcess_FlipWindingOrder | aiProcess_FlipUVs);
 #endif
 
 #ifndef ASSIMP_BUILD_NO_STEP_EXPORTER
-	exporters.push_back(Exporter::ExportFormatEntry("stp", "Step Files", "stp", &ExportSceneStep, 0));
+	exporters.emplace_back("stp", "Step Files", "stp", &ExportSceneStep, 0);
 #endif
 
 #ifndef ASSIMP_BUILD_NO_OBJ_EXPORTER
-	exporters.push_back(Exporter::ExportFormatEntry("obj", "Wavefront OBJ format", "obj", &ExportSceneObj,
-			aiProcess_GenSmoothNormals /*| aiProcess_PreTransformVertices */));
-	exporters.push_back(Exporter::ExportFormatEntry("objnomtl", "Wavefront OBJ format without material file", "obj", &ExportSceneObjNoMtl,
-			aiProcess_GenSmoothNormals /*| aiProcess_PreTransformVertices */));
+	exporters.emplace_back("obj", "Wavefront OBJ format", "obj", &ExportSceneObj,
+			aiProcess_GenSmoothNormals /*| aiProcess_PreTransformVertices */);
+	exporters.emplace_back("objnomtl", "Wavefront OBJ format without material file", "obj", &ExportSceneObjNoMtl,
+			aiProcess_GenSmoothNormals /*| aiProcess_PreTransformVertices */);
 #endif
 
 #ifndef ASSIMP_BUILD_NO_STL_EXPORTER
-	exporters.push_back(Exporter::ExportFormatEntry("stl", "Stereolithography", "stl", &ExportSceneSTL,
-			aiProcess_Triangulate | aiProcess_GenNormals | aiProcess_PreTransformVertices));
-	exporters.push_back(Exporter::ExportFormatEntry("stlb", "Stereolithography (binary)", "stl", &ExportSceneSTLBinary,
-			aiProcess_Triangulate | aiProcess_GenNormals | aiProcess_PreTransformVertices));
+	exporters.emplace_back("stl", "Stereolithography", "stl", &ExportSceneSTL,
+			aiProcess_Triangulate | aiProcess_GenNormals | aiProcess_PreTransformVertices);
+	exporters.emplace_back("stlb", "Stereolithography (binary)", "stl", &ExportSceneSTLBinary,
+			aiProcess_Triangulate | aiProcess_GenNormals | aiProcess_PreTransformVertices);
 #endif
 
 #ifndef ASSIMP_BUILD_NO_PLY_EXPORTER
-	exporters.push_back(Exporter::ExportFormatEntry("ply", "Stanford Polygon Library", "ply", &ExportScenePly,
-			aiProcess_PreTransformVertices));
-	exporters.push_back(Exporter::ExportFormatEntry("plyb", "Stanford Polygon Library (binary)", "ply", &ExportScenePlyBinary,
-			aiProcess_PreTransformVertices));
+	exporters.emplace_back("ply", "Stanford Polygon Library", "ply", &ExportScenePly,
+			aiProcess_PreTransformVertices);
+	exporters.emplace_back("plyb", "Stanford Polygon Library (binary)", "ply", &ExportScenePlyBinary,
+			aiProcess_PreTransformVertices);
 #endif
 
 #ifndef ASSIMP_BUILD_NO_3DS_EXPORTER
-	exporters.push_back(Exporter::ExportFormatEntry("3ds", "Autodesk 3DS (legacy)", "3ds", &ExportScene3DS,
-			aiProcess_Triangulate | aiProcess_SortByPType | aiProcess_JoinIdenticalVertices));
+	exporters.emplace_back("3ds", "Autodesk 3DS (legacy)", "3ds", &ExportScene3DS,
+			aiProcess_Triangulate | aiProcess_SortByPType | aiProcess_JoinIdenticalVertices);
 #endif
 
 #if !defined(ASSIMP_BUILD_NO_GLTF_EXPORTER) && !defined(ASSIMP_BUILD_NO_GLTF2_EXPORTER)
-	exporters.push_back(Exporter::ExportFormatEntry("gltf2", "GL Transmission Format v. 2", "gltf", &ExportSceneGLTF2,
-			aiProcess_JoinIdenticalVertices | aiProcess_Triangulate | aiProcess_SortByPType));
-	exporters.push_back(Exporter::ExportFormatEntry("glb2", "GL Transmission Format v. 2 (binary)", "glb", &ExportSceneGLB2,
-			aiProcess_JoinIdenticalVertices | aiProcess_Triangulate | aiProcess_SortByPType));
+	exporters.emplace_back("gltf2", "GL Transmission Format v. 2", "gltf", &ExportSceneGLTF2,
+			aiProcess_JoinIdenticalVertices | aiProcess_Triangulate | aiProcess_SortByPType);
+	exporters.emplace_back("glb2", "GL Transmission Format v. 2 (binary)", "glb", &ExportSceneGLB2,
+			aiProcess_JoinIdenticalVertices | aiProcess_Triangulate | aiProcess_SortByPType);
 #endif
 
 #if !defined(ASSIMP_BUILD_NO_GLTF_EXPORTER) && !defined(ASSIMP_BUILD_NO_GLTF1_EXPORTER)
-	exporters.push_back(Exporter::ExportFormatEntry("gltf", "GL Transmission Format", "gltf", &ExportSceneGLTF,
-			aiProcess_JoinIdenticalVertices | aiProcess_Triangulate | aiProcess_SortByPType));
-	exporters.push_back(Exporter::ExportFormatEntry("glb", "GL Transmission Format (binary)", "glb", &ExportSceneGLB,
-			aiProcess_JoinIdenticalVertices | aiProcess_Triangulate | aiProcess_SortByPType));
+	exporters.emplace_back("gltf", "GL Transmission Format", "gltf", &ExportSceneGLTF,
+			aiProcess_JoinIdenticalVertices | aiProcess_Triangulate | aiProcess_SortByPType);
+	exporters.emplace_back("glb", "GL Transmission Format (binary)", "glb", &ExportSceneGLB,
+			aiProcess_JoinIdenticalVertices | aiProcess_Triangulate | aiProcess_SortByPType);
 #endif
 
 #ifndef ASSIMP_BUILD_NO_ASSBIN_EXPORTER
-	exporters.push_back(Exporter::ExportFormatEntry("assbin", "Assimp Binary File", "assbin", &ExportSceneAssbin, 0));
+	exporters.emplace_back("assbin", "Assimp Binary File", "assbin", &ExportSceneAssbin, 0);
 #endif
 
 #ifndef ASSIMP_BUILD_NO_ASSXML_EXPORTER
-	exporters.push_back(Exporter::ExportFormatEntry("assxml", "Assimp XML Document", "assxml", &ExportSceneAssxml, 0));
+	exporters.emplace_back("assxml", "Assimp XML Document", "assxml", &ExportSceneAssxml, 0);
 #endif
 
 #ifndef ASSIMP_BUILD_NO_X3D_EXPORTER
-	exporters.push_back(Exporter::ExportFormatEntry("x3d", "Extensible 3D", "x3d", &ExportSceneX3D, 0));
+	exporters.emplace_back("x3d", "Extensible 3D", "x3d", &ExportSceneX3D, 0);
 #endif
 
 #ifndef ASSIMP_BUILD_NO_FBX_EXPORTER
-	exporters.push_back(Exporter::ExportFormatEntry("fbx", "Autodesk FBX (binary)", "fbx", &ExportSceneFBX, 0));
-	exporters.push_back(Exporter::ExportFormatEntry("fbxa", "Autodesk FBX (ascii)", "fbx", &ExportSceneFBXA, 0));
+	exporters.emplace_back("fbx", "Autodesk FBX (binary)", "fbx", &ExportSceneFBX, 0);
+	exporters.emplace_back("fbxa", "Autodesk FBX (ascii)", "fbx", &ExportSceneFBXA, 0);
 #endif
 
 #ifndef ASSIMP_BUILD_NO_M3D_EXPORTER
@@ -221,15 +221,15 @@ static void setupExporterArray(std::vector<Exporter::ExportFormatEntry> &exporte
 #endif
 
 #ifndef ASSIMP_BUILD_NO_3MF_EXPORTER
-	exporters.push_back(Exporter::ExportFormatEntry("3mf", "The 3MF-File-Format", "3mf", &ExportScene3MF, 0));
+	exporters.emplace_back("3mf", "The 3MF-File-Format", "3mf", &ExportScene3MF, 0);
 #endif
 
 #ifndef ASSIMP_BUILD_NO_PBRT_EXPORTER
-	exporters.push_back(Exporter::ExportFormatEntry("pbrt", "pbrt-v4 scene description file", "pbrt", &ExportScenePbrt, aiProcess_Triangulate | aiProcess_SortByPType));
+	exporters.emplace_back("pbrt", "pbrt-v4 scene description file", "pbrt", &ExportScenePbrt, aiProcess_Triangulate | aiProcess_SortByPType);
 #endif
 
 #ifndef ASSIMP_BUILD_NO_ASSJSON_EXPORTER
-	exporters.push_back(Exporter::ExportFormatEntry("assjson", "Assimp JSON Document", "json", &ExportAssimp2Json, 0));
+	exporters.emplace_back("assjson", "Assimp JSON Document", "json", &ExportAssimp2Json, 0);
 #endif
 }
 

--- a/code/Common/SGSpatialSort.cpp
+++ b/code/Common/SGSpatialSort.cpp
@@ -69,8 +69,8 @@ void SGSpatialSort::Add(const aiVector3D& vPosition, unsigned int index,
 {
     // store position by index and distance
     float distance = vPosition * mPlaneNormal;
-    mPositions.push_back( Entry( index, vPosition,
-        distance, smoothingGroup));
+    mPositions.emplace_back( index, vPosition,
+        distance, smoothingGroup);
 }
 // ------------------------------------------------------------------------------------------------
 void SGSpatialSort::Prepare()

--- a/code/Common/SceneCombiner.cpp
+++ b/code/Common/SceneCombiner.cpp
@@ -510,7 +510,7 @@ void SceneCombiner::MergeScenes(aiScene **_dest, aiScene *master, std::vector<At
             OffsetNodeMeshIndices(node, offset[n]);
         }
         if (n) // src[0] is the master node
-            nodes.push_back(NodeAttachmentInfo(node, srcList[n - 1].attachToNode, n));
+            nodes.emplace_back(node, srcList[n - 1].attachToNode, n);
 
         // add name prefixes?
         if (flags & AI_INT_MERGE_SCENE_GEN_UNIQUE_NAMES) {
@@ -685,19 +685,19 @@ void SceneCombiner::BuildUniqueBoneList(std::list<BoneWithHash> &asBones,
 
             for (; it2 != end2; ++it2) {
                 if ((*it2).first == itml) {
-                    (*it2).pSrcBones.push_back(BoneSrcIndex(p, iOffset));
+                    (*it2).pSrcBones.emplace_back(p, iOffset);
                     break;
                 }
             }
             if (end2 == it2) {
                 // need to begin a new bone entry
-                asBones.push_back(BoneWithHash());
+                asBones.emplace_back();
                 BoneWithHash &btz = asBones.back();
 
                 // setup members
                 btz.first = itml;
                 btz.second = &p->mName;
-                btz.pSrcBones.push_back(BoneSrcIndex(p, iOffset));
+                btz.pSrcBones.emplace_back(p, iOffset);
             }
         }
         iOffset += (*it)->mNumVertices;

--- a/code/Common/SkeletonMeshBuilder.cpp
+++ b/code/Common/SkeletonMeshBuilder.cpp
@@ -122,50 +122,50 @@ void SkeletonMeshBuilder::CreateGeometry(const aiNode *pNode) {
             mVertices.push_back(childpos);
             mVertices.push_back(-front * distanceToChild * (ai_real)0.1);
 
-            mFaces.push_back(Face(localVertexStart + 0, localVertexStart + 1, localVertexStart + 2));
-            mFaces.push_back(Face(localVertexStart + 3, localVertexStart + 4, localVertexStart + 5));
-            mFaces.push_back(Face(localVertexStart + 6, localVertexStart + 7, localVertexStart + 8));
-            mFaces.push_back(Face(localVertexStart + 9, localVertexStart + 10, localVertexStart + 11));
+            mFaces.emplace_back(localVertexStart + 0, localVertexStart + 1, localVertexStart + 2);
+            mFaces.emplace_back(localVertexStart + 3, localVertexStart + 4, localVertexStart + 5);
+            mFaces.emplace_back(localVertexStart + 6, localVertexStart + 7, localVertexStart + 8);
+            mFaces.emplace_back(localVertexStart + 9, localVertexStart + 10, localVertexStart + 11);
         }
     } else {
         // if the node has no children, it's an end node. Put a little knob there instead
         aiVector3D ownpos(pNode->mTransformation.a4, pNode->mTransformation.b4, pNode->mTransformation.c4);
         ai_real sizeEstimate = ownpos.Length() * ai_real(0.18);
 
-        mVertices.push_back(aiVector3D(-sizeEstimate, 0.0, 0.0));
-        mVertices.push_back(aiVector3D(0.0, sizeEstimate, 0.0));
-        mVertices.push_back(aiVector3D(0.0, 0.0, -sizeEstimate));
-        mVertices.push_back(aiVector3D(0.0, sizeEstimate, 0.0));
-        mVertices.push_back(aiVector3D(sizeEstimate, 0.0, 0.0));
-        mVertices.push_back(aiVector3D(0.0, 0.0, -sizeEstimate));
-        mVertices.push_back(aiVector3D(sizeEstimate, 0.0, 0.0));
-        mVertices.push_back(aiVector3D(0.0, -sizeEstimate, 0.0));
-        mVertices.push_back(aiVector3D(0.0, 0.0, -sizeEstimate));
-        mVertices.push_back(aiVector3D(0.0, -sizeEstimate, 0.0));
-        mVertices.push_back(aiVector3D(-sizeEstimate, 0.0, 0.0));
-        mVertices.push_back(aiVector3D(0.0, 0.0, -sizeEstimate));
+        mVertices.emplace_back(-sizeEstimate, 0.0, 0.0);
+        mVertices.emplace_back(0.0, sizeEstimate, 0.0);
+        mVertices.emplace_back(0.0, 0.0, -sizeEstimate);
+        mVertices.emplace_back(0.0, sizeEstimate, 0.0);
+        mVertices.emplace_back(sizeEstimate, 0.0, 0.0);
+        mVertices.emplace_back(0.0, 0.0, -sizeEstimate);
+        mVertices.emplace_back(sizeEstimate, 0.0, 0.0);
+        mVertices.emplace_back(0.0, -sizeEstimate, 0.0);
+        mVertices.emplace_back(0.0, 0.0, -sizeEstimate);
+        mVertices.emplace_back(0.0, -sizeEstimate, 0.0);
+        mVertices.emplace_back(-sizeEstimate, 0.0, 0.0);
+        mVertices.emplace_back(0.0, 0.0, -sizeEstimate);
 
-        mVertices.push_back(aiVector3D(-sizeEstimate, 0.0, 0.0));
-        mVertices.push_back(aiVector3D(0.0, 0.0, sizeEstimate));
-        mVertices.push_back(aiVector3D(0.0, sizeEstimate, 0.0));
-        mVertices.push_back(aiVector3D(0.0, sizeEstimate, 0.0));
-        mVertices.push_back(aiVector3D(0.0, 0.0, sizeEstimate));
-        mVertices.push_back(aiVector3D(sizeEstimate, 0.0, 0.0));
-        mVertices.push_back(aiVector3D(sizeEstimate, 0.0, 0.0));
-        mVertices.push_back(aiVector3D(0.0, 0.0, sizeEstimate));
-        mVertices.push_back(aiVector3D(0.0, -sizeEstimate, 0.0));
-        mVertices.push_back(aiVector3D(0.0, -sizeEstimate, 0.0));
-        mVertices.push_back(aiVector3D(0.0, 0.0, sizeEstimate));
-        mVertices.push_back(aiVector3D(-sizeEstimate, 0.0, 0.0));
+        mVertices.emplace_back(-sizeEstimate, 0.0, 0.0);
+        mVertices.emplace_back(0.0, 0.0, sizeEstimate);
+        mVertices.emplace_back(0.0, sizeEstimate, 0.0);
+        mVertices.emplace_back(0.0, sizeEstimate, 0.0);
+        mVertices.emplace_back(0.0, 0.0, sizeEstimate);
+        mVertices.emplace_back(sizeEstimate, 0.0, 0.0);
+        mVertices.emplace_back(sizeEstimate, 0.0, 0.0);
+        mVertices.emplace_back(0.0, 0.0, sizeEstimate);
+        mVertices.emplace_back(0.0, -sizeEstimate, 0.0);
+        mVertices.emplace_back(0.0, -sizeEstimate, 0.0);
+        mVertices.emplace_back(0.0, 0.0, sizeEstimate);
+        mVertices.emplace_back(-sizeEstimate, 0.0, 0.0);
 
-        mFaces.push_back(Face(vertexStartIndex + 0, vertexStartIndex + 1, vertexStartIndex + 2));
-        mFaces.push_back(Face(vertexStartIndex + 3, vertexStartIndex + 4, vertexStartIndex + 5));
-        mFaces.push_back(Face(vertexStartIndex + 6, vertexStartIndex + 7, vertexStartIndex + 8));
-        mFaces.push_back(Face(vertexStartIndex + 9, vertexStartIndex + 10, vertexStartIndex + 11));
-        mFaces.push_back(Face(vertexStartIndex + 12, vertexStartIndex + 13, vertexStartIndex + 14));
-        mFaces.push_back(Face(vertexStartIndex + 15, vertexStartIndex + 16, vertexStartIndex + 17));
-        mFaces.push_back(Face(vertexStartIndex + 18, vertexStartIndex + 19, vertexStartIndex + 20));
-        mFaces.push_back(Face(vertexStartIndex + 21, vertexStartIndex + 22, vertexStartIndex + 23));
+        mFaces.emplace_back(vertexStartIndex + 0, vertexStartIndex + 1, vertexStartIndex + 2);
+        mFaces.emplace_back(vertexStartIndex + 3, vertexStartIndex + 4, vertexStartIndex + 5);
+        mFaces.emplace_back(vertexStartIndex + 6, vertexStartIndex + 7, vertexStartIndex + 8);
+        mFaces.emplace_back(vertexStartIndex + 9, vertexStartIndex + 10, vertexStartIndex + 11);
+        mFaces.emplace_back(vertexStartIndex + 12, vertexStartIndex + 13, vertexStartIndex + 14);
+        mFaces.emplace_back(vertexStartIndex + 15, vertexStartIndex + 16, vertexStartIndex + 17);
+        mFaces.emplace_back(vertexStartIndex + 18, vertexStartIndex + 19, vertexStartIndex + 20);
+        mFaces.emplace_back(vertexStartIndex + 21, vertexStartIndex + 22, vertexStartIndex + 23);
     }
 
     unsigned int numVertices = static_cast<unsigned int>(mVertices.size() - vertexStartIndex);

--- a/code/Common/SpatialSort.cpp
+++ b/code/Common/SpatialSort.cpp
@@ -116,7 +116,7 @@ void SpatialSort::Append(const aiVector3D *pPositions, unsigned int pNumPosition
     for (unsigned int a = 0; a < pNumPositions; a++) {
         const char *tempPointer = reinterpret_cast<const char *>(pPositions);
         const aiVector3D *vec = reinterpret_cast<const aiVector3D *>(tempPointer + a * pElementOffset);
-        mPositions.push_back(Entry(static_cast<unsigned int>(a + initial), *vec));
+        mPositions.emplace_back(static_cast<unsigned int>(a + initial), *vec);
     }
 
     if (pFinalize) {

--- a/code/Common/StandardShapes.cpp
+++ b/code/Common/StandardShapes.cpp
@@ -422,15 +422,15 @@ void StandardShapes::MakeCone(ai_real height, ai_real radius1,
 
         if (!bOpen) {
             // generate the end 'cap'
-            positions.push_back(aiVector3D(s * radius2, halfHeight, t * radius2));
-            positions.push_back(aiVector3D(s2 * radius2, halfHeight, t2 * radius2));
-            positions.push_back(aiVector3D(0.0, halfHeight, 0.0));
+            positions.emplace_back(s * radius2, halfHeight, t * radius2);
+            positions.emplace_back(s2 * radius2, halfHeight, t2 * radius2);
+            positions.emplace_back(0.0, halfHeight, 0.0);
 
             if (radius1) {
                 // generate the other end 'cap'
-                positions.push_back(aiVector3D(s * radius1, -halfHeight, t * radius1));
-                positions.push_back(aiVector3D(s2 * radius1, -halfHeight, t2 * radius1));
-                positions.push_back(aiVector3D(0.0, -halfHeight, 0.0));
+                positions.emplace_back(s * radius1, -halfHeight, t * radius1);
+                positions.emplace_back(s2 * radius1, -halfHeight, t2 * radius1);
+                positions.emplace_back(0.0, -halfHeight, 0.0);
             }
         }
         s = s2;
@@ -466,13 +466,13 @@ void StandardShapes::MakeCircle(ai_real radius, unsigned int tess,
     ai_real t = 0.0; // std::sin(angle == 0);
 
     for (ai_real angle = 0.0; angle < angle_max;) {
-        positions.push_back(aiVector3D(s * radius, 0.0, t * radius));
+        positions.emplace_back(s * radius, 0.0, t * radius);
         angle += angle_delta;
         s = std::cos(angle);
         t = std::sin(angle);
-        positions.push_back(aiVector3D(s * radius, 0.0, t * radius));
+        positions.emplace_back(s * radius, 0.0, t * radius);
 
-        positions.push_back(aiVector3D(0.0, 0.0, 0.0));
+        positions.emplace_back(0.0, 0.0, 0.0);
     }
 }
 

--- a/code/PostProcessing/ProcessHelper.cpp
+++ b/code/PostProcessing/ProcessHelper.cpp
@@ -63,7 +63,7 @@ void ConvertListToStrings(const std::string &in, std::list<std::string> &out) {
                     return;
                 }
             }
-            out.push_back(std::string(base, (size_t)(s - base)));
+            out.emplace_back(base, (size_t)(s - base));
             ++s;
         } else {
             out.push_back(GetNextToken(s));

--- a/code/PostProcessing/SplitLargeMeshes.cpp
+++ b/code/PostProcessing/SplitLargeMeshes.cpp
@@ -316,13 +316,13 @@ void SplitLargeMeshesProcess_Triangle::SplitMesh(
             }
 
             // add the newly created mesh to the list
-            avList.push_back(std::pair<aiMesh*, unsigned int>(pcMesh,a));
+            avList.emplace_back(pcMesh,a);
         }
 
         // now delete the old mesh data
         delete pMesh;
     } else {
-        avList.push_back(std::pair<aiMesh*, unsigned int>(pMesh,a));
+        avList.emplace_back(pMesh,a);
     }
 }
 
@@ -484,7 +484,7 @@ void SplitLargeMeshesProcess_Vertex::SplitMesh(
                     break;
                 }
 
-                vFaces.push_back(aiFace());
+                vFaces.emplace_back();
                 aiFace& rFace = vFaces.back();
 
                 // setup face type and number of indices
@@ -605,7 +605,7 @@ void SplitLargeMeshesProcess_Vertex::SplitMesh(
             }
 
             // add the newly created mesh to the list
-            avList.push_back(std::pair<aiMesh*, unsigned int>(pcMesh,a));
+            avList.emplace_back(pcMesh,a);
 
             if (iBase == pMesh->mNumFaces) {
                 // have all faces ... finish the outer loop, too
@@ -620,5 +620,5 @@ void SplitLargeMeshesProcess_Vertex::SplitMesh(
         delete pMesh;
         return;
     }
-    avList.push_back(std::pair<aiMesh*, unsigned int>(pMesh,a));
+    avList.emplace_back(pMesh,a);
 }


### PR DESCRIPTION
This PR applies the modernize-use-emplace clang-tidy rule to the code base to improve performance/readability. The clang-tidy check prefers "emplace" to "push" on STL containers when its could improve performance. 

Using emplace prevents a temporary from being constructed as the arg to push method call and instead calls the constructor of the object at the appropiate memory location within the STL container. This particularly useful for constructing objects from c_string pointers or adding std::tuple, std::pairs to containers etc since no move operation is required. This can dramatically speed up some operations involving push items onto a STL container (like a std::vector).