### PR TITLE
Add missing cast

### DIFF
--- a/code/PostProcessing/ConvertToLHProcess.cpp
+++ b/code/PostProcessing/ConvertToLHProcess.cpp
@@ -241,7 +241,7 @@ void MakeLeftHandedProcess::ProcessAnimation(aiNodeAnim *pAnim) {
 // Converts a single camera to left handed coordinates.
 void MakeLeftHandedProcess::ProcessCamera( aiCamera* pCam)
 {
-    pCam->mLookAt = 2.0f * pCam->mPosition - pCam->mLookAt;
+    pCam->mLookAt = ai_real(2.0f) * pCam->mPosition - pCam->mLookAt;
 }
 
 #endif // !!  ASSIMP_BUILD_NO_MAKELEFTHANDED_PROCESS


### PR DESCRIPTION
Add missing cast to prevent template instantiation error with double precision build config.

See the issue [here](https://github.com/assimp/assimp/pull/5057#issuecomment-1527187329]).