### PR TITLE
Tidy Up Constructors and Destructors

### DIFF
--- a/code/AssetLib/3DS/3DSHelper.h
+++ b/code/AssetLib/3DS/3DSHelper.h
@@ -322,7 +322,6 @@ struct Texture {
     //! Default constructor
     Texture() AI_NO_EXCEPT
             : mTextureBlend(0.0f),
-              mMapName(),
               mOffsetU(0.0),
               mOffsetV(0.0),
               mScaleU(1.0),
@@ -334,51 +333,11 @@ struct Texture {
         mTextureBlend = get_qnan();
     }
 
-    Texture(const Texture &other) :
-            mTextureBlend(other.mTextureBlend),
-            mMapName(other.mMapName),
-            mOffsetU(other.mOffsetU),
-            mOffsetV(other.mOffsetV),
-            mScaleU(other.mScaleU),
-            mScaleV(other.mScaleV),
-            mRotation(other.mRotation),
-            mMapMode(other.mMapMode),
-            bPrivate(other.bPrivate),
-            iUVSrc(other.iUVSrc) {
-        // empty
-    }
+    Texture(const Texture &other) = default;
 
-    Texture(Texture &&other) AI_NO_EXCEPT : mTextureBlend(other.mTextureBlend),
-                                            mMapName(std::move(other.mMapName)),
-                                            mOffsetU(other.mOffsetU),
-                                            mOffsetV(other.mOffsetV),
-                                            mScaleU(other.mScaleU),
-                                            mScaleV(other.mScaleV),
-                                            mRotation(other.mRotation),
-                                            mMapMode(other.mMapMode),
-                                            bPrivate(other.bPrivate),
-                                            iUVSrc(other.iUVSrc) {
-        // empty
-    }
+    Texture(Texture &&other) AI_NO_EXCEPT = default;
 
-    Texture &operator=(Texture &&other) AI_NO_EXCEPT {
-        if (this == &other) {
-            return *this;
-        }
-
-        mTextureBlend = other.mTextureBlend;
-        mMapName = std::move(other.mMapName);
-        mOffsetU = other.mOffsetU;
-        mOffsetV = other.mOffsetV;
-        mScaleU = other.mScaleU;
-        mScaleV = other.mScaleV;
-        mRotation = other.mRotation;
-        mMapMode = other.mMapMode;
-        bPrivate = other.bPrivate;
-        iUVSrc = other.iUVSrc;
-
-        return *this;
-    }
+    Texture &operator=(Texture &&other) AI_NO_EXCEPT = default;
 
     //! Specifies the blend factor for the texture
     ai_real mTextureBlend;
@@ -436,83 +395,13 @@ struct Material {
         // empty
     }
 
-    Material(const Material &other) :
-            mName(other.mName),
-            mDiffuse(other.mDiffuse),
-            mSpecularExponent(other.mSpecularExponent),
-            mShininessStrength(other.mShininessStrength),
-            mSpecular(other.mSpecular),
-            mAmbient(other.mAmbient),
-            mShading(other.mShading),
-            mTransparency(other.mTransparency),
-            sTexDiffuse(other.sTexDiffuse),
-            sTexOpacity(other.sTexOpacity),
-            sTexSpecular(other.sTexSpecular),
-            sTexReflective(other.sTexReflective),
-            sTexBump(other.sTexBump),
-            sTexEmissive(other.sTexEmissive),
-            sTexShininess(other.sTexShininess),
-            mBumpHeight(other.mBumpHeight),
-            mEmissive(other.mEmissive),
-            sTexAmbient(other.sTexAmbient),
-            mTwoSided(other.mTwoSided) {
-        // empty
-    }
+    Material(const Material &other) = default;
 
-    //! Move constructor. This is explicitly written because MSVC doesn't support defaulting it
-    Material(Material &&other) AI_NO_EXCEPT : mName(std::move(other.mName)),
-                                              mDiffuse(other.mDiffuse),
-                                              mSpecularExponent(other.mSpecularExponent),
-                                              mShininessStrength(other.mShininessStrength),
-                                              mSpecular(other.mSpecular),
-                                              mAmbient(other.mAmbient),
-                                              mShading(other.mShading),
-                                              mTransparency(other.mTransparency),
-                                              sTexDiffuse(std::move(other.sTexDiffuse)),
-                                              sTexOpacity(std::move(other.sTexOpacity)),
-                                              sTexSpecular(std::move(other.sTexSpecular)),
-                                              sTexReflective(std::move(other.sTexReflective)),
-                                              sTexBump(std::move(other.sTexBump)),
-                                              sTexEmissive(std::move(other.sTexEmissive)),
-                                              sTexShininess(std::move(other.sTexShininess)),
-                                              mBumpHeight(other.mBumpHeight),
-                                              mEmissive(other.mEmissive),
-                                              sTexAmbient(std::move(other.sTexAmbient)),
-                                              mTwoSided(other.mTwoSided) {
-        // empty
-    }
+    Material(Material &&other) AI_NO_EXCEPT = default;
 
-    Material &operator=(Material &&other) AI_NO_EXCEPT {
-        if (this == &other) {
-            return *this;
-        }
+    Material &operator=(Material &&other) AI_NO_EXCEPT = default;
 
-        mName = std::move(other.mName);
-        mDiffuse = other.mDiffuse;
-        mSpecularExponent = other.mSpecularExponent;
-        mShininessStrength = other.mShininessStrength,
-        mSpecular = other.mSpecular;
-        mAmbient = other.mAmbient;
-        mShading = other.mShading;
-        mTransparency = other.mTransparency;
-        sTexDiffuse = std::move(other.sTexDiffuse);
-        sTexOpacity = std::move(other.sTexOpacity);
-        sTexSpecular = std::move(other.sTexSpecular);
-        sTexReflective = std::move(other.sTexReflective);
-        sTexBump = std::move(other.sTexBump);
-        sTexEmissive = std::move(other.sTexEmissive);
-        sTexShininess = std::move(other.sTexShininess);
-        mBumpHeight = other.mBumpHeight;
-        mEmissive = other.mEmissive;
-        sTexAmbient = std::move(other.sTexAmbient);
-        mTwoSided = other.mTwoSided;
-
-        return *this;
-    }
-
-    virtual ~Material() {
-        // empty
-    }
+    virtual ~Material() = default;
 
     //! Name of the material
     std::string mName;

--- a/code/AssetLib/3MF/3MFTypes.h
+++ b/code/AssetLib/3MF/3MFTypes.h
@@ -69,9 +69,7 @@ public:
         // empty
     }
 
