### PR TITLE
Validate node hierarchy parents

### DIFF
--- a/code/PostProcessing/ValidateDataStructure.cpp
+++ b/code/PostProcessing/ValidateDataStructure.cpp
@@ -911,7 +911,12 @@ void ValidateDSProcess::Validate(const aiNode *pNode) {
                     nodeName, pNode->mNumChildren);
         }
         for (unsigned int i = 0; i < pNode->mNumChildren; ++i) {
-            Validate(pNode->mChildren[i]);
+            const aiNode *pChild = pNode->mChildren[i];
+            Validate(pChild);
+            if (pChild->mParent != pNode) {
+                const char *parentName = (pChild->mParent != nullptr) ? pChild->mParent->mName.C_Str() : "null";
+                ReportError("aiNode \"%s\" child %i \"%s\" parent is someone else: \"%s\"", pNode->mName.C_Str(), i, pChild->mName.C_Str(), parentName);
+            }
         }
     }
 }

--- a/test/unit/ImportExport/MDL/utMDLImporter_HL1_ImportSettings.cpp
+++ b/test/unit/ImportExport/MDL/utMDLImporter_HL1_ImportSettings.cpp
@@ -190,7 +190,7 @@ private:
         Assimp::Importer importer;
         importer.SetPropertyBool(setting_key, setting_value);
         const aiScene *scene = importer.ReadFile(file_path, aiProcess_ValidateDataStructure);
-        EXPECT_NE(nullptr, scene);
+        ASSERT_NE(nullptr, scene);
         func(scene);
     }
 

--- a/test/unit/ImportExport/MDL/utMDLImporter_HL1_Materials.cpp
+++ b/test/unit/ImportExport/MDL/utMDLImporter_HL1_Materials.cpp
@@ -61,8 +61,8 @@ public:
     void flatShadeTexture() {
         Assimp::Importer importer;
         const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MDL_HL1_MODELS_DIR "chrome_sphere.mdl", aiProcess_ValidateDataStructure);
-        EXPECT_NE(nullptr, scene);
-        EXPECT_NE(nullptr, scene->mMaterials);
+        ASSERT_NE(nullptr, scene);
+        ASSERT_NE(nullptr, scene->mMaterials);
 
         aiShadingMode shading_mode = aiShadingMode_Flat;
         scene->mMaterials[0]->Get(AI_MATKEY_SHADING_MODEL, shading_mode);
@@ -74,8 +74,8 @@ public:
     void chromeTexture() {
         Assimp::Importer importer;
         const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MDL_HL1_MODELS_DIR "chrome_sphere.mdl", aiProcess_ValidateDataStructure);
-        EXPECT_NE(nullptr, scene);
-        EXPECT_NE(nullptr, scene->mMaterials);
+        ASSERT_NE(nullptr, scene);
+        ASSERT_NE(nullptr, scene->mMaterials);
 
         int chrome;
         scene->mMaterials[0]->Get(AI_MDL_HL1_MATKEY_CHROME(aiTextureType_DIFFUSE, 0), chrome);
@@ -87,8 +87,8 @@ public:
     void additiveBlendTexture() {
         Assimp::Importer importer;
         const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MDL_HL1_MODELS_DIR "blend_additive.mdl", aiProcess_ValidateDataStructure);
-        EXPECT_NE(nullptr, scene);
-        EXPECT_NE(nullptr, scene->mMaterials);
+        ASSERT_NE(nullptr, scene);
+        ASSERT_NE(nullptr, scene->mMaterials);
 
         aiBlendMode blend_mode = aiBlendMode_Default;
         scene->mMaterials[0]->Get(AI_MATKEY_BLEND_FUNC, blend_mode);
@@ -101,8 +101,8 @@ public:
     void textureWithColorMask() {
         Assimp::Importer importer;
         const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MDL_HL1_MODELS_DIR "alpha_test.mdl", aiProcess_ValidateDataStructure);
-        EXPECT_NE(nullptr, scene);
-        EXPECT_NE(nullptr, scene->mMaterials);
+        ASSERT_NE(nullptr, scene);
+        ASSERT_NE(nullptr, scene->mMaterials);
 
         int texture_flags = 0;
         scene->mMaterials[0]->Get(AI_MATKEY_TEXFLAGS_DIFFUSE(0), texture_flags);

