### PR TITLE
Fix warning related to nonportable-system-include-path.

### DIFF
--- a/code/AssetLib/Blender/BlenderTessellator.h
+++ b/code/AssetLib/Blender/BlenderTessellator.h
@@ -64,7 +64,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #if ASSIMP_BLEND_WITH_GLU_TESSELLATE
 
 #if defined( WIN32 ) || defined( _WIN32 ) || defined( _MSC_VER )
-#include <windows.h>
+#include <Windows.h>
 #endif
 #include <GL/glu.h>
 

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -1239,7 +1239,6 @@ IF (ASSIMP_WARNINGS_AS_ERRORS)
         -Wno-missing-noreturn
         -Wno-missing-variable-declarations
         -Wno-extra-semi
-        -Wno-nonportable-system-include-path
         -Wno-undefined-reinterpret-cast
         -Wno-shift-sign-overflow
         -Wno-deprecated-copy-with-user-provided-dtor

--- a/code/Common/DefaultIOSystem.cpp
+++ b/code/Common/DefaultIOSystem.cpp
@@ -54,7 +54,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 #ifdef _WIN32
-#    include <windows.h>
+#    include <Windows.h>
 #endif
 
 using namespace Assimp;

--- a/code/Common/Win32DebugLogStream.h
+++ b/code/Common/Win32DebugLogStream.h
@@ -50,7 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef _WIN32
 
 #include <assimp/LogStream.hpp>
