### PR TITLE
Fixed bug when exporting binary FBX

### DIFF
--- a/code/AssetLib/FBX/FBXCommon.h
+++ b/code/AssetLib/FBX/FBXCommon.h
@@ -55,6 +55,7 @@ const char NULL_RECORD[NumNullRecords] = { // 25 null bytes in 64-bit and 13 nul
     '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0',
     '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0', '\0'
 }; // who knows why, it looks like two integers 32/64 bit (compressed and uncompressed sizes?) + 1 byte (might be compression type?)
+static std::string NULL_RECORD_STRING(NumNullRecords, '\0');
 const std::string SEPARATOR = { '\x00', '\x01' }; // for use inside strings
 const std::string MAGIC_NODE_TAG = "_$AssimpFbx$"; // from import
 const int64_t SECOND = 46186158000; // FBX's kTime unit

--- a/code/AssetLib/FBX/FBXExportNode.cpp
+++ b/code/AssetLib/FBX/FBXExportNode.cpp
@@ -360,7 +360,7 @@ void FBX::Node::EndBinary(
     bool has_children
 ) {
     // if there were children, add a null record
-    if (has_children) { s.PutString(Assimp::FBX::NULL_RECORD); }
+    if (has_children) { s.PutString(Assimp::FBX::NULL_RECORD_STRING); }
 
     // now go back and write initial pos
     this->end_pos = s.Tell();


### PR DESCRIPTION
Fixed vector subscript out of range bug when NULL_RECORD is passed to PutString and is actually null (i.e a string "" with size 0). Replaced it with a std::string initialized by '\0' time NumNullRecords. The cause of this issue might be that the std::string constructor gets the correct const char* but stops after seeing that the first element is '\0'.