### PR TITLE
Fix warning related to unreachable-code-break.

### DIFF
--- a/code/AssetLib/Collada/ColladaParser.cpp
+++ b/code/AssetLib/Collada/ColladaParser.cpp
@@ -1855,7 +1855,6 @@ size_t ColladaParser::ReadPrimitives(XmlNode &node, Mesh &pMesh, std::vector<Inp
         default:
             // LineStrip is not supported due to expected index unmangling
             throw DeadlyImportError("Unsupported primitive type.");
-            break;
         }
 
         // store the face size to later reconstruct the face from

--- a/code/AssetLib/LWO/LWOBLoader.cpp
+++ b/code/AssetLib/LWO/LWOBLoader.cpp
@@ -65,7 +65,6 @@ void LWOImporter::LoadLWOBFile()
         if (mFileBuffer + head.length > end)
         {
             throw DeadlyImportError("LWOB: Invalid chunk length");
-            break;
         }
         uint8_t* const next = mFileBuffer+head.length;
         switch (head.type)

--- a/code/AssetLib/LWO/LWOLoader.cpp
+++ b/code/AssetLib/LWO/LWOLoader.cpp
@@ -1486,7 +1486,6 @@ void LWOImporter::LoadLWO2File() {
 
         if (mFileBuffer + head.length > end) {
             throw DeadlyImportError("LWO2: Chunk length points behind the file");
-            break;
         }
         uint8_t *const next = mFileBuffer + head.length;
         mFileBuffer += bufOffset;

--- a/code/AssetLib/Obj/ObjFileParser.cpp
+++ b/code/AssetLib/Obj/ObjFileParser.cpp
@@ -236,7 +236,7 @@ void ObjFileParser::parseFile(IOStreamBuffer<char> &streamBuffer) {
             getNameNoSpace(m_DataIt, m_DataItEnd, name);
             insideCstype = name == "cstype";
             goto pf_skip_line;
-        } break;
+        }
 
         default: {
         pf_skip_line:

--- a/code/AssetLib/Q3D/Q3DLoader.cpp
+++ b/code/AssetLib/Q3D/Q3DLoader.cpp
@@ -382,11 +382,10 @@ void Q3DImporter::InternReadFile(const std::string &pFile,
 
             // TODO
             goto outer;
-        } break;
+        }
 
         default:
             throw DeadlyImportError("Quick3D: Unknown chunk");
-            break;
         };
     }
 outer:

--- a/code/AssetLib/X/XFileParser.cpp
+++ b/code/AssetLib/X/XFileParser.cpp
@@ -839,7 +839,6 @@ void XFileParser::ParseDataObjectAnimationKey(AnimBone *pAnimBone) {
 
         default:
             ThrowException("Unknown key type ", keyType, " in animation.");
-            break;
         } // end switch
 
         // key separator

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -1246,7 +1246,6 @@ IF (ASSIMP_WARNINGS_AS_ERRORS)
         -Wno-deprecated
         -Wno-format-nonliteral
         -Wno-comma
-        -Wno-unreachable-code-break
         -Wno-implicit-fallthrough
         -Wno-unused-template
         -Wno-undefined-func-template

--- a/code/PostProcessing/ValidateDataStructure.cpp
+++ b/code/PostProcessing/ValidateDataStructure.cpp
@@ -290,7 +290,6 @@ void ValidateDSProcess::Validate(const aiMesh *pMesh) {
             switch (face.mNumIndices) {
             case 0:
                 ReportError("aiMesh::mFaces[%i].mNumIndices is 0", i);
-                break;
             case 1:
                 if (0 == (pMesh->mPrimitiveTypes & aiPrimitiveType_POINT)) {
                     ReportError("aiMesh::mFaces[%i] is a POINT but aiMesh::mPrimitiveTypes "


### PR DESCRIPTION
Fix the following warnings when `-Wno-unreachable-code-break` is removed.

```
D:\workspace\CODE\assimp\code\PostProcessing\ValidateDataStructure.cpp(293,17): error : 'break' will never be executed
[-Werror,-Wunreachable-code-break] [D:\workspace\CODE\assimp\build-msvc-clang\code\assimp.vcxproj]

D:\workspace\CODE\assimp\code\AssetLib\Collada\ColladaParser.cpp(1858,13): error : 'break' will never be executed [-Wer
ror,-Wunreachable-code-break] [D:\workspace\CODE\assimp\build-msvc-clang\code\assimp.vcxproj]
```