### PR TITLE
clang-tidy: explicitly default all empty ctors and dtors

### DIFF
--- a/code/AssetLib/3DS/3DSExporter.cpp
+++ b/code/AssetLib/3DS/3DSExporter.cpp
@@ -209,9 +209,7 @@ Discreet3DSExporter::Discreet3DSExporter(std::shared_ptr<IOStream> &outfile, con
 }
 
 // ------------------------------------------------------------------------------------------------
-Discreet3DSExporter::~Discreet3DSExporter() {
-    // empty
-}
+Discreet3DSExporter::~Discreet3DSExporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 int Discreet3DSExporter::WriteHierarchy(const aiNode &node, int seq, int sibling_level) {

--- a/code/AssetLib/3DS/3DSLoader.cpp
+++ b/code/AssetLib/3DS/3DSLoader.cpp
@@ -105,9 +105,7 @@ Discreet3DSImporter::Discreet3DSImporter() :
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-Discreet3DSImporter::~Discreet3DSImporter() {
-    // empty
-}
+Discreet3DSImporter::~Discreet3DSImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/3MF/D3MFImporter.cpp
+++ b/code/AssetLib/3MF/D3MFImporter.cpp
@@ -81,14 +81,9 @@ static const aiImporterDesc desc = {
     "3mf"
 };
 
-D3MFImporter::D3MFImporter() :
-        BaseImporter() {
-    // empty
-}
+D3MFImporter::D3MFImporter() = default;
 
-D3MFImporter::~D3MFImporter() {
-    // empty
-}
+D3MFImporter::~D3MFImporter() = default;
 
 bool D3MFImporter::CanRead(const std::string &filename, IOSystem *pIOHandler, bool /*checkSig*/) const {
     if (!ZipArchiveIOSystem::isZipArchive(pIOHandler, filename)) {

--- a/code/AssetLib/AC/ACLoader.cpp
+++ b/code/AssetLib/AC/ACLoader.cpp
@@ -146,9 +146,7 @@ AC3DImporter::AC3DImporter() :
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-AC3DImporter::~AC3DImporter() {
-    // nothing to be done here
-}
+AC3DImporter::~AC3DImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/ASE/ASELoader.cpp
+++ b/code/AssetLib/ASE/ASELoader.cpp
@@ -89,9 +89,7 @@ ASEImporter::ASEImporter() :
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-ASEImporter::~ASEImporter() {
-    // empty
-}
+ASEImporter::~ASEImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/ASE/ASEParser.h
+++ b/code/AssetLib/ASE/ASEParser.h
@@ -116,7 +116,7 @@ struct Material : public D3DS::Material {
         return *this;
     }
 
-    ~Material() {}
+    ~Material() = default;
 
     //! Contains all sub materials of this material
     std::vector<Material> avSubMaterials;

--- a/code/AssetLib/B3D/B3DImporter.cpp
+++ b/code/AssetLib/B3D/B3DImporter.cpp
@@ -88,9 +88,7 @@ void DeleteAllBarePointers(std::vector<T> &x) {
     }
 }
 
-B3DImporter::~B3DImporter() {
-    // empty
-}
+B3DImporter::~B3DImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 bool B3DImporter::CanRead(const std::string &pFile, IOSystem * /*pIOHandler*/, bool /*checkSig*/) const {

--- a/code/AssetLib/B3D/B3DImporter.cpp
+++ b/code/AssetLib/B3D/B3DImporter.cpp
@@ -671,7 +671,7 @@ void B3DImporter::ReadBB3D(aiScene *scene) {
                         int bone = v.bones[k];
                         float weight = v.weights[k];
 
-                        vweights[bone].push_back(aiVertexWeight(vertIdx + faceIndex, weight));
+                        vweights[bone].emplace_back(vertIdx + faceIndex, weight);
                     }
                 }
                 ++face;

--- a/code/AssetLib/BVH/BVHLoader.cpp
+++ b/code/AssetLib/BVH/BVHLoader.cpp
@@ -88,7 +88,7 @@ BVHLoader::BVHLoader() :
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-BVHLoader::~BVHLoader() {}
+BVHLoader::~BVHLoader() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/Blender/BlenderIntermediate.h
+++ b/code/AssetLib/Blender/BlenderIntermediate.h
@@ -65,8 +65,7 @@ namespace Blender {
     struct TempArray    {
         typedef TCLASS< T*,std::allocator<T*> > mywrap;
 
-        TempArray() {
-        }
+        TempArray() = default;
 
         ~TempArray () {
             for(T* elem : arr) {

--- a/code/AssetLib/Blender/BlenderTessellator.cpp
+++ b/code/AssetLib/Blender/BlenderTessellator.cpp
@@ -274,7 +274,7 @@ BlenderTessellatorP2T::BlenderTessellatorP2T( BlenderBMeshConverter& converter )
 }
 
 // ------------------------------------------------------------------------------------------------
-BlenderTessellatorP2T::~BlenderTessellatorP2T() = default;
+
 
 // ------------------------------------------------------------------------------------------------
 void BlenderTessellatorP2T::Tessellate( const MLoop* polyLoop, int vertexCount, const std::vector< MVert >& vertices )

--- a/code/AssetLib/Blender/BlenderTessellator.cpp
+++ b/code/AssetLib/Blender/BlenderTessellator.cpp
@@ -274,9 +274,7 @@ BlenderTessellatorP2T::BlenderTessellatorP2T( BlenderBMeshConverter& converter )
 }
 
 // ------------------------------------------------------------------------------------------------
-BlenderTessellatorP2T::~BlenderTessellatorP2T( )
-{
-}
+BlenderTessellatorP2T::~BlenderTessellatorP2T() = default;
 
 // ------------------------------------------------------------------------------------------------
 void BlenderTessellatorP2T::Tessellate( const MLoop* polyLoop, int vertexCount, const std::vector< MVert >& vertices )

--- a/code/AssetLib/Blender/BlenderTessellator.h
+++ b/code/AssetLib/Blender/BlenderTessellator.h
@@ -186,7 +186,7 @@ namespace Assimp
     {
     public:
         BlenderTessellatorP2T( BlenderBMeshConverter& converter );
-        ~BlenderTessellatorP2T( );
+        ~BlenderTessellatorP2T( ) = default;
 
         void Tessellate( const Blender::MLoop* polyLoop, int vertexCount, const std::vector< Blender::MVert >& vertices );
 

--- a/code/AssetLib/COB/COBLoader.cpp
+++ b/code/AssetLib/COB/COBLoader.cpp
@@ -91,15 +91,11 @@ static const aiImporterDesc desc = {
 
 // ------------------------------------------------------------------------------------------------
 // Constructor to be privately used by Importer
-COBImporter::COBImporter() {
-    // empty
-}
+COBImporter::COBImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-COBImporter::~COBImporter() {
-    // empty
-}
+COBImporter::~COBImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/COB/COBLoader.cpp
+++ b/code/AssetLib/COB/COBLoader.cpp
@@ -518,7 +518,7 @@ void COBImporter::ReadMat1_Ascii(Scene &out, LineSplitter &splitter, const Chunk
         return;
     }
 
-    out.materials.push_back(Material());
+    out.materials.emplace_back();
     Material &mat = out.materials.back();
     mat = nfo;
 
@@ -1004,7 +1004,7 @@ void COBImporter::ReadMat1_Binary(COB::Scene &out, StreamReaderLE &reader, const
 
     const chunk_guard cn(nfo, reader);
 
-    out.materials.push_back(Material());
+    out.materials.emplace_back();
     Material &mat = out.materials.back();
     mat = nfo;
 

--- a/code/AssetLib/COB/COBScene.h
+++ b/code/AssetLib/COB/COBScene.h
@@ -107,7 +107,7 @@ struct Node : public ChunkInfo
         TYPE_MESH,TYPE_GROUP,TYPE_LIGHT,TYPE_CAMERA,TYPE_BONE
     };
 
-    virtual ~Node() {}
+    virtual ~Node() = default;
     Node(Type type) : type(type), unit_scale(1.f){}
 
     Type type;

--- a/code/AssetLib/CSM/CSMLoader.cpp
+++ b/code/AssetLib/CSM/CSMLoader.cpp
@@ -85,8 +85,7 @@ CSMImporter::CSMImporter()
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-CSMImporter::~CSMImporter()
-{}
+CSMImporter::~CSMImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/Collada/ColladaExporter.cpp
+++ b/code/AssetLib/Collada/ColladaExporter.cpp
@@ -154,8 +154,7 @@ ColladaExporter::ColladaExporter(const aiScene *pScene, IOSystem *pIOSystem, con
 
 // ------------------------------------------------------------------------------------------------
 // Destructor
-ColladaExporter::~ColladaExporter() {
-}
+ColladaExporter::~ColladaExporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Starts writing the contents

--- a/code/AssetLib/Collada/ColladaExporter.h
+++ b/code/AssetLib/Collada/ColladaExporter.h
@@ -233,7 +233,7 @@ public:
         Surface ambient, diffuse, specular, emissive, reflective, transparent, normal;
         Property shininess, transparency, index_refraction;
 
-        Material() {}
+        Material() = default;
     };
 
     std::map<unsigned int, std::string> textures;

--- a/code/AssetLib/Collada/ColladaLoader.cpp
+++ b/code/AssetLib/Collada/ColladaLoader.cpp
@@ -111,9 +111,7 @@ ColladaLoader::ColladaLoader() :
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-ColladaLoader::~ColladaLoader() {
-    // empty
-}
+ColladaLoader::~ColladaLoader() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/DXF/DXFLoader.cpp
+++ b/code/AssetLib/DXF/DXFLoader.cpp
@@ -110,16 +110,11 @@ static const aiImporterDesc desc = {
 
 // ------------------------------------------------------------------------------------------------
 // Constructor to be privately used by Importer
-DXFImporter::DXFImporter()
-: BaseImporter() {
-    // empty
-}
+DXFImporter::DXFImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-DXFImporter::~DXFImporter() {
-    // empty
-}
+DXFImporter::~DXFImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/FBX/FBXConverter.cpp
+++ b/code/AssetLib/FBX/FBXConverter.cpp
@@ -3319,7 +3319,7 @@ FBXConverter::KeyFrameListList FBXConverter::GetKeyframeList(const std::vector<c
                 }
             }
 
-            inputs.push_back(std::make_tuple(Keys, Values, mapto));
+            inputs.emplace_back(Keys, Values, mapto);
         }
     }
     return inputs; // pray for NRVO :-)
@@ -3396,7 +3396,7 @@ FBXConverter::KeyFrameListList FBXConverter::GetRotationKeyframeList(const std::
                     }
                 }
             }
-            inputs.push_back(std::make_tuple(Keys, Values, mapto));
+            inputs.emplace_back(Keys, Values, mapto);
         }
     }
     return inputs;

--- a/code/AssetLib/FBX/FBXDeformer.cpp
+++ b/code/AssetLib/FBX/FBXDeformer.cpp
@@ -66,11 +66,7 @@ Deformer::Deformer(uint64_t id, const Element& element, const Document& doc, con
 }
 
 // ------------------------------------------------------------------------------------------------
-Deformer::~Deformer()
-{
-
-}
-
+Deformer::~Deformer() = default;
 
 // ------------------------------------------------------------------------------------------------
 Cluster::Cluster(uint64_t id, const Element& element, const Document& doc, const std::string& name)
