### PR TITLE
Fix double free when the mesh contains duplicate bones.

### DIFF
--- a/include/assimp/mesh.h
+++ b/include/assimp/mesh.h
@@ -59,6 +59,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/types.h>
 
 #ifdef __cplusplus
+#include <unordered_set>
+
 extern "C" {
 #endif
 
@@ -872,10 +874,14 @@ struct aiMesh {
 
         // DO NOT REMOVE THIS ADDITIONAL CHECK
         if (mNumBones && mBones) {
+            std::unordered_set<const aiBone *> bones;
             for (unsigned int a = 0; a < mNumBones; a++) {
                 if (mBones[a]) {
-                    delete mBones[a];
+                    bones.insert(mBones[a]);
                 }
+            }
+            for (const aiBone *bone: bones) {
+                delete bone;
             }
             delete[] mBones;
         }


### PR DESCRIPTION
The aiMesh class destructor iterates the array of bones and deletes them. 
In the case of duplicate bones, the same bone is attempted to be deleted twice which causes the 'double free or corruption error. 
We can store bones in the set and delete each bone only once. 