### PR TITLE
Fix link issue in UWP builds without functional replacement

### DIFF
--- a/contrib/unzip/crypt.c
+++ b/contrib/unzip/crypt.c
@@ -103,7 +103,7 @@ int cryptrand(unsigned char *buf, unsigned int len)
     unsigned __int64 pentium_tsc[1];
     int result = 0;
 
-
+    #if defined(WINAPI_FAMILY) && WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP
     if (CryptAcquireContext(&provider, NULL, NULL, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT | CRYPT_SILENT))
     {
         result = CryptGenRandom(provider, len, buf);
@@ -111,6 +111,7 @@ int cryptrand(unsigned char *buf, unsigned int len)
         if (result)
             return len;
     }
+    #endif
 
     for (rlen = 0; rlen < (int)len; ++rlen)
     {


### PR DESCRIPTION
After trying a version update from 5.2.5 I discovered some build issues if included in UWP projects.
I come up with a simple solution, skipping just the missing function in windows libraries. There seems to be some system function in UWP to get a similar behavior. 

For me, it doesn't matter if this function is executed that way. If there is a way to just not include unzip code or replace with UWP support, I didn't find it the last days.