### PR TITLE
Fixed issue with clang complaining about sprintf and vsprintf being depreciated

### DIFF
--- a/code/AssetLib/Collada/ColladaParser.cpp
+++ b/code/AssetLib/Collada/ColladaParser.cpp
@@ -67,7 +67,7 @@ static void ReportWarning(const char *msg, ...) {
     va_start(args, msg);
 
     char szBuffer[3000];
-    const int iLen = vsprintf(szBuffer, msg, args);
+    const int iLen = vsnprintf(szBuffer, 3000, msg, args);
     ai_assert(iLen > 0);
 
     va_end(args);

--- a/code/AssetLib/Collada/ColladaParser.cpp
+++ b/code/AssetLib/Collada/ColladaParser.cpp
@@ -67,7 +67,7 @@ static void ReportWarning(const char *msg, ...) {
     va_start(args, msg);
 
     char szBuffer[3000];
-    const int iLen = vsnprintf(szBuffer, 3000, msg, args);
+    const int iLen = vsnprintf(szBuffer, sizeof(szBuffer), msg, args);
     ai_assert(iLen > 0);
 
     va_end(args);

--- a/code/AssetLib/FBX/FBXExporter.cpp
+++ b/code/AssetLib/FBX/FBXExporter.cpp
@@ -1228,7 +1228,7 @@ void FBXExporter::WriteObjects ()
                 "Version", int32_t(101), outstream, binary, indent
             );
             char layerName[8];
-            sprintf(layerName, "COLOR_%d", colorChannelIndex);
+            snprintf(layerName, 8, "COLOR_%d", colorChannelIndex);
             FBX::Node::WritePropertyNode(
                 "Name", (const char*)layerName, outstream, binary, indent
             );

--- a/code/AssetLib/FBX/FBXExporter.cpp
+++ b/code/AssetLib/FBX/FBXExporter.cpp
@@ -1228,7 +1228,7 @@ void FBXExporter::WriteObjects ()
                 "Version", int32_t(101), outstream, binary, indent
             );
             char layerName[8];
-            snprintf(layerName, 8, "COLOR_%d", colorChannelIndex);
+            snprintf(layerName, sizeof(layerName), "COLOR_%d", colorChannelIndex);
             FBX::Node::WritePropertyNode(
                 "Name", (const char*)layerName, outstream, binary, indent
             );

--- a/code/AssetLib/MD5/MD5Parser.cpp
+++ b/code/AssetLib/MD5/MD5Parser.cpp
@@ -99,7 +99,7 @@ MD5Parser::MD5Parser(char *_buffer, unsigned int _fileSize) : buffer(_buffer), b
 // Report warning to the log stream
 /*static*/ void MD5Parser::ReportWarning(const char *warn, unsigned int line) {
     char szBuffer[1024];
-    ::snprintf(szBuffer, 1024, "[MD5] Line %u: %s", line, warn);
+    ::snprintf(szBuffer, sizeof(szBuffer), "[MD5] Line %u: %s", line, warn);
     ASSIMP_LOG_WARN(szBuffer);
 }
 

--- a/code/AssetLib/MD5/MD5Parser.cpp
+++ b/code/AssetLib/MD5/MD5Parser.cpp
@@ -99,7 +99,7 @@ MD5Parser::MD5Parser(char *_buffer, unsigned int _fileSize) : buffer(_buffer), b
 // Report warning to the log stream
 /*static*/ void MD5Parser::ReportWarning(const char *warn, unsigned int line) {
     char szBuffer[1024];
-    ::sprintf(szBuffer, "[MD5] Line %u: %s", line, warn);
+    ::snprintf(szBuffer, 1024, "[MD5] Line %u: %s", line, warn);
     ASSIMP_LOG_WARN(szBuffer);
 }
 

--- a/code/AssetLib/MDL/MDLLoader.cpp
+++ b/code/AssetLib/MDL/MDLLoader.cpp
@@ -298,7 +298,7 @@ void MDLImporter::SizeCheck(const void *szPos, const char *szFile, unsigned int 
         }
 
         char szBuffer[1024];
