### PR TITLE
fix warnings-as-errors for msvc 2019 x64

### DIFF
--- a/code/Common/SkeletonMeshBuilder.cpp
+++ b/code/Common/SkeletonMeshBuilder.cpp
@@ -131,32 +131,33 @@ void SkeletonMeshBuilder::CreateGeometry(const aiNode *pNode) {
         // if the node has no children, it's an end node. Put a little knob there instead
         aiVector3D ownpos(pNode->mTransformation.a4, pNode->mTransformation.b4, pNode->mTransformation.c4);
         ai_real sizeEstimate = ownpos.Length() * ai_real(0.18);
+        const ai_real zero(0.0);
 
-        mVertices.emplace_back(-sizeEstimate, 0.0, 0.0);
-        mVertices.emplace_back(0.0, sizeEstimate, 0.0);
-        mVertices.emplace_back(0.0, 0.0, -sizeEstimate);
-        mVertices.emplace_back(0.0, sizeEstimate, 0.0);
-        mVertices.emplace_back(sizeEstimate, 0.0, 0.0);
-        mVertices.emplace_back(0.0, 0.0, -sizeEstimate);
-        mVertices.emplace_back(sizeEstimate, 0.0, 0.0);
-        mVertices.emplace_back(0.0, -sizeEstimate, 0.0);
-        mVertices.emplace_back(0.0, 0.0, -sizeEstimate);
-        mVertices.emplace_back(0.0, -sizeEstimate, 0.0);
-        mVertices.emplace_back(-sizeEstimate, 0.0, 0.0);
-        mVertices.emplace_back(0.0, 0.0, -sizeEstimate);
+        mVertices.emplace_back(-sizeEstimate, zero, zero);
+        mVertices.emplace_back(zero, sizeEstimate, zero);
+        mVertices.emplace_back(zero, zero, -sizeEstimate);
+        mVertices.emplace_back(zero, sizeEstimate, zero);
+        mVertices.emplace_back(sizeEstimate, zero, zero);
+        mVertices.emplace_back(zero, zero, -sizeEstimate);
+        mVertices.emplace_back(sizeEstimate, zero, zero);
+        mVertices.emplace_back(zero, -sizeEstimate, zero);
+        mVertices.emplace_back(zero, zero, -sizeEstimate);
+        mVertices.emplace_back(zero, -sizeEstimate, zero);
+        mVertices.emplace_back(-sizeEstimate, zero, zero);
+        mVertices.emplace_back(zero, zero, -sizeEstimate);
 
-        mVertices.emplace_back(-sizeEstimate, 0.0, 0.0);
-        mVertices.emplace_back(0.0, 0.0, sizeEstimate);
-        mVertices.emplace_back(0.0, sizeEstimate, 0.0);
-        mVertices.emplace_back(0.0, sizeEstimate, 0.0);
-        mVertices.emplace_back(0.0, 0.0, sizeEstimate);
-        mVertices.emplace_back(sizeEstimate, 0.0, 0.0);
-        mVertices.emplace_back(sizeEstimate, 0.0, 0.0);
-        mVertices.emplace_back(0.0, 0.0, sizeEstimate);
-        mVertices.emplace_back(0.0, -sizeEstimate, 0.0);
-        mVertices.emplace_back(0.0, -sizeEstimate, 0.0);
-        mVertices.emplace_back(0.0, 0.0, sizeEstimate);
-        mVertices.emplace_back(-sizeEstimate, 0.0, 0.0);
+        mVertices.emplace_back(-sizeEstimate, zero, zero);
+        mVertices.emplace_back(zero, zero, sizeEstimate);
+        mVertices.emplace_back(zero, sizeEstimate, zero);
+        mVertices.emplace_back(zero, sizeEstimate, zero);
+        mVertices.emplace_back(zero, zero, sizeEstimate);
+        mVertices.emplace_back(sizeEstimate, zero, zero);
+        mVertices.emplace_back(sizeEstimate, zero, zero);
+        mVertices.emplace_back(zero, zero, sizeEstimate);
+        mVertices.emplace_back(zero, -sizeEstimate, zero);
+        mVertices.emplace_back(zero, -sizeEstimate, zero);
+        mVertices.emplace_back(zero, zero, sizeEstimate);
+        mVertices.emplace_back(-sizeEstimate, zero, zero);
 
         mFaces.emplace_back(vertexStartIndex + 0, vertexStartIndex + 1, vertexStartIndex + 2);
         mFaces.emplace_back(vertexStartIndex + 3, vertexStartIndex + 4, vertexStartIndex + 5);

--- a/code/Common/StandardShapes.cpp
+++ b/code/Common/StandardShapes.cpp
@@ -468,13 +468,14 @@ void StandardShapes::MakeCircle(ai_real radius, unsigned int tess,
     ai_real t = 0.0; // std::sin(angle == 0);
 
     for (ai_real angle = 0.0; angle < angle_max;) {
-        positions.emplace_back(s * radius, 0.0, t * radius);
+        const ai_real zero(0.0);
+        positions.emplace_back(s * radius, zero, t * radius);
         angle += angle_delta;
         s = std::cos(angle);
         t = std::sin(angle);
-        positions.emplace_back(s * radius, 0.0, t * radius);
+        positions.emplace_back(s * radius, zero, t * radius);
 
-        positions.emplace_back(0.0, 0.0, 0.0);
+        positions.emplace_back(zero, zero, zero);
     }
 }
 

--- a/code/Common/StandardShapes.cpp
+++ b/code/Common/StandardShapes.cpp
@@ -421,16 +421,18 @@ void StandardShapes::MakeCone(ai_real height, ai_real radius1,
         positions.push_back(v3);
 
         if (!bOpen) {
+            const ai_real zero(0.0);
+
             // generate the end 'cap'
             positions.emplace_back(s * radius2, halfHeight, t * radius2);
             positions.emplace_back(s2 * radius2, halfHeight, t2 * radius2);
-            positions.emplace_back(0.0, halfHeight, 0.0);
+            positions.emplace_back(zero, halfHeight, zero);
 
             if (radius1) {
                 // generate the other end 'cap'
                 positions.emplace_back(s * radius1, -halfHeight, t * radius1);
                 positions.emplace_back(s2 * radius1, -halfHeight, t2 * radius1);
-                positions.emplace_back(0.0, -halfHeight, 0.0);
+                positions.emplace_back(zero, -halfHeight, zero);
             }
         }
         s = s2;


### PR DESCRIPTION
Warnings-as-errors currently breaks on MSVC 2019 Debug X64:
```1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\xmemory(681,68): error C2220: the following warning is treated as an error (compiling source file ..\..\assimp\code\Common\StandardShapes.cpp)
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\vector(713): message : see reference to function template instantiation 'void std::_Default_allocator_traits<_Alloc>::construct<_Ty,float,double,float>(_Alloc &,_Objty *const ,float &&,double &&,float &&)' being compiled
1>        with
1>        [
1>            _Alloc=std::allocator<aiVector3D>,
1>            _Ty=aiVector3t<ai_real>,
1>            _Objty=aiVector3t<ai_real>
1>        ] (compiling source file ..\..\assimp\code\Common\StandardShapes.cpp)
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\vector(713): message : see reference to function template instantiation 'void std::_Default_allocator_traits<_Alloc>::construct<_Ty,float,double,float>(_Alloc &,_Objty *const ,float &&,double &&,float &&)' being compiled
1>        with
1>        [
1>            _Alloc=std::allocator<aiVector3D>,
1>            _Ty=aiVector3t<ai_real>,
1>            _Objty=aiVector3t<ai_real>
1>        ] (compiling source file ..\..\assimp\code\Common\StandardShapes.cpp)
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\vector(731): message : see reference to function template instantiation 'void std::vector<aiVector3D,std::allocator<aiVector3D>>::_Emplace_back_with_unused_capacity<_Ty,double,_Ty>(_Ty &&,double &&,_Ty &&)' being compiled
1>        with
1>        [
1>            _Ty=ai_real
1>        ] (compiling source file ..\..\assimp\code\Common\StandardShapes.cpp)
1>..\..\assimp\code\Common\StandardShapes.cpp(471): message : see reference to function template instantiation 'void std::vector<aiVector3D,std::allocator<aiVector3D>>::emplace_back<ai_real,double,ai_real>(ai_real &&,double &&,ai_real &&)' being compiled
1>C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\include\xmemory(681,68): warning C4244: 'argument': conversion from '_Ty' to 'TReal', possible loss of data
1>        with
1>        [
1>            _Ty=double
1>        ]
1>        and
1>        [
1>            TReal=ai_real
1>        ] (compiling source file ..\..\assimp\code\Common\StandardShapes.cpp)
```

Worth mentioning that this is with `ASSIMP_DOUBLE_PRECISION` set to *off*. With it set to *on* it's a whole 'nother world of compile pain.

Are the CI settings set to warnings-as-errors off?