### PR TITLE
Don't hide out-of-memory during FBX import

### DIFF
--- a/code/AssetLib/FBX/FBXDocument.cpp
+++ b/code/AssetLib/FBX/FBXDocument.cpp
@@ -199,6 +199,14 @@ const Object* LazyObject::Get(bool dieOnError) {
             object.reset(new AnimationCurveNode(id,element,name,doc));
         }
     }
+    catch (std::bad_alloc&) {
+        // out-of-memory is unrecoverable and should always lead to a failure
+
+        flags &= ~BEING_CONSTRUCTED;
+        flags |= FAILED_TO_CONSTRUCT;
+
+        throw;
+    }
     catch(std::exception& ex) {
         flags &= ~BEING_CONSTRUCTED;
         flags |= FAILED_TO_CONSTRUCT;


### PR DESCRIPTION
If an out-of-memory exception is thrown during model import, it is usually trickled up by assimp and we can determine that it is the reason for failure. However, this particular code path in the FBX importer would just blindly swallow all exceptions and simply ignore a part of the mesh. That lead to issues where parts of a mesh or the entire model were skipped and assimp reported successful import.

I'm generally not that happy that code just catches exceptions and claims it's all fine, even though it doesn't even try to figure out what kind of exception this was. IMO this is very fragile.
Though more specifically, an out-of-memory situation should always be treated as a serious error, since it is unlikely that the following code will be able to continue.