-        ::sprintf(szBuffer, "Invalid MDL file. The file is too small "
+        ::snprintf(szBuffer, 1024, "Invalid MDL file. The file is too small "
                             "or contains invalid data (File: %s Line: %u)",
                 szFilePtr, iLine);
 

--- a/code/AssetLib/MDL/MDLLoader.cpp
+++ b/code/AssetLib/MDL/MDLLoader.cpp
@@ -298,7 +298,7 @@ void MDLImporter::SizeCheck(const void *szPos, const char *szFile, unsigned int 
         }
 
         char szBuffer[1024];
-        ::snprintf(szBuffer, 1024, "Invalid MDL file. The file is too small "
+        ::snprintf(szBuffer, sizeof(szBuffer), "Invalid MDL file. The file is too small "
                             "or contains invalid data (File: %s Line: %u)",
                 szFilePtr, iLine);
 

--- a/code/PostProcessing/ValidateDataStructure.cpp
+++ b/code/PostProcessing/ValidateDataStructure.cpp
@@ -80,7 +80,7 @@ AI_WONT_RETURN void ValidateDSProcess::ReportError(const char *msg, ...) {
     va_start(args, msg);
 
     char szBuffer[3000];
-    const int iLen = vsprintf(szBuffer, msg, args);
+    const int iLen = vsnprintf(szBuffer, 3000, msg, args);
     ai_assert(iLen > 0);
 
     va_end(args);
@@ -95,7 +95,7 @@ void ValidateDSProcess::ReportWarning(const char *msg, ...) {
     va_start(args, msg);
 
     char szBuffer[3000];
-    const int iLen = vsprintf(szBuffer, msg, args);
+    const int iLen = vsnprintf(szBuffer, 3000, msg, args);
     ai_assert(iLen > 0);
 
     va_end(args);

--- a/code/PostProcessing/ValidateDataStructure.cpp
+++ b/code/PostProcessing/ValidateDataStructure.cpp
@@ -80,7 +80,7 @@ AI_WONT_RETURN void ValidateDSProcess::ReportError(const char *msg, ...) {
     va_start(args, msg);
 
     char szBuffer[3000];
-    const int iLen = vsnprintf(szBuffer, 3000, msg, args);
+    const int iLen = vsnprintf(szBuffer, sizeof(szBuffer), msg, args);
     ai_assert(iLen > 0);
 
     va_end(args);
@@ -95,7 +95,7 @@ void ValidateDSProcess::ReportWarning(const char *msg, ...) {
     va_start(args, msg);
 
     char szBuffer[3000];
-    const int iLen = vsnprintf(szBuffer, 3000, msg, args);
+    const int iLen = vsnprintf(szBuffer, sizeof(szBuffer), msg, args);
     ai_assert(iLen > 0);
 
     va_end(args);

--- a/contrib/openddlparser/code/OpenDDLExport.cpp
+++ b/contrib/openddlparser/code/OpenDDLExport.cpp
@@ -224,7 +224,7 @@ bool OpenDDLExport::writeValueType(Value::ValueType type, size_t numItems, std::
         statement += "[";
         char buffer[256];
         ::memset(buffer, '\0', 256 * sizeof(char));
-        sprintf(buffer, "%d", static_cast<int>(numItems));
+        snprintf(buffer, 256, "%d", static_cast<int>(numItems));
         statement += buffer;
         statement += "]";
     }
@@ -255,7 +255,7 @@ bool OpenDDLExport::writeValue(Value *val, std::string &statement) {
             std::stringstream stream;
             char buffer[256];
             ::memset(buffer, '\0', 256 * sizeof(char));
-            sprintf(buffer, "%d", val->getInt16());
+            snprintf(buffer, 256, "%d", val->getInt16());
             statement += buffer;
         } break;
         case Value::ValueType::ddl_int32: {
@@ -263,7 +263,7 @@ bool OpenDDLExport::writeValue(Value *val, std::string &statement) {
             char buffer[256];
             ::memset(buffer, '\0', 256 * sizeof(char));
             const int i = static_cast<int>(val->getInt32());
-            sprintf(buffer, "%d", i);
+            snprintf(buffer, 256, "%d", i);
             statement += buffer;
         } break;
         case Value::ValueType::ddl_int64: {

--- a/contrib/openddlparser/code/OpenDDLExport.cpp
+++ b/contrib/openddlparser/code/OpenDDLExport.cpp
@@ -224,7 +224,7 @@ bool OpenDDLExport::writeValueType(Value::ValueType type, size_t numItems, std::
         statement += "[";
         char buffer[256];
         ::memset(buffer, '\0', 256 * sizeof(char));
-        snprintf(buffer, 256, "%d", static_cast<int>(numItems));
+        snprintf(buffer, sizeof(buffer), "%d", static_cast<int>(numItems));
         statement += buffer;
         statement += "]";
     }
@@ -255,7 +255,7 @@ bool OpenDDLExport::writeValue(Value *val, std::string &statement) {
             std::stringstream stream;
             char buffer[256];
             ::memset(buffer, '\0', 256 * sizeof(char));
-            snprintf(buffer, 256, "%d", val->getInt16());
+            snprintf(buffer, sizeof(buffer), "%d", val->getInt16());
             statement += buffer;
         } break;
         case Value::ValueType::ddl_int32: {
@@ -263,7 +263,7 @@ bool OpenDDLExport::writeValue(Value *val, std::string &statement) {
             char buffer[256];
             ::memset(buffer, '\0', 256 * sizeof(char));
             const int i = static_cast<int>(val->getInt32());
-            snprintf(buffer, 256, "%d", i);
+            snprintf(buffer, sizeof(buffer), "%d", i);
             statement += buffer;
         } break;
         case Value::ValueType::ddl_int64: {


### PR DESCRIPTION
Clang was complaining about a security issue with sprintf and vsprintf, and that they were depreciated and produced a compiler error.