### PR TITLE
Fix warning related to nested-anon-types.

### DIFF
--- a/code/AssetLib/glTF/glTFAsset.h
+++ b/code/AssetLib/glTF/glTFAsset.h
@@ -513,21 +513,22 @@ struct Camera : public Object {
     };
 
     Type type;
+    struct Perspective {
+        float aspectRatio; //!<The floating - point aspect ratio of the field of view. (0 = undefined = use the canvas one)
+        float yfov; //!<The floating - point vertical field of view in radians. (required)
+        float zfar; //!<The floating - point distance to the far clipping plane. (required)
+        float znear; //!< The floating - point distance to the near clipping plane. (required)
+    };
 
+    struct Ortographic {
+        float xmag; //! The floating-point horizontal magnification of the view. (required)
+        float ymag; //! The floating-point vertical magnification of the view. (required)
+        float zfar; //! The floating-point distance to the far clipping plane. (required)
+        float znear; //! The floating-point distance to the near clipping plane. (required)
+    };
     union {
-        struct {
-            float aspectRatio; //!<The floating - point aspect ratio of the field of view. (0 = undefined = use the canvas one)
-            float yfov; //!<The floating - point vertical field of view in radians. (required)
-            float zfar; //!<The floating - point distance to the far clipping plane. (required)
-            float znear; //!< The floating - point distance to the near clipping plane. (required)
-        } perspective;
-
-        struct {
-            float xmag; //! The floating-point horizontal magnification of the view. (required)
-            float ymag; //! The floating-point vertical magnification of the view. (required)
-            float zfar; //! The floating-point distance to the far clipping plane. (required)
-            float znear; //! The floating-point distance to the near clipping plane. (required)
-        } ortographic;
+        struct Perspective perspective;
+        struct Ortographic ortographic;
     };
 
     Camera() = default;

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -1254,7 +1254,6 @@ IF (ASSIMP_WARNINGS_AS_ERRORS)
         -Wno-implicit-fallthrough
         -Wno-unused-template
         -Wno-undefined-func-template
-        -Wno-nested-anon-types
         -Wno-declaration-after-statement
       )
     ELSE()


### PR DESCRIPTION
Fix the following warnings when `-Wno-nested-anon-types` is removed.
```
D:\workspace\CODE\assimp\code\AssetLib/glTF/glTFAsset.h(518,9): error : anonymous types declared in an anonymous union
are an extension [-Werror,-Wnested-anon-types] [D:\workspace\CODE\assimp\build-msvc-clang\code\assimp.vcxproj]
D:\workspace\CODE\assimp\code\AssetLib/glTF/glTFAsset.h(525,9): error : anonymous types declared in an anonymous union
are an extension [-Werror,-Wnested-anon-types] [D:\workspace\CODE\assimp\build-msvc-clang\code\assimp.vcxproj]
```

The build script is as follows:
```
@echo off
setlocal
set CMAKE_HOME=D:\Tools\cmake-3.26.0-windows-x86_64
set PATH=%CMAKE_HOME%\bin;%PATH%

cmake --version
ninja --version

set SRC=%CD%

set BUILD_ROOT=%SRC%\build-msvc-clang
set BUILD_TARGET=assimp

cmake -B %BUILD_ROOT% ^
    -S %SRC% ^
    -T ClangCl ^
    -DCMAKE_INSTALL_PREFIX=install-clang ^
    -DASSIMP_BUILD_ZLIB=ON ^
    -DASSIMP_BUILD_SAMPLES=ON ^
    -DASSIMP_BUILD_DRACO=OFF ^
    -DBUILD_SHARED_LIBS=ON ^
    -DASSIMP_DOUBLE_PRECISION=OFF ^
    -DASSIMP_BUILD_ASSIMP_TOOLS=ON ^
    -DASSIMP_ASAN=OFF ^
    -DASSIMP_UBSAN=OFF ^
    -DASSIMP_BUILD_TESTS=ON

cmake --build %BUILD_ROOT% --target assimp --parallel
```