### PR TITLE
Correctly consider aiProcess_FlipWindingOrder and aiProcess_MakeLeftHanded when generating normals

### DIFF
--- a/code/PostProcessing/GenFaceNormalsProcess.cpp
+++ b/code/PostProcessing/GenFaceNormalsProcess.cpp
@@ -132,7 +132,9 @@ bool GenFaceNormalsProcess::GenMeshFaceNormals(aiMesh *pMesh) {
         const aiVector3D *pV1 = &pMesh->mVertices[face.mIndices[0]];
         const aiVector3D *pV2 = &pMesh->mVertices[face.mIndices[1]];
         const aiVector3D *pV3 = &pMesh->mVertices[face.mIndices[face.mNumIndices - 1]];
-        if (flippedWindingOrder_ != leftHanded_) // Boolean XOR
+        // Boolean XOR - if either but not both of these flags is set, then the winding order has
+        // changed and the cross product to calculate the normal needs to be reversed
+        if (flippedWindingOrder_ != leftHanded_) 
             std::swap(pV2, pV3);
         const aiVector3D vNor = ((*pV2 - *pV1) ^ (*pV3 - *pV1)).NormalizeSafe();
 

--- a/code/PostProcessing/GenFaceNormalsProcess.cpp
+++ b/code/PostProcessing/GenFaceNormalsProcess.cpp
@@ -67,6 +67,7 @@ GenFaceNormalsProcess::~GenFaceNormalsProcess() = default;
 bool GenFaceNormalsProcess::IsActive(unsigned int pFlags) const {
     force_ = (pFlags & aiProcess_ForceGenNormals) != 0;
     flippedWindingOrder_ = (pFlags & aiProcess_FlipWindingOrder) != 0;
+    leftHanded_ = (pFlags & aiProcess_MakeLeftHanded) != 0;
     return (pFlags & aiProcess_GenNormals) != 0;
 }
 
@@ -131,8 +132,8 @@ bool GenFaceNormalsProcess::GenMeshFaceNormals(aiMesh *pMesh) {
         const aiVector3D *pV1 = &pMesh->mVertices[face.mIndices[0]];
         const aiVector3D *pV2 = &pMesh->mVertices[face.mIndices[1]];
         const aiVector3D *pV3 = &pMesh->mVertices[face.mIndices[face.mNumIndices - 1]];
-        if (flippedWindingOrder_)
-            std::swap( pV2, pV3 );
+        if (flippedWindingOrder_ != leftHanded_) // Boolean XOR
+            std::swap(pV2, pV3);
         const aiVector3D vNor = ((*pV2 - *pV1) ^ (*pV3 - *pV1)).NormalizeSafe();
 
         for (unsigned int i = 0; i < face.mNumIndices; ++i) {

--- a/code/PostProcessing/GenFaceNormalsProcess.h
+++ b/code/PostProcessing/GenFaceNormalsProcess.h
@@ -81,6 +81,7 @@ private:
     bool GenMeshFaceNormals(aiMesh* pcMesh);
     mutable bool force_ = false;
     mutable bool flippedWindingOrder_ = false;
+    mutable bool leftHanded_ = false;
 };
 
 } // end of namespace Assimp

--- a/code/PostProcessing/GenVertexNormalsProcess.cpp
+++ b/code/PostProcessing/GenVertexNormalsProcess.cpp
@@ -142,7 +142,9 @@ bool GenVertexNormalsProcess::GenMeshVertexNormals(aiMesh *pMesh, unsigned int m
         const aiVector3D *pV1 = &pMesh->mVertices[face.mIndices[0]];
         const aiVector3D *pV2 = &pMesh->mVertices[face.mIndices[1]];
         const aiVector3D *pV3 = &pMesh->mVertices[face.mIndices[face.mNumIndices - 1]];
-        if (flippedWindingOrder_ != leftHanded_) // Boolean XOR
+        // Boolean XOR - if either but not both of these flags is set, then the winding order has
+        // changed and the cross product to calculate the normal needs to be reversed
+        if (flippedWindingOrder_ != leftHanded_)
             std::swap(pV2, pV3);
         const aiVector3D vNor = ((*pV2 - *pV1) ^ (*pV3 - *pV1)).NormalizeSafe();
 

--- a/code/PostProcessing/GenVertexNormalsProcess.cpp
+++ b/code/PostProcessing/GenVertexNormalsProcess.cpp
@@ -69,6 +69,7 @@ GenVertexNormalsProcess::~GenVertexNormalsProcess() = default;
 bool GenVertexNormalsProcess::IsActive(unsigned int pFlags) const {
     force_ = (pFlags & aiProcess_ForceGenNormals) != 0;
     flippedWindingOrder_ = (pFlags & aiProcess_FlipWindingOrder) != 0;
+    leftHanded_ = (pFlags & aiProcess_MakeLeftHanded) != 0;
     return (pFlags & aiProcess_GenSmoothNormals) != 0;
 }
 
@@ -141,8 +142,8 @@ bool GenVertexNormalsProcess::GenMeshVertexNormals(aiMesh *pMesh, unsigned int m
         const aiVector3D *pV1 = &pMesh->mVertices[face.mIndices[0]];
         const aiVector3D *pV2 = &pMesh->mVertices[face.mIndices[1]];
         const aiVector3D *pV3 = &pMesh->mVertices[face.mIndices[face.mNumIndices - 1]];
-        if (flippedWindingOrder_)
-            std::swap( pV2, pV3 );
+        if (flippedWindingOrder_ != leftHanded_) // Boolean XOR
+            std::swap(pV2, pV3);
         const aiVector3D vNor = ((*pV2 - *pV1) ^ (*pV3 - *pV1)).NormalizeSafe();
 
         for (unsigned int i = 0; i < face.mNumIndices; ++i) {

--- a/code/PostProcessing/GenVertexNormalsProcess.h
+++ b/code/PostProcessing/GenVertexNormalsProcess.h
@@ -105,6 +105,7 @@ private:
     ai_real configMaxAngle;
     mutable bool force_ = false;
     mutable bool flippedWindingOrder_ = false;
+    mutable bool leftHanded_ = false;
 };
 
 } // end of namespace Assimp


### PR DESCRIPTION
Fixes #3838

When assimp generates normals with aiProcess_GenNormals or aiProcess_GenSmoothNormals it does not take account of aiProcess_MakeLeftHanded, which flips the winding order and requires normals to be flipped.

Previous pull request #3838 fixed the same issue for aiProcess_FlipWindingOrder, but that broke normals for those using both flags (left handed and flipped winding order, typical for DirectX). When both flags are set, no action needs to be taken since the two normal flips cancel out. 

Corrected code flips normals if one or the other flag is set, but not both.

