### PR TITLE
Fix warning related to unreachable-code.

### DIFF
--- a/code/AssetLib/B3D/B3DImporter.cpp
+++ b/code/AssetLib/B3D/B3DImporter.cpp
@@ -418,7 +418,6 @@ void B3DImporter::ReadTRIS(int v0) {
             ASSIMP_LOG_ERROR("Bad triangle index: i0=", i0, ", i1=", i1, ", i2=", i2);
 #endif
             Fail("Bad triangle index");
-            continue;
         }
         face->mNumIndices = 3;
         face->mIndices = new unsigned[3];

--- a/code/AssetLib/LWO/LWOMaterial.cpp
+++ b/code/AssetLib/LWO/LWOMaterial.cpp
@@ -345,7 +345,7 @@ void LWOImporter::ConvertMaterial(const LWO::Surface &surf, aiMaterial *pcMat) {
 
     // (the diffuse value is just a scaling factor)
     // If a diffuse texture is set, we set this value to 1.0
-    clr = (b && false ? aiColor3D(1.0, 1.0, 1.0) : surf.mColor);
+    clr = (b ? aiColor3D(1.0, 1.0, 1.0) : surf.mColor);
     clr.r *= surf.mDiffuseValue;
     clr.g *= surf.mDiffuseValue;
     clr.b *= surf.mDiffuseValue;

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -1250,7 +1250,6 @@ IF (ASSIMP_WARNINGS_AS_ERRORS)
         -Wno-comma
         -Wno-unreachable-code-break
         -Wno-unreachable-code-return
-        -Wno-unreachable-code
         -Wno-implicit-fallthrough
         -Wno-unused-template
         -Wno-undefined-func-template

--- a/contrib/poly2tri/poly2tri/sweep/sweep.cc
+++ b/contrib/poly2tri/poly2tri/sweep/sweep.cc
@@ -118,8 +118,8 @@ void Sweep::EdgeEvent(SweepContext& tcx, Point& ep, Point& eq, Triangle* triangl
   Point* p1 = triangle->PointCCW(point);
   Orientation o1 = Orient2d(eq, *p1, ep);
   if (o1 == COLLINEAR) {
-	  // ASSIMP_CHANGE (aramis_acg)
-	  throw std::runtime_error("EdgeEvent - collinear points not supported");
+
+
     if( triangle->Contains(&eq, p1)) {
       triangle->MarkConstrainedEdge(&eq, p1 );
       // We are modifying the constraint maybe it would be better to
@@ -137,8 +137,8 @@ void Sweep::EdgeEvent(SweepContext& tcx, Point& ep, Point& eq, Triangle* triangl
   Point* p2 = triangle->PointCW(point);
   Orientation o2 = Orient2d(eq, *p2, ep);
   if (o2 == COLLINEAR) {
-	  // ASSIMP_CHANGE (aramis_acg)
-	  throw std::runtime_error("EdgeEvent - collinear points not supported");
+
+
 
     if( triangle->Contains(&eq, p2)) {
       triangle->MarkConstrainedEdge(&eq, p2 );


### PR DESCRIPTION
Fix the following warnings when `-Wno-unreachable-code` is removed.

```
D:\workspace\CODE\assimp\code\AssetLib\B3D\B3DImporter.cpp(421,13): error : code will never be executed [-Werror,-Wunre
achable-code] [D:\workspace\CODE\assimp\build-msvc-clang\code\assimp.vcxproj]

D:\workspace\CODE\assimp\code\AssetLib\LWO\LWOMaterial.cpp(348,35): error : code will never be executed [-Werror,-Wunre
achable-code] [D:\workspace\CODE\assimp\build-msvc-clang\code\assimp.vcxproj]

D:\workspace\CODE\assimp\contrib\poly2tri\poly2tri\sweep\sweep.cc(143,9): error : code will never be executed [-Werror,
-Wunreachable-code] [D:\workspace\CODE\assimp\build-msvc-clang\code\assimp.vcxproj]
D:\workspace\CODE\assimp\contrib\poly2tri\poly2tri\sweep\sweep.cc(123,9): error : code will never be executed [-Werror,
-Wunreachable-code] [D:\workspace\CODE\assimp\build-msvc-clang\code\assimp.vcxproj]
```