@@ -119,11 +115,7 @@ Cluster::Cluster(uint64_t id, const Element& element, const Document& doc, const
 
 
 // ------------------------------------------------------------------------------------------------
-Cluster::~Cluster()
-{
-
-}
-
+Cluster::~Cluster() = default;
 
 // ------------------------------------------------------------------------------------------------
 Skin::Skin(uint64_t id, const Element& element, const Document& doc, const std::string& name)
@@ -152,10 +144,7 @@ Skin::Skin(uint64_t id, const Element& element, const Document& doc, const std::
 
 
 // ------------------------------------------------------------------------------------------------
-Skin::~Skin()
-{
-
-}
+Skin::~Skin() = default;
 // ------------------------------------------------------------------------------------------------
 BlendShape::BlendShape(uint64_t id, const Element& element, const Document& doc, const std::string& name)
     : Deformer(id, element, doc, name)
@@ -171,10 +160,7 @@ BlendShape::BlendShape(uint64_t id, const Element& element, const Document& doc,
     }
 }
 // ------------------------------------------------------------------------------------------------
-BlendShape::~BlendShape()
-{
-
-}
+BlendShape::~BlendShape() = default;
 // ------------------------------------------------------------------------------------------------
 BlendShapeChannel::BlendShapeChannel(uint64_t id, const Element& element, const Document& doc, const std::string& name)
     : Deformer(id, element, doc, name)
@@ -199,10 +185,7 @@ BlendShapeChannel::BlendShapeChannel(uint64_t id, const Element& element, const 
     }
 }
 // ------------------------------------------------------------------------------------------------
-BlendShapeChannel::~BlendShapeChannel()
-{
-
-}
+BlendShapeChannel::~BlendShapeChannel() = default;
 // ------------------------------------------------------------------------------------------------
 }
 }

--- a/code/AssetLib/FBX/FBXMaterial.cpp
+++ b/code/AssetLib/FBX/FBXMaterial.cpp
@@ -136,9 +136,7 @@ Material::Material(uint64_t id, const Element& element, const Document& doc, con
 
 
 // ------------------------------------------------------------------------------------------------
-Material::~Material() {
-    // empty
-}
+Material::~Material() = default;
 
     aiVector2D uvTrans;
     aiVector2D uvScaling;
@@ -255,9 +253,7 @@ Texture::Texture(uint64_t id, const Element& element, const Document& doc, const
 }
 
 
-Texture::~Texture() {
-    // empty
-}
+Texture::~Texture() = default;
 
 LayeredTexture::LayeredTexture(uint64_t id, const Element& element, const Document& /*doc*/, const std::string& name) :
         Object(id,element,name),
@@ -276,9 +272,7 @@ LayeredTexture::LayeredTexture(uint64_t id, const Element& element, const Docume
     }
 }
 
