### PR TITLE
Fix: Use ASCII treeview in assimp-cmd.

### DIFF
--- a/code/AssetLib/X/XFileImporter.cpp
+++ b/code/AssetLib/X/XFileImporter.cpp
@@ -75,14 +75,9 @@ static const aiImporterDesc desc = {
 
 // ------------------------------------------------------------------------------------------------
 // Constructor to be privately used by Importer
-XFileImporter::XFileImporter()
-: mBuffer() {
+XFileImporter::XFileImporter() : mBuffer() {
     // empty
 }
-
-// ------------------------------------------------------------------------------------------------
-// Destructor, private as well
-XFileImporter::~XFileImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/X/XFileImporter.h
+++ b/code/AssetLib/X/XFileImporter.h
@@ -69,7 +69,7 @@ namespace XFile {
 class XFileImporter : public BaseImporter {
 public:
     XFileImporter();
-    ~XFileImporter() override;
+    ~XFileImporter() override = default;
 
     // -------------------------------------------------------------------
     /** Returns whether the class can handle the format of the given file.

--- a/code/Common/Compression.h
+++ b/code/Common/Compression.h
@@ -42,9 +42,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma once
 
 #ifdef ASSIMP_BUILD_NO_OWN_ZLIB
-#include <zlib.h>
+#   include <zlib.h>
 #else
-#include "../contrib/zlib/zlib.h"
+#   include "../contrib/zlib/zlib.h"
 #endif
 
 #include <vector>

--- a/tools/assimp_cmd/Info.cpp
+++ b/tools/assimp_cmd/Info.cpp
@@ -5,8 +5,6 @@ Open Asset Import Library (assimp)
 
 Copyright (c) 2006-2022, assimp team
 
-
-
 All rights reserved.
 
 Redistribution and use of this software in source and binary forms,
@@ -68,9 +66,15 @@ const char *TREE_CONTINUE_UTF8 = "\xe2\x94\x82 ";
 // this is well supported on pretty much any linux terminal.
 // if this causes problems on some platform,
 // put an #ifdef to use the ascii version for that platform.
+#ifdef _WIN32
+const char *TREE_BRANCH = TREE_BRANCH_ASCII;
+const char *TREE_STOP = TREE_STOP_ASCII;
+const char *TREE_CONTINUE = TREE_CONTINUE_ASCII;
+#else
 const char *TREE_BRANCH = TREE_BRANCH_UTF8;
 const char *TREE_STOP = TREE_STOP_UTF8;
 const char *TREE_CONTINUE = TREE_CONTINUE_UTF8;
+#endif
 
 // -----------------------------------------------------------------------------------
 unsigned int CountNodes(const aiNode *root) {

--- a/tools/assimp_cmd/Info.cpp
+++ b/tools/assimp_cmd/Info.cpp
@@ -48,19 +48,19 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <iostream>
 #include <string>
 
-const char *AICMD_MSG_INFO_HELP_E =
+constexpr char AICMD_MSG_INFO_HELP_E[] =
         "assimp info <file> [-r] [-v]\n"
         "\tPrint basic structure of a 3D model\n"
         "\t-r,--raw: No postprocessing, do a raw import\n"
         "\t-v,--verbose: Print verbose info such as node transform data\n"
         "\t-s, --silent: Print only minimal info\n";
 
-const char *TREE_BRANCH_ASCII = "|-";
-const char *TREE_BRANCH_UTF8 = "\xe2\x94\x9c\xe2\x95\xb4";
-const char *TREE_STOP_ASCII = "'-";
-const char *TREE_STOP_UTF8 = "\xe2\x94\x94\xe2\x95\xb4";
-const char *TREE_CONTINUE_ASCII = "| ";
-const char *TREE_CONTINUE_UTF8 = "\xe2\x94\x82 ";
+constexpr char TREE_BRANCH_ASCII[] = "|-";
+constexpr char TREE_BRANCH_UTF8[] = "\xe2\x94\x9c\xe2\x95\xb4";
+constexpr char TREE_STOP_ASCII[] = "'-";
+constexpr char TREE_STOP_UTF8[] = "\xe2\x94\x94\xe2\x95\xb4";
+constexpr char TREE_CONTINUE_ASCII[] = "| ";
+constexpr char TREE_CONTINUE_UTF8[] = "\xe2\x94\x82 ";
 
 // note: by default this is using utf-8 text.
 // this is well supported on pretty much any linux terminal.

--- a/tools/assimp_cmd/Main.cpp
+++ b/tools/assimp_cmd/Main.cpp
@@ -58,11 +58,12 @@ public:
 	~ConsoleProgressHandler() override = default;
 
 	bool Update(float percentage) override {
-        std::cout << percentage * 100.0f << " %\n";
+        std::cout << "\r" << percentage * 100.0f << " %";
 		return true;
     }
 };
-const char* AICMD_MSG_ABOUT =
+
+constexpr char AICMD_MSG_ABOUT[] =
 "------------------------------------------------------ \n"
 "Open Asset Import Library (\"Assimp\", https://github.com/assimp/assimp) \n"
 " -- Commandline toolchain --\n"
@@ -70,7 +71,7 @@ const char* AICMD_MSG_ABOUT =
 
 "Version %i.%i %s%s%s%s%s(GIT commit %x)\n\n";
 
-const char* AICMD_MSG_HELP =
+constexpr char AICMD_MSG_HELP[] =
 "assimp <verb> <parameters>\n\n"
 " verbs:\n"
 " \tinfo       - Quick file stats\n"
@@ -96,8 +97,7 @@ const char* AICMD_MSG_HELP =
 
 // ------------------------------------------------------------------------------
 // Application entry point
-int main (int argc, char* argv[])
-{
+int main (int argc, char* argv[]) {
 	if (argc <= 1)	{
 		printf("assimp: No command specified. Use \'assimp help\' for a detailed command list\n");
 		return AssimpCmdError::Success;
@@ -550,10 +550,7 @@ int ProcessStandardArguments(
 }
 
 // ------------------------------------------------------------------------------
-int Assimp_TestBatchLoad (
-	const char* const* params,
-	unsigned int num)
-{
+int Assimp_TestBatchLoad(const char* const* params, unsigned int num) {
 	for(unsigned int i = 0; i < num; ++i) {
 		globalImporter->ReadFile(params[i],aiProcessPreset_TargetRealtime_MaxQuality);
 		// we're totally silent. scene destructs automatically.

--- a/tools/assimp_cmd/Main.h
+++ b/tools/assimp_cmd/Main.h
@@ -60,25 +60,17 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/scene.h>
 #include <assimp/Importer.hpp>
 #include <assimp/DefaultLogger.hpp>
+#include "../code/Common/Compression.h"
 
 #ifndef ASSIMP_BUILD_NO_EXPORT
 #	include <assimp/Exporter.hpp>
 #endif
 
-#ifdef ASSIMP_BUILD_NO_OWN_ZLIB
-#   include <zlib.h>
-#else
-#   include <../contrib/zlib/zlib.h>
-#endif
-
-
 #ifndef SIZE_MAX
 #	define SIZE_MAX (std::numeric_limits<size_t>::max())
 #endif
 
-
 using namespace Assimp;
-
 
 // Global assimp importer instance
 extern Assimp::Importer* globalImporter;
@@ -118,8 +110,8 @@ struct ImportData {
 	aiVector3D rot;
 };
 
-/// \enum AssimpCmdError
-/// \brief General error codes used among assimp_cmd's utilities.
+// ------------------------------------------------------------------------------
+/// @brief General error codes used among assimp_cmd's utilities.
 enum AssimpCmdError {
 	Success = 0,
 	InvalidNumberOfArguments,
@@ -179,8 +171,8 @@ int Assimp_Dump (
 	const char* const* params,
 	unsigned int num);
 
-/// \enum AssimpCmdExportError
-/// \brief Error codes used by the 'Export' utility.
+// ------------------------------------------------------------------------------
+/// @brief Error codes used by the 'Export' utility.
 enum AssimpCmdExportError {
 	FailedToImportModel = AssimpCmdError::LastAssimpCmdError,
 	FailedToExportModel,
@@ -199,8 +191,8 @@ int Assimp_Export (
 	const char* const* params,
 	unsigned int num);
 
-/// \enum AssimpCmdExtractError
-/// \brief Error codes used by the 'Image Extractor' utility.
+// ------------------------------------------------------------------------------
+/// @brief Error codes used by the 'Image Extractor' utility.
 enum AssimpCmdExtractError {
 	TextureIndexIsOutOfRange = AssimpCmdError::LastAssimpCmdError,
 	NoAvailableTextureEncoderFound,
@@ -220,8 +212,8 @@ int Assimp_Extract (
 	const char* const* params,
 	unsigned int num);
 
-/// \enum AssimpCmdCompareDumpError
-/// \brief Error codes used by the 'Compare Dump' utility.
+// ------------------------------------------------------------------------------
+/// @brief Error codes used by the 'Compare Dump' utility.
 enum AssimpCmdCompareDumpError {
 	FailedToLoadExpectedInputFile = AssimpCmdError::LastAssimpCmdError,
 	FileComparaisonFailure,
@@ -241,8 +233,7 @@ int Assimp_CompareDump (
 	const char* const* params,
 	unsigned int num);
 
-/// \enum AssimpCmdInfoError
-/// \brief Error codes used by the 'Info' utility.
+/// @brief Error codes used by the 'Info' utility.
 enum AssimpCmdInfoError {
 	InvalidCombinaisonOfArguments = AssimpCmdError::LastAssimpCmdError,
 

--- a/tools/assimp_cmd/Main.h
+++ b/tools/assimp_cmd/Main.h
@@ -47,7 +47,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define AICMD_MAIN_INCLUDED
 
 #ifndef _CRT_SECURE_NO_WARNINGS
-#define _CRT_SECURE_NO_WARNINGS
+#   define _CRT_SECURE_NO_WARNINGS
 #endif
 
 #include <stdio.h>
@@ -66,9 +66,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 #ifdef ASSIMP_BUILD_NO_OWN_ZLIB
-#include <zlib.h>
+#   include <zlib.h>
 #else
-#include <../contrib/zlib/zlib.h>
+#   include <../contrib/zlib/zlib.h>
 #endif
 
 


### PR DESCRIPTION
- Improve animation in console
- Fix issue with ASCII treeview for window terminals
- closes https://github.com/assimp/assimp/issues/4724