### PR TITLE
Fix Build Without ArmaturePopulate Post Process Step

### DIFF
--- a/code/AssetLib/FBX/FBXConverter.cpp
+++ b/code/AssetLib/FBX/FBXConverter.cpp
@@ -1455,7 +1455,9 @@ static void copyBoneToSkeletonBone(aiMesh *mesh, aiBone *bone, aiSkeletonBone *s
     skeletonBone->mWeights = bone->mWeights;
     skeletonBone->mOffsetMatrix = bone->mOffsetMatrix;
     skeletonBone->mMeshId = mesh;
+#ifndef ASSIMP_BUILD_NO_ARMATUREPOPULATE_PROCESS
     skeletonBone->mNode = bone->mNode;
+#endif
     skeletonBone->mParent = -1;
 }
 

--- a/include/assimp/mesh.h
+++ b/include/assimp/mesh.h
@@ -988,8 +988,10 @@ struct aiSkeletonBone {
 #ifdef __cplusplus
     aiSkeletonBone() :
             mParent(-1),
+#ifndef ASSIMP_BUILD_NO_ARMATUREPOPULATE_PROCESS
             mArmature(nullptr),
             mNode(nullptr),
+#endif
             mNumnWeights(0),
             mMeshId(nullptr),
             mWeights(nullptr),


### PR DESCRIPTION
This post process step introduced new attributes into `aiSkeletonBone`. Said attributes are only defined with the process enabled, i.e. when the `ASSIMP_BUILD_NO_ARMATUREPOPULATE_PROCESS` macro has not been defined.

Some code, however, accessed the variables unconditionally, leading to build failures if `ASSIMP_BUILD_NO_ARMATUREPOPULATE_PROCESS` was defined.

This commit adds the missing checks.