### PR TITLE
Fixes Heap-buffer-overflow READ 4 in Assimp::ScenePreprocessor::ProcssMesh

### DIFF
--- a/code/AssetLib/OFF/OFFLoader.cpp
+++ b/code/AssetLib/OFF/OFFLoader.cpp
@@ -290,11 +290,12 @@ void OFFImporter::InternReadFile( const std::string& pFile, aiScene* pScene, IOS
         sz = line; SkipSpaces(&sz);
         idx = strtoul10(sz,&sz);
         if(!idx || idx > 9) {
-	    ASSIMP_LOG_ERROR("OFF: Faces with zero indices aren't allowed");
+	        ASSIMP_LOG_ERROR("OFF: Faces with zero indices aren't allowed");
             --mesh->mNumFaces;
+            ++i;
             continue;
-	}
-	faces->mNumIndices = idx;
+	    }
+	    faces->mNumIndices = idx;
         faces->mIndices = new unsigned int[faces->mNumIndices];
         for (unsigned int m = 0; m < faces->mNumIndices;++m) {
             SkipSpaces(&sz);


### PR DESCRIPTION
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=49797

The root cause of the crash is that [InternReadFile](https://github.com/assimp/assimp/blob/0fdae2879d78864693ee730610dcf8ee10707875/code/AssetLib/OFF/OFFLoader.cpp#L108) allocates 9 faces.
```cpp
    mesh->mNumFaces = numFaces;
    aiFace* faces = new aiFace[mesh->mNumFaces];
```

Later in the same function in [`for (unsigned int i = 0; i < numFaces; )`](https://github.com/assimp/assimp/blob/0fdae2879d78864693ee730610dcf8ee10707875/code/AssetLib/OFF/OFFLoader.cpp#L284) loop in goes into
```cpp
        if(!idx || idx > 9) {
            ASSIMP_LOG_ERROR("OFF: Faces with zero indices aren't allowed");
            --mesh->mNumFaces;
            continue;
        }
```
which decrements the number of faces an continues the loop. Note that the loop doesn't have `i++`, so it repeats the loop with the same `i` value.
This allows to decrement the number of faces more than its value 9, which leads to integer underflow and it becomes very big (4294967293).
Later it leads to heap read out of bounds since only 9 faces were allocated.