### PR TITLE
FIX: C++ std::tuple constexpr initial list on old compiler

### DIFF
--- a/test/unit/utglTF2ImportExport.cpp
+++ b/test/unit/utglTF2ImportExport.cpp
@@ -754,20 +754,17 @@ TEST_F(utglTF2ImportExport, wrongTypes) {
     using tup_T = std::tuple<std::string, std::string, std::string, std::string>;
     std::vector<tup_T> wrongTypes = {
 #ifdef __cpp_lib_constexpr_tuple
-        { "/glTF2/wrongTypes/badArray.gltf", "array", "primitives", "meshes[0]" },
-        { "/glTF2/wrongTypes/badString.gltf", "string", "name", "scenes[0]" },
-        { "/glTF2/wrongTypes/badUint.gltf", "uint", "index", "materials[0]" },
-        { "/glTF2/wrongTypes/badNumber.gltf", "number", "scale", "materials[0]" },
-        { "/glTF2/wrongTypes/badObject.gltf", "object", "pbrMetallicRoughness", "materials[0]" },
-        { "/glTF2/wrongTypes/badExtension.gltf", "object", "KHR_texture_transform", "materials[0]" }
+    #define TUPLE(x) {x}
 #else
-        tup_T( "/glTF2/wrongTypes/badArray.gltf", "array", "primitives", "meshes[0]" ),
-        tup_T( "/glTF2/wrongTypes/badString.gltf", "string", "name", "scenes[0]" ),
-        tup_T( "/glTF2/wrongTypes/badUint.gltf", "uint", "index", "materials[0]" ),
-        tup_T( "/glTF2/wrongTypes/badNumber.gltf", "number", "scale", "materials[0]" ),
-        tup_T( "/glTF2/wrongTypes/badObject.gltf", "object", "pbrMetallicRoughness", "materials[0]" ),
-        tup_T( "/glTF2/wrongTypes/badExtension.gltf", "object", "KHR_texture_transform", "materials[0]" )
+    #define TUPLE(x) tup_T(x)
 #endif
+        TUPLE("/glTF2/wrongTypes/badArray.gltf", "array", "primitives", "meshes[0]"),
+        TUPLE("/glTF2/wrongTypes/badString.gltf", "string", "name", "scenes[0]"),
+        TUPLE("/glTF2/wrongTypes/badUint.gltf", "uint", "index", "materials[0]"),
+        TUPLE("/glTF2/wrongTypes/badNumber.gltf", "number", "scale", "materials[0]"),
+        TUPLE("/glTF2/wrongTypes/badObject.gltf", "object", "pbrMetallicRoughness", "materials[0]"),
+        TUPLE("/glTF2/wrongTypes/badExtension.gltf", "object", "KHR_texture_transform", "materials[0]")
+#undef TUPLE
     };
     for (const auto& tuple : wrongTypes)
     {

--- a/test/unit/utglTF2ImportExport.cpp
+++ b/test/unit/utglTF2ImportExport.cpp
@@ -753,12 +753,21 @@ TEST_F(utglTF2ImportExport, wrongTypes) {
     // Deliberately broken version of the BoxTextured.gltf asset.
     using tup_T = std::tuple<std::string, std::string, std::string, std::string>;
     std::vector<tup_T> wrongTypes = {
+#ifdef __cpp_lib_constexpr_tuple
         { "/glTF2/wrongTypes/badArray.gltf", "array", "primitives", "meshes[0]" },
         { "/glTF2/wrongTypes/badString.gltf", "string", "name", "scenes[0]" },
         { "/glTF2/wrongTypes/badUint.gltf", "uint", "index", "materials[0]" },
         { "/glTF2/wrongTypes/badNumber.gltf", "number", "scale", "materials[0]" },
         { "/glTF2/wrongTypes/badObject.gltf", "object", "pbrMetallicRoughness", "materials[0]" },
         { "/glTF2/wrongTypes/badExtension.gltf", "object", "KHR_texture_transform", "materials[0]" }
+#else
+        tup_T( "/glTF2/wrongTypes/badArray.gltf", "array", "primitives", "meshes[0]" ),
+        tup_T( "/glTF2/wrongTypes/badString.gltf", "string", "name", "scenes[0]" ),
+        tup_T( "/glTF2/wrongTypes/badUint.gltf", "uint", "index", "materials[0]" ),
+        tup_T( "/glTF2/wrongTypes/badNumber.gltf", "number", "scale", "materials[0]" ),
+        tup_T( "/glTF2/wrongTypes/badObject.gltf", "object", "pbrMetallicRoughness", "materials[0]" ),
+        tup_T( "/glTF2/wrongTypes/badExtension.gltf", "object", "KHR_texture_transform", "materials[0]" )
+#endif
     };
     for (const auto& tuple : wrongTypes)
     {

--- a/test/unit/utglTF2ImportExport.cpp
+++ b/test/unit/utglTF2ImportExport.cpp
@@ -754,9 +754,9 @@ TEST_F(utglTF2ImportExport, wrongTypes) {
     using tup_T = std::tuple<std::string, std::string, std::string, std::string>;
     std::vector<tup_T> wrongTypes = {
 #ifdef __cpp_lib_constexpr_tuple
-    #define TUPLE(x) {x}
+    #define TUPLE(x, y, z, w) {x, y, z, w}
 #else
-    #define TUPLE(x) tup_T(x)
+    #define TUPLE(x, y, z, w) tup_T(x, y, z, w)
 #endif
         TUPLE("/glTF2/wrongTypes/badArray.gltf", "array", "primitives", "meshes[0]"),
         TUPLE("/glTF2/wrongTypes/badString.gltf", "string", "name", "scenes[0]"),


### PR DESCRIPTION
Fixing std::tuple initial list on old compiler.

compile error log on old compiler
```
/home/sietium/sarah/assimp/test/unit/utglTF2ImportExport.cpp: In member function ‘virtual void utglTF2ImportExport_wrongTypes_Test::TestBody()’:
/home/sietium/sarah/assimp/test/unit/utglTF2ImportExport.cpp:762:5: error: converting to ‘std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >’ from initializer list would use explicit constructor ‘constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {const char (&)[32], const char (&)[6], const char (&)[11], const char (&)[10]}; <template-parameter-2-2> = void; _Elements = {std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >}]’
     };
     ^
/home/sietium/sarah/assimp/test/unit/utglTF2ImportExport.cpp:762:5: error: converting to ‘std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >’ from initializer list would use explicit constructor ‘constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {const char (&)[33], const char (&)[7], const char (&)[5], const char (&)[10]}; <template-parameter-2-2> = void; _Elements = {std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >}]’
/home/sietium/sarah/assimp/test/unit/utglTF2ImportExport.cpp:762:5: error: converting to ‘std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >’ from initializer list would use explicit constructor ‘constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {const char (&)[31], const char (&)[5], const char (&)[6], const char (&)[13]}; <template-parameter-2-2> = void; _Elements = {std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >}]’
/home/sietium/sarah/assimp/test/unit/utglTF2ImportExport.cpp:762:5: error: converting to ‘std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >’ from initializer list would use explicit constructor ‘constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {const char (&)[33], const char (&)[7], const char (&)[6], const char (&)[13]}; <template-parameter-2-2> = void; _Elements = {std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >}]’
/home/sietium/sarah/assimp/test/unit/utglTF2ImportExport.cpp:762:5: error: converting to ‘std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >’ from initializer list would use explicit constructor ‘constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {const char (&)[33], const char (&)[7], const char (&)[21], const char (&)[13]}; <template-parameter-2-2> = void; _Elements = {std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >}]’
/home/sietium/sarah/assimp/test/unit/utglTF2ImportExport.cpp:762:5: error: converting to ‘std::tuple<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >’ from initializer list would use explicit constructor ‘constexpr std::tuple< <template-parameter-1-1> >::tuple(_UElements&& ...) [with _UElements = {const char (&)[36], const char (&)[7], const char (&)[22], const char (&)[13]}; <template-parameter-2-2> = void; _Elements = {std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >}]’
test/CMakeFiles/unit.dir/build.make:635: recipe for target 'test/CMakeFiles/unit.dir/unit/utglTF2ImportExport.cpp.o' failed
make[2]: *** [test/CMakeFiles/unit.dir/unit/utglTF2ImportExport.cpp.o] Error 1
make[2]: *** 正在等待未完成的任务....
CMakeFiles/Makefile2:229: recipe for target 'test/CMakeFiles/unit.dir/all' failed
make[1]: *** [test/CMakeFiles/unit.dir/all] Error 2
Makefile:135: recipe for target 'all' failed
make: *** [all] Error 2



sietium@sietium-RG-CT7600-2000-V2:~/sarah/assimp$ gcc --version
gcc (Ubuntu/Linaro 5.4.0-6kord1~16.04.12) 5.4.0 20160609
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

sietium@sietium-RG-CT7600-2000-V2:~/sarah/assimp$ g++ --version
g++ (Ubuntu/Linaro 5.4.0-6kord1~16.04.12) 5.4.0 20160609
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```
