### PR TITLE
Fix: fix incorrect math for calculating the horizontal FOV of a perspective camera in gltf2 import #4435

### DIFF
--- a/code/AssetLib/glTF2/glTF2Importer.cpp
+++ b/code/AssetLib/glTF2/glTF2Importer.cpp
@@ -853,7 +853,7 @@ void glTF2Importer::ImportCameras(glTF2::Asset &r) {
 
         if (cam.type == Camera::Perspective) {
             aicam->mAspect = cam.cameraProperties.perspective.aspectRatio;
-            aicam->mHorizontalFOV = 2.0f * std::atan(std::tan(cam.cameraProperties.perspective.yfov * 0.5f) * (aicam->mAspect == 0.f) ? 1.f : aicam->mAspect);
+            aicam->mHorizontalFOV = 2.0f * std::atan(std::tan(cam.cameraProperties.perspective.yfov * 0.5f) * ((aicam->mAspect == 0.f) ? 1.f : aicam->mAspect));
             aicam->mClipPlaneFar = cam.cameraProperties.perspective.zfar;
             aicam->mClipPlaneNear = cam.cameraProperties.perspective.znear;
         } else {

--- a/code/AssetLib/glTF2/glTF2Importer.cpp
+++ b/code/AssetLib/glTF2/glTF2Importer.cpp
@@ -853,7 +853,7 @@ void glTF2Importer::ImportCameras(glTF2::Asset &r) {
 
         if (cam.type == Camera::Perspective) {
             aicam->mAspect = cam.cameraProperties.perspective.aspectRatio;
-            aicam->mHorizontalFOV = cam.cameraProperties.perspective.yfov * ((aicam->mAspect == 0.f) ? 1.f : aicam->mAspect);
+            aicam->mHorizontalFOV = 2.0f * std::atan(std::tan(cam.cameraProperties.perspective.yfov * 0.5f) * (aicam->mAspect == 0.f) ? 1.f : aicam->mAspect);
             aicam->mClipPlaneFar = cam.cameraProperties.perspective.zfar;
             aicam->mClipPlaneNear = cam.cameraProperties.perspective.znear;
         } else {


### PR DESCRIPTION
Uses the correct math, as detailed in #4435.

This also preserves the behavior that if mAspect == 0, the computed horizontal fov will just pass through the vertical fov unchanged, so that it can be recovered and computed properly according to the gltf2 spec later.

Further math reference [here](https://stackoverflow.com/questions/5504635/computing-fovx-opengl), with a nice visual demo of why this matters [here](https://twgljs.org/examples/fov-checker.html).