### PR TITLE
Optimize subdivision process

### DIFF
--- a/code/Common/Subdivision.cpp
+++ b/code/Common/Subdivision.cpp
@@ -50,6 +50,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <stdio.h>
 
+#include <unordered_map>
+
 using namespace Assimp;
 void mydummy() {}
 
@@ -78,7 +80,7 @@ public:
     };
 
     typedef std::vector<unsigned int> UIntVector;
-    typedef std::map<uint64_t, Edge> EdgeMap;
+    typedef std::unordered_map<uint64_t, Edge> EdgeMap;
 
     // ---------------------------------------------------------------------------
     // Hashing function to derive an index into an #EdgeMap from two given


### PR DESCRIPTION
Makes subdivision process about 5 - 10% faster. Also improves the unit tests for some subdivision models so it should catch if the process goes wrong somehow.
