### PR TITLE
Add more AMF unit tests

### DIFF
--- a/code/AssetLib/AMF/AMFImporter_Postprocess.cpp
+++ b/code/AssetLib/AMF/AMFImporter_Postprocess.cpp
@@ -815,6 +815,7 @@ nl_clean_loop:
             for (; next_it != nodeArray.end(); ++next_it) {
                 if ((*next_it)->FindNode((*nl_it)->mName) != nullptr) {
                     // if current top node(nl_it) found in another top node then erase it from node_list and restart search loop.
+                    // FIXME: this leaks memory on test models test8.amf and test9.amf
                     nodeArray.erase(nl_it);
 
                     goto nl_clean_loop;

--- a/test/unit/utAMFImportExport.cpp
+++ b/test/unit/utAMFImportExport.cpp
@@ -60,6 +60,81 @@ TEST_F(utAMFImportExport, importAMFFromFileTest) {
     EXPECT_TRUE(importerTest());
 }
 
+
+// TODO: test models-nonbsd/AMF/3_bananas.amf.7z
+//       requires uncompressing it in memory and we don't currently have 7z decompressor
+
+
+TEST_F(utAMFImportExport, importTest2) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/AMF/test2.amf", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+}
+
+
+TEST_F(utAMFImportExport, importTest3) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/AMF/test3.amf", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+}
+
+
+TEST_F(utAMFImportExport, importTest4) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/AMF/test4.amf", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+}
+
+
+TEST_F(utAMFImportExport, importTest5) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/AMF/test5.amf", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+}
+
+
+TEST_F(utAMFImportExport, importTest5a) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/AMF/test5a.amf", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+}
+
+
+TEST_F(utAMFImportExport, importTest6) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/AMF/test6.amf", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+}
+
+
+TEST_F(utAMFImportExport, importTest7) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/AMF/test7.amf", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+}
+
+
+#if 0
+// FIXME: these tests are disabled because they leak memory in AMFImporter_Postprocess.cpp
+
+
+TEST_F(utAMFImportExport, importTest8) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/AMF/test8.amf", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+}
+
+
+TEST_F(utAMFImportExport, importTest9) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/AMF/test9.amf", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+}
+
+
+#endif  // 0
+
+
 TEST_F(utAMFImportExport, importAMFWithMatFromFileTest) {
     Assimp::Importer importer;
     const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/AMF/test_with_mat.amf", aiProcess_ValidateDataStructure);


### PR DESCRIPTION
`3_bananas.amf.7z` is compressed and we don't currently have an in-memory decompressor for it so it's not tested.

Two test models (`test8.amf` and `test9.amf`) leak memory and are disabled. 

Also adds a comment to `AMFImporter_Postprocess.cpp` where the leak happens.
