### PR TITLE
Fix #4877

### DIFF
--- a/code/AssetLib/Collada/ColladaParser.cpp
+++ b/code/AssetLib/Collada/ColladaParser.cpp
@@ -762,6 +762,7 @@ void ColladaParser::ReadControllerWeights(XmlNode &node, Collada::Controller &pC
                 if (text == nullptr) {
                     throw DeadlyImportError("Out of data while reading <vertex_weights>");
                 }
+                SkipSpacesAndLineEnd(&text);
                 it->first = strtoul10(text, &text);
                 SkipSpacesAndLineEnd(&text);
                 if (*text == 0) {


### PR DESCRIPTION
Remove whitespace between a <v> tag and the first number, otherwise first call to strtoul10() returns 0 and the indices are broken, leading to possible out-of-bound access and memory corruption/crash.

I am an outsider and not familiar with the code base, hence I kindly ask whether this issue is present in more instances in the code base. There are many places where SkipSpacesAndLineEnd() is called.