### PR TITLE
chore: add missing std moves and perfect forwards

### DIFF
--- a/code/AssetLib/3MF/XmlSerializer.cpp
+++ b/code/AssetLib/3MF/XmlSerializer.cpp
@@ -584,7 +584,7 @@ aiMaterial *XmlSerializer::readMaterialDef(XmlNode &node, unsigned int basemater
     stdMaterialName += strId;
     stdMaterialName += "_";
     if (hasName) {
-        stdMaterialName += std::string(std::move(name));
+        stdMaterialName += name;
     } else {
         stdMaterialName += "basemat_";
         stdMaterialName += ai_to_string(mMaterials.size());

--- a/code/AssetLib/3MF/XmlSerializer.cpp
+++ b/code/AssetLib/3MF/XmlSerializer.cpp
@@ -44,6 +44,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "3MFTypes.h"
 #include <assimp/scene.h>
 
+#include <utility>
+
 namespace Assimp {
 namespace D3MF {
 
@@ -582,7 +584,7 @@ aiMaterial *XmlSerializer::readMaterialDef(XmlNode &node, unsigned int basemater
     stdMaterialName += strId;
     stdMaterialName += "_";
     if (hasName) {
-        stdMaterialName += std::string(name);
+        stdMaterialName += std::string(std::move(name));
     } else {
         stdMaterialName += "basemat_";
         stdMaterialName += ai_to_string(mMaterials.size());

--- a/code/AssetLib/Blender/BlenderLoader.cpp
+++ b/code/AssetLib/Blender/BlenderLoader.cpp
@@ -63,6 +63,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/StringComparison.h>
 
 #include <cctype>
+#include <utility>
 
 // zlib is needed for compressed blend files
 #ifndef ASSIMP_BUILD_NO_COMPRESSED_BLEND
@@ -201,7 +202,7 @@ void BlenderImporter::InternReadFile(const std::string &pFile,
             " (64bit: ", file.i64bit ? "true" : "false",
             ", little endian: ", file.little ? "true" : "false", ")");
 
-    ParseBlendFile(file, stream);
+    ParseBlendFile(file, std::move(stream));
 
     Scene scene;
     ExtractScene(scene, file);

--- a/code/AssetLib/Collada/ColladaParser.cpp
+++ b/code/AssetLib/Collada/ColladaParser.cpp
@@ -55,6 +55,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/DefaultLogger.hpp>
 #include <assimp/IOSystem.hpp>
 #include <memory>
+#include <utility>
 
 using namespace Assimp;
 using namespace Assimp::Collada;
@@ -2305,7 +2306,7 @@ void ColladaParser::ReadScene(XmlNode &node) {
             // find the referred scene, skip the leading #
             NodeLibrary::const_iterator sit = mNodeLibrary.find(url.c_str() + 1);
             if (sit == mNodeLibrary.end()) {
-                throw DeadlyImportError("Unable to resolve visual_scene reference \"", std::string(url), "\" in <instance_visual_scene> element.");
+                throw DeadlyImportError("Unable to resolve visual_scene reference \"", std::string(std::move(url)), "\" in <instance_visual_scene> element.");
             }
             mRootNode = sit->second;
         }

--- a/code/AssetLib/DXF/DXFLoader.cpp
+++ b/code/AssetLib/DXF/DXFLoader.cpp
@@ -57,6 +57,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/importerdesc.h>
 
 #include <numeric>
+#include <utility>
 
 using namespace Assimp;
 
@@ -150,7 +151,7 @@ void DXFImporter::InternReadFile( const std::string& filename, aiScene* pScene, 
     // DXF files can grow very large, so read them via the StreamReader,
     // which will choose a suitable strategy.
     file->Seek(0,aiOrigin_SET);
-    StreamReaderLE stream( file );
+    StreamReaderLE stream( std::move(file) );
 
     DXF::LineReader reader (stream);
     DXF::FileData output;

--- a/code/AssetLib/FBX/FBXDocument.cpp
+++ b/code/AssetLib/FBX/FBXDocument.cpp
@@ -336,7 +336,7 @@ void Document::ReadGlobalSettings() {
         DOMError("GlobalSettings dictionary contains no property table");
     }
 
-    globals.reset(new FileGlobalSettings(*this, props));
+    globals.reset(new FileGlobalSettings(*this, std::move(props)));
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/code/AssetLib/FBX/FBXExportNode.h
+++ b/code/AssetLib/FBX/FBXExportNode.h
@@ -85,24 +85,24 @@ public: // constructors
 
     // convenience template to construct with properties directly
     template <typename... More>
-    Node(const std::string& n, const More... more)
+    Node(const std::string& n, More&&... more)
     : name(n)
     , properties()
     , children()
     , force_has_children(false) {
-        AddProperties(more...);
+        AddProperties(std::forward<More>(more)...);
     }
 
 public: // functions to add properties or children
     // add a single property to the node
     template <typename T>
-    void AddProperty(T value) {
+    void AddProperty(T&& value) {
         properties.emplace_back(std::forward<T>(value));
     }
 
     // convenience function to add multiple properties at once
     template <typename T, typename... More>
-    void AddProperties(T value, More... more) {
+    void AddProperties(T&& value, More&&... more) {
         properties.emplace_back(std::forward<T>(value));
         AddProperties(std::forward<More>(more)...);
     }
@@ -115,7 +115,7 @@ public: // functions to add properties or children
     template <typename... More>
     void AddChild(
         const std::string& name,
-        More... more
+        More&&... more
     ) {
         FBX::Node c(name);
         c.AddProperties(std::forward<More>(more)...);
@@ -147,7 +147,7 @@ public: // support specifically for dealing with Properties70 nodes
         const std::string& type,
         const std::string& type2,
         const std::string& flags,
-        More... more
+        More&&... more
     ) {
         Node n("P");
         n.AddProperties(name, type, type2, flags, std::forward<More>(more)...);

--- a/code/AssetLib/FBX/FBXExportNode.h
+++ b/code/AssetLib/FBX/FBXExportNode.h
@@ -119,7 +119,7 @@ public: // functions to add properties or children
     ) {
         FBX::Node c(name);
         c.AddProperties(std::forward<More>(more)...);
-        children.push_back(c);
+        children.push_back(std::move(c));
     }
 
 public: // support specifically for dealing with Properties70 nodes

--- a/code/AssetLib/FBX/FBXExportNode.h
+++ b/code/AssetLib/FBX/FBXExportNode.h
@@ -52,6 +52,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/StreamWriter.h> // StreamWriterLE
 
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace Assimp {
@@ -96,14 +97,14 @@ public: // functions to add properties or children
     // add a single property to the node
     template <typename T>
     void AddProperty(T value) {
-        properties.emplace_back(value);
+        properties.emplace_back(std::forward<T>(value));
     }
 
     // convenience function to add multiple properties at once
     template <typename T, typename... More>
     void AddProperties(T value, More... more) {
-        properties.emplace_back(value);
-        AddProperties(more...);
+        properties.emplace_back(std::forward<T>(value));
+        AddProperties(std::forward<More>(more)...);
     }
     void AddProperties() {}
 
@@ -117,7 +118,7 @@ public: // functions to add properties or children
         More... more
     ) {
         FBX::Node c(name);
-        c.AddProperties(more...);
+        c.AddProperties(std::forward<More>(more)...);
         children.push_back(c);
     }
 
@@ -149,7 +150,7 @@ public: // support specifically for dealing with Properties70 nodes
         More... more
     ) {
         Node n("P");
-        n.AddProperties(name, type, type2, flags, more...);
+        n.AddProperties(name, type, type2, flags, std::forward<More>(more)...);
         AddChild(n);
     }
 
@@ -214,7 +215,7 @@ public: // static member functions
         bool binary, int indent
     ) {
         FBX::FBXExportProperty p(value);
-        FBX::Node node(name, p);
+        FBX::Node node(name, std::move(p));
         node.Dump(s, binary, indent);
     }
 

--- a/code/AssetLib/FBX/FBXExporter.cpp
+++ b/code/AssetLib/FBX/FBXExporter.cpp
@@ -58,16 +58,17 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/mesh.h>
 
 // Header files, standard library.
-#include <memory> // shared_ptr
-#include <string>
-#include <sstream> // stringstream
+#include <array>
 #include <ctime> // localtime, tm_*
 #include <map>
-#include <set>
-#include <vector>
-#include <array>
-#include <unordered_set>
+#include <memory> // shared_ptr
 #include <numeric>
+#include <set>
+#include <sstream> // stringstream
+#include <string>
+#include <unordered_set>
+#include <utility>
+#include <vector>
 
 // RESOURCES:
 // https://code.blender.org/2013/08/fbx-binary-file-format-specification/
@@ -390,7 +391,7 @@ void FBXExporter::WriteHeaderExtension ()
         raw[i] = uint8_t(GENERIC_FILEID[i]);
     }
     FBX::Node::WritePropertyNode(
-        "FileId", raw, outstream, binary, indent
+        "FileId", std::move(raw), outstream, binary, indent
     );
     FBX::Node::WritePropertyNode(
         "CreationTime", GENERIC_CTIME, outstream, binary, indent
@@ -2497,7 +2498,7 @@ void FBXExporter::WriteModelNode(
     const aiVector3D one = {1, 1, 1};
     FBX::Node m("Model");
     std::string name = node->mName.C_Str() + FBX::SEPARATOR + "Model";
-    m.AddProperties(node_uid, name, type);
+    m.AddProperties(node_uid, std::move(name), type);
     m.AddChild("Version", int32_t(232));
     FBX::Node p("Properties70");
     p.AddP70bool("RotationActive", 1);

--- a/code/AssetLib/IFC/IFCBoolean.cpp
+++ b/code/AssetLib/IFC/IFCBoolean.cpp
@@ -51,6 +51,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <iterator>
 #include <tuple>
+#include <utility>
 
 namespace Assimp {
 namespace IFC {
@@ -674,7 +675,7 @@ void ProcessBooleanExtrudedAreaSolidDifference(const Schema_2x3::IfcExtrudedArea
     std::shared_ptr<TempMesh> meshtmp = std::shared_ptr<TempMesh>(new TempMesh());
     ProcessExtrudedAreaSolid(*as, *meshtmp, conv, false);
 
-    std::vector<TempOpening> openings(1, TempOpening(as, IfcVector3(0, 0, 0), meshtmp, std::shared_ptr<TempMesh>()));
+    std::vector<TempOpening> openings(1, TempOpening(as, IfcVector3(0, 0, 0), std::move(meshtmp), std::shared_ptr<TempMesh>()));
 
     result = first_operand;
 

--- a/code/AssetLib/IFC/IFCGeometry.cpp
+++ b/code/AssetLib/IFC/IFCGeometry.cpp
@@ -57,8 +57,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #  include "../contrib/clipper/clipper.hpp"
 #endif
 
-#include <memory>
 #include <iterator>
+#include <memory>
+#include <utility>
 
 namespace Assimp {
 namespace IFC {
@@ -713,7 +714,7 @@ void ProcessExtrudedArea(const Schema_2x3::IfcExtrudedAreaSolid& solid, const Te
         std::shared_ptr<TempMesh> profile2D = std::shared_ptr<TempMesh>(new TempMesh());
         profile2D->mVerts.insert(profile2D->mVerts.end(), in.begin(), in.end());
         profile2D->mVertcnt.push_back(static_cast<unsigned int>(in.size()));
-        conv.collect_openings->push_back(TempOpening(&solid, dir, profile, profile2D));
+        conv.collect_openings->push_back(TempOpening(&solid, dir, std::move(profile), std::move(profile2D)));
 
         ai_assert(result.IsEmpty());
     }
@@ -839,7 +840,7 @@ bool ProcessGeometricItem(const Schema_2x3::IfcRepresentationItem& geo, unsigned
         if (!meshtmp->IsEmpty()) {
             conv.collect_openings->push_back(TempOpening(geo.ToPtr<Schema_2x3::IfcSolidModel>(),
                 IfcVector3(0,0,0),
-                meshtmp,
+                std::move(meshtmp),
                 std::shared_ptr<TempMesh>()));
         }
         return true;

--- a/code/AssetLib/IFC/IFCLoader.cpp
+++ b/code/AssetLib/IFC/IFCLoader.cpp
@@ -67,6 +67,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/importerdesc.h>
 #include <assimp/scene.h>
 #include <assimp/Importer.hpp>
+#include <utility>
 
 namespace Assimp {
 template <>
@@ -227,7 +228,7 @@ void IFCImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
 #endif
     }
 
-    std::unique_ptr<STEP::DB> db(STEP::ReadFileHeader(stream));
+    std::unique_ptr<STEP::DB> db(STEP::ReadFileHeader(std::move(stream)));
     const STEP::HeaderInfo &head = static_cast<const STEP::DB &>(*db).GetHeader();
 
     if (!head.fileSchema.size() || head.fileSchema.substr(0, 3) != "IFC") {

--- a/code/AssetLib/IFC/IFCOpenings.cpp
+++ b/code/AssetLib/IFC/IFCOpenings.cpp
@@ -57,9 +57,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #  include "../contrib/clipper/clipper.hpp"
 #endif
 
-#include <iterator>
-#include <forward_list>
 #include <deque>
+#include <forward_list>
+#include <iterator>
+#include <utility>
 
 namespace Assimp {
     namespace IFC {
@@ -1699,7 +1700,7 @@ std::vector<std::vector<IfcVector2>> GetContoursInPlane(const std::shared_ptr<Te
         bool ok;
         auto contour = GetContourInPlane2D(mesh,planeSpace,planeNor,planeOffset,extrusionDir,wall_extrusion,first,ok);
         if(ok)
-            return std::vector<std::vector<IfcVector2>> {contour};
+            return std::vector<std::vector<IfcVector2>> {std::move(contour)};
         else
             return std::vector<std::vector<IfcVector2>> {};
     }

--- a/code/AssetLib/Ply/PlyParser.cpp
+++ b/code/AssetLib/Ply/PlyParser.cpp
@@ -48,6 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/ByteSwapper.h>
 #include <assimp/fast_atof.h>
 #include <assimp/DefaultLogger.hpp>
+#include <utility>
 
 using namespace Assimp;
 
@@ -381,10 +382,10 @@ bool PLY::DOM::SkipSpacesAndLineEnd(std::vector<char> &buffer) {
     return ret;
 }
 
-bool PLY::DOM::SkipComments(std::vector<char> &buffer) {
+bool PLY::DOM::SkipComments(std::vector<char> buffer) {
     ai_assert(!buffer.empty());
 
-    std::vector<char> nbuffer = buffer;
+    std::vector<char> nbuffer = std::move(buffer);
     // skip spaces
     if (!SkipSpaces(nbuffer)) {
         return false;

--- a/code/AssetLib/Ply/PlyParser.h
+++ b/code/AssetLib/Ply/PlyParser.h
@@ -431,7 +431,7 @@ public:
     static bool ParseInstanceBinary(IOStreamBuffer<char> &streamBuffer, DOM* p_pcOut, PLYImporter* loader, bool p_bBE);
 
     //! Skip all comment lines after this
-    static bool SkipComments(std::vector<char> &buffer);
+    static bool SkipComments(std::vector<char> buffer);
 
     static bool SkipSpaces(std::vector<char> &buffer);
 

--- a/code/AssetLib/XGL/XGLLoader.cpp
+++ b/code/AssetLib/XGL/XGLLoader.cpp
@@ -53,6 +53,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/importerdesc.h>
 #include <assimp/mesh.h>
 #include <assimp/scene.h>
+
+#include <utility>
 //#include <cctype>
 //#include <memory>
 
@@ -224,7 +226,7 @@ aiLight *XGLImporter::ReadDirectionalLight(XmlNode &node) {
 	std::unique_ptr<aiLight> l(new aiLight());
 	l->mType = aiLightSource_DIRECTIONAL;
 	find_node_by_name_predicate predicate("directionallight");
-	XmlNode child = node.find_child(predicate);
+	XmlNode child = node.find_child(std::move(predicate));
 	if (child.empty()) {
 		return nullptr;
 	}

--- a/code/AssetLib/glTF/glTFCommon.h
+++ b/code/AssetLib/glTF/glTFCommon.h
@@ -245,9 +245,12 @@ struct Nullable {
 
     Nullable() :
             isPresent(false) {}
-    Nullable(T &val) :
+    Nullable(const T &val) :
             value(val),
             isPresent(true) {}
+	Nullable(T &&val) :
+			value(std::move(val)),
+			isPresent(true) {}
 };
 
 //! A reference to one top-level object, which is valid

--- a/code/AssetLib/glTF/glTFCommon.h
+++ b/code/AssetLib/glTF/glTFCommon.h
@@ -245,12 +245,9 @@ struct Nullable {
 
     Nullable() :
             isPresent(false) {}
-    Nullable(const T &val) :
+    Nullable(T &val) :
             value(val),
             isPresent(true) {}
-	Nullable(T &&val) :
-			value(std::move(val)),
-			isPresent(true) {}
 };
 
 //! A reference to one top-level object, which is valid

--- a/include/assimp/XmlParser.h
+++ b/include/assimp/XmlParser.h
@@ -56,7 +56,11 @@ namespace Assimp {
 
 /// @brief  Will find a node by its name.
 struct find_node_by_name_predicate {
-    std::string mName;
+    /// @brief The default constructor.
+    find_node_by_name_predicate() = default;
+    
+    
+    std::string mName; ///< The name to find.
     find_node_by_name_predicate(const std::string &name) :
             mName(name) {
         // empty
@@ -68,7 +72,7 @@ struct find_node_by_name_predicate {
 };
 
 /// @brief  Will convert an attribute to its int value.
-/// @tparam TNodeType The node type.
+/// @tparam[in] TNodeType  The node type.
 template <class TNodeType>
 struct NodeConverter {
 public:
@@ -109,17 +113,17 @@ public:
     void clear();
 
     ///	@brief  Will search for a child-node by its name
-    /// @param  name     [in] The name of the child-node.
+    /// @param[in] name     The name of the child-node.
     /// @return The node instance or nullptr, if nothing was found.
     TNodeType *findNode(const std::string &name);
 
     /// @brief  Will return true, if the node is a child-node.
-    /// @param  name    [in] The name of the child node to look for.
+    /// @param[in]  name    The name of the child node to look for.
     /// @return true, if the node is a child-node or false if not.
     bool hasNode(const std::string &name);
 
     /// @brief  Will parse an xml-file from a given stream.
-    /// @param  stream      The input stream.
+    /// @param[in] stream      The input stream.
     /// @return true, if the parsing was successful, false if not.
     bool parse(IOStream *stream);
 
@@ -140,87 +144,87 @@ public:
     TNodeType getRootNode();
 
     /// @brief Will check if a node with the given name is in.
-    /// @param node     [in] The node to look in.
-    /// @param name     [in] The name of the child-node.
+    /// @param[in] node     The node to look in.
+    /// @param[in] name     The name of the child-node.
     /// @return true, if node was found, false if not.
     static inline bool hasNode(XmlNode &node, const char *name);
 
     /// @brief Will check if an attribute is part of the XmlNode.
-    /// @param xmlNode  [in] The node to search in.
-    /// @param name     [in} The attribute name to look for.
+    /// @param[in] xmlNode  The node to search in.
+    /// @param[in] name     The attribute name to look for.
     /// @return true, if the was found, false if not.
     static inline bool hasAttribute(XmlNode &xmlNode, const char *name);
 
     /// @brief Will try to get an unsigned int attribute value.
-    /// @param xmlNode  [in] The node to search in.
-    /// @param name     [in] The attribute name to look for.
-    /// @param val      [out] The unsigned int value from the attribute.
+    /// @param[in] xmlNode  The node to search in.
+    /// @param[in] name     The attribute name to look for.
+    /// @param[out] val     The unsigned int value from the attribute.
     /// @return true, if the node contains an attribute with the given name and if the value is an unsigned int.
     static inline bool getUIntAttribute(XmlNode &xmlNode, const char *name, unsigned int &val);
 
     /// @brief Will try to get an int attribute value.
-    /// @param xmlNode  [in] The node to search in.
-    /// @param name     [in] The attribute name to look for.
-    /// @param val      [out] The int value from the attribute.
+    /// @param[in] xmlNode  The node to search in.
+    /// @param[in] name     The attribute name to look for.
+    /// @param[out] val     The int value from the attribute.
     /// @return true, if the node contains an attribute with the given name and if the value is an int.
     static inline bool getIntAttribute(XmlNode &xmlNode, const char *name, int &val);
 
     /// @brief Will try to get a real attribute value.
-    /// @param xmlNode  [in] The node to search in.
-    /// @param name     [in] The attribute name to look for.
-    /// @param val      [out] The real value from the attribute.
+    /// @param[in] xmlNode  The node to search in.
+    /// @param[in] name     The attribute name to look for.
+    /// @param[out] val     The real value from the attribute.
     /// @return true, if the node contains an attribute with the given name and if the value is a real.
     static inline bool getRealAttribute(XmlNode &xmlNode, const char *name, ai_real &val);
 
     /// @brief Will try to get a float attribute value.
-    /// @param xmlNode  [in] The node to search in.
-    /// @param name     [in] The attribute name to look for.
-    /// @param val      [out] The float value from the attribute.
+    /// @param[in] xmlNode  The node to search in.
+    /// @param[in] name     The attribute name to look for.
+    /// @param[out] val     The float value from the attribute.
     /// @return true, if the node contains an attribute with the given name and if the value is a float.
     static inline bool getFloatAttribute(XmlNode &xmlNode, const char *name, float &val);
 
     /// @brief Will try to get a double attribute value.
-    /// @param xmlNode  [in] The node to search in.
-    /// @param name     [in] The attribute name to look for.
-    /// @param val      [out] The double value from the attribute.
+    /// @param[in] xmlNode  The node to search in.
+    /// @param[in] name     The attribute name to look for.
+    /// @param[out] val     The double value from the attribute.
     /// @return true, if the node contains an attribute with the given name and if the value is a double.
     static inline bool getDoubleAttribute(XmlNode &xmlNode, const char *name, double &val);
 
     /// @brief Will try to get a std::string attribute value.
-    /// @param xmlNode  [in] The node to search in.
-    /// @param name     [in] The attribute name to look for.
-    /// @param val      [out] The std::string value from the attribute.
+    /// @param[in] xmlNode  The node to search in.
+    /// @param[in] name     The attribute name to look for.
+    /// @param[out] val     The std::string value from the attribute.
     /// @return true, if the node contains an attribute with the given name and if the value is a std::string.
     static inline bool getStdStrAttribute(XmlNode &xmlNode, const char *name, std::string &val);
 
     /// @brief Will try to get a bool attribute value.
-    /// @param xmlNode  [in] The node to search in.
-    /// @param name     [in] The attribute name to look for.
-    /// @param val      [out] The bool value from the attribute.
+    /// @param[in] xmlNode  The node to search in.
+    /// @param[in] name     The attribute name to look for.
+    /// @param[out] val     The bool value from the attribute.
     /// @return true, if the node contains an attribute with the given name and if the value is a bool.
     static inline bool getBoolAttribute(XmlNode &xmlNode, const char *name, bool &val);
 
     /// @brief Will try to get the value of the node as a string.
-    /// @param node     [in] The node to search in.
-    /// @param text     [out] The value as a text.
+    /// @param[in] node     The node to search in.
+    /// @param[out] text    The value as a text.
     /// @return true, if the value can be read out.
     static inline bool getValueAsString(XmlNode &node, std::string &text);
 
     /// @brief Will try to get the value of the node as a float.
-    /// @param node     [in] The node to search in.
-    /// @param text     [out] The value as a float.
+    /// @param[in] node     The node to search in.
+    /// @param[out] text    The value as a float.
     /// @return true, if the value can be read out.
     static inline bool getValueAsFloat(XmlNode &node, ai_real &v);
 
     /// @brief Will try to get the value of the node as an integer.
-    /// @param node     [in] The node to search in.
-    /// @param text     [out] The value as a int.
+    /// @param[in] node     The node to search in.
+    /// @param[out] text    The value as a int.
     /// @return true, if the value can be read out.
     static inline bool getValueAsInt(XmlNode &node, int &v);
 
     /// @brief Will try to get the value of the node as an bool.
-    /// @param node     [in] The node to search in.
-    /// @param text     [out] The value as a bool.
+    /// @param[in] node     The node to search in.
+    /// @param[out] text    The value as a bool.
     /// @return true, if the value can be read out.
     static inline bool getValueAsBool(XmlNode &node, bool &v);
 

--- a/include/assimp/XmlParser.h
+++ b/include/assimp/XmlParser.h
@@ -49,6 +49,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "IOStream.hpp"
 
 #include <pugixml.hpp>
+#include <utility>
 #include <vector>
 
 namespace Assimp {
@@ -267,7 +268,7 @@ inline TNodeType *TXmlParser<TNodeType>::findNode(const std::string &name) {
     }
 
     find_node_by_name_predicate predicate(name);
-    mCurrent = mDoc->find_node(predicate);
+    mCurrent = mDoc->find_node(std::move(predicate));
     if (mCurrent.empty()) {
         return nullptr;
     }


### PR DESCRIPTION
Optimize the code by adding a lot of missing std::move and a few std::forwards for perfect forwarding. This PR should reduce the number unnecessary copies and overall increase efficiency.