### PR TITLE
Prefix symbols from stb_image.h

### DIFF
--- a/code/Common/Assimp.cpp
+++ b/code/Common/Assimp.cpp
@@ -1273,11 +1273,13 @@ ASSIMP_API void aiQuaternionInterpolate(
 #define ASSIMP_HAS_PBRT_EXPORT (!ASSIMP_BUILD_NO_EXPORT && !ASSIMP_BUILD_NO_PBRT_EXPORTER)
 #define ASSIMP_HAS_M3D ((!ASSIMP_BUILD_NO_EXPORT && !ASSIMP_BUILD_NO_M3D_EXPORTER) || !ASSIMP_BUILD_NO_M3D_IMPORTER)
 
-#if ASSIMP_HAS_PBRT_EXPORT
-#   define ASSIMP_NEEDS_STB_IMAGE 1
-#elif ASSIMP_HAS_M3D
-#   define ASSIMP_NEEDS_STB_IMAGE 1
-#   define STBI_ONLY_PNG
+#ifndef STB_USE_HUNTER
+#   if ASSIMP_HAS_PBRT_EXPORT
+#       define ASSIMP_NEEDS_STB_IMAGE 1
+#   elif ASSIMP_HAS_M3D
+#       define ASSIMP_NEEDS_STB_IMAGE 1
+#       define STBI_ONLY_PNG
+#   endif
 #endif
 
 // Ensure all symbols are linked correctly

--- a/code/Common/StbCommon.h
+++ b/code/Common/StbCommon.h
@@ -48,6 +48,64 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma GCC diagnostic ignored "-Wunused-function"
 #endif
 
+#ifndef STB_USE_HUNTER
+/*  Use prefixed names for the symbols from stb_image as it is a very commonly embedded library.
+    Including vanilla stb_image symbols causes duplicate symbol problems if assimp is linked
+    statically together with another library or executable that also embeds stb_image.
+
+    Symbols are not prefixed if using Hunter because in such case there exists a single true
+    stb_image library on the system that is used by assimp and can be used by all the other
+    libraries and executables.
+
+    The list can be regenerated using the following:
+
+    cat <path/to/stb/stb_image.h> | fgrep STBIDEF | fgrep '(' | sed -E 's/\*|\(.+//g' | \
+        awk '{print "#define " $(NF) " assimp_" $(NF) }' | sort | uniq"
+*/
+#define stbi_convert_iphone_png_to_rgb assimp_stbi_convert_iphone_png_to_rgb
+#define stbi_convert_wchar_to_utf8 assimp_stbi_convert_wchar_to_utf8
+#define stbi_failure_reason assimp_stbi_failure_reason
+#define stbi_hdr_to_ldr_gamma assimp_stbi_hdr_to_ldr_gamma
+#define stbi_hdr_to_ldr_scale assimp_stbi_hdr_to_ldr_scale
+#define stbi_image_free assimp_stbi_image_free
+#define stbi_info assimp_stbi_info
+#define stbi_info_from_callbacks assimp_stbi_info_from_callbacks
+#define stbi_info_from_file assimp_stbi_info_from_file
+#define stbi_info_from_memory assimp_stbi_info_from_memory
+#define stbi_is_16_bit assimp_stbi_is_16_bit
+#define stbi_is_16_bit_from_callbacks assimp_stbi_is_16_bit_from_callbacks
+#define stbi_is_16_bit_from_file assimp_stbi_is_16_bit_from_file
+#define stbi_is_16_bit_from_memory assimp_stbi_is_16_bit_from_memory
+#define stbi_is_hdr assimp_stbi_is_hdr
+#define stbi_is_hdr_from_callbacks assimp_stbi_is_hdr_from_callbacks
+#define stbi_is_hdr_from_file assimp_stbi_is_hdr_from_file
+#define stbi_is_hdr_from_memory assimp_stbi_is_hdr_from_memory
+#define stbi_ldr_to_hdr_gamma assimp_stbi_ldr_to_hdr_gamma
+#define stbi_ldr_to_hdr_scale assimp_stbi_ldr_to_hdr_scale
+#define stbi_load_16 assimp_stbi_load_16
+#define stbi_load_16_from_callbacks assimp_stbi_load_16_from_callbacks
+#define stbi_load_16_from_memory assimp_stbi_load_16_from_memory
+#define stbi_load assimp_stbi_load
+#define stbi_loadf assimp_stbi_loadf
+#define stbi_loadf_from_callbacks assimp_stbi_loadf_from_callbacks
+#define stbi_loadf_from_file assimp_stbi_loadf_from_file
+#define stbi_loadf_from_memory assimp_stbi_loadf_from_memory
+#define stbi_load_from_callbacks assimp_stbi_load_from_callbacks
+#define stbi_load_from_file_16 assimp_stbi_load_from_file_16
+#define stbi_load_from_file assimp_stbi_load_from_file
+#define stbi_load_from_memory assimp_stbi_load_from_memory
+#define stbi_load_gif_from_memory assimp_stbi_load_gif_from_memory
+#define stbi_set_flip_vertically_on_load assimp_stbi_set_flip_vertically_on_load
+#define stbi_set_flip_vertically_on_load_thread assimp_stbi_set_flip_vertically_on_load_thread
+#define stbi_set_unpremultiply_on_load assimp_stbi_set_unpremultiply_on_load
+#define stbi_zlib_decode_buffer assimp_stbi_zlib_decode_buffer
+#define stbi_zlib_decode_malloc assimp_stbi_zlib_decode_malloc
+#define stbi_zlib_decode_malloc_guesssize assimp_stbi_zlib_decode_malloc_guesssize
+#define stbi_zlib_decode_malloc_guesssize_headerflag assimp_stbi_zlib_decode_malloc_guesssize_headerflag
+#define stbi_zlib_decode_noheader_buffer assimp_stbi_zlib_decode_noheader_buffer
+#define stbi_zlib_decode_noheader_malloc assimp_stbi_zlib_decode_noheader_malloc
+#endif
+
 #include "stb/stb_image.h"
 
 #if _MSC_VER


### PR DESCRIPTION
This makes it possible to link assimp statically into an executable with another static library that includes stb_image.h without hiding its symbols (be it prefixing names like here, using internal linkage or not exporting in case of shared libraries).

In this particular case prefixing is the only option. Using internal linkage is not efficient because the library is used from multiple translation units. Not exporting is not possible in cases assimp is compiled as a static library.