### PR TITLE
Fixes Heap-buffer-overflow READ 1 in Assimp::MD5::MD5Parser::ParseHeader

### DIFF
--- a/code/AssetLib/MD5/MD5Parser.cpp
+++ b/code/AssetLib/MD5/MD5Parser.cpp
@@ -117,6 +117,8 @@ void MD5Parser::ParseHeader() {
         ReportError("MD5 version tag is unknown (10 is expected)");
     }
     SkipLine();
+    if (buffer == bufferEnd)
+        return;
 
     // print the command line options to the console
     // FIX: can break the log length limit, so we need to be careful

--- a/code/AssetLib/MD5/MD5Parser.cpp
+++ b/code/AssetLib/MD5/MD5Parser.cpp
@@ -5,8 +5,6 @@ Open Asset Import Library (assimp)
 
 Copyright (c) 2006-2022, assimp team
 
-
-
 All rights reserved.
 
 Redistribution and use of this software in source and binary forms,
@@ -117,8 +115,9 @@ void MD5Parser::ParseHeader() {
         ReportError("MD5 version tag is unknown (10 is expected)");
     }
     SkipLine();
-    if (buffer == bufferEnd)
+    if (buffer == bufferEnd) {
         return;
+    }
 
     // print the command line options to the console
     // FIX: can break the log length limit, so we need to be careful
@@ -137,8 +136,9 @@ bool MD5Parser::ParseSection(Section &out) {
 
     // first parse the name of the section
     char *sz = buffer;
-    while (!IsSpaceOrNewLine(*buffer))
-        buffer++;
+    while (!IsSpaceOrNewLine(*buffer)) {
+        ++buffer;
+    }
     out.mName = std::string(sz, (uintptr_t)(buffer - sz));
     SkipSpaces();
 
@@ -146,14 +146,14 @@ bool MD5Parser::ParseSection(Section &out) {
     while (running) {
         if ('{' == *buffer) {
             // it is a normal section so read all lines
-            buffer++;
+            ++buffer;
             bool run = true;
             while (run) {
                 if (!SkipSpacesAndLineEnd()) {
                     return false; // seems this was the last section
                 }
                 if ('}' == *buffer) {
-                    buffer++;
+                    ++buffer;
                     break;
                 }
 
@@ -165,7 +165,7 @@ bool MD5Parser::ParseSection(Section &out) {
 
                 // terminate the line with zero
                 while (!IsLineEnd(*buffer))
-                    buffer++;
+                    ++buffer;
                 if (*buffer) {
                     ++lineNumber;
                     *buffer++ = '\0';


### PR DESCRIPTION
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=49422 When it reaches the `SkipSpacesAndLineEnd`, `in` already points past `bufferEnd` and it leads to out of bounds memory read.