### PR TITLE
Unit test warning fixes

### DIFF
--- a/test/unit/utMetadata.cpp
+++ b/test/unit/utMetadata.cpp
@@ -212,7 +212,7 @@ TEST_F( utMetadata, copy_test ) {
 
     // int32_t test
     {
-		int32_t v = 0;
+        int32_t v = 127;
         bool ok = copy.Get( "int32", v );
         EXPECT_TRUE( ok );
         EXPECT_EQ( i32v, v );
@@ -220,7 +220,7 @@ TEST_F( utMetadata, copy_test ) {
 
     // uint64_t test
     {
-        uint64_t v;
+        uint64_t v = 255;
         bool ok = copy.Get( "uint64", v );
         EXPECT_TRUE( ok );
         EXPECT_EQ( ui64v, v );
@@ -228,14 +228,14 @@ TEST_F( utMetadata, copy_test ) {
 
     // float test
     {
-        float v;
+        float v = -9.9999f;
         EXPECT_TRUE( copy.Get( "float", v ) );
         EXPECT_EQ( fv, v );
     }
 
     // double test
     {
-        double v;
+        double v = -99.99;
         EXPECT_TRUE( copy.Get( "double", v ) );
         EXPECT_EQ( dv, v );
     }

--- a/test/unit/utSharedPPData.cpp
+++ b/test/unit/utSharedPPData.cpp
@@ -81,7 +81,7 @@ TEST_F(SharedPPDataTest, testPODProperty)
     EXPECT_FALSE(shared->GetProperty("test2",o));
     EXPECT_EQ(5, o);
 
-    float f = 12.f, m;
+    float f = 12.f, m = -98.7654f;
     shared->AddProperty("test",f);
     EXPECT_TRUE(shared->GetProperty("test",m));
     EXPECT_EQ(12.f, m);


### PR DESCRIPTION
GCC was warning about possibly uninitialized variables. Initialize them and use values which are nonzero and distinct from each other and any real value passed to any set method. This should prevent any false positives from zero initialization.