-#include "windows.h"
+#include <Windows.h>
 
 namespace Assimp    {
 

--- a/contrib/Open3DGC/o3dgcTimer.h
+++ b/contrib/Open3DGC/o3dgcTimer.h
@@ -31,7 +31,7 @@ THE SOFTWARE.
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
-#include <windows.h>
+#include <Windows.h>
 #elif __APPLE__
 #include <mach/clock.h>
 #include <mach/mach.h>

--- a/contrib/gtest/src/gtest-death-test.cc
+++ b/contrib/gtest/src/gtest-death-test.cc
@@ -55,7 +55,7 @@
 #include <stdarg.h>
 
 #if GTEST_OS_WINDOWS
-#include <windows.h>
+#include <Windows.h>
 #else
 #include <sys/mman.h>
 #include <sys/wait.h>

--- a/contrib/gtest/src/gtest-filepath.cc
+++ b/contrib/gtest/src/gtest-filepath.cc
@@ -35,7 +35,7 @@
 #include "gtest/internal/gtest-port.h"
 
 #if GTEST_OS_WINDOWS_MOBILE
-#include <windows.h>
+#include <Windows.h>
 #elif GTEST_OS_WINDOWS
 #include <direct.h>
 #include <io.h>

--- a/contrib/gtest/src/gtest-internal-inl.h
+++ b/contrib/gtest/src/gtest-internal-inl.h
@@ -55,7 +55,7 @@
 #endif
 
 #if GTEST_OS_WINDOWS
-#include <windows.h>  // NOLINT
+#include <Windows.h>  // NOLINT
 #endif                // GTEST_OS_WINDOWS
 
 #include "gtest/gtest-spi.h"

--- a/contrib/gtest/src/gtest-port.cc
+++ b/contrib/gtest/src/gtest-port.cc
@@ -41,7 +41,7 @@
 #if GTEST_OS_WINDOWS
 #include <io.h>
 #include <sys/stat.h>
-#include <windows.h>
+#include <Windows.h>
 
 #include <map>  // Used in ThreadLocal.
 #ifdef _MSC_VER

--- a/contrib/gtest/src/gtest.cc
+++ b/contrib/gtest/src/gtest.cc
@@ -80,12 +80,12 @@
 
 #elif GTEST_OS_WINDOWS_MOBILE  // We are on Windows CE.
 
-#include <windows.h>  // NOLINT
+#include <Windows.h>  // NOLINT
 #undef min
 
 #elif GTEST_OS_WINDOWS  // We are on Windows proper.
 
-#include <windows.h>  // NOLINT
+#include <Windows.h>  // NOLINT
 #undef min
 
 #ifdef _MSC_VER

--- a/contrib/openddlparser/code/OpenDDLParser.cpp
+++ b/contrib/openddlparser/code/OpenDDLParser.cpp
@@ -30,7 +30,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <sstream>
 
 #ifdef _WIN32
-#include <windows.h>
+#include <Windows.h>
 #endif // _WIN32
 
 BEGIN_ODDLPARSER_NS

--- a/contrib/unzip/crypt.c
+++ b/contrib/unzip/crypt.c
@@ -31,7 +31,7 @@
 #include <time.h>
 
 #ifdef _WIN32
-#  include <windows.h>
+#  include <Windows.h>
 #  include <wincrypt.h>
 #else
 #  include <sys/stat.h>

--- a/contrib/zip/src/miniz.h
+++ b/contrib/zip/src/miniz.h
@@ -4112,7 +4112,7 @@ void *tdefl_write_image_to_png_file_in_memory(const void *pImage, int w, int h,
 
 #if defined(_MSC_VER) || defined(__MINGW32__)
 
-#include <windows.h>
+#include <Windows.h>
 
 static wchar_t *str2wstr(const char *str) {
   int len = (int) strlen(str) + 1;

--- a/contrib/zlib/contrib/minizip/iowin32.h
+++ b/contrib/zlib/contrib/minizip/iowin32.h
@@ -11,7 +11,7 @@
 
 */
 
-#include <windows.h>
+#include <Windows.h>
 
 
 #ifdef __cplusplus

--- a/contrib/zlib/contrib/testzlib/testzlib.c
+++ b/contrib/zlib/contrib/testzlib/testzlib.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
-#include <windows.h>
+#include <Windows.h>
 
 #include "zlib.h"
 

--- a/contrib/zlib/contrib/untgz/untgz.c
+++ b/contrib/zlib/contrib/untgz/untgz.c
@@ -22,7 +22,7 @@
 #endif
 
 #ifdef WIN32
-#include <windows.h>
+#include <Windows.h>
 #  ifndef F_OK
 #    define F_OK  0
 #  endif

--- a/contrib/zlib/contrib/vstudio/vc10/zlib.rc
+++ b/contrib/zlib/contrib/vstudio/vc10/zlib.rc
@@ -1,4 +1,4 @@
-#include <windows.h>
+#include <Windows.h>
 
 #define IDR_VERSION1  1
 IDR_VERSION1	VERSIONINFO	MOVEABLE IMPURE LOADONCALL DISCARDABLE

--- a/contrib/zlib/contrib/vstudio/vc11/zlib.rc
+++ b/contrib/zlib/contrib/vstudio/vc11/zlib.rc
@@ -1,4 +1,4 @@
-#include <windows.h>
+#include <Windows.h>
 
 #define IDR_VERSION1  1
 IDR_VERSION1	VERSIONINFO	MOVEABLE IMPURE LOADONCALL DISCARDABLE

--- a/contrib/zlib/contrib/vstudio/vc12/zlib.rc
+++ b/contrib/zlib/contrib/vstudio/vc12/zlib.rc
@@ -1,4 +1,4 @@
-#include <windows.h>
+#include <Windows.h>
 
 #define IDR_VERSION1  1
 IDR_VERSION1	VERSIONINFO	MOVEABLE IMPURE LOADONCALL DISCARDABLE

--- a/contrib/zlib/contrib/vstudio/vc14/zlib.rc
+++ b/contrib/zlib/contrib/vstudio/vc14/zlib.rc
@@ -1,4 +1,4 @@
-#include <windows.h>
+#include <Windows.h>
 
 #define IDR_VERSION1  1
 IDR_VERSION1	VERSIONINFO	MOVEABLE IMPURE LOADONCALL DISCARDABLE

--- a/contrib/zlib/contrib/vstudio/vc9/zlib.rc
+++ b/contrib/zlib/contrib/vstudio/vc9/zlib.rc
@@ -1,4 +1,4 @@
-#include <windows.h>
+#include <Windows.h>
 
 #define IDR_VERSION1  1
 IDR_VERSION1	VERSIONINFO	MOVEABLE IMPURE LOADONCALL DISCARDABLE

--- a/contrib/zlib/gzguts.h
+++ b/contrib/zlib/gzguts.h
@@ -125,7 +125,7 @@
 
 /* get errno and strerror definition */
 #if defined UNDER_CE
-#  include <windows.h>
+#  include <Windows.h>
 #  define zstrerror() gz_strwinerror((DWORD)GetLastError())
 #else
 #  ifndef NO_STRERROR

--- a/contrib/zlib/zconf.h.cmakein
+++ b/contrib/zlib/zconf.h.cmakein
@@ -351,7 +351,7 @@
 #    ifdef FAR
 #      undef FAR
 #    endif
-#    include <windows.h>
+#    include <Windows.h>
      /* No need for _export, use ZLIB.DEF instead. */
      /* For complete Windows compatibility, use WINAPI, not __stdcall. */
 #    define ZEXPORT WINAPI

--- a/contrib/zlib/zconf.h.in
+++ b/contrib/zlib/zconf.h.in
@@ -349,7 +349,7 @@
 #    ifdef FAR
 #      undef FAR
 #    endif
-#    include <windows.h>
+#    include <Windows.h>
      /* No need for _export, use ZLIB.DEF instead. */
      /* For complete Windows compatibility, use WINAPI, not __stdcall. */
 #    define ZEXPORT WINAPI

--- a/contrib/zlib/zconf.h.included
+++ b/contrib/zlib/zconf.h.included
@@ -351,7 +351,7 @@
 #    ifdef FAR
 #      undef FAR
 #    endif
-#    include <windows.h>
+#    include <Windows.h>
      /* No need for _export, use ZLIB.DEF instead. */
      /* For complete Windows compatibility, use WINAPI, not __stdcall. */
 #    define ZEXPORT WINAPI

--- a/samples/SimpleTexturedOpenGL/SimpleTexturedOpenGL/src/model_loading.cpp
+++ b/samples/SimpleTexturedOpenGL/SimpleTexturedOpenGL/src/model_loading.cpp
@@ -12,7 +12,7 @@
 // Thanks to NeHe on whose OpenGL tutorials this one's based on! :)
 // http://nehe.gamedev.net/
 // ----------------------------------------------------------------------------
-#include <windows.h>
+#include <Windows.h>
 #include <shellapi.h>
 #include <stdio.h>
 #include <GL/gl.h>

--- a/tools/assimp_view/Display.h
+++ b/tools/assimp_view/Display.h
@@ -42,7 +42,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #if (!defined AV_DISPLAY_H_INCLUDED)
 #define AV_DISPLAY_H_INCLUDE
 
-#include <windows.h>
+#include <Windows.h>
 #include <shellapi.h>
 #include <commctrl.h>
 

--- a/tools/assimp_view/assimp_view.rc
+++ b/tools/assimp_view/assimp_view.rc
@@ -9,7 +9,7 @@
 // Generated from the TEXTINCLUDE 2 resource.
 //
 #define APSTUDIO_HIDDEN_SYMBOLS
-#include "windows.h"
+#include "Windows.h"
 #undef APSTUDIO_HIDDEN_SYMBOLS
 
 /////////////////////////////////////////////////////////////////////////////
@@ -168,7 +168,7 @@ END
 2 TEXTINCLUDE 
 BEGIN
     "#define APSTUDIO_HIDDEN_SYMBOLS\r\n"
-    "#include ""windows.h""\r\n"
+    "#include ""Windows.h""\r\n"
     "#undef APSTUDIO_HIDDEN_SYMBOLS\r\n"
     "\0"
 END

--- a/tools/assimp_view/stdafx.h
+++ b/tools/assimp_view/stdafx.h
@@ -24,7 +24,7 @@
 #endif
 
 // Windows-Headerdateien:
-#include <windows.h>
+#include <Windows.h>
 
 // C RunTime-Headerdateien
 #include <assert.h>


### PR DESCRIPTION
Fix the following warnings when `-Wno-nonportable-system-include-path` is removed.
```
D:\workspace\CODE\assimp\code\Common\DefaultIOSystem.cpp(57,14): error : non-portable path to file '<Windows.h>'; speci
fied path differs in case from file name on disk [-Werror,-Wnonportable-system-include-path] [D:\workspace\CODE\assimp\
build-msvc-clang\code\assimp.vcxproj]
```