### PR TITLE
Fix warning related to missing-variable-declarations.

### DIFF
--- a/code/AssetLib/Assjson/cencode.c
+++ b/code/AssetLib/Assjson/cencode.c
@@ -7,7 +7,7 @@ For details, see http://sourceforge.net/projects/libb64
 
 #include "cencode.h" // changed from <B64/cencode.h>
 
-const int CHARS_PER_LINE = 72;
+static const int CHARS_PER_LINE = 72;
 
 #ifdef _MSC_VER
 #pragma warning(push)

--- a/code/AssetLib/Blender/BlenderCustomData.cpp
+++ b/code/AssetLib/Blender/BlenderCustomData.cpp
@@ -96,7 +96,8 @@ struct CustomDataTypeDescription {
         *           other (like CD_ORCO, ...) uses arrays of rawtypes or even arrays of Structures
         *           use a special readfunction for that cases
         */
-std::array<CustomDataTypeDescription, CD_NUMTYPES> customDataTypeDescriptions = { { DECL_STRUCT_CUSTOMDATATYPEDESCRIPTION(MVert),
+static std::array<CustomDataTypeDescription, CD_NUMTYPES> customDataTypeDescriptions = { {
+        DECL_STRUCT_CUSTOMDATATYPEDESCRIPTION(MVert),
         DECL_UNSUPPORTED_CUSTOMDATATYPEDESCRIPTION,
         DECL_UNSUPPORTED_CUSTOMDATATYPEDESCRIPTION,
         DECL_STRUCT_CUSTOMDATATYPEDESCRIPTION(MEdge),

--- a/code/AssetLib/FBX/FBXMaterial.cpp
+++ b/code/AssetLib/FBX/FBXMaterial.cpp
@@ -138,20 +138,6 @@ Material::Material(uint64_t id, const Element& element, const Document& doc, con
 // ------------------------------------------------------------------------------------------------
 Material::~Material() = default;
 
-    aiVector2D uvTrans;
-    aiVector2D uvScaling;
-    ai_real    uvRotation;
-
-    std::string type;
-    std::string relativeFileName;
-    std::string fileName;
-    std::string alphaSource;
-    std::shared_ptr<const PropertyTable> props;
-
-    unsigned int crop[4]{};
-
-    const Video* media;
-
 // ------------------------------------------------------------------------------------------------
 Texture::Texture(uint64_t id, const Element& element, const Document& doc, const std::string& name) :
         Object(id,element,name),

--- a/code/AssetLib/SIB/SIBImporter.cpp
+++ b/code/AssetLib/SIB/SIBImporter.cpp
@@ -85,7 +85,7 @@ static const aiImporterDesc desc = {
 struct SIBChunk {
     uint32_t Tag;
     uint32_t Size;
-} PACK_STRUCT;
+};
 
 enum {
     POS,

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -1236,7 +1236,6 @@ IF (ASSIMP_WARNINGS_AS_ERRORS)
         -Wno-tautological-value-range-compare
         -Wno-tautological-type-limit-compare
         -Wno-missing-noreturn
-        -Wno-missing-variable-declarations
         -Wno-extra-semi
         -Wno-nonportable-system-include-path
         -Wno-undefined-reinterpret-cast

--- a/contrib/unzip/unzip.c
+++ b/contrib/unzip/unzip.c
@@ -78,7 +78,7 @@
 #   pragma warning(disable : 4131 4244 4189 4245)
 #endif // _MSC_VER
 
-const char unz_copyright[] =
+static const char unz_copyright[] =
    " unzip 1.01 Copyright 1998-2004 Gilles Vollant - http://www.winimage.com/zLibDll";
 
 /* unz_file_info_internal contain internal info about a file in zipfile*/


### PR DESCRIPTION
Fix the following warnings when `-Wno-missing-variable-declarations` is removed.
```
D:\workspace\CODE\assimp\code\AssetLib\Blender\BlenderCustomData.cpp(99,1): message : declare 'static' if the variable
is not intended to be used outside of this translation unit [D:\workspace\CODE\assimp\build-msvc-clang\code\assimp.vcxp
roj]
```