### PR TITLE
Fix a leak in FBXDocument when duplicate object IDs are found

### DIFF
--- a/code/AssetLib/FBX/FBXDocument.cpp
+++ b/code/AssetLib/FBX/FBXDocument.cpp
@@ -381,8 +381,10 @@ void Document::ReadObjects() {
             DOMError("encountered object with implicitly defined id 0",el.second);
         }
 
-        if(objects.find(id) != objects.end()) {
+        const auto foundObject = objects.find(id);
+        if(foundObject != objects.end()) {
             DOMWarning("encountered duplicate object id, ignoring first occurrence",el.second);
+            delete foundObject->second;
         }
 
         objects[id] = new LazyObject(id, *el.second, *this);


### PR DESCRIPTION
When a duplicate ID is encountered, existing LazyObject is overwritten. Previously allocated instance leaks.

This change deletes the previously allocated instance before overwriting the pointer.