--- a/test/unit/ImportExport/MDL/utMDLImporter_HL1_Nodes.cpp
+++ b/test/unit/ImportExport/MDL/utMDLImporter_HL1_Nodes.cpp
@@ -136,7 +136,7 @@ public:
     void emptyBonesNames() {
         Assimp::Importer importer;
         const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MDL_HL1_MODELS_DIR "unnamed_bones.mdl", aiProcess_ValidateDataStructure);
-        EXPECT_NE(nullptr, scene);
+        ASSERT_NE(nullptr, scene);
 
         const StringVector expected_bones_names = {
             "Bone",
@@ -172,7 +172,7 @@ public:
     void emptyBodypartsNames() {
         Assimp::Importer importer;
         const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MDL_HL1_MODELS_DIR "unnamed_bodyparts.mdl", aiProcess_ValidateDataStructure);
-        EXPECT_NE(nullptr, scene);
+        ASSERT_NE(nullptr, scene);
 
         const StringVector expected_bodyparts_names = {
             "Bodypart",
@@ -209,7 +209,7 @@ public:
     void duplicateBodypartsNames() {
         Assimp::Importer importer;
         const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MDL_HL1_MODELS_DIR "duplicate_bodyparts.mdl", aiProcess_ValidateDataStructure);
-        EXPECT_NE(nullptr, scene);
+        ASSERT_NE(nullptr, scene);
 
         const StringVector expected_bodyparts_names = {
             "Bodypart",
@@ -254,7 +254,7 @@ public:
     void duplicateSubModelsNames() {
         Assimp::Importer importer;
         const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MDL_HL1_MODELS_DIR "duplicate_submodels.mdl", aiProcess_ValidateDataStructure);
-        EXPECT_NE(nullptr, scene);
+        ASSERT_NE(nullptr, scene);
 
         const std::vector<StringVector> expected_bodypart_sub_models_names = {
             {
@@ -272,7 +272,7 @@ public:
         };
 
         const aiNode *bodyparts_node = scene->mRootNode->FindNode(AI_MDL_HL1_NODE_BODYPARTS);
-        EXPECT_NE(nullptr, bodyparts_node);
+        ASSERT_NE(nullptr, bodyparts_node);
         EXPECT_EQ(3u, bodyparts_node->mNumChildren);
 
         StringVector actual_submodels_names;
@@ -301,7 +301,7 @@ public:
     void duplicateSequenceNames() {
         Assimp::Importer importer;
         const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MDL_HL1_MODELS_DIR "duplicate_sequences.mdl", aiProcess_ValidateDataStructure);
-        EXPECT_NE(nullptr, scene);
+        ASSERT_NE(nullptr, scene);
 
         const StringVector expected_sequence_names = {
             "idle_1",
@@ -337,7 +337,7 @@ public:
     void emptySequenceNames() {
         Assimp::Importer importer;
         const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MDL_HL1_MODELS_DIR "unnamed_sequences.mdl", aiProcess_ValidateDataStructure);
-        EXPECT_NE(nullptr, scene);
+        ASSERT_NE(nullptr, scene);
 
         const StringVector expected_sequence_names = {
             "Sequence",
@@ -374,7 +374,7 @@ public:
     void duplicateSequenceGroupNames() {
         Assimp::Importer importer;
         const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MDL_HL1_MODELS_DIR "duplicate_sequence_groups/duplicate_sequence_groups.mdl", aiProcess_ValidateDataStructure);
-        EXPECT_NE(nullptr, scene);
+        ASSERT_NE(nullptr, scene);
 
         const StringVector expected_sequence_names = {
             "default",
@@ -412,7 +412,7 @@ public:
     void emptySequenceGroupNames() {
         Assimp::Importer importer;
         const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MDL_HL1_MODELS_DIR "unnamed_sequence_groups/unnamed_sequence_groups.mdl", aiProcess_ValidateDataStructure);
-        EXPECT_NE(nullptr, scene);
+        ASSERT_NE(nullptr, scene);
 
         const StringVector expected_sequence_names = {
             "default",
@@ -440,7 +440,7 @@ public:
 
         Assimp::Importer importer;
         const aiScene *scene = importer.ReadFile(MDL_HL1_FILE_MAN, aiProcess_ValidateDataStructure);
-        EXPECT_NE(nullptr, scene);
+        ASSERT_NE(nullptr, scene);
 
         aiNode *scene_bones_node = scene->mRootNode->FindNode(AI_MDL_HL1_NODE_BONES);
 


### PR DESCRIPTION
Add a check that node hierarchy parents point to correct nodes.

This reveals a problem in Half-Life MDL loader and must not be merged until that is fixed.
