### PR TITLE
Fix: Copy aiMetadata in SceneCombiner

### DIFF
--- a/code/Common/SceneCombiner.cpp
+++ b/code/Common/SceneCombiner.cpp
@@ -1349,6 +1349,9 @@ void SceneCombiner::Copy(aiMetadata **_dest, const aiMetadata *src) {
         case AI_AIVECTOR3D:
             out.mData = new aiVector3D(*static_cast<aiVector3D *>(in.mData));
             break;
+        case AI_AIMETADATA:
+            out.mData = new aiMetadata(*static_cast<aiMetadata *>(in.mData));
+            break;
         default:
             ai_assert(false);
             break;


### PR DESCRIPTION
Metadata with sub-objects failed to copy due to default assertions.


Pushed this, but have not seen that #4658 has the same fix, so this could also be merged. 