### PR TITLE
Fix MSVC Warnings With “emplace_back()”

### DIFF
--- a/code/AssetLib/MMD/MMDImporter.cpp
+++ b/code/AssetLib/MMD/MMDImporter.cpp
@@ -269,7 +269,7 @@ aiMesh *MMDImporter::CreateMesh(const pmx::PmxModel *pModel,
                 dynamic_cast<pmx::PmxVertexSkinningSDEF *>(v->skinning.get());
         switch (v->skinning_type) {
         case pmx::PmxVertexSkinningType::BDEF1:
-            bone_vertex_map[vsBDEF1_ptr->bone_index].emplace_back(index, 1.0);
+            bone_vertex_map[vsBDEF1_ptr->bone_index].emplace_back(index, static_cast<ai_real>(1));
             break;
         case pmx::PmxVertexSkinningType::BDEF2:
             bone_vertex_map[vsBDEF2_ptr->bone_index1].emplace_back(index, vsBDEF2_ptr->bone_weight);

--- a/code/AssetLib/X3D/X3DGeoHelper.cpp
+++ b/code/AssetLib/X3D/X3DGeoHelper.cpp
@@ -193,7 +193,7 @@ void X3DGeoHelper::add_color(aiMesh &pMesh, const std::list<aiColor3D> &pColors,
 
     // create RGBA array from RGB.
     for (std::list<aiColor3D>::const_iterator it = pColors.begin(); it != pColors.end(); ++it)
-        tcol.emplace_back((*it).r, (*it).g, (*it).b, 1);
+        tcol.emplace_back((*it).r, (*it).g, (*it).b, static_cast<ai_real>(1));
 
     // call existing function for adding RGBA colors
     add_color(pMesh, tcol, pColorPerVertex);
@@ -238,7 +238,7 @@ void X3DGeoHelper::add_color(aiMesh &pMesh, const std::vector<int32_t> &pCoordId
 
     // create RGBA array from RGB.
     for (std::list<aiColor3D>::const_iterator it = pColors.begin(); it != pColors.end(); ++it) {
-        tcol.emplace_back((*it).r, (*it).g, (*it).b, 1);
+        tcol.emplace_back((*it).r, (*it).g, (*it).b, static_cast<ai_real>(1));
     }
 
     // call existing function for adding RGBA colors
@@ -440,7 +440,7 @@ void X3DGeoHelper::add_tex_coord(aiMesh &pMesh, const std::vector<int32_t> &pCoo
     // copy list to array because we are need indexed access to normals.
     texcoord_arr_copy.reserve(pTexCoords.size());
     for (std::list<aiVector2D>::const_iterator it = pTexCoords.begin(); it != pTexCoords.end(); ++it) {
-        texcoord_arr_copy.emplace_back((*it).x, (*it).y, 0);
+        texcoord_arr_copy.emplace_back((*it).x, (*it).y, static_cast<ai_real>(0));
     }
 
     if (pTexCoordIdx.size() > 0) {
@@ -480,7 +480,7 @@ void X3DGeoHelper::add_tex_coord(aiMesh &pMesh, const std::list<aiVector2D> &pTe
     // copy list to array because we are need convert aiVector2D to aiVector3D and also get indexed access as a bonus.
     tc_arr_copy.reserve(pTexCoords.size());
     for (std::list<aiVector2D>::const_iterator it = pTexCoords.begin(); it != pTexCoords.end(); ++it) {
-        tc_arr_copy.emplace_back((*it).x, (*it).y, 0);
+        tc_arr_copy.emplace_back((*it).x, (*it).y, static_cast<ai_real>(0));
     }
 
     // copy texture coordinates to mesh

--- a/code/AssetLib/X3D/X3DImporter_Geometry2D.cpp
+++ b/code/AssetLib/X3D/X3DImporter_Geometry2D.cpp
@@ -151,7 +151,7 @@ void X3DImporter::readArcClose2D(XmlNode &node) {
             std::list<aiVector3D> &vlist = ((X3DNodeElementGeometry2D *)ne)->Vertices; // just short alias.
 
             if ((closureType == "PIE") || (closureType == "\"PIE\""))
-                vlist.emplace_back(0, 0, 0); // center point - first radial line
+                vlist.emplace_back(static_cast<ai_real>(0), static_cast<ai_real>(0), static_cast<ai_real>(0)); // center point - first radial line
             else if ((closureType != "CHORD") && (closureType != "\"CHORD\""))
                 Throw_IncorrectAttrValue("ArcClose2D", "closureType");
 
@@ -323,7 +323,7 @@ void X3DImporter::readPolyline2D(XmlNode &node) {
 
         // convert vec2 to vec3
         for (std::list<aiVector2D>::iterator it2 = lineSegments.begin(); it2 != lineSegments.end(); ++it2)
-            tlist.emplace_back(it2->x, it2->y, 0);
+            tlist.emplace_back(it2->x, it2->y, static_cast<ai_real>(0));
 
         // convert point set to line set
         X3DGeoHelper::extend_point_to_line(tlist, ((X3DNodeElementGeometry2D *)ne)->Vertices);
@@ -361,7 +361,7 @@ void X3DImporter::readPolypoint2D(XmlNode &node) {
 
         // convert vec2 to vec3
         for (std::list<aiVector2D>::iterator it2 = point.begin(); it2 != point.end(); ++it2) {
-            ((X3DNodeElementGeometry2D *)ne)->Vertices.emplace_back(it2->x, it2->y, 0);
+            ((X3DNodeElementGeometry2D *)ne)->Vertices.emplace_back(it2->x, it2->y, static_cast<ai_real>(0));
         }
 
         ((X3DNodeElementGeometry2D *)ne)->NumIndices = 1;
@@ -405,10 +405,10 @@ void X3DImporter::readRectangle2D(XmlNode &node) {
         float y2 = size.y / 2.0f;
         std::list<aiVector3D> &vlist = ((X3DNodeElementGeometry2D *)ne)->Vertices; // just short alias.
 
-        vlist.emplace_back(x2, y1, 0); // 1st point
-        vlist.emplace_back(x2, y2, 0); // 2nd point
-        vlist.emplace_back(x1, y2, 0); // 3rd point
-        vlist.emplace_back(x1, y1, 0); // 4th point
+        vlist.emplace_back(x2, y1, static_cast<ai_real>(0)); // 1st point
+        vlist.emplace_back(x2, y2, static_cast<ai_real>(0)); // 2nd point
+        vlist.emplace_back(x1, y2, static_cast<ai_real>(0)); // 3rd point
+        vlist.emplace_back(x1, y1, static_cast<ai_real>(0)); // 4th point
         ((X3DNodeElementGeometry2D *)ne)->Solid = solid;
         ((X3DNodeElementGeometry2D *)ne)->NumIndices = 4;
         // check for X3DMetadataObject childs.
@@ -449,7 +449,7 @@ void X3DImporter::readTriangleSet2D(XmlNode &node) {
 
         // convert vec2 to vec3
         for (std::list<aiVector2D>::iterator it2 = vertices.begin(); it2 != vertices.end(); ++it2) {
-            ((X3DNodeElementGeometry2D *)ne)->Vertices.emplace_back(it2->x, it2->y, 0);
+            ((X3DNodeElementGeometry2D *)ne)->Vertices.emplace_back(it2->x, it2->y, static_cast<ai_real>(0));
         }
 
         ((X3DNodeElementGeometry2D *)ne)->Solid = solid;


### PR DESCRIPTION
Several places in the code call `std::vector<aiVector3D>.emplace_back(0, 0, 0)`. The constructor of `aiVector3D` actually expects arguments of the type `ai_real`, (alias of `float` if compiling without `ASSIMP_DOUBLE_PRECISION`) but the literal `0` is of type `int`.

`emplace_back()` does support promotion, but `int` to `float` is a potentially lossy conversion. tl;dr: On warning level 4, MSVC spits out a very deeply nested `warning C4244: 'argument': conversion from '_Ty' to 'TReal', possible loss of data with _Ty=int and TReal=ai_real`.

I used `static_cast<ai_real>()` in the affected places because both `ai_real(0)` and `(ai_real)0` are regarded as C-style casts and frowned upon by various linters, e.g. clang-tidy.