### PR TITLE
ConvertToLHProcess now inverts viewing direction

### DIFF
--- a/code/AssetLib/FBX/FBXConverter.cpp
+++ b/code/AssetLib/FBX/FBXConverter.cpp
@@ -421,6 +421,8 @@ void FBXConverter::ConvertCamera(const Camera &cam, const std::string &orig_name
 
     out_camera->mAspect = cam.AspectWidth() / cam.AspectHeight();
 
+    // NOTE: Camera mPosition, mLookAt and mUp must be set to default here.
+    // All transformations to the camera will be handled by its node in the scenegraph.
     out_camera->mPosition = aiVector3D(0.0f);
     out_camera->mLookAt = aiVector3D(1.0f, 0.0f, 0.0f);
     out_camera->mUp = aiVector3D(0.0f, 1.0f, 0.0f);

--- a/code/AssetLib/FBX/FBXConverter.cpp
+++ b/code/AssetLib/FBX/FBXConverter.cpp
@@ -152,7 +152,7 @@ void FBXConverter::ConvertRootNode() {
     mSceneOut->mRootNode->mName.Set(unique_name);
 
     // root has ID 0
-    ConvertNodes(0L, mSceneOut->mRootNode, mSceneOut->mRootNode, aiMatrix4x4());
+    ConvertNodes(0L, mSceneOut->mRootNode, mSceneOut->mRootNode);
 }
 
 static std::string getAncestorBaseName(const aiNode *node) {
@@ -196,7 +196,7 @@ struct FBXConverter::PotentialNode {
 /// todo: get bone from stack
 /// todo: make map of aiBone* to aiNode*
 /// then update convert clusters to the new format
-void FBXConverter::ConvertNodes(uint64_t id, aiNode *parent, aiNode *root_node, const aiMatrix4x4 &globalTransform) {
+void FBXConverter::ConvertNodes(uint64_t id, aiNode *parent, aiNode *root_node) {
     const std::vector<const Connection *> &conns = doc.GetConnectionsByDestinationSequenced(id, "Model");
 
     std::vector<PotentialNode> nodes;
@@ -290,15 +290,14 @@ void FBXConverter::ConvertNodes(uint64_t id, aiNode *parent, aiNode *root_node, 
             }
 
             // recursion call - child nodes
-            aiMatrix4x4 newGlobalMatrix = globalTransform * nodes_chain.front().mNode->mTransformation;
-            ConvertNodes(model->ID(), last_parent, root_node, newGlobalMatrix);
+            ConvertNodes(model->ID(), last_parent, root_node);
 
             if (doc.Settings().readLights) {
                 ConvertLights(*model, node_name);
             }
 
             if (doc.Settings().readCameras) {
-                ConvertCameras(*model, node_name, newGlobalMatrix);
+                ConvertCameras(*model, node_name);
             }
 
             nodes.push_back(std::move(nodes_chain.front()));
@@ -328,14 +327,12 @@ void FBXConverter::ConvertLights(const Model &model, const std::string &orig_nam
     }
 }
 
-void FBXConverter::ConvertCameras(const Model &model,
-                                  const std::string &orig_name,
-                                  const aiMatrix4x4 &transform) {
+void FBXConverter::ConvertCameras(const Model &model, const std::string &orig_name) {
     const std::vector<const NodeAttribute *> &node_attrs = model.GetAttributes();
     for (const NodeAttribute *attr : node_attrs) {
         const Camera *const cam = dynamic_cast<const Camera *>(attr);
         if (cam) {
-            ConvertCamera(*cam, orig_name, transform);
+            ConvertCamera(*cam, orig_name);
         }
     }
 }
@@ -416,9 +413,7 @@ void FBXConverter::ConvertLight(const Light &light, const std::string &orig_name
     }
 }
 
-void FBXConverter::ConvertCamera(const Camera &cam,
-                                 const std::string &orig_name,
-                                 aiMatrix4x4 transform) {
+void FBXConverter::ConvertCamera(const Camera &cam, const std::string &orig_name) {
     cameras.push_back(new aiCamera());
     aiCamera *const out_camera = cameras.back();
 
@@ -426,16 +421,9 @@ void FBXConverter::ConvertCamera(const Camera &cam,
 
     out_camera->mAspect = cam.AspectWidth() / cam.AspectHeight();
 
-    aiVector3D pos = cam.Position();
-    out_camera->mLookAt = cam.InterestPosition();
-    out_camera->mUp = pos + cam.UpVector();
-    transform.Inverse();
-    pos *= transform;
-    out_camera->mLookAt *= transform;
-    out_camera->mUp *= transform;
-    out_camera->mLookAt -= pos;
-    out_camera->mUp -= pos;
     out_camera->mPosition = aiVector3D(0.0f);
+    out_camera->mLookAt = aiVector3D(1.0f, 0.0f, 0.0f);
+    out_camera->mUp = aiVector3D(0.0f, 1.0f, 0.0f);
 
     out_camera->mHorizontalFOV = AI_DEG_TO_RAD(cam.FieldOfView());
 

--- a/code/AssetLib/FBX/FBXConverter.h
+++ b/code/AssetLib/FBX/FBXConverter.h
@@ -134,22 +134,19 @@ private:
 
     // ------------------------------------------------------------------------------------------------
     // collect and assign child nodes
-    void ConvertNodes(uint64_t id, aiNode *parent, aiNode *root_node,
-                      const aiMatrix4x4 &globalTransform);
+    void ConvertNodes(uint64_t id, aiNode *parent, aiNode *root_node);
 
     // ------------------------------------------------------------------------------------------------
     void ConvertLights(const Model& model, const std::string &orig_name );
 
     // ------------------------------------------------------------------------------------------------
-    void ConvertCameras(const Model& model, const std::string &orig_name,
-                        const aiMatrix4x4 &transform);
+    void ConvertCameras(const Model& model, const std::string &orig_name );
 
     // ------------------------------------------------------------------------------------------------
     void ConvertLight( const Light& light, const std::string &orig_name );
 
     // ------------------------------------------------------------------------------------------------
-    void ConvertCamera(const Camera& cam, const std::string &orig_name,
-                       aiMatrix4x4 transform);
+    void ConvertCamera( const Camera& cam, const std::string &orig_name );
 
     // ------------------------------------------------------------------------------------------------
     void GetUniqueName( const std::string &name, std::string& uniqueName );

--- a/code/PostProcessing/ConvertToLHProcess.cpp
+++ b/code/PostProcessing/ConvertToLHProcess.cpp
@@ -113,6 +113,12 @@ void MakeLeftHandedProcess::Execute(aiScene *pScene) {
             ProcessAnimation(nodeAnim);
         }
     }
+
+    // process the cameras accordingly
+    for( unsigned int a = 0; a < pScene->mNumCameras; ++a)
+    {
+        ProcessCamera(pScene->mCameras[a]);
+    }
     ASSIMP_LOG_DEBUG("MakeLeftHandedProcess finished");
 }
 
@@ -229,6 +235,13 @@ void MakeLeftHandedProcess::ProcessAnimation(aiNodeAnim *pAnim) {
         pAnim->mRotationKeys[a].mValue.x *= -1.0f;
         pAnim->mRotationKeys[a].mValue.y *= -1.0f;
     }
+}
+
+// ------------------------------------------------------------------------------------------------
+// Converts a single camera to left handed coordinates.
+void MakeLeftHandedProcess::ProcessCamera( aiCamera* pCam)
+{
+    pCam->mLookAt = 2.0f * pCam->mPosition - pCam->mLookAt;
 }
 
 #endif // !!  ASSIMP_BUILD_NO_MAKELEFTHANDED_PROCESS

--- a/code/PostProcessing/ConvertToLHProcess.h
+++ b/code/PostProcessing/ConvertToLHProcess.h
@@ -58,6 +58,7 @@ struct aiMesh;
 struct aiNodeAnim;
 struct aiNode;
 struct aiMaterial;
+struct aiCamera;
 
 namespace Assimp    {
 
@@ -109,6 +110,14 @@ protected:
      * @param pAnim The bone animation to transform
      */
     void ProcessAnimation( aiNodeAnim* pAnim);
+
+    // -------------------------------------------------------------------
+    /** Converts a single camera to left handed coordinates.
+     * The camera viewing direction is inverted by reflecting mLookAt
+     * across mPosition.
+     * @param pCam The camera to convert
+     */
+    void ProcessCamera( aiCamera* pCam);
 };
 
 


### PR DESCRIPTION
The viewing direction of cameras should be inverted during conversion to a left handed coordinate system.