### PR TITLE
fix regression in join vertices post process.

### DIFF
--- a/code/PostProcessing/JoinVerticesProcess.cpp
+++ b/code/PostProcessing/JoinVerticesProcess.cpp
@@ -252,7 +252,8 @@ private:
     unsigned mNumColorChannels;
 };
 
-#define JOINED_VERTICES_MARK 0x80000000u
+static constexpr siue_T JOINED_VERTICES_MARK = 0x80000000u;
+
 // now start the JoinVerticesProcess
 int JoinVerticesProcess::ProcessMesh( aiMesh* pMesh, unsigned int meshIndex) {
     static_assert( AI_MAX_NUMBER_OF_COLOR_SETS    == 8, "AI_MAX_NUMBER_OF_COLOR_SETS    == 8");

--- a/code/PostProcessing/JoinVerticesProcess.cpp
+++ b/code/PostProcessing/JoinVerticesProcess.cpp
@@ -357,7 +357,8 @@ int JoinVerticesProcess::ProcessMesh( aiMesh* pMesh, unsigned int meshIndex) {
             }
         } else{
             // if the vertex is already there just find the replace index that is appropriate to it
-            replaceIndex[a] = it->second;
+			// mark it with '0x80000000'
+            replaceIndex[a] = it->second | 0x80000000;
         }
     }
 
@@ -400,17 +401,8 @@ int JoinVerticesProcess::ProcessMesh( aiMesh* pMesh, unsigned int meshIndex) {
             for ( unsigned int b = 0; b < bone->mNumWeights; b++ ) {
                 const aiVertexWeight& ow = bone->mWeights[ b ];
                 // if the vertex is a unique one, translate it
+				// filter out joined vertices by mrak.
                 if ( !( replaceIndex[ ow.mVertexId ] & 0x80000000 ) ) {
-                    bool weightAlreadyExists = false;
-                    for (std::vector<aiVertexWeight>::iterator vit = newWeights.begin(); vit != newWeights.end(); ++vit) {
-                        if (vit->mVertexId == replaceIndex[ow.mVertexId]) {
-                            weightAlreadyExists = true;
-                            break;
-                        }
-                    }
-                    if (weightAlreadyExists) {
-                        continue;
-                    }
                     aiVertexWeight nw;
                     nw.mVertexId = replaceIndex[ ow.mVertexId ];
                     nw.mWeight = ow.mWeight;

--- a/code/PostProcessing/JoinVerticesProcess.cpp
+++ b/code/PostProcessing/JoinVerticesProcess.cpp
@@ -251,6 +251,8 @@ private:
     unsigned mNumUVChannels;
     unsigned mNumColorChannels;
 };
+
+#define JOINED_VERTICES_MARK 0x80000000u
 // now start the JoinVerticesProcess
 int JoinVerticesProcess::ProcessMesh( aiMesh* pMesh, unsigned int meshIndex) {
     static_assert( AI_MAX_NUMBER_OF_COLOR_SETS    == 8, "AI_MAX_NUMBER_OF_COLOR_SETS    == 8");
@@ -357,8 +359,8 @@ int JoinVerticesProcess::ProcessMesh( aiMesh* pMesh, unsigned int meshIndex) {
             }
         } else{
             // if the vertex is already there just find the replace index that is appropriate to it
-			// mark it with '0x80000000'
-            replaceIndex[a] = it->second | 0x80000000;
+			// mark it with JOINED_VERTICES_MARK
+            replaceIndex[a] = it->second | JOINED_VERTICES_MARK;
         }
     }
 
@@ -387,7 +389,7 @@ int JoinVerticesProcess::ProcessMesh( aiMesh* pMesh, unsigned int meshIndex) {
     for( unsigned int a = 0; a < pMesh->mNumFaces; a++) {
         aiFace& face = pMesh->mFaces[a];
         for( unsigned int b = 0; b < face.mNumIndices; b++) {
-            face.mIndices[b] = replaceIndex[face.mIndices[b]] & ~0x80000000;
+            face.mIndices[b] = replaceIndex[face.mIndices[b]] & ~JOINED_VERTICES_MARK;
         }
     }
 
@@ -401,8 +403,8 @@ int JoinVerticesProcess::ProcessMesh( aiMesh* pMesh, unsigned int meshIndex) {
             for ( unsigned int b = 0; b < bone->mNumWeights; b++ ) {
                 const aiVertexWeight& ow = bone->mWeights[ b ];
                 // if the vertex is a unique one, translate it
-				// filter out joined vertices by mrak.
-                if ( !( replaceIndex[ ow.mVertexId ] & 0x80000000 ) ) {
+				// filter out joined vertices by JOINED_VERTICES_MARK.
+                if ( !( replaceIndex[ ow.mVertexId ] & JOINED_VERTICES_MARK ) ) {
                     aiVertexWeight nw;
                     nw.mVertexId = replaceIndex[ ow.mVertexId ];
                     nw.mWeight = ow.mWeight;

--- a/code/PostProcessing/JoinVerticesProcess.cpp
+++ b/code/PostProcessing/JoinVerticesProcess.cpp
@@ -55,13 +55,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <unordered_map>
 
 using namespace Assimp;
-// ------------------------------------------------------------------------------------------------
-// Constructor to be privately used by Importer
-JoinVerticesProcess::JoinVerticesProcess() = default;
-
-// ------------------------------------------------------------------------------------------------
-// Destructor, private as well
-JoinVerticesProcess::~JoinVerticesProcess() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the processing step is present in the given flag field.
@@ -252,7 +245,7 @@ private:
     unsigned mNumColorChannels;
 };
 
-static constexpr siue_T JOINED_VERTICES_MARK = 0x80000000u;
+static constexpr size_t JOINED_VERTICES_MARK = 0x80000000u;
 
 // now start the JoinVerticesProcess
 int JoinVerticesProcess::ProcessMesh( aiMesh* pMesh, unsigned int meshIndex) {

--- a/code/PostProcessing/JoinVerticesProcess.h
+++ b/code/PostProcessing/JoinVerticesProcess.h
@@ -64,8 +64,13 @@ namespace Assimp
  */
 class ASSIMP_API JoinVerticesProcess : public BaseProcess {
 public:
-    JoinVerticesProcess();
-    ~JoinVerticesProcess();
+    // -------------------------------------------------------------------
+    /// @brief  The default class constructor.
+    JoinVerticesProcess() = default;
+    
+    // -------------------------------------------------------------------
+    /// @brief  The default class destructor.
+    ~JoinVerticesProcess() = default;
 
     // -------------------------------------------------------------------
     /** Returns whether the processing step is present in the given flag field.


### PR DESCRIPTION
If a bone has too many 'mWeights'(eg : bone->mNumWeights =  50000+), It may takes more than half a minute to adjust bone vertex weights.
We can use mark '0x80000000' to remove the these duplicating weights.
reference commit id: a22aa75bca5da546abb320edefe2da0ae3316535