### PR TITLE
Fix #4262 Build With M3D Import Only

### DIFF
--- a/code/AssetLib/M3D/M3DWrapper.cpp
+++ b/code/AssetLib/M3D/M3DWrapper.cpp
@@ -39,8 +39,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ----------------------------------------------------------------------
 */
-#ifndef ASSIMP_BUILD_NO_M3D_IMPORTER
-#if !(ASSIMP_BUILD_NO_EXPORT || ASSIMP_BUILD_NO_M3D_EXPORTER)
+#if !defined ASSIMP_BUILD_NO_M3D_IMPORTER || !(defined ASSIMP_BUILD_NO_EXPORT || defined ASSIMP_BUILD_NO_M3D_EXPORTER)
 
 #include "M3DWrapper.h"
 
@@ -148,5 +147,4 @@ void M3DWrapper::ClearSave() {
 }
 } // namespace Assimp
 
-#endif
 #endif

--- a/code/AssetLib/M3D/M3DWrapper.h
+++ b/code/AssetLib/M3D/M3DWrapper.h
@@ -47,8 +47,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef AI_M3DWRAPPER_H_INC
 #define AI_M3DWRAPPER_H_INC
 
-#ifndef ASSIMP_BUILD_NO_M3D_IMPORTER
-#if !(ASSIMP_BUILD_NO_EXPORT || ASSIMP_BUILD_NO_M3D_EXPORTER)  
+#if !defined ASSIMP_BUILD_NO_M3D_IMPORTER || !(defined ASSIMP_BUILD_NO_EXPORT || defined ASSIMP_BUILD_NO_M3D_EXPORTER)
 
 #include <memory>
 #include <vector>
@@ -126,7 +125,6 @@ inline m3d_t *M3DWrapper::M3D() const {
 
 } // namespace Assimp
 
-#endif
 #endif // ASSIMP_BUILD_NO_M3D_IMPORTER
 
 #endif // AI_M3DWRAPPER_H_INC


### PR DESCRIPTION
`M3DWrapper.h` is designed to omit the definition of `class M3DWrapper` if neither M3D import nor M3D export are compiled. 608bccd9cf3a28c55163c10e84aec025293b7ab0 touched the corresponding preprocessor checks and introduced a bug:
```
#ifndef ASSIMP_BUILD_NO_M3D_IMPORTER
#if !(ASSIMP_BUILD_NO_EXPORT || ASSIMP_BUILD_NO_M3D_EXPORTER)
class M3DWrapper {
```
When compiling
- with M3D import enabled,
- but with either export generally disabled or M3D export disabled specifically, These checks evaluate to the wrong result and skip the definition, leading to a build failure in dependent code.
```
#if 1 // import enabled
#if !(1 || 1) // export disabled and M3D export disabled
```
This commit fixes the check to compile the definition if neither import is disabled.