### PR TITLE
Build assimp with ohos sdk

### DIFF
--- a/contrib/draco/src/draco/attributes/geometry_attribute.h
+++ b/contrib/draco/src/draco/attributes/geometry_attribute.h
@@ -383,8 +383,8 @@ class GeometryAttribute {
 
         // Make sure the floating point |in_value| fits within the range of
         // values that integral type OutT is able to represent.
-        if (in_value < std::numeric_limits<OutT>::min() ||
-            in_value >= std::numeric_limits<OutT>::max()) {
+        if (in_value < static_cast<T>(std::numeric_limits<OutT>::min()) ||
+            in_value >= static_cast<T>(std::numeric_limits<OutT>::max())) {
           return false;
         }
       }

--- a/contrib/draco/src/draco/compression/mesh/mesh_edgebreaker_decoder_impl.cc
+++ b/contrib/draco/src/draco/compression/mesh/mesh_edgebreaker_decoder_impl.cc
@@ -920,7 +920,7 @@ int MeshEdgebreakerDecoderImpl<TraversalDecoder>::DecodeConnectivity(
   int num_vertices = corner_table_->num_vertices();
   // If any vertex was marked as isolated, we want to remove it from the corner
   // table to ensure that all vertices in range <0, num_vertices> are valid.
-  for (const VertexIndex invalid_vert : invalid_vertices) {
+  for (const VertexIndex& invalid_vert : invalid_vertices) {
     // Find the last valid vertex and swap it with the isolated vertex.
     VertexIndex src_vert(num_vertices - 1);
     while (corner_table_->LeftMostCorner(src_vert) == kInvalidCornerIndex) {


### PR DESCRIPTION
Fix some compiler warnings when building assimp with OHOS SDK.

Create a script named as `ohos_build.cmd` in assimp folder, with its content as follows:
```
@echo off
setlocal
set PATH=C:\Tools\cmake\bin;%PATH%
set PATH=C:\Tools\Git\bin;%PATH%
set OHOS_SDK_HOME=E:\Tools\OHOS\SDK\9

set SRC_ROOT=%CD%
set BUILD_ROOT=%SRC_ROOT%\build-ohos
set BUILD_TARGET=assimp

cmake --version
ninja --version

cmake -G "Ninja Multi-Config" ^
    -S %SRC_ROOT% ^
    -B %BUILD_ROOT% ^
    -DCMAKE_TOOLCHAIN_FILE=%OHOS_SDK_HOME%\native\build\cmake\ohos.toolchain.cmake ^
    -DCMAKE_CXX_FLAGS="-Wno-unused-command-line-argument -Wall -Werror" ^
    -DCMAKE_C_FLAGS="-Wno-unused-command-line-argument -Wall -Werror" ^
    -DASSIMP_HUNTER_ENABLED=OFF ^
    -DBUILD_SHARED_LIBS=ON ^
    -DASSIMP_BUILD_ZLIB=OFF ^
    -DASSIMP_BUILD_ASSIMP_TOOLS=OFF ^
    -DASSIMP_BUILD_SAMPLES=OFF ^
    -DASSIMP_BUILD_TESTS=OFF ^
    -DASSIMP_COVERALLS=OFF ^
    -DASSIMP_INSTALL=OFF ^
    -DASSIMP_WARNINGS_AS_ERRORS=OFF ^
    -DASSIMP_IGNORE_GIT_HASH=ON ^
    -DASSIMP_INSTALL_PDB=OFF ^
    -DASSIMP_BUILD_DRACO=ON

cmake --build %BUILD_ROOT% --target %BUILD_TARGET% --parallel
```

and run in cmd:
```
call ohos_build.cmd
```