### PR TITLE
Fix warning related to format-non-iso.

### DIFF
--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -1246,7 +1246,6 @@ IF (ASSIMP_WARNINGS_AS_ERRORS)
         -Wno-deprecated-copy-with-dtor
         -Wno-deprecated
         -Wno-format-nonliteral
-        -Wno-format-non-iso
         -Wno-comma
         -Wno-unreachable-code-break
         -Wno-unreachable-code-return

--- a/include/assimp/StringUtils.h
+++ b/include/assimp/StringUtils.h
@@ -56,7 +56,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <sstream>
 #include <iomanip>
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
 #define AI_SIZEFMT "%Iu"
 #else
 #define AI_SIZEFMT "%zu"


### PR DESCRIPTION
Fix the following warnings when `-Wno-format-non-iso` is removed.
```
  In file included from D:\workspace\CODE\assimp\code\AssetLib\glTF\glTFImporter.cpp:45:
  In file included from D:\workspace\CODE\assimp\code\AssetLib/glTF/glTFAsset.h:1012:
D:\workspace\CODE\assimp\code\AssetLib\glTF/glTFAsset.inl(261,36): error : 'I' length modifier is not supported by ISO
C [-Werror,-Wformat-non-iso] [D:\workspace\CODE\assimp\build-msvc-clang\code\assimp.vcxproj]
D:\workspace\CODE\assimp\include\assimp/StringUtils.h(60,22): message : expanded from macro 'AI_SIZEFMT' [D:\workspace\
CODE\assimp\build-msvc-clang\code\assimp.vcxproj]
  In file included from D:\workspace\CODE\assimp\code\AssetLib\glTF\glTFImporter.cpp:45:
  In file included from D:\workspace\CODE\assimp\code\AssetLib/glTF/glTFAsset.h:1012:
D:\workspace\CODE\assimp\code\AssetLib\glTF/glTFAsset.inl(271,36): error : 'I' length modifier is not supported by ISO
C [-Werror,-Wformat-non-iso] [D:\workspace\CODE\assimp\build-msvc-clang\code\assimp.vcxproj]
D:\workspace\CODE\assimp\include\assimp/StringUtils.h(60,22): message : expanded from macro 'AI_SIZEFMT' [D:\workspace\
CODE\assimp\build-msvc-clang\code\assimp.vcxproj]
  In file included from D:\workspace\CODE\assimp\code\AssetLib\glTF\glTFImporter.cpp:45:
  In file included from D:\workspace\CODE\assimp\code\AssetLib/glTF/glTFAsset.h:1012:
D:\workspace\CODE\assimp\code\AssetLib\glTF/glTFAsset.inl(271,51): error : 'I' length modifier is not supported by ISO
C [-Werror,-Wformat-non-iso] [D:\workspace\CODE\assimp\build-msvc-clang\code\assimp.vcxproj]
D:\workspace\CODE\assimp\include\assimp/StringUtils.h(60,22): message : expanded from macro 'AI_SIZEFMT' [D:\workspace\
CODE\assimp\build-msvc-clang\code\assimp.vcxproj]
```

The build script is as follows:
```
@echo off
setlocal
set CMAKE_HOME=D:\Tools\cmake-3.26.0-windows-x86_64
set PATH=%CMAKE_HOME%\bin;%PATH%

cmake --version
ninja --version

set SRC=%CD%

set BUILD_ROOT=%SRC%\build-msvc-clang
set BUILD_TARGET=assimp

cmake -B %BUILD_ROOT% ^
    -S %SRC% ^
    -T ClangCl ^
    -DCMAKE_INSTALL_PREFIX=install-clang ^
    -DASSIMP_BUILD_ZLIB=ON ^
    -DASSIMP_BUILD_SAMPLES=ON ^
    -DASSIMP_BUILD_DRACO=OFF ^
    -DBUILD_SHARED_LIBS=ON ^
    -DASSIMP_DOUBLE_PRECISION=OFF ^
    -DASSIMP_BUILD_ASSIMP_TOOLS=ON ^
    -DASSIMP_ASAN=OFF ^
    -DASSIMP_UBSAN=OFF ^
    -DASSIMP_BUILD_TESTS=ON

cmake --build %BUILD_ROOT% --target unit --parallel
```
