### PR TITLE
Remove Useless “virtual”

### DIFF
--- a/code/AssetLib/Ogre/OgreImporter.h
+++ b/code/AssetLib/Ogre/OgreImporter.h
@@ -60,17 +60,17 @@ namespace Ogre {
 class OgreImporter : public BaseImporter {
 public:
     /// BaseImporter override.
-    virtual bool CanRead(const std::string &pFile, IOSystem *pIOHandler, bool checkSig) const override;
+    bool CanRead(const std::string &pFile, IOSystem *pIOHandler, bool checkSig) const override;
 
 protected:
     /// BaseImporter override.
-    virtual void InternReadFile(const std::string &pFile, aiScene *pScene, IOSystem *pIOHandler) override;
+    void InternReadFile(const std::string &pFile, aiScene *pScene, IOSystem *pIOHandler) override;
 
     /// BaseImporter override.
-    virtual const aiImporterDesc *GetInfo() const override;
+    const aiImporterDesc *GetInfo() const override;
 
     /// BaseImporter override.
-    virtual void SetupProperties(const Importer *pImp) override;
+    void SetupProperties(const Importer *pImp) override;
 
 private:
     /// Read materials referenced by the @c mesh to @c pScene.

--- a/code/AssetLib/glTF2/glTF2Importer.h
+++ b/code/AssetLib/glTF2/glTF2Importer.h
@@ -65,7 +65,7 @@ public:
 protected:
     const aiImporterDesc *GetInfo() const override;
     void InternReadFile(const std::string &pFile, aiScene *pScene, IOSystem *pIOHandler) override;
-    virtual void SetupProperties(const Importer *pImp) override;
+    void SetupProperties(const Importer *pImp) override;
 
 private:
     void ImportEmbeddedTextures(glTF2::Asset &a);


### PR DESCRIPTION
These functions are already marked “override”, and their neighbors had “virtual” removed as well.