-LayeredTexture::~LayeredTexture() {
-    // empty
-}
+LayeredTexture::~LayeredTexture() = default;
 
 void LayeredTexture::fillTexture(const Document& doc) {
     const std::vector<const Connection*>& conns = doc.GetConnectionsByDestinationSequenced(ID());

--- a/code/AssetLib/FBX/FBXMeshGeometry.cpp
+++ b/code/AssetLib/FBX/FBXMeshGeometry.cpp
@@ -665,9 +665,7 @@ ShapeGeometry::ShapeGeometry(uint64_t id, const Element& element, const std::str
 }
 
 // ------------------------------------------------------------------------------------------------
-ShapeGeometry::~ShapeGeometry() {
-    // empty
-}
+ShapeGeometry::~ShapeGeometry() = default;
 // ------------------------------------------------------------------------------------------------
 const std::vector<aiVector3D>& ShapeGeometry::GetVertices() const {
     return m_vertices;
@@ -695,9 +693,7 @@ LineGeometry::LineGeometry(uint64_t id, const Element& element, const std::strin
 }
 
 // ------------------------------------------------------------------------------------------------
-LineGeometry::~LineGeometry() {
-    // empty
-}
+LineGeometry::~LineGeometry() = default;
 // ------------------------------------------------------------------------------------------------
 const std::vector<aiVector3D>& LineGeometry::GetVertices() const {
     return m_vertices;

--- a/code/AssetLib/FBX/FBXProperties.cpp
+++ b/code/AssetLib/FBX/FBXProperties.cpp
@@ -60,29 +60,23 @@ namespace FBX {
     using namespace Util;
 
 // ------------------------------------------------------------------------------------------------
-Property::Property()
-{
-}
+    Property::Property() = default;
 
-// ------------------------------------------------------------------------------------------------
-Property::~Property()
-{
-}
+    // ------------------------------------------------------------------------------------------------
+    Property::~Property() = default;
 
-namespace {
+    namespace {
 
-void checkTokenCount(const TokenList& tok, unsigned int expectedCount)
-{
-    ai_assert(expectedCount >= 2);
-    if (tok.size() < expectedCount) {
-        const std::string& s = ParseTokenAsString(*tok[1]);
-        if (tok[1]->IsBinary()) {
-            throw DeadlyImportError("Not enough tokens for property of type ", s, " at offset ", tok[1]->Offset());
+    void checkTokenCount(const TokenList &tok, unsigned int expectedCount) {
+        ai_assert(expectedCount >= 2);
+        if (tok.size() < expectedCount) {
+            const std::string &s = ParseTokenAsString(*tok[1]);
+            if (tok[1]->IsBinary()) {
+                throw DeadlyImportError("Not enough tokens for property of type ", s, " at offset ", tok[1]->Offset());
+            } else {
+                throw DeadlyImportError("Not enough tokens for property of type ", s, " at line ", tok[1]->Line());
+            }
         }
-        else {
-            throw DeadlyImportError("Not enough tokens for property of type ", s, " at line ", tok[1]->Line());
-        }
-    }
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/code/AssetLib/FBX/FBXTokenizer.cpp
+++ b/code/AssetLib/FBX/FBXTokenizer.cpp
@@ -79,7 +79,7 @@ Token::Token(const char* sbegin, const char* send, TokenType type, unsigned int 
 }
 
 // ------------------------------------------------------------------------------------------------
-Token::~Token() = default;
+
 
 namespace {
 

--- a/code/AssetLib/FBX/FBXTokenizer.cpp
+++ b/code/AssetLib/FBX/FBXTokenizer.cpp
@@ -79,9 +79,7 @@ Token::Token(const char* sbegin, const char* send, TokenType type, unsigned int 
 }
 
 // ------------------------------------------------------------------------------------------------
-Token::~Token()
-{
-}
+Token::~Token() = default;
 
 namespace {
 

--- a/code/AssetLib/FBX/FBXTokenizer.h
+++ b/code/AssetLib/FBX/FBXTokenizer.h
@@ -96,7 +96,7 @@ public:
     /** construct a binary token */
     Token(const char* sbegin, const char* send, TokenType type, size_t offset);
 
-    ~Token();
+    ~Token() = default;
 
 public:
     std::string StringContents() const {

--- a/code/AssetLib/HMP/HMPLoader.cpp
+++ b/code/AssetLib/HMP/HMPLoader.cpp
@@ -72,15 +72,11 @@ static const aiImporterDesc desc = {
 
 // ------------------------------------------------------------------------------------------------
 // Constructor to be privately used by Importer
-HMPImporter::HMPImporter() {
-    // nothing to do here
-}
+HMPImporter::HMPImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-HMPImporter::~HMPImporter() {
-    // nothing to do here
-}
+HMPImporter::~HMPImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/IFC/IFCLoader.cpp
+++ b/code/AssetLib/IFC/IFCLoader.cpp
@@ -120,12 +120,11 @@ static const aiImporterDesc desc = {
 
 // ------------------------------------------------------------------------------------------------
 // Constructor to be privately used by Importer
-IFCImporter::IFCImporter() {}
+IFCImporter::IFCImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-IFCImporter::~IFCImporter() {
-}
+IFCImporter::~IFCImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/IFC/IFCOpenings.cpp
+++ b/code/AssetLib/IFC/IFCOpenings.cpp
@@ -399,7 +399,7 @@ void MergeWindowContours (const std::vector<IfcVector2>& a,
     ClipperLib::Polygon clip;
 
     for(const IfcVector2& pip : a) {
-        clip.push_back(ClipperLib::IntPoint(  to_int64(pip.x), to_int64(pip.y) ));
+        clip.emplace_back(to_int64(pip.x), to_int64(pip.y));
     }
 
     if (ClipperLib::Orientation(clip)) {
@@ -410,7 +410,7 @@ void MergeWindowContours (const std::vector<IfcVector2>& a,
     clip.clear();
 
     for(const IfcVector2& pip : b) {
-        clip.push_back(ClipperLib::IntPoint(  to_int64(pip.x), to_int64(pip.y) ));
+        clip.emplace_back(to_int64(pip.x), to_int64(pip.y));
     }
 
     if (ClipperLib::Orientation(clip)) {
@@ -433,7 +433,7 @@ void MakeDisjunctWindowContours (const std::vector<IfcVector2>& a,
     ClipperLib::Polygon clip;
 
     for(const IfcVector2& pip : a) {
-        clip.push_back(ClipperLib::IntPoint(  to_int64(pip.x), to_int64(pip.y) ));
+        clip.emplace_back(to_int64(pip.x), to_int64(pip.y));
     }
 
     if (ClipperLib::Orientation(clip)) {
@@ -444,7 +444,7 @@ void MakeDisjunctWindowContours (const std::vector<IfcVector2>& a,
     clip.clear();
 
     for(const IfcVector2& pip : b) {
-        clip.push_back(ClipperLib::IntPoint(  to_int64(pip.x), to_int64(pip.y) ));
+        clip.emplace_back(to_int64(pip.x), to_int64(pip.y));
     }
 
     if (ClipperLib::Orientation(clip)) {
@@ -466,7 +466,7 @@ void CleanupWindowContour(ProjectedWindowContour& window)
     ClipperLib::ExPolygons clipped;
 
     for(const IfcVector2& pip : contour) {
-        subject.push_back(ClipperLib::IntPoint(  to_int64(pip.x), to_int64(pip.y) ));
+        subject.emplace_back(to_int64(pip.x), to_int64(pip.y));
     }
 
     clipper.AddPolygon(subject,ClipperLib::ptSubject);
@@ -524,7 +524,7 @@ void CleanupOuterContour(const std::vector<IfcVector2>& contour_flat, TempMesh& 
         ClipperLib::Polygon clip;
         clip.reserve(contour_flat.size());
         for(const IfcVector2& pip : contour_flat) {
-            clip.push_back(ClipperLib::IntPoint(  to_int64(pip.x), to_int64(pip.y) ));
+            clip.emplace_back(to_int64(pip.x), to_int64(pip.y));
         }
 
         if (!ClipperLib::Orientation(clip)) {
@@ -544,7 +544,7 @@ void CleanupOuterContour(const std::vector<IfcVector2>& contour_flat, TempMesh& 
                     continue;
                 }
             }
-            subject.push_back(ClipperLib::IntPoint(  to_int64(pip.x), to_int64(pip.y) ));
+            subject.emplace_back(to_int64(pip.x), to_int64(pip.y));
             if (--countdown == 0) {
                 if (!ClipperLib::Orientation(subject)) {
                     std::reverse(subject.begin(), subject.end());
@@ -1378,12 +1378,12 @@ bool GenerateOpenings(std::vector<TempOpening>& openings,
 
         if(!temp_contour.empty()) {
             if (generate_connection_geometry) {
-                contours_to_openings.push_back(std::vector<TempOpening*>(
-                    joined_openings.begin(),
-                    joined_openings.end()));
+                contours_to_openings.emplace_back(
+                        joined_openings.begin(),
+                        joined_openings.end());
             }
 
-            contours.push_back(ProjectedWindowContour(temp_contour, bb, is_rectangle));
+            contours.emplace_back(temp_contour, bb, is_rectangle);
         }
     }
 
@@ -1791,7 +1791,7 @@ bool TryAddOpenings_Poly2Tri(const std::vector<TempOpening>& openings,
                     pip.x = (pip.x - vmin.x) / vmax.x;
                     pip.y = (pip.y - vmin.y) / vmax.y;
 
-                    hole.push_back(ClipperLib::IntPoint(to_int64(pip.x),to_int64(pip.y)));
+                    hole.emplace_back(to_int64(pip.x), to_int64(pip.y));
                 }
 
                 if(!ClipperLib::Orientation(hole)) {
@@ -1833,7 +1833,7 @@ bool TryAddOpenings_Poly2Tri(const std::vector<TempOpening>& openings,
                 pip.x  = (pip.x - vmin.x) / vmax.x;
                 pip.y  = (pip.y - vmin.y) / vmax.y;
 
-                poly.push_back(ClipperLib::IntPoint( to_int64(pip.x), to_int64(pip.y) ));
+                poly.emplace_back(to_int64(pip.x), to_int64(pip.y));
             }
 
             if (ClipperLib::Orientation(poly)) {

--- a/code/AssetLib/IFC/IFCUtil.h
+++ b/code/AssetLib/IFC/IFCUtil.h
@@ -344,8 +344,7 @@ protected:
 public:
     typedef std::pair<IfcFloat, IfcFloat> ParamRange;
 
-    virtual ~Curve() {}
-
+    virtual ~Curve() = default;
 
     // check if a curve is closed
     virtual bool IsClosed() const = 0;

--- a/code/AssetLib/IQM/IQMImporter.h
+++ b/code/AssetLib/IQM/IQMImporter.h
@@ -58,7 +58,7 @@ public:
 	IQMImporter();
     ~IQMImporter() override = default;
 
-	/// \brief  Returns whether the class can handle the format of the given file.
+    /// \brief  Returns whether the class can handle the format of the given file.
 	/// \remark See BaseImporter::CanRead() for details.
 	bool CanRead(const std::string &pFile, IOSystem *pIOHandler, bool checkSig) const override;
 

--- a/code/AssetLib/IQM/IQMImporter.h
+++ b/code/AssetLib/IQM/IQMImporter.h
@@ -56,7 +56,7 @@ class IQMImporter : public BaseImporter {
 public:
 	/// \brief  Default constructor
 	IQMImporter();
-    ~IQMImporter() override {}
+    ~IQMImporter() override = default;
 
 	/// \brief  Returns whether the class can handle the format of the given file.
 	/// \remark See BaseImporter::CanRead() for details.

--- a/code/AssetLib/Irr/IRRLoader.cpp
+++ b/code/AssetLib/Irr/IRRLoader.cpp
@@ -88,9 +88,7 @@ IRRImporter::IRRImporter() :
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-IRRImporter::~IRRImporter() {
-	// empty
-}
+IRRImporter::~IRRImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/Irr/IRRLoader.h
+++ b/code/AssetLib/Irr/IRRLoader.h
@@ -206,8 +206,7 @@ private:
      */
     struct SkyboxVertex
     {
-        SkyboxVertex()
-        {}
+        SkyboxVertex() = default;
 
         //! Construction from single vertex components
         SkyboxVertex(ai_real px, ai_real py, ai_real pz,

--- a/code/AssetLib/Irr/IRRMeshLoader.cpp
+++ b/code/AssetLib/Irr/IRRMeshLoader.cpp
@@ -79,7 +79,7 @@ IRRMeshImporter::IRRMeshImporter() :
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-IRRMeshImporter::~IRRMeshImporter() {}
+IRRMeshImporter::~IRRMeshImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/LWO/LWOBLoader.cpp
+++ b/code/AssetLib/LWO/LWOBLoader.cpp
@@ -218,7 +218,7 @@ void LWOImporter::CopyFaceIndicesLWOB(FaceList::iterator& it,
 // ------------------------------------------------------------------------------------------------
 LWO::Texture* LWOImporter::SetupNewTextureLWOB(LWO::TextureList& list,unsigned int size)
 {
-    list.push_back(LWO::Texture());
+    list.emplace_back();
     LWO::Texture* tex = &list.back();
 
     std::string type;

--- a/code/AssetLib/LWO/LWOFileData.h
+++ b/code/AssetLib/LWO/LWOFileData.h
@@ -338,13 +338,7 @@ struct Face : public aiFace {
     uint32_t type;
 
     //! Assignment operator
-    Face &operator=(const LWO::Face &f) {
-        aiFace::operator=(f);
-        surfaceIndex = f.surfaceIndex;
-        smoothGroup = f.smoothGroup;
-        type = f.type;
-        return *this;
-    }
+    Face &operator=(const LWO::Face &f) = default;
 };
 
 // ---------------------------------------------------------------------------
@@ -354,7 +348,7 @@ struct VMapEntry {
     explicit VMapEntry(unsigned int _dims) :
             dims(_dims) {}
 
-    virtual ~VMapEntry() {}
+    virtual ~VMapEntry() = default;
 
     //! allocates memory for the vertex map
     virtual void Allocate(unsigned int num) {

--- a/code/AssetLib/LWO/LWOLoader.cpp
+++ b/code/AssetLib/LWO/LWOLoader.cpp
@@ -100,9 +100,7 @@ LWOImporter::LWOImporter() :
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-LWOImporter::~LWOImporter() {
-    // empty
-}
+LWOImporter::~LWOImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/LWO/LWOLoader.cpp
+++ b/code/AssetLib/LWO/LWOLoader.cpp
@@ -1095,7 +1095,7 @@ void LWOImporter::LoadLWO2VertexMap(unsigned int length, bool perPoly) {
 void LWOImporter::LoadLWO2Clip(unsigned int length) {
     AI_LWO_VALIDATE_CHUNK_LENGTH(length, CLIP, 10);
 
-    mClips.push_back(LWO::Clip());
+    mClips.emplace_back();
     LWO::Clip &clip = mClips.back();
 
     // first - get the index of the clip
@@ -1165,7 +1165,7 @@ void LWOImporter::LoadLWO2Clip(unsigned int length) {
 void LWOImporter::LoadLWO3Clip(unsigned int length) {
     AI_LWO_VALIDATE_CHUNK_LENGTH(length, CLIP, 12);
 
-    mClips.push_back(LWO::Clip());
+    mClips.emplace_back();
     LWO::Clip &clip = mClips.back();
 
     // first - get the index of the clip
@@ -1238,7 +1238,7 @@ void LWOImporter::LoadLWO2Envelope(unsigned int length) {
     LE_NCONST uint8_t *const end = mFileBuffer + length;
     AI_LWO_VALIDATE_CHUNK_LENGTH(length, ENVL, 4);
 
-    mEnvelopes.push_back(LWO::Envelope());
+    mEnvelopes.emplace_back();
     LWO::Envelope &envelope = mEnvelopes.back();
 
     // Get the index of the envelope
@@ -1346,7 +1346,7 @@ void LWOImporter::LoadLWO3Envelope(unsigned int length) {
     LE_NCONST uint8_t *const end = mFileBuffer + length;
     AI_LWO_VALIDATE_CHUNK_LENGTH(length, ENVL, 4);
 
-    mEnvelopes.push_back(LWO::Envelope());
+    mEnvelopes.emplace_back();
     LWO::Envelope &envelope = mEnvelopes.back();
 
     // Get the index of the envelope

--- a/code/AssetLib/LWS/LWSLoader.cpp
+++ b/code/AssetLib/LWS/LWSLoader.cpp
@@ -141,9 +141,7 @@ LWSImporter::LWSImporter() :
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-LWSImporter::~LWSImporter() {
-    // nothing to do here
-}
+LWSImporter::~LWSImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/LWS/LWSLoader.h
+++ b/code/AssetLib/LWS/LWSLoader.h
@@ -69,7 +69,7 @@ namespace LWS {
  */
 class Element {
 public:
-    Element() {}
+    Element() = default;
 
     // first: name, second: rest
     std::string tokens[2];

--- a/code/AssetLib/MD2/MD2Loader.cpp
+++ b/code/AssetLib/MD2/MD2Loader.cpp
@@ -102,8 +102,7 @@ MD2Importer::MD2Importer()
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-MD2Importer::~MD2Importer()
-{}
+MD2Importer::~MD2Importer() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/MD3/MD3Loader.cpp
+++ b/code/AssetLib/MD3/MD3Loader.cpp
@@ -345,7 +345,7 @@ MD3Importer::MD3Importer() :
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-MD3Importer::~MD3Importer() {}
+MD3Importer::~MD3Importer() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/MD5/MD5Loader.cpp
+++ b/code/AssetLib/MD5/MD5Loader.cpp
@@ -94,9 +94,7 @@ MD5Importer::MD5Importer() :
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-MD5Importer::~MD5Importer() {
-    // empty
-}
+MD5Importer::~MD5Importer() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/MD5/MD5Parser.cpp
+++ b/code/AssetLib/MD5/MD5Parser.cpp
@@ -76,7 +76,7 @@ MD5Parser::MD5Parser(char *_buffer, unsigned int _fileSize) {
     // and read all sections until we're finished
     bool running = true;
     while (running) {
-        mSections.push_back(Section());
+        mSections.emplace_back();
         Section &sec = mSections.back();
         if (!ParseSection(sec)) {
             break;
@@ -158,7 +158,7 @@ bool MD5Parser::ParseSection(Section &out) {
                     break;
                 }
 
-                out.mElements.push_back(Element());
+                out.mElements.emplace_back();
                 Element &elem = out.mElements.back();
 
                 elem.iLineNumber = lineNumber;
@@ -253,7 +253,7 @@ MD5MeshParser::MD5MeshParser(SectionList &mSections) {
         } else if ((*iter).mName == "joints") {
             // "origin" -1 ( -0.000000 0.016430 -0.006044 ) ( 0.707107 0.000000 0.707107 )
             for (const auto &elem : (*iter).mElements) {
-                mJoints.push_back(BoneDesc());
+                mJoints.emplace_back();
                 BoneDesc &desc = mJoints.back();
 
                 const char *sz = elem.szStart;
@@ -267,7 +267,7 @@ MD5MeshParser::MD5MeshParser(SectionList &mSections) {
                 AI_MD5_READ_TRIPLE(desc.mRotationQuat); // normalized quaternion, so w is not there
             }
         } else if ((*iter).mName == "mesh") {
-            mMeshes.push_back(MeshDesc());
+            mMeshes.emplace_back();
             MeshDesc &desc = mMeshes.back();
 
             for (const auto &elem : (*iter).mElements) {
@@ -364,7 +364,7 @@ MD5AnimParser::MD5AnimParser(SectionList &mSections) {
         if ((*iter).mName == "hierarchy") {
             // "sheath" 0 63 6
             for (const auto &elem : (*iter).mElements) {
-                mAnimatedBones.push_back(AnimBoneDesc());
+                mAnimatedBones.emplace_back();
                 AnimBoneDesc &desc = mAnimatedBones.back();
 
                 const char *sz = elem.szStart;
@@ -389,7 +389,7 @@ MD5AnimParser::MD5AnimParser(SectionList &mSections) {
             for (const auto &elem : (*iter).mElements) {
                 const char *sz = elem.szStart;
 
-                mBaseFrames.push_back(BaseFrameDesc());
+                mBaseFrames.emplace_back();
                 BaseFrameDesc &desc = mBaseFrames.back();
 
                 AI_MD5_READ_TRIPLE(desc.vPositionXYZ);
@@ -401,7 +401,7 @@ MD5AnimParser::MD5AnimParser(SectionList &mSections) {
                 continue;
             }
 
-            mFrames.push_back(FrameDesc());
+            mFrames.emplace_back();
             FrameDesc &desc = mFrames.back();
             desc.iIndex = strtoul10((*iter).mGlobalValue.c_str());
 
@@ -459,7 +459,7 @@ MD5CameraParser::MD5CameraParser(SectionList &mSections) {
             for (const auto &elem : (*iter).mElements) {
                 const char *sz = elem.szStart;
 
-                frames.push_back(CameraAnimFrameDesc());
+                frames.emplace_back();
                 CameraAnimFrameDesc &cur = frames.back();
                 AI_MD5_READ_TRIPLE(cur.vPositionXYZ);
                 AI_MD5_READ_TRIPLE(cur.vRotationQuat);

--- a/code/AssetLib/MDC/MDCLoader.cpp
+++ b/code/AssetLib/MDC/MDCLoader.cpp
@@ -105,9 +105,7 @@ MDCImporter::MDCImporter() :
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-MDCImporter::~MDCImporter() {
-    // empty
-}
+MDCImporter::~MDCImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/MDL/HalfLife/UniqueNameGenerator.cpp
+++ b/code/AssetLib/MDL/HalfLife/UniqueNameGenerator.cpp
@@ -68,8 +68,7 @@ UniqueNameGenerator::UniqueNameGenerator(const char *template_name, const char *
     separator_(separator) {
 }
 
-UniqueNameGenerator::~UniqueNameGenerator() {
-}
+UniqueNameGenerator::~UniqueNameGenerator() = default;
 
 void UniqueNameGenerator::make_unique(std::vector<std::string> &names) {
     struct DuplicateInfo {

--- a/code/AssetLib/MDL/MDLLoader.cpp
+++ b/code/AssetLib/MDL/MDLLoader.cpp
@@ -98,9 +98,7 @@ MDLImporter::MDLImporter() :
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-MDLImporter::~MDLImporter() {
-    // empty
-}
+MDLImporter::~MDLImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/MMD/MMDImporter.cpp
+++ b/code/AssetLib/MMD/MMDImporter.cpp
@@ -269,43 +269,30 @@ aiMesh *MMDImporter::CreateMesh(const pmx::PmxModel *pModel,
                 dynamic_cast<pmx::PmxVertexSkinningSDEF *>(v->skinning.get());
         switch (v->skinning_type) {
         case pmx::PmxVertexSkinningType::BDEF1:
-            bone_vertex_map[vsBDEF1_ptr->bone_index].push_back(
-                    aiVertexWeight(index, 1.0));
+            bone_vertex_map[vsBDEF1_ptr->bone_index].emplace_back(index, 1.0);
             break;
         case pmx::PmxVertexSkinningType::BDEF2:
-            bone_vertex_map[vsBDEF2_ptr->bone_index1].push_back(
-                    aiVertexWeight(index, vsBDEF2_ptr->bone_weight));
-            bone_vertex_map[vsBDEF2_ptr->bone_index2].push_back(
-                    aiVertexWeight(index, 1.0f - vsBDEF2_ptr->bone_weight));
+            bone_vertex_map[vsBDEF2_ptr->bone_index1].emplace_back(index, vsBDEF2_ptr->bone_weight);
+            bone_vertex_map[vsBDEF2_ptr->bone_index2].emplace_back(index, 1.0f - vsBDEF2_ptr->bone_weight);
             break;
         case pmx::PmxVertexSkinningType::BDEF4:
-            bone_vertex_map[vsBDEF4_ptr->bone_index1].push_back(
-                    aiVertexWeight(index, vsBDEF4_ptr->bone_weight1));
-            bone_vertex_map[vsBDEF4_ptr->bone_index2].push_back(
-                    aiVertexWeight(index, vsBDEF4_ptr->bone_weight2));
-            bone_vertex_map[vsBDEF4_ptr->bone_index3].push_back(
-                    aiVertexWeight(index, vsBDEF4_ptr->bone_weight3));
-            bone_vertex_map[vsBDEF4_ptr->bone_index4].push_back(
-                    aiVertexWeight(index, vsBDEF4_ptr->bone_weight4));
+            bone_vertex_map[vsBDEF4_ptr->bone_index1].emplace_back(index, vsBDEF4_ptr->bone_weight1);
+            bone_vertex_map[vsBDEF4_ptr->bone_index2].emplace_back(index, vsBDEF4_ptr->bone_weight2);
+            bone_vertex_map[vsBDEF4_ptr->bone_index3].emplace_back(index, vsBDEF4_ptr->bone_weight3);
+            bone_vertex_map[vsBDEF4_ptr->bone_index4].emplace_back(index, vsBDEF4_ptr->bone_weight4);
             break;
         case pmx::PmxVertexSkinningType::SDEF: // TODO: how to use sdef_c, sdef_r0,
                 // sdef_r1?
-            bone_vertex_map[vsSDEF_ptr->bone_index1].push_back(
-                    aiVertexWeight(index, vsSDEF_ptr->bone_weight));
-            bone_vertex_map[vsSDEF_ptr->bone_index2].push_back(
-                    aiVertexWeight(index, 1.0f - vsSDEF_ptr->bone_weight));
+            bone_vertex_map[vsSDEF_ptr->bone_index1].emplace_back(index, vsSDEF_ptr->bone_weight);
+            bone_vertex_map[vsSDEF_ptr->bone_index2].emplace_back(index, 1.0f - vsSDEF_ptr->bone_weight);
             break;
         case pmx::PmxVertexSkinningType::QDEF:
             const auto vsQDEF_ptr =
                     dynamic_cast<pmx::PmxVertexSkinningQDEF *>(v->skinning.get());
-            bone_vertex_map[vsQDEF_ptr->bone_index1].push_back(
-                    aiVertexWeight(index, vsQDEF_ptr->bone_weight1));
-            bone_vertex_map[vsQDEF_ptr->bone_index2].push_back(
-                    aiVertexWeight(index, vsQDEF_ptr->bone_weight2));
-            bone_vertex_map[vsQDEF_ptr->bone_index3].push_back(
-                    aiVertexWeight(index, vsQDEF_ptr->bone_weight3));
-            bone_vertex_map[vsQDEF_ptr->bone_index4].push_back(
-                    aiVertexWeight(index, vsQDEF_ptr->bone_weight4));
+            bone_vertex_map[vsQDEF_ptr->bone_index1].emplace_back(index, vsQDEF_ptr->bone_weight1);
+            bone_vertex_map[vsQDEF_ptr->bone_index2].emplace_back(index, vsQDEF_ptr->bone_weight2);
+            bone_vertex_map[vsQDEF_ptr->bone_index3].emplace_back(index, vsQDEF_ptr->bone_weight3);
+            bone_vertex_map[vsQDEF_ptr->bone_index4].emplace_back(index, vsQDEF_ptr->bone_weight4);
             break;
         }
     }

--- a/code/AssetLib/MMD/MMDImporter.cpp
+++ b/code/AssetLib/MMD/MMDImporter.cpp
@@ -83,9 +83,7 @@ MMDImporter::MMDImporter() :
 
 // ------------------------------------------------------------------------------------------------
 //  Destructor.
-MMDImporter::~MMDImporter() {
-    // empty
-}
+MMDImporter::~MMDImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 //  Returns true, if file is an pmx file.

--- a/code/AssetLib/MMD/MMDPmxParser.h
+++ b/code/AssetLib/MMD/MMDPmxParser.h
@@ -88,7 +88,7 @@ namespace pmx
 	{
 	public:
 		virtual void Read(std::istream *stream, PmxSetting *setting) = 0;
-		virtual ~PmxVertexSkinning() {}
+		virtual ~PmxVertexSkinning() = default;
 	};
 
 	class PmxVertexSkinningBDEF1 : public PmxVertexSkinning

--- a/code/AssetLib/MS3D/MS3DLoader.cpp
+++ b/code/AssetLib/MS3D/MS3DLoader.cpp
@@ -86,8 +86,7 @@ MS3DImporter::MS3DImporter()
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-MS3DImporter::~MS3DImporter()
-{}
+MS3DImporter::~MS3DImporter() = default;
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.
 bool MS3DImporter::CanRead( const std::string& pFile, IOSystem* pIOHandler, bool /*checkSig*/) const

--- a/code/AssetLib/NDO/NDOLoader.cpp
+++ b/code/AssetLib/NDO/NDOLoader.cpp
@@ -70,13 +70,11 @@ static const aiImporterDesc desc = {
 
 // ------------------------------------------------------------------------------------------------
 // Constructor to be privately used by Importer
-NDOImporter::NDOImporter()
-{}
+NDOImporter::NDOImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-NDOImporter::~NDOImporter()
-{}
+NDOImporter::~NDOImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/NFF/NFFLoader.cpp
+++ b/code/AssetLib/NFF/NFFLoader.cpp
@@ -73,11 +73,11 @@ static const aiImporterDesc desc = {
 
 // ------------------------------------------------------------------------------------------------
 // Constructor to be privately used by Importer
-NFFImporter::NFFImporter() {}
+NFFImporter::NFFImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-NFFImporter::~NFFImporter() {}
+NFFImporter::~NFFImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/OFF/OFFLoader.cpp
+++ b/code/AssetLib/OFF/OFFLoader.cpp
@@ -73,13 +73,11 @@ static const aiImporterDesc desc = {
 
 // ------------------------------------------------------------------------------------------------
 // Constructor to be privately used by Importer
-OFFImporter::OFFImporter()
-{}
+OFFImporter::OFFImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-OFFImporter::~OFFImporter()
-{}
+OFFImporter::~OFFImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/Obj/ObjExporter.cpp
+++ b/code/AssetLib/Obj/ObjExporter.cpp
@@ -137,9 +137,7 @@ ObjExporter::ObjExporter(const char* _filename, const aiScene* pScene, bool noMt
 }
 
 // ------------------------------------------------------------------------------------------------
-ObjExporter::~ObjExporter() {
-    // empty
-}
+ObjExporter::~ObjExporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 std::string ObjExporter::GetMaterialLibName() {

--- a/code/AssetLib/Obj/ObjFileMtlImporter.cpp
+++ b/code/AssetLib/Obj/ObjFileMtlImporter.cpp
@@ -108,9 +108,7 @@ ObjFileMtlImporter::ObjFileMtlImporter(std::vector<char> &buffer,
 
 // -------------------------------------------------------------------
 //  Destructor
-ObjFileMtlImporter::~ObjFileMtlImporter() {
-    // empty
-}
+ObjFileMtlImporter::~ObjFileMtlImporter() = default;
 
 // -------------------------------------------------------------------
 //  Loads the material description

--- a/code/AssetLib/Obj/ObjFileParser.cpp
+++ b/code/AssetLib/Obj/ObjFileParser.cpp
@@ -97,8 +97,7 @@ ObjFileParser::ObjFileParser(IOStreamBuffer<char> &streamBuffer, const std::stri
     parseFile(streamBuffer);
 }
 
-ObjFileParser::~ObjFileParser() {
-}
+ObjFileParser::~ObjFileParser() = default;
 
 void ObjFileParser::setBuffer(std::vector<char> &buffer) {
     m_DataIt = buffer.begin();

--- a/code/AssetLib/Ogre/OgreStructs.cpp
+++ b/code/AssetLib/Ogre/OgreStructs.cpp
@@ -272,8 +272,7 @@ std::set<uint16_t> IVertexData::ReferencedBonesByWeights() const {
 
 // VertexData
 
-VertexData::VertexData() {
-}
+VertexData::VertexData() = default;
 
 VertexData::~VertexData() {
     Reset();
@@ -310,8 +309,7 @@ VertexElement *VertexData::GetVertexElement(VertexElement::Semantic semantic, ui
 
 // VertexDataXml
 
-VertexDataXml::VertexDataXml() {
-}
+VertexDataXml::VertexDataXml() = default;
 
 bool VertexDataXml::HasPositions() const {
     return !positions.empty();

--- a/code/AssetLib/OpenGEX/OpenGEXExporter.cpp
+++ b/code/AssetLib/OpenGEX/OpenGEXExporter.cpp
@@ -48,7 +48,7 @@ namespace OpenGEX {
 
 OpenGEXExporter::OpenGEXExporter() = default;
 
-OpenGEXExporter::~OpenGEXExporter() = default;
+
 
 bool OpenGEXExporter::exportScene( const char * /*filename*/, const aiScene* /*pScene*/ ) {
     return true;

--- a/code/AssetLib/OpenGEX/OpenGEXExporter.cpp
+++ b/code/AssetLib/OpenGEX/OpenGEXExporter.cpp
@@ -46,11 +46,9 @@ namespace OpenGEX {
 
 #ifndef ASSIMP_BUILD_NO_OPENGEX_EXPORTER
 
-OpenGEXExporter::OpenGEXExporter() {
-}
+OpenGEXExporter::OpenGEXExporter() = default;
 
-OpenGEXExporter::~OpenGEXExporter() {
-}
+OpenGEXExporter::~OpenGEXExporter() = default;
 
 bool OpenGEXExporter::exportScene( const char * /*filename*/, const aiScene* /*pScene*/ ) {
     return true;

--- a/code/AssetLib/OpenGEX/OpenGEXExporter.h
+++ b/code/AssetLib/OpenGEX/OpenGEXExporter.h
@@ -55,7 +55,7 @@ namespace OpenGEX {
 class OpenGEXExporter {
 public:
     OpenGEXExporter();
-    ~OpenGEXExporter();
+    ~OpenGEXExporter() = default;
     bool exportScene( const char *filename, const aiScene* pScene );
 };
 

--- a/code/AssetLib/Ply/PlyExporter.cpp
+++ b/code/AssetLib/Ply/PlyExporter.cpp
@@ -245,9 +245,7 @@ PlyExporter::PlyExporter(const char* _filename, const aiScene* pScene, bool bina
 }
 
 // ------------------------------------------------------------------------------------------------
-PlyExporter::~PlyExporter() {
-    // empty
-}
+PlyExporter::~PlyExporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 void PlyExporter::WriteMeshVerts(const aiMesh* m, unsigned int components)

--- a/code/AssetLib/Ply/PlyLoader.cpp
+++ b/code/AssetLib/Ply/PlyLoader.cpp
@@ -94,9 +94,7 @@ PLYImporter::PLYImporter() :
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-PLYImporter::~PLYImporter() {
-    // empty
-}
+PLYImporter::~PLYImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/Q3D/Q3DLoader.cpp
+++ b/code/AssetLib/Q3D/Q3DLoader.cpp
@@ -72,15 +72,11 @@ static const aiImporterDesc desc = {
 
 // ------------------------------------------------------------------------------------------------
 // Constructor to be privately used by Importer
-Q3DImporter::Q3DImporter() {
-    // empty
-}
+Q3DImporter::Q3DImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-Q3DImporter::~Q3DImporter() {
-    // empty
-}
+Q3DImporter::~Q3DImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/Q3D/Q3DLoader.cpp
+++ b/code/AssetLib/Q3D/Q3DLoader.cpp
@@ -418,7 +418,7 @@ outer:
                 (*fit).mat = 0;
             }
             if (fidx[(*fit).mat].empty()) ++pScene->mNumMeshes;
-            fidx[(*fit).mat].push_back(FaceIdx(p, q));
+            fidx[(*fit).mat].emplace_back(p, q);
         }
     }
     pScene->mNumMaterials = pScene->mNumMeshes;

--- a/code/AssetLib/Raw/RawLoader.cpp
+++ b/code/AssetLib/Raw/RawLoader.cpp
@@ -72,15 +72,11 @@ static const aiImporterDesc desc = {
 
 // ------------------------------------------------------------------------------------------------
 // Constructor to be privately used by Importer
-RAWImporter::RAWImporter() {
-    // empty
-}
+RAWImporter::RAWImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-RAWImporter::~RAWImporter() {
-    // empty
-}
+RAWImporter::~RAWImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/SIB/SIBImporter.cpp
+++ b/code/AssetLib/SIB/SIBImporter.cpp
@@ -202,15 +202,11 @@ static aiString ReadString(StreamReaderLE *stream, uint32_t numWChars) {
 
 // ------------------------------------------------------------------------------------------------
 // Constructor to be privately used by Importer
-SIBImporter::SIBImporter() {
-    // empty
-}
+SIBImporter::SIBImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-SIBImporter::~SIBImporter() {
-    // empty
-}
+SIBImporter::~SIBImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/SMD/SMDLoader.cpp
+++ b/code/AssetLib/SMD/SMDLoader.cpp
@@ -95,9 +95,7 @@ SMDImporter::SMDImporter() :
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-SMDImporter::~SMDImporter() {
-    // empty
-}
+SMDImporter::~SMDImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.
@@ -322,7 +320,7 @@ void SMDImporter::CreateOutputMeshes() {
                             "to the vertex' parent node");
                         continue;
                     }
-                    aaiBones[pairval.first].push_back(TempWeightListEntry(iNum,pairval.second));
+                    aaiBones[pairval.first].emplace_back(iNum,pairval.second);
                     fSum += pairval.second;
                 }
                 // ******************************************************************
@@ -350,8 +348,7 @@ void SMDImporter::CreateOutputMeshes() {
                             }
                         }
                     } else {
-                        aaiBones[face.avVertices[iVert].iParentNode].push_back(
-                            TempWeightListEntry(iNum,1.0f-fSum));
+                        aaiBones[face.avVertices[iVert].iParentNode].emplace_back(iNum,1.0f-fSum);
                     }
                 }
                 pcMesh->mFaces[iFace].mIndices[iVert] = iNum++;

--- a/code/AssetLib/STL/STLLoader.cpp
+++ b/code/AssetLib/STL/STLLoader.cpp
@@ -134,9 +134,7 @@ STLImporter::STLImporter() :
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-STLImporter::~STLImporter() {
-    // empty
-}
+STLImporter::~STLImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/Terragen/TerragenLoader.cpp
+++ b/code/AssetLib/Terragen/TerragenLoader.cpp
@@ -75,9 +75,7 @@ TerragenImporter::TerragenImporter() :
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-TerragenImporter::~TerragenImporter() {
-    // empty
-}
+TerragenImporter::~TerragenImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/Unreal/UnrealLoader.cpp
+++ b/code/AssetLib/Unreal/UnrealLoader.cpp
@@ -174,9 +174,7 @@ UnrealImporter::UnrealImporter() :
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-UnrealImporter::~UnrealImporter() {
-    // empty
-}
+UnrealImporter::~UnrealImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/X/XFileImporter.cpp
+++ b/code/AssetLib/X/XFileImporter.cpp
@@ -82,9 +82,7 @@ XFileImporter::XFileImporter()
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-XFileImporter::~XFileImporter() {
-    // empty
-}
+XFileImporter::~XFileImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/X3D/X3DExporter.hpp
+++ b/code/AssetLib/X3D/X3DExporter.hpp
@@ -241,7 +241,7 @@ public:
 
     /// \fn ~X3DExporter()
     /// Default destructor.
-    ~X3DExporter() {}
+    ~X3DExporter() = default;
 
 }; // class X3DExporter
 

--- a/code/AssetLib/X3D/X3DImporter.hpp
+++ b/code/AssetLib/X3D/X3DImporter.hpp
@@ -270,7 +270,7 @@ public:
     void Clear();
 
 private:
-    X3DNodeElementBase *MACRO_USE_CHECKANDAPPLY(XmlNode &node, std::string pDEF, std::string pUSE, X3DElemType pType, X3DNodeElementBase *pNE);
+    X3DNodeElementBase *MACRO_USE_CHECKANDAPPLY(XmlNode &node, const std::string &pDEF, const std::string &pUSE, X3DElemType pType, X3DNodeElementBase *pNE);
     bool isNodeEmpty(XmlNode &node);
     void checkNodeMustBeEmpty(XmlNode &node);
     void skipUnsupportedNode(const std::string &pParentNodeName, XmlNode &node);

--- a/code/AssetLib/X3D/X3DImporter_Macro.hpp
+++ b/code/AssetLib/X3D/X3DImporter_Macro.hpp
@@ -59,7 +59,7 @@ namespace Assimp {
 /// \param [in] pUSE - string holding "USE" value.
 /// \param [in] pType - type of element to find.
 /// \param [out] pNE - pointer to found node element.
-inline X3DNodeElementBase *X3DImporter::MACRO_USE_CHECKANDAPPLY(XmlNode &node, std::string pDEF, std::string pUSE, X3DElemType pType, X3DNodeElementBase *pNE) {
+inline X3DNodeElementBase *X3DImporter::MACRO_USE_CHECKANDAPPLY(XmlNode &node, const std::string &pDEF, const std::string &pUSE, X3DElemType pType, X3DNodeElementBase *pNE) {
     checkNodeMustBeEmpty(node);
     if (!pDEF.empty())
         Assimp::Throw_DEF_And_USE(node.name());

--- a/code/AssetLib/glTF/glTFAsset.h
+++ b/code/AssetLib/glTF/glTFAsset.h
@@ -314,7 +314,7 @@ struct Object {
     virtual bool IsSpecial() const { return false; }
 
     Object() = default;
-    virtual ~Object() {}
+    virtual ~Object() = default;
 
     //! Maps special IDs to another ID, where needed. Subclasses may override it (statically)
     static const char *TranslateId(Asset & /*r*/, const char *id) { return id; }
@@ -666,7 +666,7 @@ struct Mesh : public Object {
     std::vector<Primitive> primitives;
     std::list<SExtension *> Extension; ///< List of extensions used in mesh.
 
-    Mesh() {}
+    Mesh() = default;
 
     /// Destructor.
     ~Mesh() {
@@ -706,12 +706,12 @@ struct Node : public Object {
 
     Ref<Node> parent; //!< This is not part of the glTF specification. Used as a helper.
 
-    Node() {}
+    Node() = default;
     void Read(Value &obj, Asset &r);
 };
 
 struct Program : public Object {
-    Program() {}
+    Program() = default;
     void Read(Value &obj, Asset &r);
 };
 
@@ -830,7 +830,7 @@ struct Animation : public Object {
 //! Base class for LazyDict that acts as an interface
 class LazyDictBase {
 public:
-    virtual ~LazyDictBase() {}
+    virtual ~LazyDictBase() = default;
 
     virtual void AttachToDocument(Document &doc) = 0;
     virtual void DetachFromDocument() = 0;

--- a/code/AssetLib/glTF/glTFImporter.cpp
+++ b/code/AssetLib/glTF/glTFImporter.cpp
@@ -84,9 +84,7 @@ glTFImporter::glTFImporter() :
     // empty
 }
 
-glTFImporter::~glTFImporter() {
-    // empty
-}
+glTFImporter::~glTFImporter() = default;
 
 const aiImporterDesc *glTFImporter::GetInfo() const {
     return &desc;

--- a/code/AssetLib/glTF2/glTF2Asset.h
+++ b/code/AssetLib/glTF2/glTF2Asset.h
@@ -391,7 +391,7 @@ struct Object {
     //! Objects marked as special are not exported (used to emulate the binary body buffer)
     virtual bool IsSpecial() const { return false; }
 
-    virtual ~Object() {}
+    virtual ~Object() = default;
 
     //! Maps special IDs to another ID, where needed. Subclasses may override it (statically)
     static const char *TranslateId(Asset & /*r*/, const char *id) { return id; }
@@ -613,7 +613,7 @@ struct Accessor : public Object {
         return Indexer(*this);
     }
 
-    Accessor() {}
+    Accessor() = default;
     void Read(Value &obj, Asset &r);
 
     //sparse
@@ -681,7 +681,7 @@ struct Light : public Object {
     float innerConeAngle;
     float outerConeAngle;
 
-    Light() {}
+    Light() = default;
     void Read(Value &obj, Asset &r);
 };
 
@@ -877,7 +877,7 @@ struct Mesh : public Object {
     std::vector<float> weights;
     std::vector<std::string> targetNames;
 
-    Mesh() {}
+    Mesh() = default;
 
     /// Get mesh data from JSON-object and place them to root asset.
     /// \param [in] pJSON_Object - reference to pJSON-object from which data are read.
@@ -903,12 +903,12 @@ struct Node : public Object {
 
     Ref<Node> parent; //!< This is not part of the glTF specification. Used as a helper.
 
-    Node() {}
+    Node() = default;
     void Read(Value &obj, Asset &r);
 };
 
 struct Program : public Object {
-    Program() {}
+    Program() = default;
     void Read(Value &obj, Asset &r);
 };
 
@@ -927,12 +927,12 @@ struct Scene : public Object {
     std::string name;
     std::vector<Ref<Node>> nodes;
 
-    Scene() {}
+    Scene() = default;
     void Read(Value &obj, Asset &r);
 };
 
 struct Shader : public Object {
-    Shader() {}
+    Shader() = default;
     void Read(Value &obj, Asset &r);
 };
 
@@ -942,7 +942,7 @@ struct Skin : public Object {
     std::vector<Ref<Node>> jointNames; //!< Joint names of the joints (nodes with a jointName property) in this skin.
     std::string name; //!< The user-defined name of this object.
 
-    Skin() {}
+    Skin() = default;
     void Read(Value &obj, Asset &r);
 };
 
@@ -957,7 +957,7 @@ struct Texture : public Object {
     //TextureTarget target; //!< The target that the WebGL texture should be bound to. (default: TextureTarget_TEXTURE_2D)
     //TextureType type; //!< Texel datatype. (default: TextureType_UNSIGNED_BYTE)
 
-    Texture() {}
+    Texture() = default;
     void Read(Value &obj, Asset &r);
 };
 
@@ -990,14 +990,14 @@ struct Animation : public Object {
     std::vector<Sampler> samplers; //!< All the key-frame data for this animation.
     std::vector<Channel> channels; //!< Data to connect nodes to key-frames.
 
-    Animation() {}
+    Animation() = default;
     void Read(Value &obj, Asset &r);
 };
 
 //! Base class for LazyDict that acts as an interface
 class LazyDictBase {
 public:
-    virtual ~LazyDictBase() {}
+    virtual ~LazyDictBase() = default;
 
     virtual void AttachToDocument(Document &doc) = 0;
     virtual void DetachFromDocument() = 0;

--- a/code/AssetLib/glTF2/glTF2Exporter.cpp
+++ b/code/AssetLib/glTF2/glTF2Exporter.cpp
@@ -124,9 +124,7 @@ glTF2Exporter::glTF2Exporter(const char *filename, IOSystem *pIOSystem, const ai
     }
 }
 
-glTF2Exporter::~glTF2Exporter() {
-    // empty
-}
+glTF2Exporter::~glTF2Exporter() = default;
 
 /*
  * Copy a 4x4 matrix from struct aiMatrix to typedef mat4.

--- a/code/AssetLib/glTF2/glTF2Importer.cpp
+++ b/code/AssetLib/glTF2/glTF2Importer.cpp
@@ -103,9 +103,7 @@ glTF2Importer::glTF2Importer() :
     // empty
 }
 
-glTF2Importer::~glTF2Importer() {
-    // empty
-}
+glTF2Importer::~glTF2Importer() = default;
 
 const aiImporterDesc *glTF2Importer::GetInfo() const {
     return &desc;

--- a/code/Common/BaseImporter.cpp
+++ b/code/Common/BaseImporter.cpp
@@ -70,9 +70,7 @@ BaseImporter::BaseImporter() AI_NO_EXCEPT
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-BaseImporter::~BaseImporter() {
-    // nothing to do here
-}
+BaseImporter::~BaseImporter() = default;
 
 void BaseImporter::UpdateImporterScale(Importer *pImp) {
     ai_assert(pImp != nullptr);

--- a/code/Common/BaseProcess.cpp
+++ b/code/Common/BaseProcess.cpp
@@ -59,9 +59,7 @@ BaseProcess::BaseProcess() AI_NO_EXCEPT
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-BaseProcess::~BaseProcess() {
-    // nothing to do here
-}
+BaseProcess::~BaseProcess() = default;
 
 // ------------------------------------------------------------------------------------------------
 void BaseProcess::ExecuteOnScene(Importer *pImp) {

--- a/code/Common/BaseProcess.h
+++ b/code/Common/BaseProcess.h
@@ -63,7 +63,7 @@ class Importer;
 class SharedPostProcessInfo {
 public:
     struct Base {
-        virtual ~Base() {}
+        virtual ~Base() = default;
     };
 
     //! Represents data that is allocated on the heap, thus needs to be deleted
@@ -84,7 +84,7 @@ public:
         explicit TStaticData(T in) :
                 data(in) {}
 
-        ~TStaticData() {}
+        ~TStaticData() = default;
 
         T data;
     };

--- a/code/Common/Exporter.cpp
+++ b/code/Common/Exporter.cpp
@@ -585,19 +585,10 @@ void Exporter::UnregisterExporter(const char* id) {
 }
 
 // ------------------------------------------------------------------------------------------------
-ExportProperties::ExportProperties() {
-    // empty
-}
+ExportProperties::ExportProperties() = default;
 
 // ------------------------------------------------------------------------------------------------
-ExportProperties::ExportProperties(const ExportProperties &other)
-: mIntProperties(other.mIntProperties)
-, mFloatProperties(other.mFloatProperties)
-, mStringProperties(other.mStringProperties)
-, mMatrixProperties(other.mMatrixProperties)
-, mCallbackProperties(other.mCallbackProperties){
-    // empty
-}
+ExportProperties::ExportProperties(const ExportProperties &other) = default;
 
 bool ExportProperties::SetPropertyCallback(const char *szName, const std::function<void *(void *)> &f) {
     return SetGenericProperty<std::function<void *(void *)>>(mCallbackProperties, szName, f);

--- a/code/Common/SGSpatialSort.cpp
+++ b/code/Common/SGSpatialSort.cpp
@@ -59,10 +59,7 @@ SGSpatialSort::SGSpatialSort()
 }
 // ------------------------------------------------------------------------------------------------
 // Destructor
-SGSpatialSort::~SGSpatialSort()
-{
-    // nothing to do here, everything destructs automatically
-}
+SGSpatialSort::~SGSpatialSort() = default;
 // ------------------------------------------------------------------------------------------------
 void SGSpatialSort::Add(const aiVector3D& vPosition, unsigned int index,
     unsigned int smoothingGroup)

--- a/code/Common/SpatialSort.cpp
+++ b/code/Common/SpatialSort.cpp
@@ -73,9 +73,7 @@ SpatialSort::SpatialSort() :
 
 // ------------------------------------------------------------------------------------------------
 // Destructor
-SpatialSort::~SpatialSort() {
-    // empty
-}
+SpatialSort::~SpatialSort() = default;
 
 // ------------------------------------------------------------------------------------------------
 void SpatialSort::Fill(const aiVector3D *pPositions, unsigned int pNumPositions,

--- a/code/Common/ZipArchiveIOSystem.cpp
+++ b/code/Common/ZipArchiveIOSystem.cpp
@@ -279,8 +279,7 @@ ZipFile::ZipFile(std::string &filename, size_t size) :
     m_Buffer = std::unique_ptr<uint8_t[]>(new uint8_t[m_Size]);
 }
 
-ZipFile::~ZipFile() {
-}
+ZipFile::~ZipFile() = default;
 
 size_t ZipFile::Read(void *pvBuffer, size_t pSize, size_t pCount) {
     // Should be impossible

--- a/code/Pbrt/PbrtExporter.cpp
+++ b/code/Pbrt/PbrtExporter.cpp
@@ -162,9 +162,7 @@ PbrtExporter::PbrtExporter(
 }
 
 // Destructor
-PbrtExporter::~PbrtExporter() {
-    // Empty
-}
+PbrtExporter::~PbrtExporter() = default;
 
 void PbrtExporter::WriteMetaData() {
     mOutput << "#############################\n";

--- a/code/PostProcessing/ArmaturePopulate.cpp
+++ b/code/PostProcessing/ArmaturePopulate.cpp
@@ -48,15 +48,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace Assimp {
 
 /// The default class constructor.
-ArmaturePopulate::ArmaturePopulate() :
-        BaseProcess() {
-    // do nothing
-}
+ArmaturePopulate::ArmaturePopulate() = default;
 
 /// The class destructor.
-ArmaturePopulate::~ArmaturePopulate() {
-    // do nothing
-}
+ArmaturePopulate::~ArmaturePopulate() = default;
 
 bool ArmaturePopulate::IsActive(unsigned int pFlags) const {
     return (pFlags & aiProcess_PopulateArmatureData) != 0;

--- a/code/PostProcessing/CalcTangentsProcess.cpp
+++ b/code/PostProcessing/CalcTangentsProcess.cpp
@@ -62,9 +62,7 @@ CalcTangentsProcess::CalcTangentsProcess() :
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-CalcTangentsProcess::~CalcTangentsProcess() {
-    // nothing to do here
-}
+CalcTangentsProcess::~CalcTangentsProcess() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the processing step is present in the given flag field.

--- a/code/PostProcessing/ComputeUVMappingProcess.cpp
+++ b/code/PostProcessing/ComputeUVMappingProcess.cpp
@@ -59,17 +59,11 @@ namespace {
 
 // ------------------------------------------------------------------------------------------------
 // Constructor to be privately used by Importer
-ComputeUVMappingProcess::ComputeUVMappingProcess()
-{
-    // nothing to do here
-}
+ComputeUVMappingProcess::ComputeUVMappingProcess() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-ComputeUVMappingProcess::~ComputeUVMappingProcess()
-{
-    // nothing to do here
-}
+ComputeUVMappingProcess::~ComputeUVMappingProcess() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the processing step is present in the given flag field.

--- a/code/PostProcessing/ConvertToLHProcess.cpp
+++ b/code/PostProcessing/ConvertToLHProcess.cpp
@@ -81,16 +81,11 @@ void flipUVs(aiMeshType *pMesh) {
 
 // ------------------------------------------------------------------------------------------------
 // Constructor to be privately used by Importer
-MakeLeftHandedProcess::MakeLeftHandedProcess() :
-        BaseProcess() {
-    // empty
-}
+MakeLeftHandedProcess::MakeLeftHandedProcess() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-MakeLeftHandedProcess::~MakeLeftHandedProcess() {
-    // empty
-}
+MakeLeftHandedProcess::~MakeLeftHandedProcess() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the processing step is present in the given flag field.
@@ -250,11 +245,11 @@ void MakeLeftHandedProcess::ProcessAnimation(aiNodeAnim *pAnim) {
 
 // ------------------------------------------------------------------------------------------------
 // Constructor to be privately used by Importer
-FlipUVsProcess::FlipUVsProcess() {}
+FlipUVsProcess::FlipUVsProcess() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-FlipUVsProcess::~FlipUVsProcess() {}
+FlipUVsProcess::~FlipUVsProcess() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the processing step is present in the given flag field.
@@ -312,11 +307,11 @@ void FlipUVsProcess::ProcessMesh(aiMesh *pMesh) {
 
 // ------------------------------------------------------------------------------------------------
 // Constructor to be privately used by Importer
-FlipWindingOrderProcess::FlipWindingOrderProcess() {}
+FlipWindingOrderProcess::FlipWindingOrderProcess() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-FlipWindingOrderProcess::~FlipWindingOrderProcess() {}
+FlipWindingOrderProcess::~FlipWindingOrderProcess() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the processing step is present in the given flag field.

--- a/code/PostProcessing/DeboneProcess.cpp
+++ b/code/PostProcessing/DeboneProcess.cpp
@@ -66,10 +66,7 @@ DeboneProcess::DeboneProcess()
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-DeboneProcess::~DeboneProcess()
-{
-    // nothing to do here
-}
+DeboneProcess::~DeboneProcess() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the processing step is present in the given flag field.

--- a/code/PostProcessing/DeboneProcess.cpp
+++ b/code/PostProcessing/DeboneProcess.cpp
@@ -153,7 +153,7 @@ void DeboneProcess::Execute( aiScene* pScene)
             }
             else    {
                 // Mesh is kept unchanged - store it's new place in the mesh array
-                mSubMeshIndices[a].push_back(std::pair<unsigned int,aiNode*>(static_cast<unsigned int>(meshes.size()),(aiNode*)0));
+                mSubMeshIndices[a].emplace_back(static_cast<unsigned int>(meshes.size()), (aiNode *)0);
                 meshes.push_back(srcMesh);
             }
         }

--- a/code/PostProcessing/DropFaceNormalsProcess.cpp
+++ b/code/PostProcessing/DropFaceNormalsProcess.cpp
@@ -56,17 +56,11 @@ using namespace Assimp;
 
 // ------------------------------------------------------------------------------------------------
 // Constructor to be privately used by Importer
-DropFaceNormalsProcess::DropFaceNormalsProcess()
-{
-    // nothing to do here
-}
+DropFaceNormalsProcess::DropFaceNormalsProcess() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-DropFaceNormalsProcess::~DropFaceNormalsProcess()
-{
-    // nothing to do here
-}
+DropFaceNormalsProcess::~DropFaceNormalsProcess() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the processing step is present in the given flag field.

--- a/code/PostProcessing/EmbedTexturesProcess.cpp
+++ b/code/PostProcessing/EmbedTexturesProcess.cpp
@@ -49,14 +49,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using namespace Assimp;
 
-EmbedTexturesProcess::EmbedTexturesProcess() :
-        BaseProcess() {
-    // empty
-}
+EmbedTexturesProcess::EmbedTexturesProcess() = default;
 
-EmbedTexturesProcess::~EmbedTexturesProcess() {
-    // empty
-}
+EmbedTexturesProcess::~EmbedTexturesProcess() = default;
 
 bool EmbedTexturesProcess::IsActive(unsigned int pFlags) const {
     return (pFlags & aiProcess_EmbedTextures) != 0;

--- a/code/PostProcessing/FindDegenerates.cpp
+++ b/code/PostProcessing/FindDegenerates.cpp
@@ -65,9 +65,7 @@ FindDegeneratesProcess::FindDegeneratesProcess() :
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-FindDegeneratesProcess::~FindDegeneratesProcess() {
-    // nothing to do here
-}
+FindDegeneratesProcess::~FindDegeneratesProcess() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the processing step is present in the given flag field.

--- a/code/PostProcessing/FindInstancesProcess.cpp
+++ b/code/PostProcessing/FindInstancesProcess.cpp
@@ -60,8 +60,7 @@ FindInstancesProcess::FindInstancesProcess()
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-FindInstancesProcess::~FindInstancesProcess()
-{}
+FindInstancesProcess::~FindInstancesProcess() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the processing step is present in the given flag field.

--- a/code/PostProcessing/FindInvalidDataProcess.cpp
+++ b/code/PostProcessing/FindInvalidDataProcess.cpp
@@ -62,9 +62,7 @@ FindInvalidDataProcess::FindInvalidDataProcess() :
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-FindInvalidDataProcess::~FindInvalidDataProcess() {
-    // nothing to do here
-}
+FindInvalidDataProcess::~FindInvalidDataProcess() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the processing step is present in the given flag field.

--- a/code/PostProcessing/FixNormalsStep.cpp
+++ b/code/PostProcessing/FixNormalsStep.cpp
@@ -59,17 +59,11 @@ using namespace Assimp;
 
 // ------------------------------------------------------------------------------------------------
 // Constructor to be privately used by Importer
-FixInfacingNormalsProcess::FixInfacingNormalsProcess()
-{
-    // nothing to do here
-}
+FixInfacingNormalsProcess::FixInfacingNormalsProcess() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-FixInfacingNormalsProcess::~FixInfacingNormalsProcess()
-{
-    // nothing to do here
-}
+FixInfacingNormalsProcess::~FixInfacingNormalsProcess() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the processing step is present in the given flag field.

--- a/code/PostProcessing/GenBoundingBoxesProcess.cpp
+++ b/code/PostProcessing/GenBoundingBoxesProcess.cpp
@@ -48,14 +48,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace Assimp {
 
-GenBoundingBoxesProcess::GenBoundingBoxesProcess()
-: BaseProcess() {
+GenBoundingBoxesProcess::GenBoundingBoxesProcess() = default;
 
-}
-
-GenBoundingBoxesProcess::~GenBoundingBoxesProcess() {
-    // empty
-}
+GenBoundingBoxesProcess::~GenBoundingBoxesProcess() = default;
 
 bool GenBoundingBoxesProcess::IsActive(unsigned int pFlags) const {
     return 0 != ( pFlags & aiProcess_GenBoundingBoxes );

--- a/code/PostProcessing/GenFaceNormalsProcess.cpp
+++ b/code/PostProcessing/GenFaceNormalsProcess.cpp
@@ -56,15 +56,11 @@ using namespace Assimp;
 
 // ------------------------------------------------------------------------------------------------
 // Constructor to be privately used by Importer
-GenFaceNormalsProcess::GenFaceNormalsProcess() {
-    // nothing to do here
-}
+GenFaceNormalsProcess::GenFaceNormalsProcess() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-GenFaceNormalsProcess::~GenFaceNormalsProcess() {
-    // nothing to do here
-}
+GenFaceNormalsProcess::~GenFaceNormalsProcess() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the processing step is present in the given flag field.

--- a/code/PostProcessing/GenVertexNormalsProcess.cpp
+++ b/code/PostProcessing/GenVertexNormalsProcess.cpp
@@ -62,9 +62,7 @@ GenVertexNormalsProcess::GenVertexNormalsProcess() :
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-GenVertexNormalsProcess::~GenVertexNormalsProcess() {
-    // nothing to do here
-}
+GenVertexNormalsProcess::~GenVertexNormalsProcess() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the processing step is present in the given flag field.

--- a/code/PostProcessing/ImproveCacheLocality.cpp
+++ b/code/PostProcessing/ImproveCacheLocality.cpp
@@ -70,9 +70,7 @@ ImproveCacheLocalityProcess::ImproveCacheLocalityProcess()
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-ImproveCacheLocalityProcess::~ImproveCacheLocalityProcess() {
-    // nothing to do here
-}
+ImproveCacheLocalityProcess::~ImproveCacheLocalityProcess() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the processing step is present in the given flag field.

--- a/code/PostProcessing/JoinVerticesProcess.cpp
+++ b/code/PostProcessing/JoinVerticesProcess.cpp
@@ -57,15 +57,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using namespace Assimp;
 // ------------------------------------------------------------------------------------------------
 // Constructor to be privately used by Importer
-JoinVerticesProcess::JoinVerticesProcess() {
-    // nothing to do here
-}
+JoinVerticesProcess::JoinVerticesProcess() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-JoinVerticesProcess::~JoinVerticesProcess() {
-    // nothing to do here
-}
+JoinVerticesProcess::~JoinVerticesProcess() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the processing step is present in the given flag field.

--- a/code/PostProcessing/LimitBoneWeightsProcess.cpp
+++ b/code/PostProcessing/LimitBoneWeightsProcess.cpp
@@ -62,10 +62,7 @@ LimitBoneWeightsProcess::LimitBoneWeightsProcess()
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-LimitBoneWeightsProcess::~LimitBoneWeightsProcess()
-{
-    // nothing to do here
-}
+LimitBoneWeightsProcess::~LimitBoneWeightsProcess() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the processing step is present in the given flag field.

--- a/code/PostProcessing/MakeVerboseFormat.cpp
+++ b/code/PostProcessing/MakeVerboseFormat.cpp
@@ -50,13 +50,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using namespace Assimp;
 
 // ------------------------------------------------------------------------------------------------
-MakeVerboseFormatProcess::MakeVerboseFormatProcess() {
-    // nothing to do here
-}
+MakeVerboseFormatProcess::MakeVerboseFormatProcess() = default;
 // ------------------------------------------------------------------------------------------------
-MakeVerboseFormatProcess::~MakeVerboseFormatProcess() {
-    // nothing to do here
-}
+MakeVerboseFormatProcess::~MakeVerboseFormatProcess() = default;
 // ------------------------------------------------------------------------------------------------
 // Executes the post processing step on the given imported data.
 void MakeVerboseFormatProcess::Execute(aiScene *pScene) {

--- a/code/PostProcessing/OptimizeGraph.cpp
+++ b/code/PostProcessing/OptimizeGraph.cpp
@@ -80,9 +80,7 @@ OptimizeGraphProcess::OptimizeGraphProcess() :
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-OptimizeGraphProcess::~OptimizeGraphProcess() {
-	// empty
-}
+OptimizeGraphProcess::~OptimizeGraphProcess() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the processing step is present in the given flag field.

--- a/code/PostProcessing/OptimizeMeshes.cpp
+++ b/code/PostProcessing/OptimizeMeshes.cpp
@@ -71,9 +71,7 @@ OptimizeMeshesProcess::OptimizeMeshesProcess()
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-OptimizeMeshesProcess::~OptimizeMeshesProcess() {
-    // empty
-}
+OptimizeMeshesProcess::~OptimizeMeshesProcess() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the processing step is present in the given flag field.

--- a/code/PostProcessing/PretransformVertices.cpp
+++ b/code/PostProcessing/PretransformVertices.cpp
@@ -70,9 +70,7 @@ PretransformVertices::PretransformVertices() :
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-PretransformVertices::~PretransformVertices() {
-	// nothing to do here
-}
+PretransformVertices::~PretransformVertices() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the processing step is present in the given flag field.

--- a/code/PostProcessing/ProcessHelper.cpp
+++ b/code/PostProcessing/ProcessHelper.cpp
@@ -208,7 +208,7 @@ VertexWeightTable *ComputeVertexBoneWeightTable(const aiMesh *pMesh) {
         aiBone *bone = pMesh->mBones[i];
         for (unsigned int a = 0; a < bone->mNumWeights; ++a) {
             const aiVertexWeight &weight = bone->mWeights[a];
-            avPerVertexWeights[weight.mVertexId].push_back(std::pair<unsigned int, float>(i, weight.mWeight));
+            avPerVertexWeights[weight.mVertexId].emplace_back(i, weight.mWeight);
         }
     }
     return avPerVertexWeights;

--- a/code/PostProcessing/RemoveRedundantMaterials.cpp
+++ b/code/PostProcessing/RemoveRedundantMaterials.cpp
@@ -64,10 +64,7 @@ RemoveRedundantMatsProcess::RemoveRedundantMatsProcess()
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-RemoveRedundantMatsProcess::~RemoveRedundantMatsProcess()
-{
-    // nothing to do here
-}
+RemoveRedundantMatsProcess::~RemoveRedundantMatsProcess() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the processing step is present in the given flag field.

--- a/code/PostProcessing/RemoveVCProcess.cpp
+++ b/code/PostProcessing/RemoveVCProcess.cpp
@@ -58,7 +58,7 @@ RemoveVCProcess::RemoveVCProcess() :
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-RemoveVCProcess::~RemoveVCProcess() {}
+RemoveVCProcess::~RemoveVCProcess() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the processing step is present in the given flag field.

--- a/code/PostProcessing/ScaleProcess.cpp
+++ b/code/PostProcessing/ScaleProcess.cpp
@@ -52,9 +52,7 @@ ScaleProcess::ScaleProcess()
 , mScale( AI_CONFIG_GLOBAL_SCALE_FACTOR_DEFAULT ) {
 }
 
-ScaleProcess::~ScaleProcess() {
-    // empty
-}
+ScaleProcess::~ScaleProcess() = default;
 
 void ScaleProcess::setScale( ai_real scale ) {
     mScale = scale;

--- a/code/PostProcessing/SortByPTypeProcess.cpp
+++ b/code/PostProcessing/SortByPTypeProcess.cpp
@@ -309,7 +309,7 @@ void SortByPTypeProcess::Execute(aiScene *pScene) {
                         VertexWeightTable &tbl = avw[idx];
                         for (VertexWeightTable::const_iterator it = tbl.begin(), end = tbl.end();
                                 it != end; ++it) {
-                            tempBones[(*it).first].push_back(aiVertexWeight(outIdx, (*it).second));
+                            tempBones[(*it).first].emplace_back(outIdx, (*it).second);
                         }
                     }
 

--- a/code/PostProcessing/SortByPTypeProcess.cpp
+++ b/code/PostProcessing/SortByPTypeProcess.cpp
@@ -61,9 +61,7 @@ SortByPTypeProcess::SortByPTypeProcess() :
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-SortByPTypeProcess::~SortByPTypeProcess() {
-    // nothing to do here
-}
+SortByPTypeProcess::~SortByPTypeProcess() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the processing step is present in the given flag field.

--- a/code/PostProcessing/SplitByBoneCountProcess.cpp
+++ b/code/PostProcessing/SplitByBoneCountProcess.cpp
@@ -173,7 +173,7 @@ void SplitByBoneCountProcess::SplitMesh( const aiMesh* pMesh, std::vector<aiMesh
           if (bone->mWeights[b].mWeight > 0.0f)
           {
             int vertexId = bone->mWeights[b].mVertexId;
-            vertexBones[vertexId].push_back( BoneWeight( a, bone->mWeights[b].mWeight));
+            vertexBones[vertexId].emplace_back(a, bone->mWeights[b].mWeight);
             if (vertexBones[vertexId].size() > mMaxBoneCount)
             {
               throw DeadlyImportError("SplitByBoneCountProcess: Single face requires more bones than specified max bone count!");

--- a/code/PostProcessing/SplitByBoneCountProcess.cpp
+++ b/code/PostProcessing/SplitByBoneCountProcess.cpp
@@ -67,10 +67,7 @@ SplitByBoneCountProcess::SplitByBoneCountProcess()
 
 // ------------------------------------------------------------------------------------------------
 // Destructor
-SplitByBoneCountProcess::~SplitByBoneCountProcess()
-{
-    // nothing to do here
-}
+SplitByBoneCountProcess::~SplitByBoneCountProcess() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the processing step is present in the given flag.

--- a/code/PostProcessing/SplitLargeMeshes.cpp
+++ b/code/PostProcessing/SplitLargeMeshes.cpp
@@ -56,9 +56,7 @@ SplitLargeMeshesProcess_Triangle::SplitLargeMeshesProcess_Triangle() {
 }
 
 // ------------------------------------------------------------------------------------------------
-SplitLargeMeshesProcess_Triangle::~SplitLargeMeshesProcess_Triangle() {
-    // nothing to do here
-}
+SplitLargeMeshesProcess_Triangle::~SplitLargeMeshesProcess_Triangle() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the processing step is present in the given flag field.
@@ -332,9 +330,7 @@ SplitLargeMeshesProcess_Vertex::SplitLargeMeshesProcess_Vertex() {
 }
 
 // ------------------------------------------------------------------------------------------------
-SplitLargeMeshesProcess_Vertex::~SplitLargeMeshesProcess_Vertex() {
-    // nothing to do here
-}
+SplitLargeMeshesProcess_Vertex::~SplitLargeMeshesProcess_Vertex() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the processing step is present in the given flag field.

--- a/code/PostProcessing/TextureTransform.cpp
+++ b/code/PostProcessing/TextureTransform.cpp
@@ -64,10 +64,7 @@ TextureTransformStep::TextureTransformStep() :
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-TextureTransformStep::~TextureTransformStep()
-{
-    // nothing to do here
-}
+TextureTransformStep::~TextureTransformStep() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the processing step is present in the given flag field.

--- a/code/PostProcessing/TextureTransform.cpp
+++ b/code/PostProcessing/TextureTransform.cpp
@@ -434,7 +434,7 @@ void TextureTransformStep::Execute( aiScene* pScene)
         for (unsigned int n = 0; n < AI_MAX_NUMBER_OF_TEXTURECOORDS;++n) {
             if (ref[n])
                 continue;
-            trafo.push_back(STransformVecInfo());
+            trafo.emplace_back();
             trafo.back().uvIndex = n;
         }
 

--- a/code/PostProcessing/TriangulateProcess.cpp
+++ b/code/PostProcessing/TriangulateProcess.cpp
@@ -159,17 +159,11 @@ namespace {
 
 // ------------------------------------------------------------------------------------------------
 // Constructor to be privately used by Importer
-TriangulateProcess::TriangulateProcess()
-{
-    // nothing to do here
-}
+TriangulateProcess::TriangulateProcess() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-TriangulateProcess::~TriangulateProcess()
-{
-    // nothing to do here
-}
+TriangulateProcess::~TriangulateProcess() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the processing step is present in the given flag field.

--- a/code/PostProcessing/ValidateDataStructure.cpp
+++ b/code/PostProcessing/ValidateDataStructure.cpp
@@ -65,7 +65,7 @@ ValidateDSProcess::ValidateDSProcess() :
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
-ValidateDSProcess::~ValidateDSProcess() {}
+ValidateDSProcess::~ValidateDSProcess() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the processing step is present in the given flag field.

--- a/include/assimp/IOStream.hpp
+++ b/include/assimp/IOStream.hpp
@@ -134,9 +134,7 @@ IOStream::IOStream() AI_NO_EXCEPT {
 
 // ----------------------------------------------------------------------------------
 AI_FORCE_INLINE
-IOStream::~IOStream() {
-    // empty
-}
+IOStream::~IOStream() = default;
 // ----------------------------------------------------------------------------------
 
 } //!namespace Assimp

--- a/include/assimp/IOSystem.hpp
+++ b/include/assimp/IOSystem.hpp
@@ -243,9 +243,7 @@ AI_FORCE_INLINE IOSystem::IOSystem() AI_NO_EXCEPT :
 }
 
 // ----------------------------------------------------------------------------
-AI_FORCE_INLINE IOSystem::~IOSystem() {
-    // empty
-}
+AI_FORCE_INLINE IOSystem::~IOSystem() = default;
 
 // ----------------------------------------------------------------------------
 // For compatibility, the interface of some functions taking a std::string was

--- a/include/assimp/LogStream.hpp
+++ b/include/assimp/LogStream.hpp
@@ -99,13 +99,9 @@ public:
 
 }; // !class LogStream
 
-inline LogStream::LogStream() AI_NO_EXCEPT {
-    // empty
-}
+inline LogStream::LogStream() AI_NO_EXCEPT = default;
 
-inline LogStream::~LogStream() {
-    // empty
-}
+inline LogStream::~LogStream() = default;
 
 } // Namespace Assimp
 

--- a/include/assimp/Logger.hpp
+++ b/include/assimp/Logger.hpp
@@ -263,9 +263,7 @@ inline Logger::Logger() AI_NO_EXCEPT :
 }
 
 // ----------------------------------------------------------------------------------
-inline Logger::~Logger() {
-    // empty
-}
+inline Logger::~Logger() = default;
 
 // ----------------------------------------------------------------------------------
 inline Logger::Logger(LogSeverity severity) :

--- a/include/assimp/Subdivision.h
+++ b/include/assimp/Subdivision.h
@@ -122,10 +122,7 @@ public:
 
 };
 
-inline
-Subdivider::~Subdivider() {
-    // empty
-}
+inline Subdivider::~Subdivider() = default;
 
 } // end namespace Assimp
 

--- a/include/assimp/aabb.h
+++ b/include/assimp/aabb.h
@@ -73,9 +73,7 @@ struct aiAABB {
     }
 
     ///	@brief  The class destructor.
-    ~aiAABB() {
-        // empty
-    }
+    ~aiAABB() = default;
 
 #endif // __cplusplus
 };

--- a/test/unit/AbstractImportExportBase.cpp
+++ b/test/unit/AbstractImportExportBase.cpp
@@ -44,6 +44,4 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using namespace ::Assimp;
 
-AbstractImportExportBase::~AbstractImportExportBase() {
-    // empty
-}
+AbstractImportExportBase::~AbstractImportExportBase() = default;

--- a/test/unit/ImportExport/utExporter.cpp
+++ b/test/unit/ImportExport/utExporter.cpp
@@ -55,9 +55,7 @@ public:
         // empty
     }
 
-    virtual ~TestProgressHandler() {
-        // empty
-    }
+    virtual ~TestProgressHandler() = default;
 
     bool Update(float percentage = -1.f) override {
         mPercentage = percentage;

--- a/test/unit/SceneDiffer.cpp
+++ b/test/unit/SceneDiffer.cpp
@@ -53,9 +53,7 @@ SceneDiffer::SceneDiffer()
     // empty
 }
 
-SceneDiffer::~SceneDiffer() {
-    // empty
-}
+SceneDiffer::~SceneDiffer() = default;
 
 bool SceneDiffer::isEqual( const aiScene *expected, const aiScene *toCompare ) {
     if ( expected == toCompare ) {

--- a/test/unit/UTLogStream.h
+++ b/test/unit/UTLogStream.h
@@ -56,7 +56,7 @@ public:
 
     virtual void write(const char* message) {
         if ( nullptr != message ) {
-            m_messages.push_back( std::string( message ) );
+            m_messages.emplace_back(message);
         }
     }
 

--- a/test/unit/utBlendImportAreaLight.cpp
+++ b/test/unit/utBlendImportAreaLight.cpp
@@ -69,7 +69,7 @@ TEST_F(BlendImportAreaLight, testImportLight) {
     std::vector<std::pair<std::string, size_t>> lightNames;
 
     for (size_t i = 0; i < pTest->mNumLights; i++) {
-        lightNames.push_back(std::make_pair(pTest->mLights[i]->mName.C_Str(), i));
+        lightNames.emplace_back(pTest->mLights[i]->mName.C_Str(), i);
     }
 
     std::sort(lightNames.begin(), lightNames.end());

--- a/test/unit/utLimitBoneWeights.cpp
+++ b/test/unit/utLimitBoneWeights.cpp
@@ -114,7 +114,7 @@ TEST_F(LimitBoneWeightsTest, testProcess) {
         aiBone &pcBone = **(mMesh->mBones + i);
         for (unsigned int q = 0; q < pcBone.mNumWeights; ++q) {
             aiVertexWeight weight = pcBone.mWeights[q];
-            asWeights[weight.mVertexId].push_back(LimitBoneWeightsProcess::Weight(i, weight.mWeight));
+            asWeights[weight.mVertexId].emplace_back(i, weight.mWeight);
         }
     }
 

--- a/test/unit/utObjTools.cpp
+++ b/test/unit/utObjTools.cpp
@@ -55,9 +55,7 @@ public:
         // empty
     }
 
-    ~TestObjFileParser() {
-        // empty
-    }
+    ~TestObjFileParser() = default;
 
     void testCopyNextWord(char *pBuffer, size_t length) {
         copyNextWord(pBuffer, length);

--- a/tools/assimp_cmd/CompareDump.cpp
+++ b/tools/assimp_cmd/CompareDump.cpp
@@ -125,10 +125,10 @@ public:
         ai_assert(expect);
 
         fseek(actual,0,SEEK_END);
-        lengths.push(std::make_pair(static_cast<uint32_t>(ftell(actual)),0));
+        lengths.emplace(static_cast<uint32_t>(ftell(actual)),0);
         fseek(actual,0,SEEK_SET);
 
-        history.push_back(HistoryEntry("---",PerChunkCounter()));
+        history.emplace_back("---",PerChunkCounter());
     }
 
 public:
@@ -144,7 +144,7 @@ public:
         }
         else history.back().second[s] = 0;
 
-        history.push_back(HistoryEntry(s,PerChunkCounter()));
+        history.emplace_back(s,PerChunkCounter());
         debug_trace.push_back("PUSH " + s);
     }
 
@@ -158,7 +158,7 @@ public:
 
     /* push current chunk length and start offset on top of stack */
     void push_length(uint32_t nl, uint32_t start) {
-        lengths.push(std::make_pair(nl,start));
+        lengths.emplace(nl,start);
         ++cnt_chunks;
     }
 

--- a/tools/assimp_cmd/CompareDump.cpp
+++ b/tools/assimp_cmd/CompareDump.cpp
@@ -569,8 +569,7 @@ public:
     {}
 
     //
-    ~sliced_chunk_reader() {
-    }
+    ~sliced_chunk_reader() = default;
 
 public:
 

--- a/tools/assimp_cmd/Main.cpp
+++ b/tools/assimp_cmd/Main.cpp
@@ -55,9 +55,7 @@ public:
 		// empty
 	}
 
-	~ConsoleProgressHandler() override {
-		// empty
-	}
+	~ConsoleProgressHandler() override = default;
 
 	bool Update(float percentage) override {
         std::cout << percentage * 100.0f << " %\n";


### PR DESCRIPTION
Applying yet another static analysis clang-tidy rule: [modernize-use-equals-default](https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-equals-default.html). 

This check explicitly defaults empty ctors destructors. This tells the compiler that the destructor is trivial and may enable more aggressive compiler optimizations. Specifically, it make some class and structs trivial if all its members are trivial. Without this, compilers may not treat the class as trivial even if the custom defined ctor / dtor is empty. It also increases readability and consistency with the rest of the codebase.