### PR TITLE
Wrong object is created here!

### DIFF
--- a/code/PostProcessing/JoinVerticesProcess.cpp
+++ b/code/PostProcessing/JoinVerticesProcess.cpp
@@ -345,8 +345,7 @@ int JoinVerticesProcess::ProcessMesh( aiMesh* pMesh, unsigned int meshIndex) {
             uniqueVertices.push_back(v);
             if (hasAnimMeshes) {
                 for (unsigned int animMeshIndex = 0; animMeshIndex < pMesh->mNumAnimMeshes; animMeshIndex++) {
-                    Vertex aniMeshVertex(pMesh->mAnimMeshes[animMeshIndex], a);
-                    uniqueAnimatedVertices[animMeshIndex].push_back(v);
+                    uniqueAnimatedVertices[animMeshIndex].emplace_back(pMesh->mAnimMeshes[animMeshIndex], a);
                 }
             }
         } else{


### PR DESCRIPTION
If I'm not mistaken. Because this is originally push_back(aniMeshVertex) instead of push_back(v).
And the fact that aniMeshVertex is just getting created and destroyed for nothing.
It need to be replaced with this then? A Clang-tidy syntax to create the same aniMeshVertex.

I found this in pull request #4527 I think it may need to be reviewed too.
Hope it help!