### PR TITLE
Modernize smartptrs and use C++11 literals

### DIFF
--- a/code/AssetLib/AC/ACLoader.cpp
+++ b/code/AssetLib/AC/ACLoader.cpp
@@ -295,7 +295,7 @@ void AC3DImporter::LoadObjectSection(std::vector<Object> &objects) {
                 Surface &surf = obj.surfaces.back();
                 surf.flags = strtoul_cppstyle(buffer);
 
-                while (1) {
+                while (true) {
                     if (!GetNextLine()) {
                         throw DeadlyImportError("AC3D: Unexpected EOF: surface is incomplete");
                     }
@@ -750,7 +750,7 @@ void AC3DImporter::InternReadFile(const std::string &pFile,
     std::unique_ptr<IOStream> file(pIOHandler->Open(pFile, "rb"));
 
     // Check whether we can read from the file
-    if (file.get() == nullptr) {
+    if (file == nullptr) {
         throw DeadlyImportError("Failed to open AC3D file ", pFile, ".");
     }
 

--- a/code/AssetLib/AMF/AMFImporter.cpp
+++ b/code/AssetLib/AMF/AMFImporter.cpp
@@ -261,7 +261,7 @@ void AMFImporter::ParseFile(const std::string &pFile, IOSystem *pIOHandler) {
     std::unique_ptr<IOStream> file(pIOHandler->Open(pFile, "rb"));
 
     // Check whether we can read from the file
-    if (file.get() == nullptr) {
+    if (file == nullptr) {
         throw DeadlyImportError("Failed to open AMF file ", pFile, ".");
     }
 

--- a/code/AssetLib/ASE/ASELoader.cpp
+++ b/code/AssetLib/ASE/ASELoader.cpp
@@ -122,7 +122,7 @@ void ASEImporter::InternReadFile(const std::string &pFile,
     std::unique_ptr<IOStream> file(pIOHandler->Open(pFile, "rb"));
 
     // Check whether we can read from the file
-    if (file.get() == nullptr) {
+    if (file == nullptr) {
         throw DeadlyImportError("Failed to open ASE file ", pFile, ".");
     }
 

--- a/code/AssetLib/Assxml/AssxmlFileWriter.cpp
+++ b/code/AssetLib/Assxml/AssxmlFileWriter.cpp
@@ -652,7 +652,7 @@ void DumpSceneToAssxml(
         const char *pFile, const char *cmd, IOSystem *pIOSystem,
         const aiScene *pScene, bool shortened) {
     std::unique_ptr<IOStream> file(pIOSystem->Open(pFile, "wt"));
-    if (!file.get()) {
+    if (!file) {
         throw std::runtime_error("Unable to open output file " + std::string(pFile) + '\n');
     }
 

--- a/code/AssetLib/B3D/B3DImporter.cpp
+++ b/code/AssetLib/B3D/B3DImporter.cpp
@@ -116,7 +116,7 @@ void B3DImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
     std::unique_ptr<IOStream> file(pIOHandler->Open(pFile));
 
     // Check whether we can read from the file
-    if (file.get() == nullptr) {
+    if (file == nullptr) {
         throw DeadlyImportError("Failed to open B3D file ", pFile, ".");
     }
 
@@ -253,7 +253,7 @@ size_t B3DImporter::ChunkSize() {
 template <class T>
 T *B3DImporter::to_array(const vector<T> &v) {
     if (v.empty()) {
-        return 0;
+        return nullptr;
     }
     T *p = new T[v.size()];
     for (size_t i = 0; i < v.size(); ++i) {
@@ -266,7 +266,7 @@ T *B3DImporter::to_array(const vector<T> &v) {
 template <class T>
 T **unique_to_array(vector<std::unique_ptr<T>> &v) {
     if (v.empty()) {
-        return 0;
+        return nullptr;
     }
     T **p = new T *[v.size()];
     for (size_t i = 0; i < v.size(); ++i) {
@@ -617,7 +617,7 @@ void B3DImporter::ReadBB3D(aiScene *scene) {
             } else if (chunk == "BRUS") {
                 ReadBRUS();
             } else if (chunk == "NODE") {
-                ReadNODE(0);
+                ReadNODE(nullptr);
             }
             ExitChunk();
         }
@@ -642,7 +642,7 @@ void B3DImporter::ReadBB3D(aiScene *scene) {
             int n_tris = mesh->mNumFaces;
             int n_verts = mesh->mNumVertices = n_tris * 3;
 
-            aiVector3D *mv = mesh->mVertices = new aiVector3D[n_verts], *mn = 0, *mc = 0;
+            aiVector3D *mv = mesh->mVertices = new aiVector3D[n_verts], *mn = nullptr, *mc = nullptr;
             if (_vflags & 1) {
                 mn = mesh->mNormals = new aiVector3D[n_verts];
             }

--- a/code/AssetLib/BVH/BVHLoader.cpp
+++ b/code/AssetLib/BVH/BVHLoader.cpp
@@ -115,7 +115,7 @@ void BVHLoader::InternReadFile(const std::string &pFile, aiScene *pScene, IOSyst
 
     // read file into memory
     std::unique_ptr<IOStream> file(pIOHandler->Open(pFile));
-    if (file.get() == nullptr) {
+    if (file == nullptr) {
         throw DeadlyImportError("Failed to open file ", pFile, ".");
     }
 
@@ -191,7 +191,7 @@ aiNode *BVHLoader::ReadNode() {
 
     // now read the node's contents
     std::string siteToken;
-    while (1) {
+    while (true) {
         std::string token = GetNextToken();
 
         // node offset to parent node
@@ -247,7 +247,7 @@ aiNode *BVHLoader::ReadEndSite(const std::string &pParentName) {
 
     // now read the node's contents. Only possible entry is "OFFSET"
     std::string token;
-    while (1) {
+    while (true) {
         token.clear();
         token = GetNextToken();
 

--- a/code/AssetLib/Blender/BlenderBMesh.cpp
+++ b/code/AssetLib/Blender/BlenderBMesh.cpp
@@ -140,7 +140,7 @@ void BlenderBMeshConverter::ConvertPolyToFaces(const MPoly &poly) {
                 ThrowException("BMesh uv loop array has incorrect size");
             }
             const MLoopUV *loopUV = &BMesh->mloopuv[poly.loopstart];
-            AddTFace(loopUV[0].uv, loopUV[1].uv, loopUV[2].uv, poly.totloop == 4 ? loopUV[3].uv : 0);
+            AddTFace(loopUV[0].uv, loopUV[1].uv, loopUV[2].uv, poly.totloop == 4 ? loopUV[3].uv : nullptr);
         }
     } else if (poly.totloop > 4) {
 #if ASSIMP_BLEND_WITH_GLU_TESSELLATE

--- a/code/AssetLib/Blender/BlenderBMesh.h
+++ b/code/AssetLib/Blender/BlenderBMesh.h
@@ -80,7 +80,7 @@ namespace Assimp
         void DestroyTriMesh( );
         void ConvertPolyToFaces( const Blender::MPoly& poly );
         void AddFace( int v1, int v2, int v3, int v4 = 0 );
-        void AddTFace( const float* uv1, const float* uv2, const float *uv3, const float* uv4 = 0 );
+        void AddTFace(const float *uv1, const float *uv2, const float *uv3, const float *uv4 = nullptr);
 
         const Blender::Mesh* BMesh;
         Blender::Mesh* triMesh;

--- a/code/AssetLib/Blender/BlenderDNA.cpp
+++ b/code/AssetLib/Blender/BlenderDNA.cpp
@@ -72,7 +72,7 @@ struct Type {
 
 // ------------------------------------------------------------------------------------------------
 void DNAParser::Parse() {
-    StreamReaderAny &stream = *db.reader.get();
+    StreamReaderAny &stream = *db.reader;
     DNA &dna = db.dna;
 
     if (!match4(stream, "SDNA")) {

--- a/code/AssetLib/Blender/BlenderLoader.cpp
+++ b/code/AssetLib/Blender/BlenderLoader.cpp
@@ -63,6 +63,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/StringComparison.h>
 
 #include <cctype>
+#include <memory>
 #include <utility>
 
 // zlib is needed for compressed blend files
@@ -182,7 +183,7 @@ void BlenderImporter::InternReadFile(const std::string &pFile,
         }
 
         // replace the input stream with a memory stream
-        stream.reset(new MemoryIOStream(reinterpret_cast<uint8_t *>(uncompressed.data()), total));
+        stream = std::make_shared<MemoryIOStream>(reinterpret_cast<uint8_t *>(uncompressed.data()), total);
 
         // .. and retry
         stream->Read(magic, 7, 1);
@@ -219,7 +220,7 @@ void BlenderImporter::ParseBlendFile(FileDatabase &out, std::shared_ptr<IOStream
 
     out.entries.reserve(128);
     { // even small BLEND files tend to consist of many file blocks
-        SectionParser parser(*out.reader.get(), out.i64bit);
+        SectionParser parser(*out.reader, out.i64bit);
 
         // first parse the file in search for the DNA and insert all other sections into the database
         while ((parser.Next(), 1)) {

--- a/code/AssetLib/COB/COBLoader.cpp
+++ b/code/AssetLib/COB/COBLoader.cpp
@@ -158,7 +158,7 @@ void COBImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
     // sort faces by material indices
     for (std::shared_ptr<Node> &n : scene.nodes) {
         if (n->type == Node::TYPE_MESH) {
-            Mesh &mesh = (Mesh &)(*n.get());
+            Mesh &mesh = (Mesh &)(*n);
             for (Face &f : mesh.faces) {
                 mesh.temp_map[f.material].push_back(&f);
             }
@@ -168,7 +168,7 @@ void COBImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
     // count meshes
     for (std::shared_ptr<Node> &n : scene.nodes) {
         if (n->type == Node::TYPE_MESH) {
-            Mesh &mesh = (Mesh &)(*n.get());
+            Mesh &mesh = (Mesh &)(*n);
             if (mesh.vertex_positions.size() && mesh.texture_coords.size()) {
                 pScene->mNumMeshes += static_cast<unsigned int>(mesh.temp_map.size());
             }
@@ -211,7 +211,7 @@ void COBImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
         }
     }
 
-    pScene->mRootNode = BuildNodes(*root.get(), scene, pScene);
+    pScene->mRootNode = BuildNodes(*root, scene, pScene);
     //flip normals after import
     FlipWindingOrderProcess flip;
     flip.Execute(pScene);
@@ -868,7 +868,7 @@ void COBImporter::ReadBinaryFile(Scene &out, StreamReaderLE *reader) {
         return;
     }
 
-    while (1) {
+    while (true) {
         std::string type;
         type += reader->GetI1();
         type += reader->GetI1();
@@ -1054,7 +1054,7 @@ void COBImporter::ReadMat1_Binary(COB::Scene &out, StreamReaderLE &reader, const
     id[0] = reader.GetI1(), id[1] = reader.GetI1();
 
     if (id[0] == 'e' && id[1] == ':') {
-        mat.tex_env.reset(new Texture());
+        mat.tex_env = std::make_shared<Texture>();
 
         reader.GetI1();
         ReadString_Binary(mat.tex_env->path, reader);
@@ -1064,7 +1064,7 @@ void COBImporter::ReadMat1_Binary(COB::Scene &out, StreamReaderLE &reader, const
     }
 
     if (id[0] == 't' && id[1] == ':') {
-        mat.tex_color.reset(new Texture());
+        mat.tex_color = std::make_shared<Texture>();
 
         reader.GetI1();
         ReadString_Binary(mat.tex_color->path, reader);
@@ -1080,7 +1080,7 @@ void COBImporter::ReadMat1_Binary(COB::Scene &out, StreamReaderLE &reader, const
     }
 
     if (id[0] == 'b' && id[1] == ':') {
-        mat.tex_bump.reset(new Texture());
+        mat.tex_bump = std::make_shared<Texture>();
 
         reader.GetI1();
         ReadString_Binary(mat.tex_bump->path, reader);

--- a/code/AssetLib/CSM/CSMLoader.cpp
+++ b/code/AssetLib/CSM/CSMLoader.cpp
@@ -117,7 +117,7 @@ void CSMImporter::InternReadFile( const std::string& pFile,
     std::unique_ptr<IOStream> file( pIOHandler->Open( pFile, "rb"));
 
     // Check whether we can read from the file
-    if( file.get() == nullptr) {
+    if (file == nullptr) {
         throw DeadlyImportError( "Failed to open CSM file ", pFile, ".");
     }
 
@@ -130,7 +130,7 @@ void CSMImporter::InternReadFile( const std::string& pFile,
     int first = 0, last = 0x00ffffff;
 
     // now process the file and look out for '$' sections
-    while (1)   {
+    while (true) {
         SkipSpaces(&buffer);
         if ('\0' == *buffer)
             break;
@@ -154,7 +154,7 @@ void CSMImporter::InternReadFile( const std::string& pFile,
             else if (TokenMatchI(buffer,"order",5)) {
                 std::vector< aiNodeAnim* > anims_temp;
                 anims_temp.reserve(30);
-                while (1)   {
+                while (true) {
                     SkipSpaces(&buffer);
                     if (IsLineEnd(*buffer) && SkipSpacesAndLineEnd(&buffer) && *buffer == '$')
                         break; // next section
@@ -196,7 +196,7 @@ void CSMImporter::InternReadFile( const std::string& pFile,
                 unsigned int filled = 0;
 
                 // Now read all point data.
-                while (1)   {
+                while (true) {
                     SkipSpaces(&buffer);
                     if (IsLineEnd(*buffer) && (!SkipSpacesAndLineEnd(&buffer) || *buffer == '$'))   {
                         break; // next section

--- a/code/AssetLib/Collada/ColladaExporter.cpp
+++ b/code/AssetLib/Collada/ColladaExporter.cpp
@@ -246,7 +246,7 @@ void ColladaExporter::WriteHeader() {
     }
 
     // Assimp root nodes can have meshes, Collada Scenes cannot
-    if (mScene->mRootNode->mNumChildren == 0 || mScene->mRootNode->mMeshes != 0) {
+    if (mScene->mRootNode->mNumChildren == 0 || mScene->mRootNode->mMeshes != nullptr) {
         mAdd_root_node = true;
     }
 

--- a/code/AssetLib/Collada/ColladaLoader.cpp
+++ b/code/AssetLib/Collada/ColladaLoader.cpp
@@ -1264,12 +1264,12 @@ void ColladaLoader::CreateAnimation(aiScene *pScene, const ColladaParser &pParse
             // now for every unique point in time, find or interpolate the key values for that time
             // and apply them to the transform chain. Then the node's present transformation can be calculated.
             ai_real time = startTime;
-            while (1) {
+            while (true) {
                 for (ChannelEntry & e : entries) {
                     // find the keyframe behind the current point in time
                     size_t pos = 0;
                     ai_real postTime = 0.0;
-                    while (1) {
+                    while (true) {
                         if (pos >= e.mTimeAccessor->mCount) {
                             break;
                         }
@@ -1680,7 +1680,7 @@ aiString ColladaLoader::FindFilenameForEffectTexture(const ColladaParser &pParse
 
     // recurse through the param references until we end up at an image
     std::string name = pName;
-    while (1) {
+    while (true) {
         // the given string is a param entry. Find it
         Effect::ParamLibrary::const_iterator it = pEffect.mParams.find(name);
         // if not found, we're at the end of the recursion. The resulting string should be the image ID

--- a/code/AssetLib/Collada/ColladaParser.cpp
+++ b/code/AssetLib/Collada/ColladaParser.cpp
@@ -145,7 +145,7 @@ ColladaParser::ColladaParser(IOSystem *pIOHandler, const std::string &pFile) :
     } else {
         // attempt to open the file directly
         daefile.reset(pIOHandler->Open(pFile));
-        if (daefile.get() == nullptr) {
+        if (daefile == nullptr) {
             throw DeadlyImportError("Failed to open file '", pFile, "'.");
         }
     }
@@ -759,7 +759,7 @@ void ColladaParser::ReadControllerWeights(XmlNode &node, Collada::Controller &pC
             XmlParser::getValueAsString(currentNode, stdText);
             const char *text = stdText.c_str();
             for (std::vector<std::pair<size_t, size_t>>::iterator it = pController.mWeights.begin(); it != pController.mWeights.end(); ++it) {
-                if (text == 0) {
+                if (text == nullptr) {
                     throw DeadlyImportError("Out of data while reading <vertex_weights>");
                 }
                 it->first = strtoul10(text, &text);

--- a/code/AssetLib/DXF/DXFLoader.cpp
+++ b/code/AssetLib/DXF/DXFLoader.cpp
@@ -136,7 +136,7 @@ void DXFImporter::InternReadFile( const std::string& filename, aiScene* pScene, 
     std::shared_ptr<IOStream> file = std::shared_ptr<IOStream>( pIOHandler->Open( filename) );
 
     // Check whether we can read the file
-    if( file.get() == nullptr ) {
+    if (file == nullptr) {
         throw DeadlyImportError( "Failed to open DXF file ", filename, "");
     }
 

--- a/code/AssetLib/FBX/FBXConverter.cpp
+++ b/code/AssetLib/FBX/FBXConverter.cpp
@@ -119,7 +119,7 @@ FBXConverter::FBXConverter(aiScene *out, const Document &doc, bool removeEmptyBo
             if (mat) {
 
                 if (materials_converted.find(mat) == materials_converted.end()) {
-                    ConvertMaterial(*mat, 0);
+                    ConvertMaterial(*mat, nullptr);
                 }
             }
         }

--- a/code/AssetLib/FBX/FBXDocument.cpp
+++ b/code/AssetLib/FBX/FBXDocument.cpp
@@ -78,7 +78,7 @@ const Object* LazyObject::Get(bool dieOnError) {
         return nullptr;
     }
 
-    if (object.get()) {
+    if (object) {
         return object.get();
     }
 
@@ -214,7 +214,7 @@ const Object* LazyObject::Get(bool dieOnError) {
         return nullptr;
     }
 
-    if (!object.get()) {
+    if (!object) {
         //DOMError("failed to convert element to DOM object, class: " + classtag + ", name: " + name,&element);
     }
 

--- a/code/AssetLib/FBX/FBXDocument.h
+++ b/code/AssetLib/FBX/FBXDocument.h
@@ -168,7 +168,7 @@ public:
 
     const PropertyTable& Props() const {
         ai_assert(props.get());
-        return *props.get();
+        return *props;
     }
 
 private:
@@ -432,7 +432,7 @@ public:
 
     const PropertyTable& Props() const {
         ai_assert(props.get());
-        return *props.get();
+        return *props;
     }
 
     /** Get material links */
@@ -503,7 +503,7 @@ public:
 
     const PropertyTable& Props() const {
         ai_assert(props.get());
-        return *props.get();
+        return *props;
     }
 
     // return a 4-tuple
@@ -618,7 +618,7 @@ public:
 
     const PropertyTable& Props() const {
         ai_assert(props.get());
-        return *props.get();
+        return *props;
     }
 
     const uint8_t* Content() const {
@@ -632,7 +632,7 @@ public:
 
     uint8_t* RelinquishContent() {
         uint8_t* ptr = content;
-        content = 0;
+        content = nullptr;
         return ptr;
     }
 
@@ -663,7 +663,7 @@ public:
 
     const PropertyTable& Props() const {
         ai_assert(props.get());
-        return *props.get();
+        return *props;
     }
 
     const TextureMap& Textures() const {
@@ -735,7 +735,7 @@ public:
 
     const PropertyTable& Props() const {
         ai_assert(props.get());
-        return *props.get();
+        return *props;
     }
 
 
@@ -780,7 +780,7 @@ public:
 
     const PropertyTable& Props() const {
         ai_assert(props.get());
-        return *props.get();
+        return *props;
     }
 
     /* the optional white list specifies a list of property names for which the caller
@@ -808,7 +808,7 @@ public:
 
     const PropertyTable& Props() const {
         ai_assert(props.get());
-        return *props.get();
+        return *props;
     }
 
     const AnimationLayerList& Layers() const {
@@ -829,7 +829,7 @@ public:
 
     const PropertyTable& Props() const {
         ai_assert(props.get());
-        return *props.get();
+        return *props;
     }
 
 private:
@@ -1018,7 +1018,7 @@ public:
 
     const PropertyTable& Props() const {
         ai_assert(props.get());
-        return *props.get();
+        return *props;
     }
 
     const Document& GetDocument() const {
@@ -1097,7 +1097,7 @@ public:
 
     const FileGlobalSettings& GlobalSettings() const {
         ai_assert(globals.get());
-        return *globals.get();
+        return *globals;
     }
 
     const PropertyTemplateMap& Templates() const {

--- a/code/AssetLib/FBX/FBXDocumentUtil.h
+++ b/code/AssetLib/FBX/FBXDocumentUtil.h
@@ -58,12 +58,11 @@ namespace Util {
 
 /* DOM/Parse error reporting - does not return */
 AI_WONT_RETURN void DOMError(const std::string& message, const Token& token) AI_WONT_RETURN_SUFFIX;
-AI_WONT_RETURN void DOMError(const std::string& message, const Element* element = NULL) AI_WONT_RETURN_SUFFIX;
+AI_WONT_RETURN void DOMError(const std::string &message, const Element *element = nullptr) AI_WONT_RETURN_SUFFIX;
 
 // does return
 void DOMWarning(const std::string& message, const Token& token);
-void DOMWarning(const std::string& message, const Element* element = NULL);
-
+void DOMWarning(const std::string &message, const Element *element = nullptr);
 
 // fetch a property table and the corresponding property template
 std::shared_ptr<const PropertyTable> GetPropertyTable(const Document& doc,

--- a/code/AssetLib/FBX/FBXExporter.cpp
+++ b/code/AssetLib/FBX/FBXExporter.cpp
@@ -681,9 +681,9 @@ void FBXExporter::WriteDefinitions ()
         pt = FBX::Node("PropertyTemplate", "FBXAnimLayer");
         p = FBX::Node("Properties70");
         p.AddP70("Weight", "Number", "", "A", double(100));
-        p.AddP70bool("Mute", 0);
-        p.AddP70bool("Solo", 0);
-        p.AddP70bool("Lock", 0);
+        p.AddP70bool("Mute", false);
+        p.AddP70bool("Solo", false);
+        p.AddP70bool("Lock", false);
         p.AddP70color("Color", 0.8, 0.8, 0.8);
         p.AddP70("BlendMode", "enum", "", "", int32_t(0));
         p.AddP70("RotationAccumulationMode", "enum", "", "", int32_t(0));
@@ -733,42 +733,42 @@ void FBXExporter::WriteDefinitions ()
         p.AddP70vector("RotationPivot", 0.0, 0.0, 0.0);
         p.AddP70vector("ScalingOffset", 0.0, 0.0, 0.0);
         p.AddP70vector("ScalingPivot", 0.0, 0.0, 0.0);
-        p.AddP70bool("TranslationActive", 0);
+        p.AddP70bool("TranslationActive", false);
         p.AddP70vector("TranslationMin", 0.0, 0.0, 0.0);
         p.AddP70vector("TranslationMax", 0.0, 0.0, 0.0);
-        p.AddP70bool("TranslationMinX", 0);
-        p.AddP70bool("TranslationMinY", 0);
-        p.AddP70bool("TranslationMinZ", 0);
-        p.AddP70bool("TranslationMaxX", 0);
-        p.AddP70bool("TranslationMaxY", 0);
-        p.AddP70bool("TranslationMaxZ", 0);
+        p.AddP70bool("TranslationMinX", false);
+        p.AddP70bool("TranslationMinY", false);
+        p.AddP70bool("TranslationMinZ", false);
+        p.AddP70bool("TranslationMaxX", false);
+        p.AddP70bool("TranslationMaxY", false);
+        p.AddP70bool("TranslationMaxZ", false);
         p.AddP70enum("RotationOrder", 0);
-        p.AddP70bool("RotationSpaceForLimitOnly", 0);
+        p.AddP70bool("RotationSpaceForLimitOnly", false);
         p.AddP70double("RotationStiffnessX", 0.0);
         p.AddP70double("RotationStiffnessY", 0.0);
         p.AddP70double("RotationStiffnessZ", 0.0);
         p.AddP70double("AxisLen", 10.0);
         p.AddP70vector("PreRotation", 0.0, 0.0, 0.0);
         p.AddP70vector("PostRotation", 0.0, 0.0, 0.0);
-        p.AddP70bool("RotationActive", 0);
+        p.AddP70bool("RotationActive", false);
         p.AddP70vector("RotationMin", 0.0, 0.0, 0.0);
         p.AddP70vector("RotationMax", 0.0, 0.0, 0.0);
-        p.AddP70bool("RotationMinX", 0);
-        p.AddP70bool("RotationMinY", 0);
-        p.AddP70bool("RotationMinZ", 0);
-        p.AddP70bool("RotationMaxX", 0);
-        p.AddP70bool("RotationMaxY", 0);
-        p.AddP70bool("RotationMaxZ", 0);
+        p.AddP70bool("RotationMinX", false);
+        p.AddP70bool("RotationMinY", false);
+        p.AddP70bool("RotationMinZ", false);
+        p.AddP70bool("RotationMaxX", false);
+        p.AddP70bool("RotationMaxY", false);
+        p.AddP70bool("RotationMaxZ", false);
         p.AddP70enum("InheritType", 0);
-        p.AddP70bool("ScalingActive", 0);
+        p.AddP70bool("ScalingActive", false);
         p.AddP70vector("ScalingMin", 0.0, 0.0, 0.0);
         p.AddP70vector("ScalingMax", 1.0, 1.0, 1.0);
-        p.AddP70bool("ScalingMinX", 0);
-        p.AddP70bool("ScalingMinY", 0);
-        p.AddP70bool("ScalingMinZ", 0);
-        p.AddP70bool("ScalingMaxX", 0);
-        p.AddP70bool("ScalingMaxY", 0);
-        p.AddP70bool("ScalingMaxZ", 0);
+        p.AddP70bool("ScalingMinX", false);
+        p.AddP70bool("ScalingMinY", false);
+        p.AddP70bool("ScalingMinZ", false);
+        p.AddP70bool("ScalingMaxX", false);
+        p.AddP70bool("ScalingMaxY", false);
+        p.AddP70bool("ScalingMaxZ", false);
         p.AddP70vector("GeometricTranslation", 0.0, 0.0, 0.0);
         p.AddP70vector("GeometricRotation", 0.0, 0.0, 0.0);
         p.AddP70vector("GeometricScaling", 1.0, 1.0, 1.0);
@@ -789,11 +789,11 @@ void FBXExporter::WriteDefinitions ()
         p.AddP70double("PreferedAngleZ", 0.0);
         p.AddP70("LookAtProperty", "object", "", "");
         p.AddP70("UpVectorProperty", "object", "", "");
-        p.AddP70bool("Show", 1);
-        p.AddP70bool("NegativePercentShapeSupport", 1);
+        p.AddP70bool("Show", true);
+        p.AddP70bool("NegativePercentShapeSupport", true);
         p.AddP70int("DefaultAttributeIndex", -1);
-        p.AddP70bool("Freeze", 0);
-        p.AddP70bool("LODBox", 0);
+        p.AddP70bool("Freeze", false);
+        p.AddP70bool("LODBox", false);
         p.AddP70(
             "Lcl Translation", "Lcl Translation", "", "A",
             double(0), double(0), double(0)
@@ -840,9 +840,9 @@ void FBXExporter::WriteDefinitions ()
         p.AddP70color("Color", 0, 0, 0);
         p.AddP70vector("BBoxMin", 0, 0, 0);
         p.AddP70vector("BBoxMax", 0, 0, 0);
-        p.AddP70bool("Primary Visibility", 1);
-        p.AddP70bool("Casts Shadows", 1);
-        p.AddP70bool("Receive Shadows", 1);
+        p.AddP70bool("Primary Visibility", true);
+        p.AddP70bool("Casts Shadows", true);
+        p.AddP70bool("Receive Shadows", true);
         pt.AddChild(p);
         n.AddChild(pt);
         object_nodes.push_back(n);
@@ -873,7 +873,7 @@ void FBXExporter::WriteDefinitions ()
         } else {
             p.AddP70string("ShadingModel", "Lambert");
         }
-        p.AddP70bool("MultiLayer", 0);
+        p.AddP70bool("MultiLayer", false);
         p.AddP70colorA("EmissiveColor", 0.0, 0.0, 0.0);
         p.AddP70numberA("EmissiveFactor", 1.0);
         p.AddP70colorA("AmbientColor", 0.2, 0.2, 0.2);
@@ -910,7 +910,7 @@ void FBXExporter::WriteDefinitions ()
         n.AddChild("Count", count);
         pt = FBX::Node("PropertyTemplate", "FbxVideo");
         p = FBX::Node("Properties70");
-        p.AddP70bool("ImageSequence", 0);
+        p.AddP70bool("ImageSequence", false);
         p.AddP70int("ImageSequenceOffset", 0);
         p.AddP70double("FrameRate", 0.0);
         p.AddP70int("LastFrame", 0);
@@ -922,8 +922,8 @@ void FBXExporter::WriteDefinitions ()
         p.AddP70double("PlaySpeed", 0.0);
         p.AddP70time("Offset", 0);
         p.AddP70enum("InterlaceMode", 0);
-        p.AddP70bool("FreeRunning", 0);
-        p.AddP70bool("Loop", 0);
+        p.AddP70bool("FreeRunning", false);
+        p.AddP70bool("Loop", false);
         p.AddP70enum("AccessMode", 0);
         pt.AddChild(p);
         n.AddChild(pt);
@@ -944,8 +944,8 @@ void FBXExporter::WriteDefinitions ()
         p.AddP70enum("CurrentMappingType", 0);
         p.AddP70enum("WrapModeU", 0);
         p.AddP70enum("WrapModeV", 0);
-        p.AddP70bool("UVSwap", 0);
-        p.AddP70bool("PremultiplyAlpha", 1);
+        p.AddP70bool("UVSwap", false);
+        p.AddP70bool("PremultiplyAlpha", true);
         p.AddP70vectorA("Translation", 0.0, 0.0, 0.0);
         p.AddP70vectorA("Rotation", 0.0, 0.0, 0.0);
         p.AddP70vectorA("Scaling", 1.0, 1.0, 1.0);
@@ -953,8 +953,8 @@ void FBXExporter::WriteDefinitions ()
         p.AddP70vector("TextureScalingPivot", 0.0, 0.0, 0.0);
         p.AddP70enum("CurrentTextureBlendMode", 1);
         p.AddP70string("UVSet", "default");
-        p.AddP70bool("UseMaterial", 0);
-        p.AddP70bool("UseMipMap", 0);
+        p.AddP70bool("UseMaterial", false);
+        p.AddP70bool("UseMipMap", false);
         pt.AddChild(p);
         n.AddChild(pt);
         object_nodes.push_back(n);
@@ -1708,7 +1708,7 @@ void FBXExporter::WriteObjects ()
             p.AddP70vectorA("Scaling", trafo.mScaling[0], trafo.mScaling[1], 0.0);
             p.AddP70enum("CurrentTextureBlendMode", 0); // TODO: verify
             //p.AddP70string("UVSet", ""); // TODO: how should this work?
-            p.AddP70bool("UseMaterial", 1);
+            p.AddP70bool("UseMaterial", true);
             tnode.AddChild(p);
             // can't easily determine which texture path will be correct,
             // so just store what we have in every field.
@@ -2501,7 +2501,7 @@ void FBXExporter::WriteModelNode(
     m.AddProperties(node_uid, std::move(name), type);
     m.AddChild("Version", int32_t(232));
     FBX::Node p("Properties70");
-    p.AddP70bool("RotationActive", 1);
+    p.AddP70bool("RotationActive", true);
     p.AddP70int("DefaultAttributeIndex", 0);
     p.AddP70enum("InheritType", inherit_type);
     if (transform_chain.empty()) {

--- a/code/AssetLib/FBX/FBXMaterial.cpp
+++ b/code/AssetLib/FBX/FBXMaterial.cpp
@@ -292,10 +292,10 @@ void LayeredTexture::fillTexture(const Document& doc) {
 }
 
 // ------------------------------------------------------------------------------------------------
-Video::Video(uint64_t id, const Element& element, const Document& doc, const std::string& name) :
-        Object(id,element,name),
+Video::Video(uint64_t id, const Element &element, const Document &doc, const std::string &name) :
+        Object(id, element, name),
         contentLength(0),
-        content(0) {
+        content(nullptr) {
     const Scope& sc = GetRequiredScope(element);
 
     const Element* const Type = sc["Type"];
@@ -379,7 +379,6 @@ Video::Video(uint64_t id, const Element& element, const Document& doc, const std
 
     props = GetPropertyTable(doc,"Video.FbxVideo",element,sc);
 }
-
 
 Video::~Video() {
     delete[] content;

--- a/code/AssetLib/FBX/FBXParser.h
+++ b/code/AssetLib/FBX/FBXParser.h
@@ -163,7 +163,7 @@ public:
     ~Parser() = default;
 
     const Scope& GetRootScope() const {
-        return *root.get();
+        return *root;
     }
 
     bool IsBinary() const {

--- a/code/AssetLib/HMP/HMPLoader.cpp
+++ b/code/AssetLib/HMP/HMPLoader.cpp
@@ -104,7 +104,7 @@ void HMPImporter::InternReadFile(const std::string &pFile,
     std::unique_ptr<IOStream> file(mIOHandler->Open(pFile));
 
     // Check whether we can read from the file
-    if (file.get() == nullptr) {
+    if (file == nullptr) {
         throw DeadlyImportError("Failed to open HMP file ", pFile, ".");
     }
 

--- a/code/AssetLib/IFC/IFCBoolean.cpp
+++ b/code/AssetLib/IFC/IFCBoolean.cpp
@@ -388,7 +388,7 @@ void ProcessPolygonalBoundedBooleanHalfSpaceDifference(const Schema_2x3::IfcPoly
     n.Normalize();
 
     // obtain the polygonal bounding volume
-    std::shared_ptr<TempMesh> profile = std::shared_ptr<TempMesh>(new TempMesh());
+    std::shared_ptr<TempMesh> profile = std::make_shared<TempMesh>();
     if (!ProcessCurve(hs->PolygonalBoundary, *profile, conv)) {
         IFCImporter::LogError("expected valid polyline for boundary of boolean halfspace");
         return;
@@ -672,7 +672,7 @@ void ProcessBooleanExtrudedAreaSolidDifference(const Schema_2x3::IfcExtrudedArea
     // operand should be near-planar. Luckily, this is usually the case in Ifc
     // buildings.
 
-    std::shared_ptr<TempMesh> meshtmp = std::shared_ptr<TempMesh>(new TempMesh());
+    std::shared_ptr<TempMesh> meshtmp = std::make_shared<TempMesh>();
     ProcessExtrudedAreaSolid(*as, *meshtmp, conv, false);
 
     std::vector<TempOpening> openings(1, TempOpening(as, IfcVector3(0, 0, 0), std::move(meshtmp), std::shared_ptr<TempMesh>()));

--- a/code/AssetLib/IFC/IFCBoolean.cpp
+++ b/code/AssetLib/IFC/IFCBoolean.cpp
@@ -389,7 +389,7 @@ void ProcessPolygonalBoundedBooleanHalfSpaceDifference(const Schema_2x3::IfcPoly
 
     // obtain the polygonal bounding volume
     std::shared_ptr<TempMesh> profile = std::shared_ptr<TempMesh>(new TempMesh());
-    if (!ProcessCurve(hs->PolygonalBoundary, *profile.get(), conv)) {
+    if (!ProcessCurve(hs->PolygonalBoundary, *profile, conv)) {
         IFCImporter::LogError("expected valid polyline for boundary of boolean halfspace");
         return;
     }

--- a/code/AssetLib/IFC/IFCGeometry.cpp
+++ b/code/AssetLib/IFC/IFCGeometry.cpp
@@ -610,7 +610,7 @@ void ProcessExtrudedArea(const Schema_2x3::IfcExtrudedAreaSolid& solid, const Te
 
         nors.reserve(conv.apply_openings->size());
         for(TempOpening& t : *conv.apply_openings) {
-            TempMesh& bounds = *t.profileMesh.get();
+            TempMesh &bounds = *t.profileMesh;
 
             if( bounds.mVerts.size() <= 2 ) {
                 nors.emplace_back();
@@ -787,7 +787,7 @@ bool ProcessGeometricItem(const Schema_2x3::IfcRepresentationItem& geo, unsigned
                 const ::Assimp::STEP::EXPRESS::ENTITY& e = shell->To<::Assimp::STEP::EXPRESS::ENTITY>();
                 const Schema_2x3::IfcConnectedFaceSet& fs = conv.db.MustGetObject(e).To<Schema_2x3::IfcConnectedFaceSet>();
 
-                ProcessConnectedFaceSet(fs,*meshtmp.get(),conv);
+                ProcessConnectedFaceSet(fs, *meshtmp, conv);
             }
             catch(std::bad_cast&) {
                 IFCImporter::LogWarn("unexpected type error, IfcShell ought to inherit from IfcConnectedFaceSet");
@@ -796,27 +796,27 @@ bool ProcessGeometricItem(const Schema_2x3::IfcRepresentationItem& geo, unsigned
         fix_orientation = true;
     }
     else  if(const Schema_2x3::IfcConnectedFaceSet* fset = geo.ToPtr<Schema_2x3::IfcConnectedFaceSet>()) {
-        ProcessConnectedFaceSet(*fset,*meshtmp.get(),conv);
+        ProcessConnectedFaceSet(*fset, *meshtmp, conv);
         fix_orientation = true;
     }
     else  if(const Schema_2x3::IfcSweptAreaSolid* swept = geo.ToPtr<Schema_2x3::IfcSweptAreaSolid>()) {
-        ProcessSweptAreaSolid(*swept,*meshtmp.get(),conv);
+        ProcessSweptAreaSolid(*swept, *meshtmp, conv);
     }
     else  if(const Schema_2x3::IfcSweptDiskSolid* disk = geo.ToPtr<Schema_2x3::IfcSweptDiskSolid>()) {
-        ProcessSweptDiskSolid(*disk,*meshtmp.get(),conv);
+        ProcessSweptDiskSolid(*disk, *meshtmp, conv);
     }
     else if(const Schema_2x3::IfcManifoldSolidBrep* brep = geo.ToPtr<Schema_2x3::IfcManifoldSolidBrep>()) {
-        ProcessConnectedFaceSet(brep->Outer,*meshtmp.get(),conv);
+        ProcessConnectedFaceSet(brep->Outer, *meshtmp, conv);
         fix_orientation = true;
     }
     else if(const Schema_2x3::IfcFaceBasedSurfaceModel* surf = geo.ToPtr<Schema_2x3::IfcFaceBasedSurfaceModel>()) {
         for(const Schema_2x3::IfcConnectedFaceSet& fc : surf->FbsmFaces) {
-            ProcessConnectedFaceSet(fc,*meshtmp.get(),conv);
+            ProcessConnectedFaceSet(fc, *meshtmp, conv);
         }
         fix_orientation = true;
     }
     else  if(const Schema_2x3::IfcBooleanResult* boolean = geo.ToPtr<Schema_2x3::IfcBooleanResult>()) {
-        ProcessBoolean(*boolean,*meshtmp.get(),conv);
+        ProcessBoolean(*boolean, *meshtmp, conv);
     }
     else if(geo.ToPtr<Schema_2x3::IfcBoundingBox>()) {
         // silently skip over bounding boxes

--- a/code/AssetLib/IFC/IFCLoader.cpp
+++ b/code/AssetLib/IFC/IFCLoader.cpp
@@ -48,6 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <iterator>
 #include <limits>
+#include <memory>
 #include <tuple>
 
 #ifndef ASSIMP_BUILD_NO_COMPRESSED_IFC
@@ -186,7 +187,7 @@ void IFCImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
                 // get file size, etc.
                 unz_file_info fileInfo;
                 char filename[256];
-                unzGetCurrentFileInfo(zip, &fileInfo, filename, sizeof(filename), 0, 0, 0, 0);
+                unzGetCurrentFileInfo(zip, &fileInfo, filename, sizeof(filename), nullptr, 0, nullptr, 0);
                 if (GetExtension(filename) != "ifc") {
                     continue;
                 }
@@ -211,7 +212,7 @@ void IFCImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
                     ThrowException("Failed to decompress IFC ZIP file");
                 }
                 unzCloseCurrentFile(zip);
-                stream.reset(new MemoryIOStream(buff, fileInfo.uncompressed_size, true));
+                stream = std::make_shared<MemoryIOStream>(buff, fileInfo.uncompressed_size, true);
                 if (unzGoToNextFile(zip) == UNZ_END_OF_LIST_OF_FILE) {
                     ThrowException("Found no IFC file member in IFCZIP file (1)");
                 }

--- a/code/AssetLib/IFC/IFCReaderGen1_2x3.cpp
+++ b/code/AssetLib/IFC/IFCReaderGen1_2x3.cpp
@@ -1065,28 +1065,28 @@ template <> size_t GenericFill<IfcRoot>(const DB& db, const LIST& params, IfcRoo
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcRoot,4>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->GlobalId, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcRoot to be a `IfcGloballyUniqueId`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'OwnerHistory' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcRoot,4>::aux_is_derived[1]=true; break; }
         try { GenericConvert( in->OwnerHistory, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcRoot to be a `IfcOwnerHistory`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'Name' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcRoot,4>::aux_is_derived[2]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Name, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcRoot to be a `IfcLabel`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'Description' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcRoot,4>::aux_is_derived[3]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Description, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcRoot to be a `IfcText`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcObjectDefinition>(const DB& db, const LIST& params, IfcObjectDefinition* in)
@@ -1152,28 +1152,28 @@ template <> size_t GenericFill<IfcRepresentation>(const DB& db, const LIST& para
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcRepresentation,4>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->ContextOfItems, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcRepresentation to be a `IfcRepresentationContext`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'RepresentationIdentifier' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcRepresentation,4>::aux_is_derived[1]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->RepresentationIdentifier, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcRepresentation to be a `IfcLabel`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'RepresentationType' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcRepresentation,4>::aux_is_derived[2]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->RepresentationType, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcRepresentation to be a `IfcLabel`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'Items' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcRepresentation,4>::aux_is_derived[3]=true; break; }
         try { GenericConvert( in->Items, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcRepresentation to be a `SET [1:?] OF IfcRepresentationItem`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcShapeModel>(const DB& db, const LIST& params, IfcShapeModel* in)
@@ -1239,8 +1239,8 @@ template <> size_t GenericFill<IfcObject>(const DB& db, const LIST& params, IfcO
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->ObjectType, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 4 to IfcObject to be a `IfcLabel`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcControl>(const DB& db, const LIST& params, IfcControl* in)
@@ -1292,21 +1292,21 @@ template <> size_t GenericFill<IfcProductRepresentation>(const DB& db, const LIS
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Name, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcProductRepresentation to be a `IfcLabel`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'Description' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcProductRepresentation,3>::aux_is_derived[1]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Description, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcProductRepresentation to be a `IfcText`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'Representations' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcProductRepresentation,3>::aux_is_derived[2]=true; break; }
         try { GenericConvert( in->Representations, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcProductRepresentation to be a `LIST [1:?] OF IfcRepresentation`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcProduct>(const DB& db, const LIST& params, IfcProduct* in)
@@ -1318,15 +1318,15 @@ template <> size_t GenericFill<IfcProduct>(const DB& db, const LIST& params, Ifc
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->ObjectPlacement, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 5 to IfcProduct to be a `IfcObjectPlacement`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'Representation' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcProduct,2>::aux_is_derived[1]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Representation, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 6 to IfcProduct to be a `IfcProductRepresentation`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcElement>(const DB& db, const LIST& params, IfcElement* in)
@@ -1338,8 +1338,8 @@ template <> size_t GenericFill<IfcElement>(const DB& db, const LIST& params, Ifc
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Tag, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 7 to IfcElement to be a `IfcIdentifier`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcDistributionElement>(const DB& db, const LIST& params, IfcDistributionElement* in)
@@ -1376,14 +1376,14 @@ template <> size_t GenericFill<IfcCompositeCurve>(const DB& db, const LIST& para
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcCompositeCurve,2>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->Segments, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcCompositeCurve to be a `LIST [1:?] OF IfcCompositeCurveSegment`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'SelfIntersect' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcCompositeCurve,2>::aux_is_derived[1]=true; break; }
         try { GenericConvert( in->SelfIntersect, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcCompositeCurve to be a `LOGICAL`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<Ifc2DCompositeCurve>(const DB& db, const LIST& params, Ifc2DCompositeCurve* in)
@@ -1402,28 +1402,28 @@ template <> size_t GenericFill<IfcCartesianTransformationOperator>(const DB& db,
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Axis1, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcCartesianTransformationOperator to be a `IfcDirection`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'Axis2' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcCartesianTransformationOperator,4>::aux_is_derived[1]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Axis2, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcCartesianTransformationOperator to be a `IfcDirection`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'LocalOrigin' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcCartesianTransformationOperator,4>::aux_is_derived[2]=true; break; }
         try { GenericConvert( in->LocalOrigin, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcCartesianTransformationOperator to be a `IfcCartesianPoint`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'Scale' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcCartesianTransformationOperator,4>::aux_is_derived[3]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Scale, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcCartesianTransformationOperator to be a `REAL`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcCartesianTransformationOperator3D>(const DB& db, const LIST& params, IfcCartesianTransformationOperator3D* in)
@@ -1435,8 +1435,8 @@ template <> size_t GenericFill<IfcCartesianTransformationOperator3D>(const DB& d
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Axis3, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 4 to IfcCartesianTransformationOperator3D to be a `IfcDirection`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcProperty>(const DB& db, const LIST& params, IfcProperty* in)
@@ -1447,15 +1447,15 @@ template <> size_t GenericFill<IfcProperty>(const DB& db, const LIST& params, If
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcProperty,2>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->Name, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcProperty to be a `IfcIdentifier`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'Description' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcProperty,2>::aux_is_derived[1]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Description, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcProperty to be a `IfcText`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcSimpleProperty>(const DB& db, const LIST& params, IfcSimpleProperty* in)
@@ -1499,8 +1499,8 @@ template <> size_t GenericFill<IfcElementarySurface>(const DB& db, const LIST& p
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcElementarySurface,1>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->Position, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcElementarySurface to be a `IfcAxis2Placement3D`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcPlane>(const DB& db, const LIST& params, IfcPlane* in)
@@ -1517,20 +1517,20 @@ template <> size_t GenericFill<IfcBooleanResult>(const DB& db, const LIST& param
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcBooleanResult,3>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->Operator, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcBooleanResult to be a `IfcBooleanOperator`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'FirstOperand' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcBooleanResult,3>::aux_is_derived[1]=true; break; }
         try { GenericConvert( in->FirstOperand, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcBooleanResult to be a `IfcBooleanOperand`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'SecondOperand' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcBooleanResult,3>::aux_is_derived[2]=true; break; }
         try { GenericConvert( in->SecondOperand, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcBooleanResult to be a `IfcBooleanOperand`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcBooleanClippingResult>(const DB& db, const LIST& params, IfcBooleanClippingResult* in)
@@ -1553,8 +1553,8 @@ template <> size_t GenericFill<IfcManifoldSolidBrep>(const DB& db, const LIST& p
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcManifoldSolidBrep,1>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->Outer, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcManifoldSolidBrep to be a `IfcClosedShell`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcFlowTerminalType>(const DB& db, const LIST& params, IfcFlowTerminalType* in)
@@ -1632,13 +1632,13 @@ template <> size_t GenericFill<IfcRelFillsElement>(const DB& db, const LIST& par
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->RelatingOpeningElement, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 4 to IfcRelFillsElement to be a `IfcOpeningElement`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'RelatedBuildingElement' argument
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->RelatedBuildingElement, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 5 to IfcRelFillsElement to be a `IfcElement`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcProcedure>(const DB& db, const LIST& params, IfcProcedure* in)
@@ -1683,13 +1683,13 @@ template <> size_t GenericFill<IfcRelContainedInSpatialStructure>(const DB& db, 
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->RelatedElements, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 4 to IfcRelContainedInSpatialStructure to be a `SET [1:?] OF IfcProduct`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'RelatingStructure' argument
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->RelatingStructure, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 5 to IfcRelContainedInSpatialStructure to be a `IfcSpatialStructureElement`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcTopologicalRepresentationItem>(const DB& db, const LIST& params, IfcTopologicalRepresentationItem* in)
@@ -1774,8 +1774,8 @@ template <> size_t GenericFill<IfcDirection>(const DB& db, const LIST& params, I
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->DirectionRatios, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcDirection to be a `LIST [2:3] OF REAL`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcProfileDef>(const DB& db, const LIST& params, IfcProfileDef* in)
@@ -1786,15 +1786,15 @@ template <> size_t GenericFill<IfcProfileDef>(const DB& db, const LIST& params, 
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcProfileDef,2>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->ProfileType, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcProfileDef to be a `IfcProfileTypeEnum`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'ProfileName' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcProfileDef,2>::aux_is_derived[1]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->ProfileName, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcProfileDef to be a `IfcLabel`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcParameterizedProfileDef>(const DB& db, const LIST& params, IfcParameterizedProfileDef* in)
@@ -1805,8 +1805,8 @@ template <> size_t GenericFill<IfcParameterizedProfileDef>(const DB& db, const L
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcParameterizedProfileDef,1>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->Position, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcParameterizedProfileDef to be a `IfcAxis2Placement2D`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcCShapeProfileDef>(const DB& db, const LIST& params, IfcCShapeProfileDef* in)
@@ -1912,8 +1912,8 @@ template <> size_t GenericFill<IfcCircleProfileDef>(const DB& db, const LIST& pa
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcCircleProfileDef,1>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->Radius, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcCircleProfileDef to be a `IfcPositiveLengthMeasure`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcCircleHollowProfileDef>(const DB& db, const LIST& params, IfcCircleHollowProfileDef* in)
@@ -1923,8 +1923,8 @@ template <> size_t GenericFill<IfcCircleHollowProfileDef>(const DB& db, const LI
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->WallThickness, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 4 to IfcCircleHollowProfileDef to be a `IfcPositiveLengthMeasure`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcPlacement>(const DB& db, const LIST& params, IfcPlacement* in)
@@ -1935,8 +1935,8 @@ template <> size_t GenericFill<IfcPlacement>(const DB& db, const LIST& params, I
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcPlacement,1>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->Location, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcPlacement to be a `IfcCartesianPoint`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcAxis2Placement3D>(const DB& db, const LIST& params, IfcAxis2Placement3D* in)
@@ -1947,14 +1947,14 @@ template <> size_t GenericFill<IfcAxis2Placement3D>(const DB& db, const LIST& pa
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Axis, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcAxis2Placement3D to be a `IfcDirection`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'RefDirection' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->RefDirection, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcAxis2Placement3D to be a `IfcDirection`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcPresentationStyle>(const DB& db, const LIST& params, IfcPresentationStyle* in)
@@ -1966,8 +1966,8 @@ template <> size_t GenericFill<IfcPresentationStyle>(const DB& db, const LIST& p
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Name, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcPresentationStyle to be a `IfcLabel`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcEquipmentElement>(const DB& db, const LIST& params, IfcEquipmentElement* in)
@@ -1984,18 +1984,18 @@ template <> size_t GenericFill<IfcCompositeCurveSegment>(const DB& db, const LIS
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Transition, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcCompositeCurveSegment to be a `IfcTransitionCode`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'SameSense' argument
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->SameSense, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcCompositeCurveSegment to be a `BOOLEAN`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'ParentCurve' argument
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->ParentCurve, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcCompositeCurveSegment to be a `IfcCurve`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcRectangleProfileDef>(const DB& db, const LIST& params, IfcRectangleProfileDef* in)
@@ -2006,14 +2006,14 @@ template <> size_t GenericFill<IfcRectangleProfileDef>(const DB& db, const LIST&
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcRectangleProfileDef,2>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->XDim, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcRectangleProfileDef to be a `IfcPositiveLengthMeasure`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'YDim' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcRectangleProfileDef,2>::aux_is_derived[1]=true; break; }
         try { GenericConvert( in->YDim, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 4 to IfcRectangleProfileDef to be a `IfcPositiveLengthMeasure`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcBuildingElementProxy>(const DB& db, const LIST& params, IfcBuildingElementProxy* in)
@@ -2108,13 +2108,13 @@ template <> size_t GenericFill<IfcLocalPlacement>(const DB& db, const LIST& para
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->PlacementRelTo, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcLocalPlacement to be a `IfcObjectPlacement`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'RelativePlacement' argument
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->RelativePlacement, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcLocalPlacement to be a `IfcAxis2Placement`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcSweptAreaSolid>(const DB& db, const LIST& params, IfcSweptAreaSolid* in)
@@ -2125,14 +2125,14 @@ template <> size_t GenericFill<IfcSweptAreaSolid>(const DB& db, const LIST& para
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcSweptAreaSolid,2>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->SweptArea, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcSweptAreaSolid to be a `IfcProfileDef`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'Position' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcSweptAreaSolid,2>::aux_is_derived[1]=true; break; }
         try { GenericConvert( in->Position, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcSweptAreaSolid to be a `IfcAxis2Placement3D`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcRevolvedAreaSolid>(const DB& db, const LIST& params, IfcRevolvedAreaSolid* in)
@@ -2142,13 +2142,13 @@ template <> size_t GenericFill<IfcRevolvedAreaSolid>(const DB& db, const LIST& p
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Axis, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcRevolvedAreaSolid to be a `IfcAxis1Placement`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'Angle' argument
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Angle, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcRevolvedAreaSolid to be a `IfcPlaneAngleMeasure`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcStructuralSurfaceConnection>(const DB& db, const LIST& params, IfcStructuralSurfaceConnection* in)
@@ -2172,29 +2172,29 @@ template <> size_t GenericFill<IfcSweptDiskSolid>(const DB& db, const LIST& para
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Directrix, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcSweptDiskSolid to be a `IfcCurve`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'Radius' argument
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Radius, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcSweptDiskSolid to be a `IfcPositiveLengthMeasure`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'InnerRadius' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->InnerRadius, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcSweptDiskSolid to be a `IfcPositiveLengthMeasure`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'StartParam' argument
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->StartParam, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcSweptDiskSolid to be a `IfcParameterValue`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'EndParam' argument
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->EndParam, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 4 to IfcSweptDiskSolid to be a `IfcParameterValue`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcHalfSpaceSolid>(const DB& db, const LIST& params, IfcHalfSpaceSolid* in)
@@ -2205,14 +2205,14 @@ template <> size_t GenericFill<IfcHalfSpaceSolid>(const DB& db, const LIST& para
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcHalfSpaceSolid,2>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->BaseSurface, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcHalfSpaceSolid to be a `IfcSurface`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'AgreementFlag' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcHalfSpaceSolid,2>::aux_is_derived[1]=true; break; }
         try { GenericConvert( in->AgreementFlag, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcHalfSpaceSolid to be a `BOOLEAN`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcPolygonalBoundedHalfSpace>(const DB& db, const LIST& params, IfcPolygonalBoundedHalfSpace* in)
@@ -2222,13 +2222,13 @@ template <> size_t GenericFill<IfcPolygonalBoundedHalfSpace>(const DB& db, const
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Position, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcPolygonalBoundedHalfSpace to be a `IfcAxis2Placement3D`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'PolygonalBoundary' argument
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->PolygonalBoundary, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcPolygonalBoundedHalfSpace to be a `IfcBoundedCurve`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcTimeSeriesSchedule>(const DB& db, const LIST& params, IfcTimeSeriesSchedule* in)
@@ -2253,24 +2253,24 @@ template <> size_t GenericFill<IfcProject>(const DB& db, const LIST& params, Ifc
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->LongName, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 5 to IfcProject to be a `IfcLabel`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'Phase' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Phase, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 6 to IfcProject to be a `IfcLabel`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'RepresentationContexts' argument
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->RepresentationContexts, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 7 to IfcProject to be a `SET [1:?] OF IfcRepresentationContext`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'UnitsInContext' argument
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->UnitsInContext, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 8 to IfcProject to be a `IfcUnitAssignment`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcEvaporatorType>(const DB& db, const LIST& params, IfcEvaporatorType* in)
@@ -2329,28 +2329,28 @@ template <> size_t GenericFill<IfcTrimmedCurve>(const DB& db, const LIST& params
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->BasisCurve, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcTrimmedCurve to be a `IfcCurve`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'Trim1' argument
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Trim1, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcTrimmedCurve to be a `SET [1:2] OF IfcTrimmingSelect`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'Trim2' argument
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Trim2, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcTrimmedCurve to be a `SET [1:2] OF IfcTrimmingSelect`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'SenseAgreement' argument
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->SenseAgreement, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcTrimmedCurve to be a `BOOLEAN`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'MasterRepresentation' argument
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->MasterRepresentation, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 4 to IfcTrimmedCurve to be a `IfcTrimmingPreference`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcRelDefines>(const DB& db, const LIST& params, IfcRelDefines* in)
@@ -2361,8 +2361,8 @@ template <> size_t GenericFill<IfcRelDefines>(const DB& db, const LIST& params, 
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcRelDefines,1>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->RelatedObjects, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 4 to IfcRelDefines to be a `SET [1:?] OF IfcObject`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcRelDefinesByProperties>(const DB& db, const LIST& params, IfcRelDefinesByProperties* in)
@@ -2373,8 +2373,8 @@ template <> size_t GenericFill<IfcRelDefinesByProperties>(const DB& db, const LI
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcRelDefinesByProperties,1>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->RelatingPropertyDefinition, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 5 to IfcRelDefinesByProperties to be a `IfcPropertySetDefinition`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcActor>(const DB& db, const LIST& params, IfcActor* in)
@@ -2406,8 +2406,8 @@ template <> size_t GenericFill<IfcArbitraryOpenProfileDef>(const DB& db, const L
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcArbitraryOpenProfileDef,1>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->Curve, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcArbitraryOpenProfileDef to be a `IfcBoundedCurve`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcPermit>(const DB& db, const LIST& params, IfcPermit* in)
@@ -2572,14 +2572,14 @@ template <> size_t GenericFill<IfcRelDecomposes>(const DB& db, const LIST& param
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcRelDecomposes,2>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->RelatingObject, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 4 to IfcRelDecomposes to be a `IfcObjectDefinition`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'RelatedObjects' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcRelDecomposes,2>::aux_is_derived[1]=true; break; }
         try { GenericConvert( in->RelatedObjects, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 5 to IfcRelDecomposes to be a `SET [1:?] OF IfcObjectDefinition`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcCovering>(const DB& db, const LIST& params, IfcCovering* in)
@@ -2596,8 +2596,8 @@ template <> size_t GenericFill<IfcPolyline>(const DB& db, const LIST& params, If
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Points, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcPolyline to be a `LIST [2:?] OF IfcCartesianPoint`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcPath>(const DB& db, const LIST& params, IfcPath* in)
@@ -2628,13 +2628,13 @@ template <> size_t GenericFill<IfcMappedItem>(const DB& db, const LIST& params, 
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->MappingSource, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcMappedItem to be a `IfcRepresentationMap`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'MappingTarget' argument
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->MappingTarget, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcMappedItem to be a `IfcCartesianTransformationOperator`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcRectangularPyramid>(const DB& db, const LIST& params, IfcRectangularPyramid* in)
@@ -2660,14 +2660,14 @@ template <> size_t GenericFill<IfcNamedUnit>(const DB& db, const LIST& params, I
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcNamedUnit,2>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->Dimensions, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcNamedUnit to be a `IfcDimensionalExponents`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'UnitType' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcNamedUnit,2>::aux_is_derived[1]=true; break; }
         try { GenericConvert( in->UnitType, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcNamedUnit to be a `IfcUnitEnum`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcContextDependentUnit>(const DB& db, const LIST& params, IfcContextDependentUnit* in)
@@ -2721,14 +2721,14 @@ template <> size_t GenericFill<IfcSpatialStructureElement>(const DB& db, const L
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->LongName, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 7 to IfcSpatialStructureElement to be a `IfcLabel`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'CompositionType' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcSpatialStructureElement,2>::aux_is_derived[1]=true; break; }
         try { GenericConvert( in->CompositionType, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 8 to IfcSpatialStructureElement to be a `IfcElementCompositionEnum`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcBuilding>(const DB& db, const LIST& params, IfcBuilding* in)
@@ -2739,20 +2739,20 @@ template <> size_t GenericFill<IfcBuilding>(const DB& db, const LIST& params, If
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->ElevationOfRefHeight, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 9 to IfcBuilding to be a `IfcLengthMeasure`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'ElevationOfTerrain' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->ElevationOfTerrain, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 10 to IfcBuilding to be a `IfcLengthMeasure`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'BuildingAddress' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->BuildingAddress, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 11 to IfcBuilding to be a `IfcPostalAddress`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcConnectedFaceSet>(const DB& db, const LIST& params, IfcConnectedFaceSet* in)
@@ -2763,8 +2763,8 @@ template <> size_t GenericFill<IfcConnectedFaceSet>(const DB& db, const LIST& pa
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcConnectedFaceSet,1>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->CfsFaces, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcConnectedFaceSet to be a `SET [1:?] OF IfcFace`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcOpenShell>(const DB& db, const LIST& params, IfcOpenShell* in)
@@ -2789,8 +2789,8 @@ template <> size_t GenericFill<IfcConic>(const DB& db, const LIST& params, IfcCo
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcConic,1>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->Position, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcConic to be a `IfcAxis2Placement`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcCoveringType>(const DB& db, const LIST& params, IfcCoveringType* in)
@@ -2836,33 +2836,33 @@ template <> size_t GenericFill<IfcIShapeProfileDef>(const DB& db, const LIST& pa
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcIShapeProfileDef,5>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->OverallWidth, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcIShapeProfileDef to be a `IfcPositiveLengthMeasure`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'OverallDepth' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcIShapeProfileDef,5>::aux_is_derived[1]=true; break; }
         try { GenericConvert( in->OverallDepth, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 4 to IfcIShapeProfileDef to be a `IfcPositiveLengthMeasure`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'WebThickness' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcIShapeProfileDef,5>::aux_is_derived[2]=true; break; }
         try { GenericConvert( in->WebThickness, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 5 to IfcIShapeProfileDef to be a `IfcPositiveLengthMeasure`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'FlangeThickness' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcIShapeProfileDef,5>::aux_is_derived[3]=true; break; }
         try { GenericConvert( in->FlangeThickness, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 6 to IfcIShapeProfileDef to be a `IfcPositiveLengthMeasure`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'FilletRadius' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcIShapeProfileDef,5>::aux_is_derived[4]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->FilletRadius, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 7 to IfcIShapeProfileDef to be a `IfcPositiveLengthMeasure`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcAsymmetricIShapeProfileDef>(const DB& db, const LIST& params, IfcAsymmetricIShapeProfileDef* in)
@@ -2935,14 +2935,14 @@ template <> size_t GenericFill<IfcPropertyListValue>(const DB& db, const LIST& p
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->ListValues, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcPropertyListValue to be a `LIST [1:?] OF IfcValue`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'Unit' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Unit, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcPropertyListValue to be a `IfcUnit`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcFurnitureStandard>(const DB& db, const LIST& params, IfcFurnitureStandard* in)
@@ -2967,14 +2967,14 @@ template <> size_t GenericFill<IfcDoor>(const DB& db, const LIST& params, IfcDoo
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->OverallHeight, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 8 to IfcDoor to be a `IfcPositiveLengthMeasure`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'OverallWidth' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->OverallWidth, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 9 to IfcDoor to be a `IfcPositiveLengthMeasure`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcStyledItem>(const DB& db, const LIST& params, IfcStyledItem* in)
@@ -2986,21 +2986,21 @@ template <> size_t GenericFill<IfcStyledItem>(const DB& db, const LIST& params, 
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Item, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcStyledItem to be a `IfcRepresentationItem`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'Styles' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcStyledItem,3>::aux_is_derived[1]=true; break; }
         try { GenericConvert( in->Styles, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcStyledItem to be a `SET [1:?] OF IfcPresentationStyleAssignment`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'Name' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcStyledItem,3>::aux_is_derived[2]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Name, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcStyledItem to be a `IfcLabel`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcAnnotationOccurrence>(const DB& db, const LIST& params, IfcAnnotationOccurrence* in)
@@ -3025,8 +3025,8 @@ template <> size_t GenericFill<IfcArbitraryClosedProfileDef>(const DB& db, const
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcArbitraryClosedProfileDef,1>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->OuterCurve, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcArbitraryClosedProfileDef to be a `IfcCurve`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcArbitraryProfileDefWithVoids>(const DB& db, const LIST& params, IfcArbitraryProfileDefWithVoids* in)
@@ -3043,13 +3043,13 @@ template <> size_t GenericFill<IfcLine>(const DB& db, const LIST& params, IfcLin
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Pnt, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcLine to be a `IfcCartesianPoint`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'Dir' argument
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Dir, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcLine to be a `IfcVector`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcFlowSegmentType>(const DB& db, const LIST& params, IfcFlowSegmentType* in)
@@ -3074,14 +3074,14 @@ template <> size_t GenericFill<IfcPropertySingleValue>(const DB& db, const LIST&
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->NominalValue, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcPropertySingleValue to be a `IfcValue`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'Unit' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Unit, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcPropertySingleValue to be a `IfcUnit`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcAlarmType>(const DB& db, const LIST& params, IfcAlarmType* in)
@@ -3113,8 +3113,8 @@ template <> size_t GenericFill<IfcSurfaceStyleShading>(const DB& db, const LIST&
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcSurfaceStyleShading,1>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->SurfaceColour, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcSurfaceStyleShading to be a `IfcColourRgb`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcPumpType>(const DB& db, const LIST& params, IfcPumpType* in)

--- a/code/AssetLib/IFC/IFCReaderGen2_2x3.cpp
+++ b/code/AssetLib/IFC/IFCReaderGen2_2x3.cpp
@@ -61,13 +61,13 @@ template <> size_t GenericFill<IfcSurfaceStyle>(const DB& db, const LIST& params
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Side, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcSurfaceStyle to be a `IfcSurfaceSide`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'Styles' argument
         std::shared_ptr<const DataType> arg = params[ base++ ];
         try { GenericConvert( in->Styles, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcSurfaceStyle to be a `SET [1:5] OF IfcSurfaceStyleElementSelect`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcAnnotationSurface>(const DB& db, const LIST& params, IfcAnnotationSurface* in)
@@ -120,8 +120,8 @@ template <> size_t GenericFill<IfcFace>(const DB& db, const LIST& params, IfcFac
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcFace,1>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->Bounds, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcFace to be a `SET [1:?] OF IfcFaceBound`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcStructuralSurfaceMember>(const DB& db, const LIST& params, IfcStructuralSurfaceMember* in)
@@ -175,8 +175,8 @@ template <> size_t GenericFill<IfcColourSpecification>(const DB& db, const LIST&
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Name, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcColourSpecification to be a `IfcLabel`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcVector>(const DB& db, const LIST& params, IfcVector* in)
@@ -186,13 +186,13 @@ template <> size_t GenericFill<IfcVector>(const DB& db, const LIST& params, IfcV
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Orientation, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcVector to be a `IfcDirection`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'Magnitude' argument
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Magnitude, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcVector to be a `IfcLengthMeasure`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcBeam>(const DB& db, const LIST& params, IfcBeam* in)
@@ -209,18 +209,18 @@ template <> size_t GenericFill<IfcColourRgb>(const DB& db, const LIST& params, I
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Red, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcColourRgb to be a `IfcNormalisedRatioMeasure`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'Green' argument
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Green, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcColourRgb to be a `IfcNormalisedRatioMeasure`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'Blue' argument
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Blue, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcColourRgb to be a `IfcNormalisedRatioMeasure`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcStructuralPlanarAction>(const DB& db, const LIST& params, IfcStructuralPlanarAction* in)
@@ -245,32 +245,32 @@ template <> size_t GenericFill<IfcSite>(const DB& db, const LIST& params, IfcSit
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->RefLatitude, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 9 to IfcSite to be a `IfcCompoundPlaneAngleMeasure`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'RefLongitude' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->RefLongitude, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 10 to IfcSite to be a `IfcCompoundPlaneAngleMeasure`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'RefElevation' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->RefElevation, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 11 to IfcSite to be a `IfcLengthMeasure`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'LandTitleNumber' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->LandTitleNumber, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 12 to IfcSite to be a `IfcLabel`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'SiteAddress' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->SiteAddress, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 13 to IfcSite to be a `IfcPostalAddress`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcDiscreteAccessoryType>(const DB& db, const LIST& params, IfcDiscreteAccessoryType* in)
@@ -414,32 +414,32 @@ template <> size_t GenericFill<IfcBSplineCurve>(const DB& db, const LIST& params
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcBSplineCurve,5>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->Degree, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcBSplineCurve to be a `INTEGER`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'ControlPointsList' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcBSplineCurve,5>::aux_is_derived[1]=true; break; }
         try { GenericConvert( in->ControlPointsList, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcBSplineCurve to be a `LIST [2:?] OF IfcCartesianPoint`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'CurveForm' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcBSplineCurve,5>::aux_is_derived[2]=true; break; }
         try { GenericConvert( in->CurveForm, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcBSplineCurve to be a `IfcBSplineCurveForm`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'ClosedCurve' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcBSplineCurve,5>::aux_is_derived[3]=true; break; }
         try { GenericConvert( in->ClosedCurve, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcBSplineCurve to be a `LOGICAL`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'SelfIntersect' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcBSplineCurve,5>::aux_is_derived[4]=true; break; }
         try { GenericConvert( in->SelfIntersect, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 4 to IfcBSplineCurve to be a `LOGICAL`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcBezierCurve>(const DB& db, const LIST& params, IfcBezierCurve* in)
@@ -476,8 +476,8 @@ template <> size_t GenericFill<IfcShellBasedSurfaceModel>(const DB& db, const LI
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->SbsmBoundary, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcShellBasedSurfaceModel to be a `SET [1:?] OF IfcShell`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcActionRequest>(const DB& db, const LIST& params, IfcActionRequest* in)
@@ -494,13 +494,13 @@ template <> size_t GenericFill<IfcExtrudedAreaSolid>(const DB& db, const LIST& p
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->ExtrudedDirection, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcExtrudedAreaSolid to be a `IfcDirection`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'Depth' argument
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Depth, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcExtrudedAreaSolid to be a `IfcPositiveLengthMeasure`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcSystem>(const DB& db, const LIST& params, IfcSystem* in)
@@ -524,13 +524,13 @@ template <> size_t GenericFill<IfcRelVoidsElement>(const DB& db, const LIST& par
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->RelatingBuildingElement, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 4 to IfcRelVoidsElement to be a `IfcElement`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'RelatedOpeningElement' argument
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->RelatedOpeningElement, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 5 to IfcRelVoidsElement to be a `IfcFeatureElementSubtraction`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcSurfaceCurveSweptAreaSolid>(const DB& db, const LIST& params, IfcSurfaceCurveSweptAreaSolid* in)
@@ -548,14 +548,14 @@ template <> size_t GenericFill<IfcCartesianTransformationOperator3DnonUniform>(c
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Scale2, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 5 to IfcCartesianTransformationOperator3DnonUniform to be a `REAL`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'Scale3' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Scale3, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 6 to IfcCartesianTransformationOperator3DnonUniform to be a `REAL`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcCurtainWallType>(const DB& db, const LIST& params, IfcCurtainWallType* in)
@@ -636,8 +636,8 @@ template <> size_t GenericFill<IfcAxis2Placement2D>(const DB& db, const LIST& pa
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->RefDirection, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcAxis2Placement2D to be a `IfcDirection`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcSpaceProgram>(const DB& db, const LIST& params, IfcSpaceProgram* in)
@@ -660,8 +660,8 @@ template <> size_t GenericFill<IfcCartesianPoint>(const DB& db, const LIST& para
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Coordinates, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcCartesianPoint to be a `LIST [1:3] OF IfcLengthMeasure`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcBoundedSurface>(const DB& db, const LIST& params, IfcBoundedSurface* in)
@@ -684,8 +684,8 @@ template <> size_t GenericFill<IfcPolyLoop>(const DB& db, const LIST& params, If
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Polygon, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcPolyLoop to be a `LIST [3:?] OF IfcCartesianPoint`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcTerminatorSymbol>(const DB& db, const LIST& params, IfcTerminatorSymbol* in)
@@ -718,15 +718,15 @@ template <> size_t GenericFill<IfcRepresentationContext>(const DB& db, const LIS
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->ContextIdentifier, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcRepresentationContext to be a `IfcLabel`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'ContextType' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcRepresentationContext,2>::aux_is_derived[1]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->ContextType, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcRepresentationContext to be a `IfcLabel`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcGeometricRepresentationContext>(const DB& db, const LIST& params, IfcGeometricRepresentationContext* in)
@@ -737,28 +737,28 @@ template <> size_t GenericFill<IfcGeometricRepresentationContext>(const DB& db, 
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcGeometricRepresentationContext,4>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->CoordinateSpaceDimension, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcGeometricRepresentationContext to be a `IfcDimensionCount`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'Precision' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcGeometricRepresentationContext,4>::aux_is_derived[1]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Precision, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcGeometricRepresentationContext to be a `REAL`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'WorldCoordinateSystem' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcGeometricRepresentationContext,4>::aux_is_derived[2]=true; break; }
         try { GenericConvert( in->WorldCoordinateSystem, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 4 to IfcGeometricRepresentationContext to be a `IfcAxis2Placement`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'TrueNorth' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcGeometricRepresentationContext,4>::aux_is_derived[3]=true; break; }
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->TrueNorth, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 5 to IfcGeometricRepresentationContext to be a `IfcDirection`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcCurveBoundedPlane>(const DB& db, const LIST& params, IfcCurveBoundedPlane* in)
@@ -776,13 +776,13 @@ template <> size_t GenericFill<IfcSIUnit>(const DB& db, const LIST& params, IfcS
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Prefix, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcSIUnit to be a `IfcSIPrefix`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'Name' argument
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Name, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcSIUnit to be a `IfcSIUnitName`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcStructuralReaction>(const DB& db, const LIST& params, IfcStructuralReaction* in)
@@ -807,8 +807,8 @@ template <> size_t GenericFill<IfcAxis1Placement>(const DB& db, const LIST& para
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Axis, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcAxis1Placement to be a `IfcDirection`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcElectricApplianceType>(const DB& db, const LIST& params, IfcElectricApplianceType* in)
@@ -860,13 +860,13 @@ template <> size_t GenericFill<IfcRepresentationMap>(const DB& db, const LIST& p
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->MappingOrigin, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcRepresentationMap to be a `IfcAxis2Placement`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'MappedRepresentation' argument
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->MappedRepresentation, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcRepresentationMap to be a `IfcRepresentation`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcClosedShell>(const DB& db, const LIST& params, IfcClosedShell* in)
@@ -1014,13 +1014,13 @@ template <> size_t GenericFill<IfcMeasureWithUnit>(const DB& db, const LIST& par
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->ValueComponent, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcMeasureWithUnit to be a `IfcValue`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'UnitComponent' argument
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->UnitComponent, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcMeasureWithUnit to be a `IfcUnit`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcSlabType>(const DB& db, const LIST& params, IfcSlabType* in)
@@ -1127,8 +1127,8 @@ template <> size_t GenericFill<IfcFaceBasedSurfaceModel>(const DB& db, const LIS
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->FbsmFaces, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcFaceBasedSurfaceModel to be a `SET [1:?] OF IfcConnectedFaceSet`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcEnergyConversionDevice>(const DB& db, const LIST& params, IfcEnergyConversionDevice* in)
@@ -1174,14 +1174,14 @@ template <> size_t GenericFill<IfcFaceBound>(const DB& db, const LIST& params, I
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcFaceBound,2>::aux_is_derived[0]=true; break; }
         try { GenericConvert( in->Bound, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcFaceBound to be a `IfcLoop`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'Orientation' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const ISDERIVED*>(&*arg)) { in->ObjectHelper<Assimp::IFC::Schema_2x3::IfcFaceBound,2>::aux_is_derived[1]=true; break; }
         try { GenericConvert( in->Orientation, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcFaceBound to be a `BOOLEAN`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcFaceOuterBound>(const DB& db, const LIST& params, IfcFaceOuterBound* in)
@@ -1218,13 +1218,13 @@ template <> size_t GenericFill<IfcComplexProperty>(const DB& db, const LIST& par
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->UsageName, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcComplexProperty to be a `IfcIdentifier`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'HasProperties' argument
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->HasProperties, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcComplexProperty to be a `SET [1:?] OF IfcProperty`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcFooting>(const DB& db, const LIST& params, IfcFooting* in)
@@ -1276,8 +1276,8 @@ template <> size_t GenericFill<IfcUnitAssignment>(const DB& db, const LIST& para
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Units, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcUnitAssignment to be a `SET [1:?] OF IfcUnit`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcFlowTerminal>(const DB& db, const LIST& params, IfcFlowTerminal* in)
@@ -1309,13 +1309,13 @@ template <> size_t GenericFill<IfcElementQuantity>(const DB& db, const LIST& par
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->MethodOfMeasurement, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 4 to IfcElementQuantity to be a `IfcLabel`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'Quantities' argument
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Quantities, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 5 to IfcElementQuantity to be a `SET [1:?] OF IfcPhysicalQuantity`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcCurtainWall>(const DB& db, const LIST& params, IfcCurtainWall* in)
@@ -1381,8 +1381,8 @@ template <> size_t GenericFill<IfcPresentationStyleAssignment>(const DB& db, con
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Styles, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcPresentationStyleAssignment to be a `SET [1:?] OF IfcPresentationStyleSelect`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcStructuralCurveMember>(const DB& db, const LIST& params, IfcStructuralCurveMember* in)
@@ -1420,14 +1420,14 @@ template <> size_t GenericFill<IfcSpace>(const DB& db, const LIST& params, IfcSp
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->InteriorOrExteriorSpace, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 9 to IfcSpace to be a `IfcInternalOrExternalEnum`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'ElevationWithFlooring' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->ElevationWithFlooring, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 10 to IfcSpace to be a `IfcLengthMeasure`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcHeatExchangerType>(const DB& db, const LIST& params, IfcHeatExchangerType* in)
@@ -1486,8 +1486,8 @@ template <> size_t GenericFill<IfcSurfaceStyleWithTextures>(const DB& db, const 
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Textures, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcSurfaceStyleWithTextures to be a `LIST [1:?] OF IfcSurfaceTexture`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcBoundingBox>(const DB& db, const LIST& params, IfcBoundingBox* in)
@@ -1497,23 +1497,23 @@ template <> size_t GenericFill<IfcBoundingBox>(const DB& db, const LIST& params,
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Corner, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 0 to IfcBoundingBox to be a `IfcCartesianPoint`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'XDim' argument
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->XDim, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcBoundingBox to be a `IfcPositiveLengthMeasure`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'YDim' argument
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->YDim, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcBoundingBox to be a `IfcPositiveLengthMeasure`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'ZDim' argument
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->ZDim, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcBoundingBox to be a `IfcPositiveLengthMeasure`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcWallType>(const DB& db, const LIST& params, IfcWallType* in)
@@ -1537,8 +1537,8 @@ template <> size_t GenericFill<IfcCircle>(const DB& db, const LIST& params, IfcC
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Radius, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcCircle to be a `IfcPositiveLengthMeasure`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcOffsetCurve2D>(const DB& db, const LIST& params, IfcOffsetCurve2D* in)
@@ -1625,13 +1625,13 @@ template <> size_t GenericFill<IfcConversionBasedUnit>(const DB& db, const LIST&
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->Name, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcConversionBasedUnit to be a `IfcLabel`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'ConversionFactor' argument
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->ConversionFactor, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcConversionBasedUnit to be a `IfcMeasureWithUnit`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcGeometricRepresentationSubContext>(const DB& db, const LIST& params, IfcGeometricRepresentationSubContext* in)
@@ -1746,13 +1746,13 @@ template <> size_t GenericFill<IfcEllipse>(const DB& db, const LIST& params, Ifc
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->SemiAxis1, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcEllipse to be a `IfcPositiveLengthMeasure`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'SemiAxis2' argument
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->SemiAxis2, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcEllipse to be a `IfcPositiveLengthMeasure`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcProductDefinitionShape>(const DB& db, const LIST& params, IfcProductDefinitionShape* in)
@@ -1818,8 +1818,8 @@ template <> size_t GenericFill<IfcPropertySet>(const DB& db, const LIST& params,
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->HasProperties, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 4 to IfcPropertySet to be a `SET [1:?] OF IfcProperty`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcSurfaceStyleRendering>(const DB& db, const LIST& params, IfcSurfaceStyleRendering* in)
@@ -1830,49 +1830,49 @@ template <> size_t GenericFill<IfcSurfaceStyleRendering>(const DB& db, const LIS
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->Transparency, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 1 to IfcSurfaceStyleRendering to be a `IfcNormalisedRatioMeasure`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'DiffuseColour' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->DiffuseColour, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 2 to IfcSurfaceStyleRendering to be a `IfcColourOrFactor`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'TransmissionColour' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->TransmissionColour, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 3 to IfcSurfaceStyleRendering to be a `IfcColourOrFactor`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'DiffuseTransmissionColour' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->DiffuseTransmissionColour, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 4 to IfcSurfaceStyleRendering to be a `IfcColourOrFactor`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'ReflectionColour' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->ReflectionColour, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 5 to IfcSurfaceStyleRendering to be a `IfcColourOrFactor`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'SpecularColour' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->SpecularColour, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 6 to IfcSurfaceStyleRendering to be a `IfcColourOrFactor`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'SpecularHighlight' argument
         std::shared_ptr<const DataType> arg = params[base++];
         if (dynamic_cast<const UNSET*>(&*arg)) break;
         try { GenericConvert( in->SpecularHighlight, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 7 to IfcSurfaceStyleRendering to be a `IfcSpecularHighlightSelect`")); }
-    } while(0);
+    } while (false);
     do { // convert the 'ReflectanceMethod' argument
         std::shared_ptr<const DataType> arg = params[base++];
         try { GenericConvert( in->ReflectanceMethod, arg, db ); break; }
         catch (const TypeError& t) { throw TypeError(t.what() + std::string(" - expected argument 8 to IfcSurfaceStyleRendering to be a `IfcReflectanceMethodEnum`")); }
-    } while(0);
-	return base;
+    } while (false);
+    return base;
 }
 // -----------------------------------------------------------------------------------------------------------
 template <> size_t GenericFill<IfcDistributionPort>(const DB& db, const LIST& params, IfcDistributionPort* in)

--- a/code/AssetLib/IQM/IQMImporter.cpp
+++ b/code/AssetLib/IQM/IQMImporter.cpp
@@ -127,7 +127,7 @@ const aiImporterDesc *IQMImporter::GetInfo() const {
 void IQMImporter::InternReadFile(const std::string &file, aiScene *pScene, IOSystem *pIOHandler) {
     // Read file into memory
     std::unique_ptr<IOStream> pStream(pIOHandler->Open(file, "rb"));
-    if (!pStream.get()) {
+    if (!pStream) {
         throw DeadlyImportError("Failed to open file ", file, ".");
     }
 

--- a/code/AssetLib/Irr/IRRLoader.cpp
+++ b/code/AssetLib/Irr/IRRLoader.cpp
@@ -842,11 +842,11 @@ void IRRImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
 	std::unique_ptr<IOStream> file(pIOHandler->Open(pFile));
 
 	// Check whether we can read from the file
-	if (file.get() == nullptr) {
+    if (file == nullptr) {
         throw DeadlyImportError("Failed to open IRR file ", pFile);
-	}
+    }
 
-	// Construct the irrXML parser
+    // Construct the irrXML parser
 	XmlParser st;
     if (!st.parse( file.get() )) {
         throw DeadlyImportError("XML parse error while loading IRR file ", pFile);

--- a/code/AssetLib/Irr/IRRMeshLoader.cpp
+++ b/code/AssetLib/Irr/IRRMeshLoader.cpp
@@ -120,7 +120,7 @@ void IRRMeshImporter::InternReadFile(const std::string &pFile,
 	std::unique_ptr<IOStream> file(pIOHandler->Open(pFile));
 
 	// Check whether we can read from the file
-	if (file.get() == NULL)
+    if (file == nullptr)
         throw DeadlyImportError("Failed to open IRRMESH file ", pFile);
 
 	// Construct the irrXML parser

--- a/code/AssetLib/Irr/IRRMeshLoader.cpp
+++ b/code/AssetLib/Irr/IRRMeshLoader.cpp
@@ -120,15 +120,15 @@ void IRRMeshImporter::InternReadFile(const std::string &pFile,
 	std::unique_ptr<IOStream> file(pIOHandler->Open(pFile));
 
 	// Check whether we can read from the file
-    if (file == nullptr)
-        throw DeadlyImportError("Failed to open IRRMESH file ", pFile);
+	if (file == nullptr)
+		throw DeadlyImportError("Failed to open IRRMESH file ", pFile);
 
 	// Construct the irrXML parser
 	XmlParser parser;
-    if (!parser.parse( file.get() )) {
-        throw DeadlyImportError("XML parse error while loading IRRMESH file ", pFile);
-    }
-    XmlNode root = parser.getRootNode();
+	if (!parser.parse( file.get() )) {
+		throw DeadlyImportError("XML parse error while loading IRRMESH file ", pFile);
+	}
+	XmlNode root = parser.getRootNode();
 
 	// final data
 	std::vector<aiMaterial *> materials;

--- a/code/AssetLib/LWO/LWOAnimation.cpp
+++ b/code/AssetLib/LWO/LWOAnimation.cpp
@@ -463,7 +463,7 @@ void AnimResolver::GetKeys(std::vector<aiVectorKey> &out,
     cur_z = envl_z->keys.begin();
 
     end_x = end_y = end_z = false;
-    while (1) {
+    while (true) {
 
         aiVectorKey fill;
 

--- a/code/AssetLib/LWO/LWOLoader.cpp
+++ b/code/AssetLib/LWO/LWOLoader.cpp
@@ -135,7 +135,7 @@ void LWOImporter::InternReadFile(const std::string &pFile,
     std::unique_ptr<IOStream> file(pIOHandler->Open(pFile, "rb"));
 
     // Check whether we can read from the file
-    if (file.get() == nullptr) {
+    if (file == nullptr) {
         throw DeadlyImportError("Failed to open LWO file ", pFile, ".");
     }
 

--- a/code/AssetLib/LWS/LWSLoader.cpp
+++ b/code/AssetLib/LWS/LWSLoader.cpp
@@ -494,7 +494,7 @@ void LWSImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
     std::unique_ptr<IOStream> file(pIOHandler->Open(pFile, "rb"));
 
     // Check whether we can read from the file
-    if (file.get() == nullptr) {
+    if (file == nullptr) {
         throw DeadlyImportError("Failed to open LWS file ", pFile, ".");
     }
 

--- a/code/AssetLib/MD2/MD2Loader.cpp
+++ b/code/AssetLib/MD2/MD2Loader.cpp
@@ -205,7 +205,7 @@ void MD2Importer::InternReadFile( const std::string& pFile,
     std::unique_ptr<IOStream> file( pIOHandler->Open( pFile));
 
     // Check whether we can read from the file
-    if (file.get() == nullptr) {
+    if (file == nullptr) {
         throw DeadlyImportError("Failed to open MD2 file ", pFile, "");
     }
 

--- a/code/AssetLib/MD3/MD3Loader.cpp
+++ b/code/AssetLib/MD3/MD3Loader.cpp
@@ -109,7 +109,7 @@ Q3Shader::BlendFunc StringToBlendFunc(const std::string &m) {
 // Load a Quake 3 shader
 bool Q3Shader::LoadShader(ShaderData &fill, const std::string &pFile, IOSystem *io) {
     std::unique_ptr<IOStream> file(io->Open(pFile, "rt"));
-    if (!file.get())
+    if (!file)
         return false; // if we can't access the file, don't worry and return
 
     ASSIMP_LOG_INFO("Loading Quake3 shader file ", pFile);
@@ -223,7 +223,7 @@ bool Q3Shader::LoadShader(ShaderData &fill, const std::string &pFile, IOSystem *
 // Load a Quake 3 skin
 bool Q3Shader::LoadSkin(SkinData &fill, const std::string &pFile, IOSystem *io) {
     std::unique_ptr<IOStream> file(io->Open(pFile, "rt"));
-    if (!file.get())
+    if (!file)
         return false; // if we can't access the file, don't worry and return
 
     ASSIMP_LOG_INFO("Loading Quake3 skin file ", pFile);
@@ -709,7 +709,7 @@ void MD3Importer::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
     std::unique_ptr<IOStream> file(pIOHandler->Open(pFile));
 
     // Check whether we can read from the file
-    if (file.get() == nullptr) {
+    if (file == nullptr) {
         throw DeadlyImportError("Failed to open MD3 file ", pFile, ".");
     }
 

--- a/code/AssetLib/MD5/MD5Loader.cpp
+++ b/code/AssetLib/MD5/MD5Loader.cpp
@@ -331,7 +331,7 @@ void MD5Importer::LoadMD5MeshFile() {
     std::unique_ptr<IOStream> file(mIOHandler->Open(filename, "rb"));
 
     // Check whether we can read from the file
-    if (file.get() == nullptr || !file->FileSize()) {
+    if (file == nullptr || !file->FileSize()) {
         ASSIMP_LOG_WARN("Failed to access MD5MESH file: ", filename);
         return;
     }
@@ -553,7 +553,7 @@ void MD5Importer::LoadMD5AnimFile() {
     std::unique_ptr<IOStream> file(mIOHandler->Open(pFile, "rb"));
 
     // Check whether we can read from the file
-    if (!file.get() || !file->FileSize()) {
+    if (!file || !file->FileSize()) {
         ASSIMP_LOG_WARN("Failed to read MD5ANIM file: ", pFile);
         return;
     }
@@ -661,7 +661,7 @@ void MD5Importer::LoadMD5CameraFile() {
     std::unique_ptr<IOStream> file(mIOHandler->Open(pFile, "rb"));
 
     // Check whether we can read from the file
-    if (!file.get() || !file->FileSize()) {
+    if (!file || !file->FileSize()) {
         throw DeadlyImportError("Failed to read MD5CAMERA file: ", pFile);
     }
     mHadMD5Camera = true;

--- a/code/AssetLib/MDC/MDCLoader.cpp
+++ b/code/AssetLib/MDC/MDCLoader.cpp
@@ -199,7 +199,7 @@ void MDCImporter::InternReadFile(
     std::unique_ptr<IOStream> file(pIOHandler->Open(pFile));
 
     // Check whether we can read from the file
-    if (file.get() == nullptr) {
+    if (file == nullptr) {
         throw DeadlyImportError("Failed to open MDC file ", pFile, ".");
     }
 

--- a/code/AssetLib/MDL/HalfLife/HL1MDLLoader.h
+++ b/code/AssetLib/MDL/HalfLife/HL1MDLLoader.h
@@ -222,7 +222,7 @@ void HL1MDLLoader::load_file_into_buffer(const std::string &file_path, unsigned 
 
     std::unique_ptr<IOStream> file(io_->Open(file_path));
 
-    if (file.get() == nullptr) {
+    if (file == nullptr) {
         throw DeadlyImportError("Failed to open MDL file ", DefaultIOSystem::fileName(file_path), ".");
     }
 

--- a/code/AssetLib/MDL/MDLLoader.cpp
+++ b/code/AssetLib/MDL/MDLLoader.cpp
@@ -159,7 +159,7 @@ void MDLImporter::InternReadFile(const std::string &pFile,
     std::unique_ptr<IOStream> file(pIOHandler->Open(pFile));
 
     // Check whether we can read from the file
-    if (file.get() == nullptr) {
+    if (file == nullptr) {
         throw DeadlyImportError("Failed to open MDL file ", pFile, ".");
     }
 

--- a/code/AssetLib/NDO/NDOLoader.cpp
+++ b/code/AssetLib/NDO/NDOLoader.cpp
@@ -268,7 +268,7 @@ void NDOImporter::InternReadFile( const std::string& pFile,
 
             const unsigned int key = v.first;
             unsigned int cur_edge = v.second;
-            while (1) {
+            while (true) {
                 unsigned int next_edge, next_vert;
                 if (key == obj.edges[cur_edge].edge[3]) {
                     next_edge = obj.edges[cur_edge].edge[5];

--- a/code/AssetLib/NFF/NFFLoader.cpp
+++ b/code/AssetLib/NFF/NFFLoader.cpp
@@ -129,7 +129,7 @@ void NFFImporter::LoadNFF2MaterialTable(std::vector<ShadingInfo> &output,
     std::unique_ptr<IOStream> file(pIOHandler->Open(path, "rb"));
 
     // Check whether we can read from the file
-    if (!file.get()) {
+    if (!file) {
         ASSIMP_LOG_ERROR("NFF2: Unable to open material library ", path, ".");
         return;
     }
@@ -211,7 +211,7 @@ void NFFImporter::InternReadFile(const std::string &pFile,
     std::unique_ptr<IOStream> file(pIOHandler->Open(pFile, "rb"));
 
     // Check whether we can read from the file
-    if (!file.get())
+    if (!file)
         throw DeadlyImportError("Failed to open NFF file ", pFile, ".");
 
     // allocate storage and copy the contents of the file to a memory buffer

--- a/code/AssetLib/OFF/OFFLoader.cpp
+++ b/code/AssetLib/OFF/OFFLoader.cpp
@@ -109,8 +109,8 @@ void OFFImporter::InternReadFile( const std::string& pFile, aiScene* pScene, IOS
     std::unique_ptr<IOStream> file( pIOHandler->Open( pFile, "rb"));
 
     // Check whether we can read from the file
-    if( file.get() == nullptr) {
-        throw DeadlyImportError( "Failed to open OFF file ", pFile, ".");
+    if (file == nullptr) {
+    throw DeadlyImportError("Failed to open OFF file ", pFile, ".");
     }
 
     // allocate storage and copy the contents of the file to a memory buffer

--- a/code/AssetLib/OFF/OFFLoader.cpp
+++ b/code/AssetLib/OFF/OFFLoader.cpp
@@ -110,7 +110,7 @@ void OFFImporter::InternReadFile( const std::string& pFile, aiScene* pScene, IOS
 
     // Check whether we can read from the file
     if (file == nullptr) {
-    throw DeadlyImportError("Failed to open OFF file ", pFile, ".");
+      throw DeadlyImportError("Failed to open OFF file ", pFile, ".");
     }
 
     // allocate storage and copy the contents of the file to a memory buffer

--- a/code/AssetLib/Obj/ObjFileImporter.cpp
+++ b/code/AssetLib/Obj/ObjFileImporter.cpp
@@ -108,7 +108,7 @@ void ObjFileImporter::InternReadFile(const std::string &file, aiScene *pScene, I
         pIOHandler->Close(pStream);
     };
     std::unique_ptr<IOStream, decltype(streamCloser)> fileStream(pIOHandler->Open(file, mode), streamCloser);
-    if (!fileStream.get()) {
+    if (!fileStream) {
         throw DeadlyImportError("Failed to open file ", file, ".");
     }
 

--- a/code/AssetLib/Ogre/OgreMaterial.cpp
+++ b/code/AssetLib/Ogre/OgreMaterial.cpp
@@ -111,7 +111,7 @@ void OgreImporter::AssignMaterials(aiScene *pScene, std::vector<aiMaterial *> &m
 
 aiMaterial *OgreImporter::ReadMaterial(const std::string &pFile, Assimp::IOSystem *pIOHandler, const std::string &materialName) {
     if (materialName.empty()) {
-        return 0;
+        return nullptr;
     }
 
     // Full reference and examples of Ogre Material Script
@@ -154,7 +154,7 @@ aiMaterial *OgreImporter::ReadMaterial(const std::string &pFile, Assimp::IOSyste
         if (!m_userDefinedMaterialLibFile.empty())
             potentialFiles.push_back(m_userDefinedMaterialLibFile);
 
-        IOStream *materialFile = 0;
+        IOStream *materialFile = nullptr;
         for (size_t i = 0; i < potentialFiles.size(); ++i) {
             materialFile = pIOHandler->Open(potentialFiles[i]);
             if (materialFile) {
@@ -164,13 +164,13 @@ aiMaterial *OgreImporter::ReadMaterial(const std::string &pFile, Assimp::IOSyste
         }
         if (!materialFile) {
             ASSIMP_LOG_ERROR("Failed to find source file for material '", materialName, "'");
-            return 0;
+            return nullptr;
         }
 
         std::unique_ptr<IOStream> stream(materialFile);
         if (stream->FileSize() == 0) {
             ASSIMP_LOG_WARN("Source file for material '", materialName, "' is empty (size is 0 bytes)");
-            return 0;
+            return nullptr;
         }
 
         // Read bytes

--- a/code/AssetLib/Ogre/OgreStructs.cpp
+++ b/code/AssetLib/Ogre/OgreStructs.cpp
@@ -296,7 +296,7 @@ uint32_t VertexData::VertexSize(uint16_t source) const {
 MemoryStream *VertexData::VertexBuffer(uint16_t source) {
     if (vertexBindings.find(source) != vertexBindings.end())
         return vertexBindings[source].get();
-    return 0;
+    return nullptr;
 }
 
 VertexElement *VertexData::GetVertexElement(VertexElement::Semantic semantic, uint16_t index) {
@@ -304,7 +304,7 @@ VertexElement *VertexData::GetVertexElement(VertexElement::Semantic semantic, ui
         if (element.semantic == semantic && element.index == index)
             return &element;
     }
-    return 0;
+    return nullptr;
 }
 
 // VertexDataXml
@@ -399,7 +399,7 @@ SubMesh *Mesh::GetSubMesh(size_t index) const {
             return subMeshes[i];
         }
     }
-    return 0;
+    return nullptr;
 }
 
 void Mesh::ConvertToAssimpScene(aiScene *dest) {
@@ -459,7 +459,7 @@ ISubMesh::ISubMesh() :
 // SubMesh
 
 SubMesh::SubMesh() :
-        vertexData(0),
+        vertexData(nullptr),
         indexData(new IndexData()) {
 }
 
@@ -515,9 +515,9 @@ aiMesh *SubMesh::ConvertToAssimpMesh(Mesh *parent) {
 
     // Source streams
     MemoryStream *positions = src->VertexBuffer(positionsElement->source);
-    MemoryStream *normals = (normalsElement ? src->VertexBuffer(normalsElement->source) : 0);
-    MemoryStream *uv1 = (uv1Element ? src->VertexBuffer(uv1Element->source) : 0);
-    MemoryStream *uv2 = (uv2Element ? src->VertexBuffer(uv2Element->source) : 0);
+    MemoryStream *normals = (normalsElement ? src->VertexBuffer(normalsElement->source) : nullptr);
+    MemoryStream *uv1 = (uv1Element ? src->VertexBuffer(uv1Element->source) : nullptr);
+    MemoryStream *uv2 = (uv2Element ? src->VertexBuffer(uv2Element->source) : nullptr);
 
     // Element size
     const size_t sizePosition = positionsElement->Size();
@@ -544,7 +544,7 @@ aiMesh *SubMesh::ConvertToAssimpMesh(Mesh *parent) {
             dest->mTextureCoords[0] = new aiVector3D[dest->mNumVertices];
         } else {
             ASSIMP_LOG_WARN("Ogre imported UV0 type ", uv1Element->TypeToString(), " is not compatible with Assimp. Ignoring UV.");
-            uv1 = 0;
+            uv1 = nullptr;
         }
     }
     if (uv2) {
@@ -553,12 +553,12 @@ aiMesh *SubMesh::ConvertToAssimpMesh(Mesh *parent) {
             dest->mTextureCoords[1] = new aiVector3D[dest->mNumVertices];
         } else {
             ASSIMP_LOG_WARN("Ogre imported UV0 type ", uv2Element->TypeToString(), " is not compatible with Assimp. Ignoring UV.");
-            uv2 = 0;
+            uv2 = nullptr;
         }
     }
 
-    aiVector3D *uv1Dest = (uv1 ? dest->mTextureCoords[0] : 0);
-    aiVector3D *uv2Dest = (uv2 ? dest->mTextureCoords[1] : 0);
+    aiVector3D *uv1Dest = (uv1 ? dest->mTextureCoords[0] : nullptr);
+    aiVector3D *uv2Dest = (uv2 ? dest->mTextureCoords[1] : nullptr);
 
     MemoryStream *faces = indexData->buffer.get();
     for (size_t fi = 0, isize = indexData->IndexSize(), fsize = indexData->FaceSize();
@@ -640,8 +640,8 @@ aiMesh *SubMesh::ConvertToAssimpMesh(Mesh *parent) {
 // MeshXml
 
 MeshXml::MeshXml() :
-        skeleton(0),
-        sharedVertexData(0) {
+        skeleton(nullptr),
+        sharedVertexData(nullptr) {
 }
 
 MeshXml::~MeshXml() {
@@ -666,7 +666,7 @@ SubMeshXml *MeshXml::GetSubMesh(uint16_t index) const {
     for (size_t i = 0; i < subMeshes.size(); ++i)
         if (subMeshes[i]->index == index)
             return subMeshes[i];
-    return 0;
+    return nullptr;
 }
 
 void MeshXml::ConvertToAssimpScene(aiScene *dest) {
@@ -714,7 +714,7 @@ void MeshXml::ConvertToAssimpScene(aiScene *dest) {
 
 SubMeshXml::SubMeshXml() :
         indexData(new IndexDataXml()),
-        vertexData(0) {
+        vertexData(nullptr) {
 }
 
 SubMeshXml::~SubMeshXml() {
@@ -827,7 +827,7 @@ Animation::Animation(Skeleton *parent) :
 
 Animation::Animation(Mesh *parent) :
         parentMesh(parent),
-        parentSkeleton(0),
+        parentSkeleton(nullptr),
         length(0.0f),
         baseTime(-1.0f) {
     // empty
@@ -910,7 +910,7 @@ Bone *Skeleton::BoneByName(const std::string &name) const {
         if ((*iter)->name == name)
             return (*iter);
     }
-    return 0;
+    return nullptr;
 }
 
 Bone *Skeleton::BoneById(uint16_t id) const {
@@ -918,20 +918,20 @@ Bone *Skeleton::BoneById(uint16_t id) const {
         if ((*iter)->id == id)
             return (*iter);
     }
-    return 0;
+    return nullptr;
 }
 
 // Bone
 
 Bone::Bone() :
         id(0),
-        parent(0),
+        parent(nullptr),
         parentId(-1),
         scale(1.0f, 1.0f, 1.0f) {
 }
 
 bool Bone::IsParented() const {
-    return (parentId != -1 && parent != 0);
+    return (parentId != -1 && parent != nullptr);
 }
 
 uint16_t Bone::ParentId() const {

--- a/code/AssetLib/Ogre/OgreStructs.h
+++ b/code/AssetLib/Ogre/OgreStructs.h
@@ -437,7 +437,7 @@ public:
     void CalculateWorldMatrixAndDefaultPose(Skeleton *skeleton);
 
     /// Convert to Assimp node (animation nodes).
-    aiNode *ConvertToAssimpNode(Skeleton *parent, aiNode *parentNode = 0);
+    aiNode *ConvertToAssimpNode(Skeleton *parent, aiNode *parentNode = nullptr);
 
     /// Convert to Assimp bone (mesh bones).
     aiBone *ConvertToAssimpBone(Skeleton *parent, const std::vector<aiVertexWeight> &boneWeights);

--- a/code/AssetLib/Ogre/OgreXmlSerializer.cpp
+++ b/code/AssetLib/Ogre/OgreXmlSerializer.cpp
@@ -535,7 +535,7 @@ XmlParserPtr OgreXmlSerializer::OpenXmlParser(Assimp::IOSystem *pIOHandler, cons
     }
 
     std::unique_ptr<IOStream> file(pIOHandler->Open(filename));
-    if (!file.get()) {
+    if (!file) {
         throw DeadlyImportError("Failed to open skeleton file ", filename);
     }
 

--- a/code/AssetLib/Ply/PlyLoader.cpp
+++ b/code/AssetLib/Ply/PlyLoader.cpp
@@ -133,7 +133,7 @@ static bool isBigEndian(const char *szMe) {
 void PLYImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSystem *pIOHandler) {
     const std::string mode = "rb";
     std::unique_ptr<IOStream> fileStream(pIOHandler->Open(pFile, mode));
-    if (!fileStream.get()) {
+    if (!fileStream) {
         throw DeadlyImportError("Failed to open file ", pFile, ".");
     }
 

--- a/code/AssetLib/Raw/RawLoader.cpp
+++ b/code/AssetLib/Raw/RawLoader.cpp
@@ -96,7 +96,7 @@ void RAWImporter::InternReadFile(const std::string &pFile,
     std::unique_ptr<IOStream> file(pIOHandler->Open(pFile, "rb"));
 
     // Check whether we can read from the file
-    if (file.get() == nullptr) {
+    if (file == nullptr) {
         throw DeadlyImportError("Failed to open RAW file ", pFile, ".");
     }
 

--- a/code/AssetLib/SMD/SMDLoader.cpp
+++ b/code/AssetLib/SMD/SMDLoader.cpp
@@ -535,7 +535,7 @@ void SMDImporter::GetAnimationFileList(const std::string &pFile, IOSystem* pIOHa
     auto path = base + "/" + name + "_animation.txt";
 
     std::unique_ptr<IOStream> file(pIOHandler->Open(path.c_str(), "rb"));
-    if (file.get() == nullptr) {
+    if (file == nullptr) {
         return;
     }
 
@@ -675,7 +675,7 @@ void SMDImporter::ReadSmd(const std::string &pFile, IOSystem* pIOHandler) {
     std::unique_ptr<IOStream> file(pIOHandler->Open(pFile, "rb"));
 
     // Check whether we can read from the file
-    if (file.get() == nullptr) {
+    if (file == nullptr) {
         throw DeadlyImportError("Failed to open SMD/VTA file ", pFile, ".");
     }
 

--- a/code/AssetLib/STL/STLLoader.cpp
+++ b/code/AssetLib/STL/STLLoader.cpp
@@ -166,7 +166,7 @@ void STLImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
     std::unique_ptr<IOStream> file(pIOHandler->Open(pFile, "rb"));
 
     // Check whether we can read from the file
-    if (file.get() == nullptr) {
+    if (file == nullptr) {
         throw DeadlyImportError("Failed to open STL file ", pFile, ".");
     }
 

--- a/code/AssetLib/Step/STEPFile.h
+++ b/code/AssetLib/Step/STEPFile.h
@@ -195,7 +195,7 @@ public:
     template <typename T>
     const T *ResolveSelectPtr(const DB &db) const {
         const EXPRESS::ENTITY *e = ToPtr<EXPRESS::ENTITY>();
-        return e ? Couple<T>(db).MustGetObject(*e)->template ToPtr<T>() : (const T *)0;
+        return e ? Couple<T>(db).MustGetObject(*e)->template ToPtr<T>() : (const T *)nullptr;
     }
 
 public:
@@ -207,7 +207,7 @@ public:
      */
     static std::shared_ptr<const EXPRESS::DataType> Parse(const char *&inout,
             uint64_t line = SyntaxError::LINE_NOT_SPECIFIED,
-            const EXPRESS::ConversionSchema *schema = NULL);
+            const EXPRESS::ConversionSchema *schema = nullptr);
 };
 
 typedef DataType SELECT;
@@ -306,7 +306,7 @@ public:
      */
     static std::shared_ptr<const EXPRESS::LIST> Parse(const char *&inout,
             uint64_t line = SyntaxError::LINE_NOT_SPECIFIED,
-            const EXPRESS::ConversionSchema *schema = NULL);
+            const EXPRESS::ConversionSchema *schema = nullptr);
 
 private:
     typedef std::vector<std::shared_ptr<const DataType>> MemberList;

--- a/code/AssetLib/Unreal/UnrealLoader.cpp
+++ b/code/AssetLib/Unreal/UnrealLoader.cpp
@@ -315,7 +315,7 @@ void UnrealImporter::InternReadFile(const std::string &pFile,
 
     // we can live without the uc file if necessary
     std::unique_ptr<IOStream> pb(pIOHandler->Open(uc_path));
-    if (pb.get()) {
+    if (pb) {
 
         std::vector<char> _data;
         TextFileToBuffer(pb.get(), _data);

--- a/code/AssetLib/X/XFileImporter.cpp
+++ b/code/AssetLib/X/XFileImporter.cpp
@@ -97,7 +97,7 @@ const aiImporterDesc* XFileImporter::GetInfo () const {
 void XFileImporter::InternReadFile( const std::string& pFile, aiScene* pScene, IOSystem* pIOHandler) {
     // read file into memory
     std::unique_ptr<IOStream> file( pIOHandler->Open( pFile));
-    if ( file.get() == nullptr ) {
+    if (file == nullptr) {
         throw DeadlyImportError( "Failed to open file ", pFile, "." );
     }
 

--- a/code/AssetLib/X3D/X3DImporter.cpp
+++ b/code/AssetLib/X3D/X3DImporter.cpp
@@ -207,7 +207,7 @@ void X3DImporter::ParseFile(const std::string &file, IOSystem *pIOHandler) {
 
     static const std::string mode = "rb";
     std::unique_ptr<IOStream> fileStream(pIOHandler->Open(file, mode));
-    if (!fileStream.get()) {
+    if (!fileStream) {
         throw DeadlyImportError("Failed to open file " + file + ".");
     }
 

--- a/code/AssetLib/XGL/XGLLoader.cpp
+++ b/code/AssetLib/XGL/XGLLoader.cpp
@@ -54,6 +54,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/mesh.h>
 #include <assimp/scene.h>
 
+#include <memory>
 #include <utility>
 //#include <cctype>
 //#include <memory>
@@ -121,11 +122,11 @@ void XGLImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
 	std::shared_ptr<IOStream> stream(pIOHandler->Open(pFile, "rb"));
 
 	// check whether we can read from the file
-	if (stream.get() == NULL) {
-		throw DeadlyImportError("Failed to open XGL/ZGL file " + pFile);
-	}
+    if (stream == nullptr) {
+        throw DeadlyImportError("Failed to open XGL/ZGL file " + pFile);
+    }
 
-	// see if its compressed, if so uncompress it
+    // see if its compressed, if so uncompress it
 	if (GetExtension(pFile) == "zgl") {
 #ifdef ASSIMP_BUILD_NO_COMPRESSED_XGL
 		ThrowException("Cannot read ZGL file since Assimp was built without compression support");
@@ -141,7 +142,7 @@ void XGLImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
             compression.close();
         }
 		// replace the input stream with a memory stream
-		stream.reset(new MemoryIOStream(reinterpret_cast<uint8_t*>(uncompressed.data()), total));
+        stream = std::make_shared<MemoryIOStream>(reinterpret_cast<uint8_t *>(uncompressed.data()), total);
 #endif
 	}
 

--- a/code/AssetLib/glTF/glTFAsset.h
+++ b/code/AssetLib/glTF/glTFAsset.h
@@ -374,7 +374,7 @@ struct Accessor : public Object {
         }
 
         inline bool IsValid() const {
-            return data != 0;
+            return data != nullptr;
         }
     };
 
@@ -873,7 +873,7 @@ class LazyDict : public LazyDictBase {
     Ref<T> Add(T *obj);
 
 public:
-    LazyDict(Asset &asset, const char *dictId, const char *extId = 0);
+    LazyDict(Asset &asset, const char *dictId, const char *extId = nullptr);
     ~LazyDict();
 
     Ref<T> Get(const char *id);
@@ -970,17 +970,17 @@ public:
     Ref<Scene> scene;
 
 public:
-    Asset(IOSystem *io = 0) :
-            mIOSystem(io), 
-            asset(), 
-            accessors(*this, "accessors"), 
-            animations(*this, "animations"), 
-            buffers(*this, "buffers"), 
-            bufferViews(*this, "bufferViews"), 
-            cameras(*this, "cameras"), 
-            images(*this, "images"), 
-            materials(*this, "materials"), 
-            meshes(*this, "meshes"), 
+    Asset(IOSystem *io = nullptr) :
+            mIOSystem(io),
+            asset(),
+            accessors(*this, "accessors"),
+            animations(*this, "animations"),
+            buffers(*this, "buffers"),
+            bufferViews(*this, "bufferViews"),
+            cameras(*this, "cameras"),
+            images(*this, "images"),
+            materials(*this, "materials"),
+            meshes(*this, "meshes"),
             nodes(*this, "nodes"),
             samplers(*this, "samplers"),
             scenes(*this, "scenes"),

--- a/code/AssetLib/glTF/glTFAsset.inl
+++ b/code/AssetLib/glTF/glTFAsset.inl
@@ -68,7 +68,7 @@ using namespace glTFCommon;
 
 template <class T>
 inline LazyDict<T>::LazyDict(Asset &asset, const char *dictId, const char *extId) :
-        mDictId(dictId), mExtId(extId), mDict(0), mAsset(asset) {
+        mDictId(dictId), mExtId(extId), mDict(nullptr), mAsset(asset) {
     asset.mDicts.push_back(this); // register to the list of dictionaries
 }
 
@@ -81,7 +81,7 @@ inline LazyDict<T>::~LazyDict() {
 
 template <class T>
 inline void LazyDict<T>::AttachToDocument(Document &doc) {
-    Value *container = 0;
+    Value *container = nullptr;
 
     if (mExtId) {
         if (Value *exts = FindObject(doc, "extensions")) {
@@ -98,7 +98,7 @@ inline void LazyDict<T>::AttachToDocument(Document &doc) {
 
 template <class T>
 inline void LazyDict<T>::DetachFromDocument() {
-    mDict = 0;
+    mDict = nullptr;
 }
 
 template <class T>
@@ -194,7 +194,7 @@ inline void Buffer::Read(Value &obj, Asset &r) {
     glTFCommon::Util::DataURI dataURI;
     if (ParseDataURI(uri, it->GetStringLength(), dataURI)) {
         if (dataURI.base64) {
-            uint8_t *data = 0;
+            uint8_t *data = nullptr;
             this->byteLength = Base64::Decode(dataURI.data, dataURI.dataLength, data);
             this->mData.reset(data, std::default_delete<uint8_t[]>());
 
@@ -383,9 +383,9 @@ inline unsigned int Accessor::GetElementSize() {
 }
 
 inline uint8_t *Accessor::GetPointer() {
-    if (!bufferView || !bufferView->buffer) return 0;
+    if (!bufferView || !bufferView->buffer) return nullptr;
     uint8_t *basePtr = bufferView->buffer->GetPointer();
-    if (!basePtr) return 0;
+    if (!basePtr) return nullptr;
 
     size_t offset = byteOffset + bufferView->byteOffset;
 
@@ -698,7 +698,7 @@ inline void Mesh::Read(Value &pJSON_Object, Asset &pAsset_Root) {
                     // and WEIGHT.Attribute semantics can be of the form[semantic]_[set_index], e.g., TEXCOORD_0, TEXCOORD_1, etc.
 
                     int undPos = 0;
-                    Mesh::AccessorList *vec = 0;
+                    Mesh::AccessorList *vec = nullptr;
                     if (GetAttribVector(prim, attr, vec, undPos)) {
                         size_t idx = (attr[undPos] == '_') ? atoi(attr + undPos + 1) : 0;
                         if ((*vec).size() <= idx) (*vec).resize(idx + 1);

--- a/code/AssetLib/glTF/glTFAssetWriter.inl
+++ b/code/AssetLib/glTF/glTFAssetWriter.inl
@@ -525,7 +525,7 @@ namespace glTF {
     {
         std::unique_ptr<IOStream> jsonOutFile(mAsset.OpenFile(path, "wt", true));
 
-        if (jsonOutFile == 0) {
+        if (jsonOutFile == nullptr) {
             throw DeadlyExportError("Could not open output file: " + std::string(path));
         }
 
@@ -548,7 +548,7 @@ namespace glTF {
 
             std::unique_ptr<IOStream> binOutFile(mAsset.OpenFile(binPath, "wb", true));
 
-            if (binOutFile == 0) {
+            if (binOutFile == nullptr) {
                 throw DeadlyExportError("Could not open output file: " + binPath);
             }
 
@@ -564,7 +564,7 @@ namespace glTF {
     {
         std::unique_ptr<IOStream> outfile(mAsset.OpenFile(path, "wb", true));
 
-        if (outfile == 0) {
+        if (outfile == nullptr) {
             throw DeadlyExportError("Could not open output file: " + std::string(path));
         }
 

--- a/code/AssetLib/glTF/glTFCommon.h
+++ b/code/AssetLib/glTF/glTFCommon.h
@@ -259,7 +259,7 @@ class Ref {
 
 public:
     Ref() :
-            vector(0),
+            vector(nullptr),
             index(0) {}
     Ref(std::vector<T *> &vec, unsigned int idx) :
             vector(&vec),
@@ -495,22 +495,22 @@ inline Value *FindExtension(Value &val, const char *extensionId) {
 
 inline Value *FindString(Value &val, const char *id) {
     Value::MemberIterator it = val.FindMember(id);
-    return (it != val.MemberEnd() && it->value.IsString()) ? &it->value : 0;
+    return (it != val.MemberEnd() && it->value.IsString()) ? &it->value : nullptr;
 }
 
 inline Value *FindObject(Value &val, const char *id) {
     Value::MemberIterator it = val.FindMember(id);
-    return (it != val.MemberEnd() && it->value.IsObject()) ? &it->value : 0;
+    return (it != val.MemberEnd() && it->value.IsObject()) ? &it->value : nullptr;
 }
 
 inline Value *FindArray(Value &val, const char *id) {
     Value::MemberIterator it = val.FindMember(id);
-    return (it != val.MemberEnd() && it->value.IsArray()) ? &it->value : 0;
+    return (it != val.MemberEnd() && it->value.IsArray()) ? &it->value : nullptr;
 }
 
 inline Value *FindNumber(Value &val, const char *id) {
     Value::MemberIterator it = val.FindMember(id);
-    return (it != val.MemberEnd() && it->value.IsNumber()) ? &it->value : 0;
+    return (it != val.MemberEnd() && it->value.IsNumber()) ? &it->value : nullptr;
 }
 
 } // namespace glTFCommon

--- a/code/AssetLib/glTF/glTFExporter.cpp
+++ b/code/AssetLib/glTF/glTFExporter.cpp
@@ -111,7 +111,7 @@ glTFExporter::glTFExporter(const char* filename, IOSystem* pIOSystem, const aiSc
 
     mScene.reset(sceneCopy_tmp);
 
-    mAsset.reset( new glTF::Asset( pIOSystem ) );
+    mAsset = std::make_shared<glTF::Asset>(pIOSystem);
 
     if (isBinary) {
         mAsset->SetAsBinary();

--- a/code/AssetLib/glTF/glTFImporter.cpp
+++ b/code/AssetLib/glTF/glTFImporter.cpp
@@ -283,7 +283,7 @@ void glTFImporter::ImportMeshes(glTF::Asset &r) {
                 }
             }
 
-            aiFace *faces = 0;
+            aiFace *faces = nullptr;
             unsigned int nFaces = 0;
 
             if (prim.indices) {

--- a/code/AssetLib/glTF2/glTF2Asset.h
+++ b/code/AssetLib/glTF2/glTF2Asset.h
@@ -1044,7 +1044,7 @@ class LazyDict : public LazyDictBase {
     Ref<T> Add(T *obj);
 
 public:
-    LazyDict(Asset &asset, const char *dictId, const char *extId = 0);
+    LazyDict(Asset &asset, const char *dictId, const char *extId = nullptr);
     ~LazyDict();
 
     Ref<T> Retrieve(unsigned int i);

--- a/code/AssetLib/glTF2/glTF2Asset.inl
+++ b/code/AssetLib/glTF2/glTF2Asset.inl
@@ -371,7 +371,7 @@ template <class T>
 inline LazyDict<T>::LazyDict(Asset &asset, const char *dictId, const char *extId) :
         mDictId(dictId),
         mExtId(extId),
-        mDict(0),
+        mDict(nullptr),
         mAsset(asset) {
     asset.mDicts.push_back(this); // register to the list of dictionaries
 }
@@ -903,7 +903,7 @@ inline void Accessor::Read(Value &obj, Asset &r) {
 
         const unsigned int elementSize = GetElementSize();
         const size_t dataSize = count * elementSize;
-        sparse->PopulateData(dataSize, bufferView ? bufferView->GetPointer(byteOffset) : 0);
+        sparse->PopulateData(dataSize, bufferView ? bufferView->GetPointer(byteOffset) : nullptr);
         sparse->PatchData(elementSize);
     }
 }

--- a/code/AssetLib/glTF2/glTF2AssetWriter.inl
+++ b/code/AssetLib/glTF2/glTF2AssetWriter.inl
@@ -758,7 +758,7 @@ namespace glTF2 {
     {
         std::unique_ptr<IOStream> jsonOutFile(mAsset.OpenFile(path, "wt", true));
 
-        if (jsonOutFile == 0) {
+        if (jsonOutFile == nullptr) {
             throw DeadlyExportError("Could not open output file: " + std::string(path));
         }
 
@@ -781,7 +781,7 @@ namespace glTF2 {
 
             std::unique_ptr<IOStream> binOutFile(mAsset.OpenFile(binPath, "wb", true));
 
-            if (binOutFile == 0) {
+            if (binOutFile == nullptr) {
                 throw DeadlyExportError("Could not open output file: " + binPath);
             }
 
@@ -797,7 +797,7 @@ namespace glTF2 {
     {
         std::unique_ptr<IOStream> outfile(mAsset.OpenFile(path, "wb", true));
 
-        if (outfile == 0) {
+        if (outfile == nullptr) {
             throw DeadlyExportError("Could not open output file: " + std::string(path));
         }
 

--- a/code/AssetLib/glTF2/glTF2Exporter.cpp
+++ b/code/AssetLib/glTF2/glTF2Exporter.cpp
@@ -321,7 +321,7 @@ inline size_t NZDiff(ComponentType compType, void *data, void *dataBase, size_t 
 }
 
 inline Ref<Accessor> ExportDataSparse(Asset &a, std::string &meshName, Ref<Buffer> &buffer,
-        size_t count, void *data, AttribType::Value typeIn, AttribType::Value typeOut, ComponentType compType, BufferViewTarget target = BufferViewTarget_NONE, void *dataBase = 0) {
+        size_t count, void *data, AttribType::Value typeIn, AttribType::Value typeOut, ComponentType compType, BufferViewTarget target = BufferViewTarget_NONE, void *dataBase = nullptr) {
     if (!count || !data) {
         return Ref<Accessor>();
     }
@@ -356,7 +356,7 @@ inline Ref<Accessor> ExportDataSparse(Asset &a, std::string &meshName, Ref<Buffe
     acc->type = typeOut;
 
     if (data) {
-        void *nzDiff = 0, *nzIdx = 0;
+        void *nzDiff = nullptr, *nzIdx = nullptr;
         size_t nzCount = NZDiff(compType, data, dataBase, count, numCompsIn, numCompsOut, nzDiff, nzIdx);
         acc->sparse.reset(new Accessor::Sparse);
         acc->sparse->count = nzCount;

--- a/code/Common/Assimp.cpp
+++ b/code/Common/Assimp.cpp
@@ -1131,7 +1131,7 @@ ASSIMP_API void aiMatrix4RotationX(
 ASSIMP_API void aiMatrix4RotationY(
         C_STRUCT aiMatrix4x4 *mat,
         const float angle) {
-    ai_assert(NULL != mat);
+    ai_assert(nullptr != mat);
     aiMatrix4x4::RotationY(angle, *mat);
 }
 

--- a/code/Common/Exporter.cpp
+++ b/code/Common/Exporter.cpp
@@ -595,7 +595,7 @@ bool ExportProperties::SetPropertyCallback(const char *szName, const std::functi
 }
 
 std::function<void *(void *)> ExportProperties::GetPropertyCallback(const char *szName) const {
-    return GetGenericProperty<std::function<void *(void *)>>(mCallbackProperties, szName, 0);
+    return GetGenericProperty<std::function<void *(void *)>>(mCallbackProperties, szName, nullptr);
 }
 
 bool ExportProperties::HasPropertyCallback(const char *szName) const {

--- a/code/Common/IFF.h
+++ b/code/Common/IFF.h
@@ -122,7 +122,7 @@ inline const char* ReadHeader(uint8_t* outFile, uint32_t& fileType)
     }
     ::memcpy(&fileType, outFile, 4);
     AI_LSWAP4(fileType);
-    return 0;
+    return nullptr;
 }
 
 

--- a/code/Common/ZipArchiveIOSystem.cpp
+++ b/code/Common/ZipArchiveIOSystem.cpp
@@ -121,7 +121,7 @@ voidpf IOSystem2Unzip::open(voidpf opaque, const char *filename, int mode) {
 
 voidpf IOSystem2Unzip::opendisk(voidpf opaque, voidpf stream, uint32_t number_disk, int mode) {
     ZipFile *io_stream = (ZipFile *)stream;
-    voidpf ret = NULL;
+    voidpf ret = nullptr;
     int i;
 
     char *disk_filename = (char*)malloc(io_stream->m_Filename.length() + 1);

--- a/code/PostProcessing/DeboneProcess.cpp
+++ b/code/PostProcessing/DeboneProcess.cpp
@@ -133,9 +133,9 @@ void DeboneProcess::Execute( aiScene* pScene)
 
                 // store new meshes and indices of the new meshes
                 for(unsigned int b=0;b<newMeshes.size();b++)    {
-                    const aiString *find = newMeshes[b].second?&newMeshes[b].second->mName:0;
+                    const aiString *find = newMeshes[b].second ? &newMeshes[b].second->mName : nullptr;
 
-                    aiNode *theNode = find?pScene->mRootNode->FindNode(*find):0;
+                    aiNode *theNode = find ? pScene->mRootNode->FindNode(*find) : nullptr;
                     std::pair<unsigned int,aiNode*> push_pair(static_cast<unsigned int>(meshes.size()),theNode);
 
                     mSubMeshIndices[a].push_back(push_pair);
@@ -153,7 +153,7 @@ void DeboneProcess::Execute( aiScene* pScene)
             }
             else    {
                 // Mesh is kept unchanged - store it's new place in the mesh array
-                mSubMeshIndices[a].emplace_back(static_cast<unsigned int>(meshes.size()), (aiNode *)0);
+                mSubMeshIndices[a].emplace_back(static_cast<unsigned int>(meshes.size()), (aiNode *)nullptr);
                 meshes.push_back(srcMesh);
             }
         }
@@ -341,7 +341,7 @@ void DeboneProcess::SplitMesh( const aiMesh* pMesh, std::vector< std::pair< aiMe
         }
 
         aiMesh *baseMesh = MakeSubmesh(pMesh,subFaces,0);
-        std::pair<aiMesh*,const aiBone*> push_pair(baseMesh,(const aiBone*)0);
+        std::pair<aiMesh *, const aiBone *> push_pair(baseMesh, (const aiBone *)nullptr);
 
         poNewMeshes.push_back(push_pair);
     }

--- a/code/PostProcessing/MakeVerboseFormat.cpp
+++ b/code/PostProcessing/MakeVerboseFormat.cpp
@@ -93,8 +93,8 @@ bool MakeVerboseFormatProcess::MakeVerboseFormat(aiMesh *pcMesh) {
         pvBitangents = new aiVector3D[iNumVerts];
     }
 
-    aiVector3D *apvTextureCoords[AI_MAX_NUMBER_OF_TEXTURECOORDS] = { 0 };
-    aiColor4D *apvColorSets[AI_MAX_NUMBER_OF_COLOR_SETS] = { 0 };
+    aiVector3D *apvTextureCoords[AI_MAX_NUMBER_OF_TEXTURECOORDS] = { nullptr };
+    aiColor4D *apvColorSets[AI_MAX_NUMBER_OF_COLOR_SETS] = { nullptr };
 
     unsigned int p = 0;
     while (pcMesh->HasTextureCoords(p))

--- a/test/unit/Common/utSpatialSort.cpp
+++ b/test/unit/Common/utSpatialSort.cpp
@@ -51,7 +51,7 @@ public
 
 protected:
     void SetUp() override {
-        ::srand(static_cast<unsigned>(time(0)));
+        ::srand(static_cast<unsigned>(time(nullptr)));
         vecs = new aiVector3D[100];
         for (size_t i = 0; i < 100; ++i) {
             vecs[i].x = static_cast<float>(rand()) / (static_cast<float>(RAND_MAX / 100));

--- a/test/unit/TestIOSystem.h
+++ b/test/unit/TestIOSystem.h
@@ -73,7 +73,7 @@ public:
     virtual IOStream* Open( const char* pFile, const char* pMode = "rb" ) {
         EXPECT_NE( nullptr, pFile );
         EXPECT_NE( nullptr, pMode );
-        return NULL;
+        return nullptr;
     }
 
     virtual void Close( IOStream* pFile ) {

--- a/test/unit/TestModelFactory.h
+++ b/test/unit/TestModelFactory.h
@@ -67,7 +67,7 @@ public:
         aiColor3D color( 1, 0, 0 );
         EXPECT_EQ( AI_SUCCESS, scene->mMaterials[ 0 ]->AddProperty( &color, 1, AI_MATKEY_COLOR_DIFFUSE ) );
 
-        ::srand( static_cast< unsigned int >( ::time( NULL ) ) );
+        ::srand(static_cast<unsigned int>(::time(nullptr)));
         opacity = float( rand() ) / float( RAND_MAX );
         EXPECT_EQ( AI_SUCCESS, scene->mMaterials[ 0 ]->AddProperty( &opacity, 1, AI_MATKEY_OPACITY ) );
 

--- a/test/unit/utBlendImportMaterials.cpp
+++ b/test/unit/utBlendImportMaterials.cpp
@@ -62,7 +62,7 @@ protected:
 // ------------------------------------------------------------------------------------------------
 TEST_F(BlendImportMaterials, testImportMaterial) {
     const aiScene *pTest = im->ReadFile(ASSIMP_TEST_MODELS_DIR "/BLEND/BlenderMaterial_269.blend", aiProcess_ValidateDataStructure);
-    ASSERT_TRUE(pTest != NULL);
+    ASSERT_TRUE(pTest != nullptr);
     ASSERT_TRUE(pTest->HasMaterials());
 
     ASSERT_EQ(1U, pTest->mNumMaterials);
@@ -121,7 +121,7 @@ TEST_F(BlendImportMaterials, testImportMaterial) {
 
 TEST_F(BlendImportMaterials, testImportMaterialwith2texturesAnd2TexCoordMappings) {
     const aiScene *pTest = im->ReadFile(ASSIMP_TEST_MODELS_DIR "/BLEND/plane_2_textures_2_texcoords_279.blend", aiProcess_ValidateDataStructure);
-    ASSERT_TRUE(pTest != NULL);
+    ASSERT_TRUE(pTest != nullptr);
 
     // material has 2 diffuse textures
     ASSERT_TRUE(pTest->HasMaterials());

--- a/test/unit/utBlenderWork.cpp
+++ b/test/unit/utBlenderWork.cpp
@@ -62,7 +62,7 @@ protected:
 
 TEST_F(BlenderWorkTest, work_279) {
     const aiScene *pTest = im->ReadFile(ASSIMP_TEST_MODELS_DIR "/BLEND/test_279.blend", aiProcess_ValidateDataStructure);
-    ASSERT_TRUE(pTest != NULL);
+    ASSERT_TRUE(pTest != nullptr);
 
     // material has 2 diffuse textures
     ASSERT_TRUE(pTest->HasMaterials());

--- a/test/unit/utColladaExport.cpp
+++ b/test/unit/utColladaExport.cpp
@@ -169,7 +169,7 @@ TEST_F(utColladaExport, testExportLight) {
 
     const aiScene *imported = im->ReadFile(file, aiProcess_ValidateDataStructure);
 
-    ASSERT_TRUE(imported != NULL);
+    ASSERT_TRUE(imported != nullptr);
 
     // Check common metadata survived roundtrip
     aiString readImporter;

--- a/test/unit/utFindInvalidData.cpp
+++ b/test/unit/utFindInvalidData.cpp
@@ -115,17 +115,17 @@ TEST_F(utFindInvalidDataProcess, testStepNegativeResult) {
 
     mProcess->ProcessMesh(mMesh);
 
-    EXPECT_TRUE(NULL != mMesh->mVertices);
-    EXPECT_EQ(NULL, mMesh->mNormals);
-    EXPECT_EQ(NULL, mMesh->mTangents);
-    EXPECT_EQ(NULL, mMesh->mBitangents);
+    EXPECT_TRUE(nullptr != mMesh->mVertices);
+    EXPECT_EQ(nullptr, mMesh->mNormals);
+    EXPECT_EQ(nullptr, mMesh->mTangents);
+    EXPECT_EQ(nullptr, mMesh->mBitangents);
 
     for (unsigned int i = 0; i < 2; ++i) {
-        EXPECT_TRUE(NULL != mMesh->mTextureCoords[i]);
+        EXPECT_TRUE(nullptr != mMesh->mTextureCoords[i]);
     }
 
     for (unsigned int i = 2; i < AI_MAX_NUMBER_OF_TEXTURECOORDS; ++i) {
-        EXPECT_EQ(NULL, mMesh->mTextureCoords[i]);
+        EXPECT_EQ(nullptr, mMesh->mTextureCoords[i]);
     }
 }
 

--- a/test/unit/utGenNormals.cpp
+++ b/test/unit/utGenNormals.cpp
@@ -82,5 +82,5 @@ void GenNormalsTest::TearDown() {
 // ------------------------------------------------------------------------------------------------
 TEST_F(GenNormalsTest, testSimpleTriangle) {
     piProcess->GenMeshVertexNormals(pcMesh, 0);
-    EXPECT_TRUE(pcMesh->mNormals != NULL);
+    EXPECT_TRUE(pcMesh->mNormals != nullptr);
 }

--- a/test/unit/utImporter.cpp
+++ b/test/unit/utImporter.cpp
@@ -174,7 +174,7 @@ TEST_F(ImporterTest, testMemoryRead) {
     const aiScene *sc = pImp->ReadFileFromMemory(InputData_abRawBlock, InputData_BLOCK_SIZE,
             aiProcessPreset_TargetRealtime_Quality, "3ds");
 
-    ASSERT_TRUE(sc != NULL);
+    ASSERT_TRUE(sc != nullptr);
     EXPECT_EQ(aiString("<3DSRoot>"), sc->mRootNode->mName);
     EXPECT_EQ(1U, sc->mNumMeshes);
     EXPECT_EQ(24U, sc->mMeshes[0]->mNumVertices);
@@ -220,10 +220,10 @@ TEST_F(ImporterTest, testPluginInterface) {
     EXPECT_FALSE(pImp->IsExtensionSupported("."));
 
     TestPlugin *p = (TestPlugin *)pImp->GetImporter(".windows");
-    ASSERT_TRUE(NULL != p);
+    ASSERT_TRUE(nullptr != p);
 
     try {
-        p->InternReadFile("", 0, NULL);
+        p->InternReadFile("", nullptr, nullptr);
     } catch (const DeadlyImportError &dead) {
         EXPECT_TRUE(!strcmp(dead.what(), AIUT_DEF_ERROR_TEXT));
 

--- a/test/unit/utMatrix4x4.cpp
+++ b/test/unit/utMatrix4x4.cpp
@@ -49,7 +49,7 @@ class utMatrix4x4 : public ::testing::Test {
 TEST_F(utMatrix4x4, badIndexOperatorTest) {
     aiMatrix4x4 m;
     ai_real *a0 = m[4];
-    EXPECT_EQ(NULL, a0);
+    EXPECT_EQ(nullptr, a0);
 }
 
 TEST_F(utMatrix4x4, indexOperatorTest) {

--- a/test/unit/utRemoveComponent.cpp
+++ b/test/unit/utRemoveComponent.cpp
@@ -111,7 +111,7 @@ TEST_F(RemoveVCProcessTest, testMeshRemove) {
     piProcess->SetDeleteFlags(aiComponent_MESHES);
     piProcess->Execute(pScene);
 
-    EXPECT_TRUE(NULL == pScene->mMeshes);
+    EXPECT_TRUE(nullptr == pScene->mMeshes);
     EXPECT_EQ(0U, pScene->mNumMeshes);
     EXPECT_TRUE(pScene->mFlags == AI_SCENE_FLAGS_INCOMPLETE);
 }
@@ -121,7 +121,7 @@ TEST_F(RemoveVCProcessTest, testAnimRemove) {
     piProcess->SetDeleteFlags(aiComponent_ANIMATIONS);
     piProcess->Execute(pScene);
 
-    EXPECT_TRUE(NULL == pScene->mAnimations);
+    EXPECT_TRUE(nullptr == pScene->mAnimations);
     EXPECT_EQ(0U, pScene->mNumAnimations);
     EXPECT_EQ(0U, pScene->mFlags);
 }
@@ -143,7 +143,7 @@ TEST_F(RemoveVCProcessTest, testTextureRemove) {
     piProcess->SetDeleteFlags(aiComponent_TEXTURES);
     piProcess->Execute(pScene);
 
-    EXPECT_TRUE(NULL == pScene->mTextures);
+    EXPECT_TRUE(nullptr == pScene->mTextures);
     EXPECT_EQ(0U, pScene->mNumTextures);
     EXPECT_EQ(0U, pScene->mFlags);
 }
@@ -153,7 +153,7 @@ TEST_F(RemoveVCProcessTest, testCameraRemove) {
     piProcess->SetDeleteFlags(aiComponent_CAMERAS);
     piProcess->Execute(pScene);
 
-    EXPECT_TRUE(NULL == pScene->mCameras);
+    EXPECT_TRUE(nullptr == pScene->mCameras);
     EXPECT_EQ(0U, pScene->mNumCameras);
     EXPECT_EQ(0U, pScene->mFlags);
 }
@@ -163,7 +163,7 @@ TEST_F(RemoveVCProcessTest, testLightRemove) {
     piProcess->SetDeleteFlags(aiComponent_LIGHTS);
     piProcess->Execute(pScene);
 
-    EXPECT_TRUE(NULL == pScene->mLights);
+    EXPECT_TRUE(nullptr == pScene->mLights);
     EXPECT_EQ(0U, pScene->mNumLights);
     EXPECT_EQ(0U, pScene->mFlags);
 }

--- a/test/unit/utRemoveRedundantMaterials.cpp
+++ b/test/unit/utRemoveRedundantMaterials.cpp
@@ -149,10 +149,10 @@ TEST_F(RemoveRedundantMatsTest, testRedundantMaterials) {
 
     piProcess->Execute(pcScene1);
     EXPECT_EQ(3U, pcScene1->mNumMaterials);
-    EXPECT_TRUE(0 != pcScene1->mMaterials &&
-                0 != pcScene1->mMaterials[0] &&
-                0 != pcScene1->mMaterials[1] &&
-                0 != pcScene1->mMaterials[2]);
+    EXPECT_TRUE(nullptr != pcScene1->mMaterials &&
+                nullptr != pcScene1->mMaterials[0] &&
+                nullptr != pcScene1->mMaterials[1] &&
+                nullptr != pcScene1->mMaterials[2]);
 
     aiString sName;
     EXPECT_EQ(AI_SUCCESS, aiGetMaterialString(pcScene1->mMaterials[2], AI_MATKEY_NAME, &sName));
@@ -165,11 +165,11 @@ TEST_F(RemoveRedundantMatsTest, testRedundantMaterialsWithExcludeList) {
 
     piProcess->Execute(pcScene1);
     EXPECT_EQ(4U, pcScene1->mNumMaterials);
-    EXPECT_TRUE(0 != pcScene1->mMaterials &&
-                0 != pcScene1->mMaterials[0] &&
-                0 != pcScene1->mMaterials[1] &&
-                0 != pcScene1->mMaterials[2] &&
-                0 != pcScene1->mMaterials[3]);
+    EXPECT_TRUE(nullptr != pcScene1->mMaterials &&
+                nullptr != pcScene1->mMaterials[0] &&
+                nullptr != pcScene1->mMaterials[1] &&
+                nullptr != pcScene1->mMaterials[2] &&
+                nullptr != pcScene1->mMaterials[3]);
 
     aiString sName;
     EXPECT_EQ(AI_SUCCESS, aiGetMaterialString(pcScene1->mMaterials[3], AI_MATKEY_NAME, &sName));

--- a/test/unit/utSortByPType.cpp
+++ b/test/unit/utSortByPType.cpp
@@ -184,13 +184,13 @@ TEST_F(SortByPTypeProcessTest, SortByPTypeStep) {
 
                 aiMesh *mesh = mScene->mMeshes[real];
 
-                EXPECT_TRUE(NULL != mesh);
+                EXPECT_TRUE(nullptr != mesh);
                 EXPECT_EQ(AI_PRIMITIVE_TYPE_FOR_N_INDICES(n + 1), mesh->mPrimitiveTypes);
-                EXPECT_TRUE(NULL != mesh->mVertices);
-                EXPECT_TRUE(NULL != mesh->mNormals);
-                EXPECT_TRUE(NULL != mesh->mTangents);
-                EXPECT_TRUE(NULL != mesh->mBitangents);
-                EXPECT_TRUE(NULL != mesh->mTextureCoords[0]);
+                EXPECT_TRUE(nullptr != mesh->mVertices);
+                EXPECT_TRUE(nullptr != mesh->mNormals);
+                EXPECT_TRUE(nullptr != mesh->mTangents);
+                EXPECT_TRUE(nullptr != mesh->mBitangents);
+                EXPECT_TRUE(nullptr != mesh->mTextureCoords[0]);
 
                 EXPECT_TRUE(mesh->mNumFaces == idx);
                 for (unsigned int f = 0; f < mesh->mNumFaces; ++f) {

--- a/test/unit/utSplitLargeMeshes.cpp
+++ b/test/unit/utSplitLargeMeshes.cpp
@@ -103,8 +103,8 @@ TEST_F(SplitLargeMeshesTest, testVertexSplit) {
             iter != end; ++iter) {
         aiMesh *mesh = (*iter).first;
         EXPECT_LT(mesh->mNumVertices, 1000U);
-        EXPECT_TRUE(NULL != mesh->mNormals);
-        EXPECT_TRUE(NULL != mesh->mVertices);
+        EXPECT_TRUE(nullptr != mesh->mNormals);
+        EXPECT_TRUE(nullptr != mesh->mVertices);
 
         iOldFaceNum -= mesh->mNumFaces;
         delete mesh;
@@ -145,8 +145,8 @@ TEST_F(SplitLargeMeshesTest, testTriangleSplit) {
             iter != end; ++iter) {
         aiMesh *mesh = (*iter).first;
         EXPECT_LT(mesh->mNumFaces, 1000U);
-        EXPECT_TRUE(NULL != mesh->mNormals);
-        EXPECT_TRUE(NULL != mesh->mVertices);
+        EXPECT_TRUE(nullptr != mesh->mNormals);
+        EXPECT_TRUE(nullptr != mesh->mVertices);
 
         iOldFaceNum -= mesh->mNumFaces;
         delete mesh;

--- a/test/unit/utTriangulate.cpp
+++ b/test/unit/utTriangulate.cpp
@@ -133,5 +133,5 @@ TEST_F(TriangulateProcessTest, testTriangulation) {
     }
 
     // we should have no valid normal vectors now because we aren't a pure polygon mesh
-    EXPECT_TRUE(pcMesh->mNormals == NULL);
+    EXPECT_TRUE(pcMesh->mNormals == nullptr);
 }

--- a/tools/assimp_cmd/CompareDump.cpp
+++ b/tools/assimp_cmd/CompareDump.cpp
@@ -910,7 +910,7 @@ int Assimp_CompareDump (const char* const* params, unsigned int num)
             if (m_file)
             {
                 fclose(m_file);
-                m_file = NULL;
+                m_file = nullptr;
             }
         }
 

--- a/tools/assimp_cmd/Info.cpp
+++ b/tools/assimp_cmd/Info.cpp
@@ -177,7 +177,7 @@ void FindSpecialPoints(const aiScene *scene, aiVector3D special_points[3]) {
 
 // -----------------------------------------------------------------------------------
 std::string FindPTypes(const aiScene *scene) {
-    bool haveit[4] = { 0 };
+    bool haveit[4] = { false };
     for (unsigned int i = 0; i < scene->mNumMeshes; ++i) {
         const unsigned int pt = scene->mMeshes[i]->mPrimitiveTypes;
         if (pt & aiPrimitiveType_POINT) {

--- a/tools/assimp_cmd/Main.cpp
+++ b/tools/assimp_cmd/Main.cpp
@@ -291,8 +291,8 @@ const aiScene* ImportModel(
 	// Now validate this flag combination
 	if(!globalImporter->ValidateFlags(imp.ppFlags)) {
 		printf("ERROR: Unsupported post-processing flags \n");
-		return NULL;
-	}
+        return nullptr;
+    }
 	printf("Validating postprocessing flags ...  OK\n");
 	if (imp.showLog) {
 		PrintHorBar();
@@ -311,8 +311,8 @@ const aiScene* ImportModel(
 	}
 	if (!scene) {
 		printf("ERROR: Failed to load file: %s\n", globalImporter->GetErrorString());
-		return NULL;
-	}
+        return nullptr;
+    }
 
 	const clock_t second = ::clock();
 	const double seconds = static_cast<double>(second-first) / CLOCKS_PER_SEC;

--- a/tools/assimp_cmd/Main.cpp
+++ b/tools/assimp_cmd/Main.cpp
@@ -291,8 +291,8 @@ const aiScene* ImportModel(
 	// Now validate this flag combination
 	if(!globalImporter->ValidateFlags(imp.ppFlags)) {
 		printf("ERROR: Unsupported post-processing flags \n");
-        return nullptr;
-    }
+		return nullptr;
+	}
 	printf("Validating postprocessing flags ...  OK\n");
 	if (imp.showLog) {
 		PrintHorBar();
@@ -311,8 +311,8 @@ const aiScene* ImportModel(
 	}
 	if (!scene) {
 		printf("ERROR: Failed to load file: %s\n", globalImporter->GetErrorString());
-        return nullptr;
-    }
+		return nullptr;
+	}
 
 	const clock_t second = ::clock();
 	const double seconds = static_cast<double>(second-first) / CLOCKS_PER_SEC;


### PR DESCRIPTION
I added some more clang-tidy checks:
* I applied several checks that should make the codebase more readable:
* Use make_shared when possible which is more efficient than calling the ctor or reset.
* Remove redundant calls to `.get()` for smartprs
* Use nullptr and bool literals whenever possible.