-    virtual ~Resource() {
-        // empty
-    }
+    virtual ~Resource() = default;
 
     virtual ResourceType getType() const {
         return ResourceType::RT_Unknown;

--- a/code/AssetLib/3MF/D3MFExporter.cpp
+++ b/code/AssetLib/3MF/D3MFExporter.cpp
@@ -83,7 +83,7 @@ void ExportScene3MF(const char *pFile, IOSystem *pIOSystem, const aiScene *pScen
 namespace D3MF {
 
 D3MFExporter::D3MFExporter(const char *pFile, const aiScene *pScene) :
-        mArchiveName(pFile), m_zipArchive(nullptr), mScene(pScene), mModelOutput(), mRelOutput(), mContentOutput(), mBuildItems(), mRelations() {
+        mArchiveName(pFile), m_zipArchive(nullptr), mScene(pScene) {
     // empty
 }
 

--- a/code/AssetLib/AMF/AMFImporter.cpp
+++ b/code/AssetLib/AMF/AMFImporter.cpp
@@ -83,11 +83,7 @@ void AMFImporter::Clear() {
 
 AMFImporter::AMFImporter() AI_NO_EXCEPT :
         mNodeElement_Cur(nullptr),
-        mXmlParser(nullptr),
-        mUnit(),
-        mVersion(),
-        mMaterial_Converted(),
-        mTexture_Converted() {
+        mXmlParser(nullptr) {
     // empty
 }
 

--- a/code/AssetLib/AMF/AMFImporter_Node.hpp
+++ b/code/AssetLib/AMF/AMFImporter_Node.hpp
@@ -88,9 +88,7 @@ public:
 	std::list<AMFNodeElementBase *> Child; ///< Child elements.
 
 public: /// Destructor, virtual..
-	virtual ~AMFNodeElementBase() {
-		// empty
-	}
+	virtual ~AMFNodeElementBase() = default;
 
 	/// Disabled copy constructor and co.
 	AMFNodeElementBase(const AMFNodeElementBase &pNodeElement) = delete;
@@ -103,7 +101,7 @@ protected:
 	/// \param [in] pType - element type.
 	/// \param [in] pParent - parent element.
 	AMFNodeElementBase(const EType pType, AMFNodeElementBase *pParent) :
-			Type(pType), ID(), Parent(pParent), Child() {
+			Type(pType), Parent(pParent) {
 		// empty
 	}
 }; // class IAMFImporter_NodeElement
@@ -174,7 +172,7 @@ struct AMFColor : public AMFNodeElementBase {
 	/// @brief  Constructor.
 	/// @param [in] pParent - pointer to parent node.
 	AMFColor(AMFNodeElementBase *pParent) :
-			AMFNodeElementBase(ENET_Color, pParent), Composed(false), Color(), Profile() {
+			AMFNodeElementBase(ENET_Color, pParent), Composed(false), Color() {
 		// empty
 	}
 };
@@ -270,7 +268,7 @@ struct AMFTexMap : public AMFNodeElementBase {
 	/// Constructor.
 	/// \param [in] pParent - pointer to parent node.
 	AMFTexMap(AMFNodeElementBase *pParent) :
-			AMFNodeElementBase(ENET_TexMap, pParent), TextureCoordinate{}, TextureID_R(), TextureID_G(), TextureID_B(), TextureID_A() {
+			AMFNodeElementBase(ENET_TexMap, pParent), TextureCoordinate{} {
 		// empty
 	}
 };

--- a/code/AssetLib/Blender/BlenderDNA.h
+++ b/code/AssetLib/Blender/BlenderDNA.h
@@ -106,9 +106,7 @@ struct ElemBase {
         // empty
     }
 
-    virtual ~ElemBase() {
-        // empty
-    }
+    virtual ~ElemBase() = default;
 
     /** Type name of the element. The type
      * string points is the `c_str` of the `name` attribute of the

--- a/code/AssetLib/Blender/BlenderModifier.h
+++ b/code/AssetLib/Blender/BlenderModifier.h
@@ -62,9 +62,7 @@ public:
     /**
      *  The class destructor, virtual.
      */
-    virtual ~BlenderModifier() {
-        // empty
-    }
+    virtual ~BlenderModifier() = default;
 
     // --------------------
     /**

--- a/code/AssetLib/Blender/BlenderScene.h
+++ b/code/AssetLib/Blender/BlenderScene.h
@@ -182,7 +182,7 @@ struct MVert : ElemBase {
     int bweight;
 
     MVert() :
-            ElemBase(), flag(0), mat_nr(0), bweight(0) {}
+            flag(0), mat_nr(0), bweight(0) {}
 };
 
 // -------------------------------------------------------------------------------
@@ -417,7 +417,6 @@ struct CustomDataLayer : ElemBase {
     std::shared_ptr<ElemBase> data; // must be converted to real type according type member
 
     CustomDataLayer() :
-            ElemBase(),
             type(0),
             offset(0),
             flag(0),
@@ -729,7 +728,7 @@ struct Object : ElemBase {
     ListBase modifiers;
 
     Object() :
-            ElemBase(), type(Type_EMPTY), parent(nullptr), track(), proxy(), proxy_from(), data() {
+            type(Type_EMPTY), parent(nullptr) {
         // empty
     }
 };
@@ -741,8 +740,7 @@ struct Base : ElemBase {
     std::shared_ptr<Object> object WARN;
 
     Base() :
-            ElemBase(), prev(nullptr), next(), object() {
-        // empty
+            prev(nullptr) {
         // empty
     }
 };
@@ -758,10 +756,7 @@ struct Scene : ElemBase {
 
     ListBase base;
 
-    Scene() :
-            ElemBase(), camera(), world(), basact(), master_collection() {
-        // empty
-    }
+    Scene() = default;
 };
 
 // -------------------------------------------------------------------------------
@@ -791,10 +786,7 @@ struct Image : ElemBase {
 
     short gen_x, gen_y, gen_type;
 
-    Image() :
-            ElemBase() {
-        // empty
-    }
+    Image() = default;
 };
 
 // -------------------------------------------------------------------------------
@@ -884,7 +876,7 @@ struct Tex : ElemBase {
     //char use_nodes;
 
     Tex() :
-            ElemBase(), imaflag(ImageFlags_INTERPOL), type(Type_CLOUDS), ima() {
+            imaflag(ImageFlags_INTERPOL), type(Type_CLOUDS) {
         // empty
     }
 };
@@ -976,10 +968,7 @@ struct MTex : ElemBase {
     //float shadowfac;
     //float zenupfac, zendownfac, blendfac;
 
-    MTex() :
-            ElemBase() {
-        // empty
-    }
+    MTex() = default;
 };
 
 } // namespace Blender

--- a/code/AssetLib/Blender/BlenderTessellator.cpp
+++ b/code/AssetLib/Blender/BlenderTessellator.cpp
@@ -81,9 +81,7 @@ BlenderTessellatorGL::BlenderTessellatorGL( BlenderBMeshConverter& converter ):
 }
 
 // ------------------------------------------------------------------------------------------------
-BlenderTessellatorGL::~BlenderTessellatorGL( )
-{
-}
+BlenderTessellatorGL::~BlenderTessellatorGL() = default;
 
 // ------------------------------------------------------------------------------------------------
 void BlenderTessellatorGL::Tessellate( const MLoop* polyLoop, int vertexCount, const std::vector< MVert >& vertices )

--- a/code/AssetLib/C4D/C4DImporter.cpp
+++ b/code/AssetLib/C4D/C4DImporter.cpp
@@ -106,15 +106,10 @@ static const aiImporterDesc desc = {
 
 
 // ------------------------------------------------------------------------------------------------
-C4DImporter::C4DImporter()
-: BaseImporter() {
-    // empty
-}
+C4DImporter::C4DImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
-C4DImporter::~C4DImporter() {
-    // empty
-}
+C4DImporter::~C4DImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 bool C4DImporter::CanRead( const std::string& pFile, IOSystem* /*pIOHandler*/, bool /*checkSig*/) const {

--- a/code/AssetLib/Collada/ColladaLoader.cpp
+++ b/code/AssetLib/Collada/ColladaLoader.cpp
@@ -92,15 +92,6 @@ inline void AddNodeMetaData(aiNode *node, const std::string &key, const T &value
 // ------------------------------------------------------------------------------------------------
 // Constructor to be privately used by Importer
 ColladaLoader::ColladaLoader() :
-        mFileName(),
-        mMeshIndexByID(),
-        mMaterialIndexByName(),
-        mMeshes(),
-        newMats(),
-        mCameras(),
-        mLights(),
-        mTextures(),
-        mAnims(),
         noSkeletonMesh(false),
         removeEmptyBones(false),
         ignoreUpDirection(false),

--- a/code/AssetLib/DXF/DXFHelper.h
+++ b/code/AssetLib/DXF/DXFHelper.h
@@ -65,7 +65,6 @@ public:
     LineReader(StreamReaderLE& reader)
     : splitter(reader,false,true)
     , groupcode( 0 )
-    , value()
     , end() {
         // empty
     }
@@ -186,8 +185,7 @@ struct InsertBlock {
     InsertBlock()
     : pos()
     , scale(1.f,1.f,1.f)
-    , angle()
-    , name() {
+    , angle() {
         // empty
     }
 

--- a/code/AssetLib/FBX/FBXExportNode.h
+++ b/code/AssetLib/FBX/FBXExportNode.h
@@ -77,8 +77,6 @@ public: // constructors
     /// The class constructor with the name.
     Node(const std::string& n)
     : name(n)
-    , properties()
-    , children()
     , force_has_children( false ) {
         // empty
     }
@@ -87,8 +85,6 @@ public: // constructors
     template <typename... More>
     Node(const std::string& n, More&&... more)
     : name(n)
-    , properties()
-    , children()
     , force_has_children(false) {
         AddProperties(std::forward<More>(more)...);
     }

--- a/code/AssetLib/FBX/FBXImporter.cpp
+++ b/code/AssetLib/FBX/FBXImporter.cpp
@@ -90,10 +90,7 @@ static const aiImporterDesc desc = {
 
 // ------------------------------------------------------------------------------------------------
 // Constructor to be privately used by #Importer
-FBXImporter::FBXImporter() :
-        mSettings() {
-    // empty
-}
+FBXImporter::FBXImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/Irr/IRRMeshLoader.cpp
+++ b/code/AssetLib/Irr/IRRMeshLoader.cpp
@@ -71,11 +71,7 @@ static const aiImporterDesc desc = {
 
 // ------------------------------------------------------------------------------------------------
 // Constructor to be privately used by Importer
-IRRMeshImporter::IRRMeshImporter() :
-        BaseImporter(),
-        IrrlichtBase() {
-    // empty
-}
+IRRMeshImporter::IRRMeshImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well

--- a/code/AssetLib/Irr/IRRShared.h
+++ b/code/AssetLib/Irr/IRRShared.h
@@ -63,9 +63,7 @@ protected:
         // empty
     }
 
-    ~IrrlichtBase() {
-        // empty
-    }
+    ~IrrlichtBase() = default;
 
     /** @brief Data structure for a simple name-value property
      */

--- a/code/AssetLib/M3D/M3DImporter.h
+++ b/code/AssetLib/M3D/M3DImporter.h
@@ -65,7 +65,7 @@ class M3DImporter : public BaseImporter {
 public:
 	/// \brief  Default constructor
 	M3DImporter();
-    ~M3DImporter() override {}
+    ~M3DImporter() override = default;
 
 	/// \brief  Returns whether the class can handle the format of the given file.
 	/// \remark See BaseImporter::CanRead() for details.

--- a/code/AssetLib/OpenGEX/OpenGEXImporter.cpp
+++ b/code/AssetLib/OpenGEX/OpenGEXImporter.cpp
@@ -261,7 +261,6 @@ OpenGEXImporter::RefInfo::RefInfo(aiNode *node, Type type, std::vector<std::stri
 OpenGEXImporter::OpenGEXImporter() :
         m_root(nullptr),
         m_nodeChildMap(),
-        m_meshCache(),
         m_mesh2refMap(),
         m_material2refMap(),
         m_ctx(nullptr),

--- a/code/AssetLib/Ply/PlyParser.h
+++ b/code/AssetLib/Ply/PlyParser.h
@@ -296,9 +296,7 @@ class PropertyInstance
 public:
 
     //! Default constructor
-    PropertyInstance() AI_NO_EXCEPT {
-        // empty
-    }
+    PropertyInstance() AI_NO_EXCEPT = default;
 
     union ValueUnion
     {
@@ -359,10 +357,7 @@ public:
 class ElementInstance {
 public:
     //! Default constructor
-    ElementInstance()  AI_NO_EXCEPT
-    : alProperties() {
-        // empty
-    }
+    ElementInstance() AI_NO_EXCEPT = default;
 
     //! List of all parsed properties
     std::vector< PropertyInstance > alProperties;
@@ -386,10 +381,7 @@ class ElementInstanceList
 public:
 
     //! Default constructor
-    ElementInstanceList() AI_NO_EXCEPT
-    : alInstances() {
-        // empty
-    }
+    ElementInstanceList() AI_NO_EXCEPT = default;
 
     //! List of all element instances
     std::vector< ElementInstance > alInstances;
@@ -413,11 +405,7 @@ class DOM
 public:
 
     //! Default constructor
-    DOM() AI_NO_EXCEPT
-    : alElements()
-    , alElementData() {
-
-    }
+    DOM() AI_NO_EXCEPT = default;
 
 
     //! Contains all elements of the file format

--- a/code/AssetLib/Q3BSP/Q3BSPFileData.h
+++ b/code/AssetLib/Q3BSP/Q3BSPFileData.h
@@ -169,19 +169,7 @@ struct Q3BSPModel {
     std::vector<char> m_EntityData;
     std::string m_ModelName;
 
-    Q3BSPModel() :
-        m_Data(),
-        m_Lumps(),
-        m_Vertices(),
-        m_Faces(),
-        m_Indices(),
-        m_Textures(),
-        m_Lightmaps(),
-        m_EntityData(),
-        m_ModelName()
-    {
-        // empty
-    }
+    Q3BSPModel() = default;
 
     ~Q3BSPModel() {
         for ( unsigned int i=0; i<m_Lumps.size(); i++ ) {

--- a/code/AssetLib/Q3BSP/Q3BSPFileImporter.cpp
+++ b/code/AssetLib/Q3BSP/Q3BSPFileImporter.cpp
@@ -139,7 +139,7 @@ static void normalizePathName(const std::string &rPath, std::string &normalizedP
 // ------------------------------------------------------------------------------------------------
 //  Constructor.
 Q3BSPFileImporter::Q3BSPFileImporter() :
-        m_pCurrentMesh(nullptr), m_pCurrentFace(nullptr), m_MaterialLookupMap(), mTextures() {
+        m_pCurrentMesh(nullptr), m_pCurrentFace(nullptr) {
     // empty
 }
 

--- a/code/AssetLib/SMD/SMDLoader.cpp
+++ b/code/AssetLib/SMD/SMDLoader.cpp
@@ -83,7 +83,6 @@ static const aiImporterDesc desc = {
 // Constructor to be privately used by Importer
 SMDImporter::SMDImporter() :
         configFrameID(), 
-        mBuffer(), 
         pScene( nullptr ), 
         iFileSize( 0 ), 
         iSmallestFrame( INT_MAX ),

--- a/code/AssetLib/SMD/SMDLoader.h
+++ b/code/AssetLib/SMD/SMDLoader.h
@@ -87,7 +87,7 @@ struct Vertex {
 */
 struct Face {
     Face() AI_NO_EXCEPT :
-            iTexture(0x0), avVertices{} {
+            iTexture(0x0) {
         // empty
     }
     

--- a/code/AssetLib/X/XFileHelper.h
+++ b/code/AssetLib/X/XFileHelper.h
@@ -67,7 +67,6 @@ struct TexEntry {
     bool mIsNormalMap; // true if the texname was specified in a NormalmapFilename tag
 
     TexEntry() AI_NO_EXCEPT :
-            mName(),
             mIsNormalMap(false) {
         // empty
     }
@@ -128,17 +127,8 @@ struct Mesh {
 
     explicit Mesh(const std::string &pName = std::string()) AI_NO_EXCEPT
             : mName(pName),
-              mPositions(),
-              mPosFaces(),
-              mNormals(),
-              mNormFaces(),
               mNumTextures(0),
-              mTexCoords{},
-              mNumColorSets(0),
-              mColors{},
-              mFaceMaterials(),
-              mMaterials(),
-              mBones() {
+              mNumColorSets(0) {
         // empty
     }
 };
@@ -152,15 +142,12 @@ struct Node {
     std::vector<Mesh *> mMeshes;
 
     Node() AI_NO_EXCEPT
-            : mName(),
-              mTrafoMatrix(),
-              mParent(nullptr),
-              mChildren(),
-              mMeshes() {
+            : mTrafoMatrix(),
+              mParent(nullptr) {
         // empty
     }
     explicit Node(Node *pParent) :
-            mName(), mTrafoMatrix(), mParent(pParent), mChildren(), mMeshes() {
+            mTrafoMatrix(), mParent(pParent) {
         // empty
     }
 
@@ -211,8 +198,6 @@ struct Scene {
 
     Scene() AI_NO_EXCEPT
             : mRootNode(nullptr),
-              mGlobalMeshes(),
-              mGlobalMaterials(),
               mAnimTicksPerSecond(0) {
         // empty
     }

--- a/code/AssetLib/X/XFileImporter.cpp
+++ b/code/AssetLib/X/XFileImporter.cpp
@@ -75,9 +75,7 @@ static const aiImporterDesc desc = {
 
 // ------------------------------------------------------------------------------------------------
 // Constructor to be privately used by Importer
-XFileImporter::XFileImporter() : mBuffer() {
-    // empty
-}
+XFileImporter::XFileImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/X3D/X3DExporter.hpp
+++ b/code/AssetLib/X3D/X3DExporter.hpp
@@ -52,22 +52,14 @@ class X3DExporter {
     struct SAttribute {
         const std::string Name;
         const std::string Value;
-        SAttribute() :
-                Name(),
-                Value() {
-            // empty
-        }
+        SAttribute() = default;
         SAttribute(const std::string &name, const std::string &value) :
                 Name(name),
                 Value(value) {
             // empty
         }
 
-        SAttribute(SAttribute &&rhs) AI_NO_EXCEPT :
-                Name(rhs.Name),
-                Value(rhs.Value) {
-            // empty
-        }
+        SAttribute(SAttribute &&rhs) AI_NO_EXCEPT = default;
     };
 
     /***********************************************/

--- a/code/AssetLib/X3D/X3DImporter_Node.hpp
+++ b/code/AssetLib/X3D/X3DImporter_Node.hpp
@@ -108,9 +108,7 @@ struct X3DNodeElementBase {
     std::list<X3DNodeElementBase *> Children;
     X3DElemType Type;
 
-    virtual ~X3DNodeElementBase() {
-        // empty
-    }
+    virtual ~X3DNodeElementBase() = default;
 
 protected:
     X3DNodeElementBase(X3DElemType type, X3DNodeElementBase *pParent) :
@@ -367,9 +365,7 @@ struct X3DNodeElementMeta : X3DNodeElementBase {
     std::string Name; ///< Name of metadata object.
     std::string Reference;
 
-    virtual ~X3DNodeElementMeta() {
-        // empty
-    }
+    virtual ~X3DNodeElementMeta() = default;
 
 protected:
     X3DNodeElementMeta(X3DElemType type, X3DNodeElementBase *parent) :

--- a/code/AssetLib/glTF/glTFAsset.h
+++ b/code/AssetLib/glTF/glTFAsset.h
@@ -629,9 +629,7 @@ struct Mesh : public Object {
         SExtension(const EType pType) :
                 Type(pType) {}
 
-        virtual ~SExtension() {
-            // empty
-        }
+        virtual ~SExtension() = default;
     };
 
 #ifdef ASSIMP_IMPORTER_GLTF_USE_OPEN3DGC
@@ -657,9 +655,7 @@ struct Mesh : public Object {
             // empty
         }
 
-        virtual ~SCompression_Open3DGC() {
-            // empty
-        }
+        virtual ~SCompression_Open3DGC() = default;
     };
 #endif
 

--- a/code/AssetLib/glTF/glTFImporter.cpp
+++ b/code/AssetLib/glTF/glTFImporter.cpp
@@ -80,7 +80,7 @@ static const aiImporterDesc desc = {
 };
 
 glTFImporter::glTFImporter() :
-        BaseImporter(), meshOffsets(), embeddedTexIdxs(), mScene(nullptr) {
+        mScene(nullptr) {
     // empty
 }
 

--- a/code/AssetLib/glTF2/glTF2Asset.h
+++ b/code/AssetLib/glTF2/glTF2Asset.h
@@ -365,16 +365,7 @@ struct CustomExtension {
 
     ~CustomExtension() = default;
 
-    CustomExtension(const CustomExtension &other) :
-            name(other.name),
-            mStringValue(other.mStringValue),
-            mDoubleValue(other.mDoubleValue),
-            mUint64Value(other.mUint64Value),
-            mInt64Value(other.mInt64Value),
-            mBoolValue(other.mBoolValue),
-            mValues(other.mValues) {
-        // empty
-    }
+    CustomExtension(const CustomExtension &other) = default;
 
     CustomExtension& operator=(const CustomExtension&) = default;
 };
@@ -1086,8 +1077,7 @@ struct AssetMetadata {
 
     void Read(Document &doc);
 
-    AssetMetadata() :
-            version() {}
+    AssetMetadata() = default;
 };
 
 //

--- a/code/AssetLib/glTF2/glTF2Importer.cpp
+++ b/code/AssetLib/glTF2/glTF2Importer.cpp
@@ -96,9 +96,6 @@ static const aiImporterDesc desc = {
 };
 
 glTF2Importer::glTF2Importer() :
-        BaseImporter(),
-        meshOffsets(),
-        mEmbeddedTexIdxs(),
         mScene(nullptr) {
     // empty
 }

--- a/code/Common/FileSystemFilter.h
+++ b/code/Common/FileSystemFilter.h
@@ -93,9 +93,7 @@ public:
     }
 
     /** Destructor. */
-    ~FileSystemFilter() {
-        // empty
-    }
+    ~FileSystemFilter() = default;
 
     // -------------------------------------------------------------------
     /** Tests for the existence of a file at the given path. */

--- a/include/assimp/IOStream.hpp
+++ b/include/assimp/IOStream.hpp
@@ -128,9 +128,7 @@ public:
 
 // ----------------------------------------------------------------------------------
 AI_FORCE_INLINE
-IOStream::IOStream() AI_NO_EXCEPT {
-    // empty
-}
+IOStream::IOStream() AI_NO_EXCEPT = default;
 
 // ----------------------------------------------------------------------------------
 AI_FORCE_INLINE

--- a/include/assimp/IOStreamBuffer.h
+++ b/include/assimp/IOStreamBuffer.h
@@ -141,9 +141,7 @@ AI_FORCE_INLINE IOStreamBuffer<T>::IOStreamBuffer(size_t cache) :
 }
 
 template <class T>
-AI_FORCE_INLINE IOStreamBuffer<T>::~IOStreamBuffer() {
-    // empty
-}
+AI_FORCE_INLINE IOStreamBuffer<T>::~IOStreamBuffer() = default;
 
 template <class T>
 AI_FORCE_INLINE bool IOStreamBuffer<T>::open(IOStream *stream) {

--- a/include/assimp/IOSystem.hpp
+++ b/include/assimp/IOSystem.hpp
@@ -237,10 +237,7 @@ private:
 };
 
 // ----------------------------------------------------------------------------
-AI_FORCE_INLINE IOSystem::IOSystem() AI_NO_EXCEPT :
-        m_pathStack() {
-    // empty
-}
+AI_FORCE_INLINE IOSystem::IOSystem() AI_NO_EXCEPT = default;
 
 // ----------------------------------------------------------------------------
 AI_FORCE_INLINE IOSystem::~IOSystem() = default;

--- a/include/assimp/LineSplitter.h
+++ b/include/assimp/LineSplitter.h
@@ -145,7 +145,6 @@ private:
 
 AI_FORCE_INLINE LineSplitter::LineSplitter(StreamReaderLE& stream, bool skip_empty_lines, bool trim ) :
         mIdx(0),
-        mCur(),
         mStream(stream),
         mSwallow(),
         mSkip_empty_lines(skip_empty_lines),
@@ -155,9 +154,7 @@ AI_FORCE_INLINE LineSplitter::LineSplitter(StreamReaderLE& stream, bool skip_emp
     mIdx = 0;
 }
 
-AI_FORCE_INLINE LineSplitter::~LineSplitter() {
-    // empty
-}
+AI_FORCE_INLINE LineSplitter::~LineSplitter() = default;
 
 AI_FORCE_INLINE LineSplitter& LineSplitter::operator++() {
     if (mSwallow) {

--- a/include/assimp/MemoryIOWrapper.h
+++ b/include/assimp/MemoryIOWrapper.h
@@ -162,8 +162,7 @@ public:
     }
 
     /** Destructor. */
-    ~MemoryIOSystem() {
-    }
+    ~MemoryIOSystem() = default;
 
     // -------------------------------------------------------------------
     /** Tests for the existence of a file at the given path. */

--- a/include/assimp/Profiler.h
+++ b/include/assimp/Profiler.h
@@ -68,9 +68,7 @@ using namespace Formatter;
  */
 class Profiler {
 public:
-    Profiler() {
-        // empty
-    }
+    Profiler() = default;
 
 
     /** Start a named timer */

--- a/include/assimp/ProgressHandler.hpp
+++ b/include/assimp/ProgressHandler.hpp
@@ -67,15 +67,11 @@ class ASSIMP_API ProgressHandler
 {
 protected:
     /// @brief  Default constructor
-    ProgressHandler () AI_NO_EXCEPT {
-        // empty
-    }
+    ProgressHandler () AI_NO_EXCEPT = default;
 
 public:
     /// @brief  Virtual destructor.
-    virtual ~ProgressHandler () {
-        // empty
-    }
+    virtual ~ProgressHandler () = default;
 
     // -------------------------------------------------------------------
     /** @brief Progress callback.

--- a/include/assimp/SceneCombiner.h
+++ b/include/assimp/SceneCombiner.h
@@ -191,13 +191,9 @@ struct SceneHelper {
  */
 class ASSIMP_API SceneCombiner {
     // class cannot be instanced
-    SceneCombiner() {
-        // empty
-    }
+    SceneCombiner() = delete;
 
-    ~SceneCombiner() {
-        // empty
-    }
+    ~SceneCombiner() = delete;
 
 public:
     // -------------------------------------------------------------------


### PR DESCRIPTION
This commit does not add or remove c’tors or d’tors, so it is *not* ABI-breaking.

If a c’tor/d’tor does nothing else than the default behavior, this commit replaces it with `= default`.

If an initializer list entry does nothing else than the default behavior, this commit removes it. First and foremost, remove default c’tor calls of base classes (always called by the compiler if no other base c’tor is explicitly called) and c’tor calls of members with complex types (e.g. `std::vector`).

In a few instances, user-defined copy c’tors / move c’tors / assignment operators / move assignment operators were replaced with `= default`, too. I only did this if I had a clear understanding of what’s going on.