### PR TITLE
{cmake} Remove dead code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -388,14 +388,6 @@ IF (NOT TARGET uninstall AND ASSIMP_INSTALL)
   ADD_CUSTOM_TARGET(uninstall "${CMAKE_COMMAND}" -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake")
 ENDIF()
 
-# cmake configuration files
-if(${BUILD_SHARED_LIBS})
-  set(BUILD_LIB_TYPE SHARED)
-else()
-  set(BUILD_LIB_TYPE STATIC)
-  add_definitions(-DDDL_STATIC_LIBRARY=OFF)
-endif()
-
 IF( UNIX )
   # Use GNUInstallDirs for Unix predefined directories
   INCLUDE(GNUInstallDirs)


### PR DESCRIPTION
`BUILD_LIB_TYPE` isn't used anywhere.

I think the intent with _add_definitions_ here was to affect cmake (?), but it's actually just adding `#define DDL_STATIC_LIBRARY OFF` which isn't used in the code anywhere.