### PR TITLE
fix vertices being joined duplicating weights

### DIFF
--- a/code/PostProcessing/JoinVerticesProcess.cpp
+++ b/code/PostProcessing/JoinVerticesProcess.cpp
@@ -394,6 +394,16 @@ int JoinVerticesProcess::ProcessMesh( aiMesh* pMesh, unsigned int meshIndex) {
                 const aiVertexWeight& ow = bone->mWeights[ b ];
                 // if the vertex is a unique one, translate it
                 if ( !( replaceIndex[ ow.mVertexId ] & 0x80000000 ) ) {
+                    bool weightAlreadyExists = false;
+                    for (std::vector<aiVertexWeight>::iterator vit = newWeights.begin(); vit != newWeights.end(); ++vit) {
+                        if (vit->mVertexId == replaceIndex[ow.mVertexId]) {
+                            weightAlreadyExists = true;
+                            break;
+                        }
+                    }
+                    if (weightAlreadyExists) {
+                        continue;
+                    }                    
                     aiVertexWeight nw;
                     nw.mVertexId = replaceIndex[ ow.mVertexId ];
                     nw.mWeight = ow.mWeight;


### PR DESCRIPTION
This bug causes weights to duplicate, i.e. one bone will have several (equal) weights assigned to the same vertex - which then has the potential to cause even bigger problems when combined with `LimitBoneWeightsProcess`.

The fix is not the prettiest but I'm a week before deadline here.