### PR TITLE
Change mMethod type to enum aiMorphingMethod

### DIFF
--- a/include/assimp/mesh.h
+++ b/include/assimp/mesh.h
@@ -566,6 +566,9 @@ struct aiAnimMesh {
 /** @brief Enumerates the methods of mesh morphing supported by Assimp.
  */
 enum aiMorphingMethod {
+    /** Morphing method to be determined */
+    aiMorphingMethod_UNKNOWN = 0x0,
+
     /** Interpolation between morph targets */
     aiMorphingMethod_VERTEX_BLEND = 0x1,
 
@@ -747,7 +750,7 @@ struct aiMesh {
      *  Method of morphing when anim-meshes are specified.
      *  @see aiMorphingMethod to learn more about the provided morphing targets.
      */
-    unsigned int mMethod;
+    enum aiMorphingMethod mMethod;
 
     /**
      *  The bounding box.
@@ -778,7 +781,7 @@ struct aiMesh {
               mMaterialIndex(0),
               mNumAnimMeshes(0),
               mAnimMeshes(nullptr),
-              mMethod(0),
+              mMethod(aiMorphingMethod_UNKNOWN),
               mAABB(),
               mTextureCoordsNames(nullptr) {
         for (unsigned int a = 0; a < AI_MAX_NUMBER_OF_TEXTURECOORDS; ++a) {
@@ -1002,7 +1005,7 @@ struct aiSkeletonBone {
 #endif // __cplusplus
 };
 /**
- *  @brief  
+ *  @brief
  */
 struct aiSkeleton {
     /**


### PR DESCRIPTION
(Reported in issue #4874)

Improve type safety for `mMethod`:
 - change type of `mMethod` from `unsigned int` to `enum aiMorphingMethod`
 - add enum value `aiMorphingMethod_UNKNOWN ` to cover the current default assignment
