### PR TITLE
Fixes Heap-buffer-overflow READ 1 in Assimp::ObjFileParser::getFace

### DIFF
--- a/code/AssetLib/Obj/ObjFileParser.cpp
+++ b/code/AssetLib/Obj/ObjFileParser.cpp
@@ -440,7 +440,7 @@ void ObjFileParser::getFace(aiPrimitiveType type) {
     const bool vt = (!m_pModel->mTextureCoord.empty());
     const bool vn = (!m_pModel->mNormals.empty());
     int iPos = 0;
-    while (m_DataIt != m_DataItEnd) {
+    while (m_DataIt < m_DataItEnd) {
         int iStep = 1;
 
         if (IsLineEnd(*m_DataIt)) {

--- a/code/AssetLib/Obj/ObjTools.h
+++ b/code/AssetLib/Obj/ObjTools.h
@@ -111,6 +111,9 @@ inline Char_T getNextToken(Char_T pBuffer, Char_T pEnd) {
  */
 template <class char_t>
 inline char_t skipLine(char_t it, char_t end, unsigned int &uiLine) {
+    if (it >= end)
+        return it;
+
     while (!isEndOfBuffer(it, end) && !IsLineEnd(*it)) {
         ++it;
     }

--- a/code/AssetLib/Obj/ObjTools.h
+++ b/code/AssetLib/Obj/ObjTools.h
@@ -2,7 +2,7 @@
 Open Asset Import Library (assimp)
 ----------------------------------------------------------------------
 
-Copyright (c) 2006-2021, assimp team
+Copyright (c) 2006-2022, assimp team
 
 All rights reserved.
 
@@ -111,8 +111,9 @@ inline Char_T getNextToken(Char_T pBuffer, Char_T pEnd) {
  */
 template <class char_t>
 inline char_t skipLine(char_t it, char_t end, unsigned int &uiLine) {
-    if (it >= end)
+    if (it >= end) {
         return it;
+    }
 
     while (!isEndOfBuffer(it, end) && !IsLineEnd(*it)) {
         ++it;
@@ -132,7 +133,7 @@ inline char_t skipLine(char_t it, char_t end, unsigned int &uiLine) {
 
 /** 
  *  @brief  Get a name from the current line. Preserve space in the middle,
- *    but trim it at the end.
+ *          but trim it at the end.
  *  @param[in]  it      set to current position
  *  @param[in]  end     set to end of scratch buffer for readout
  *  @param[out] name    Separated name


### PR DESCRIPTION
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=49274

The `m_DataIt` in `void ObjFileParser::getFace` is increased in steps `m_DataIt += iStep;` that may jump over `m_DataItEnd` and then `while (m_DataIt != m_DataItEnd)` continues. This leads to out of bounds memory read access.