### PR TITLE
Perfect forward val to utMaybe.cpp

### DIFF
--- a/code/Common/Maybe.h
+++ b/code/Common/Maybe.h
@@ -41,6 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 #include <assimp/ai_assert.h>
+#include <utility>
 
 namespace Assimp {
 
@@ -48,13 +49,14 @@ namespace Assimp {
 /// @tparam T   The type to store.
 template <typename T>
 struct Maybe {
-    /// @brief 
+    /// @brief
     Maybe() = default;
 
-    /// @brief 
-    /// @param val 
-    explicit Maybe(const T &val) :
-            _val(val), _valid(true) {}
+    /// @brief
+    /// @param val
+    template <typename U>
+    explicit Maybe(U &&val) :
+            _val(std::forward<U>(val)), _valid(true) {}
 
     /// @brief Validate the value
     /// @return true if valid.
@@ -64,11 +66,12 @@ struct Maybe {
 
     /// @brief Will assign a value.
     /// @param v The new valid value.
-    void Set(T &v) {
+    template <typename U>
+    void Set(U &&v) {
         ai_assert(!_valid);
 
         _valid = true;
-        _val = v;
+        _val = std::forward<U>(v);
     }
 
     /// @brief  Will return the value when it is valid.


### PR DESCRIPTION
Something I should have caught in my review of https://github.com/assimp/assimp/pull/4715 . The val arg should be perfectly forwarded with a universal reference to utMaybe. This allows the value T to be move assigned which allows both can make it more efficient and also allows utMaybe to work with values that are only move assignable. By using perfect forwarding, it will also just pass the reference if T is a reference.

Sorry for not catching this yesterday @kimkulling