### PR TITLE
std::getenv is not supported using uwp

### DIFF
--- a/code/Common/ImporterRegistry.cpp
+++ b/code/Common/ImporterRegistry.cpp
@@ -214,7 +214,12 @@ void GetImporterInstanceList(std::vector<BaseImporter *> &out) {
     // Some importers may be unimplemented or otherwise unsuitable for general use
     // in their current state. Devs can set ASSIMP_ENABLE_DEV_IMPORTERS in their
     // local environment to enable them, otherwise they're left out of the registry.
+#if defined(WINAPI_FAMILY) && WINAPI_FAMILY == WINAPI_FAMILY_DESKTOP_APP
+    // not supported under uwp
     const char *envStr = std::getenv("ASSIMP_ENABLE_DEV_IMPORTERS");
+#else
+    const char *envStr = { "0" };
+#endif
     bool devImportersEnabled = envStr && strcmp(envStr, "0");
 
     // Ensure no unused var warnings if all uses are #ifndef'd away below:
@@ -378,7 +383,7 @@ void GetImporterInstanceList(std::vector<BaseImporter *> &out) {
     out.push_back(new IQMImporter());
 #endif
     //#ifndef ASSIMP_BUILD_NO_STEP_IMPORTER
-    //    out.push_back(new StepFile::StepFileImporter());
+    //     out.push_back(new StepFile::StepFileImporter());
     //#endif
 }
 


### PR DESCRIPTION
Found another line that is not supported in uwp environments. Already discussed in #3937. Without std:: is offered by spdlogger but also just return nothing as uwp app.