### PR TITLE
Build Zlib if missing for other platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,7 @@ IF (WIN32)
 ELSE()
   OPTION( ASSIMP_BUILD_ZLIB
     "Build your own zlib"
-    OFF
+    ON
   )
 ENDIF()
 


### PR DESCRIPTION
Fixes #5062 https://github.com/assimp/assimp/issues/5062

By allowing default action like prior for building of zlib for specific other platform targets. Recent changes made this occur for win32 only. Unsure why ! ?

Compiles now on iOS / Emscripten with latest master (this)