### PR TITLE
Update cpp-pm / hunter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ IF(ASSIMP_HUNTER_ENABLED)
   include("cmake-modules/HunterGate.cmake")
   HunterGate(
     URL "https://github.com/cpp-pm/hunter/archive/v0.24.17.tar.gz"
-    SHA1 "d9a9de341c9341b7d42d7374340f1871"
+    SHA1 "e6396699e414120e32557fe92db097b7655b760b"
   )
 
   add_definitions(-DASSIMP_USE_HUNTER)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,8 +49,8 @@ option(ASSIMP_HUNTER_ENABLED "Enable Hunter package manager support" OFF)
 IF(ASSIMP_HUNTER_ENABLED)
   include("cmake-modules/HunterGate.cmake")
   HunterGate(
-    URL "https://github.com/cpp-pm/hunter/archive/v0.24.16.tar.gz"
-    SHA1 "aefcc56d2ad0021aa5bd5df72890151c"
+    URL "https://github.com/cpp-pm/hunter/archive/v0.24.17.tar.gz"
+    SHA1 "d9a9de341c9341b7d42d7374340f1871"
   )
 
   add_definitions(-DASSIMP_USE_HUNTER)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,8 +49,8 @@ option(ASSIMP_HUNTER_ENABLED "Enable Hunter package manager support" OFF)
 IF(ASSIMP_HUNTER_ENABLED)
   include("cmake-modules/HunterGate.cmake")
   HunterGate(
-    URL "https://github.com/cpp-pm/hunter/archive/v0.24.0.tar.gz"
-    SHA1 "a3d7f4372b1dcd52faa6ff4a3bd5358e1d0e5efd"
+    URL "https://github.com/cpp-pm/hunter/archive/v0.24.16.tar.gz"
+    SHA1 "aefcc56d2ad0021aa5bd5df72890151c"
   )
 
   add_definitions(-DASSIMP_USE_HUNTER)


### PR DESCRIPTION
Fix a lot of CVE vulnerabilities

Update abseil to LTFS 20220623.1 by @butteredmonkey in #656 Fix Hunter on Windows MSVC CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE 'ARM64EC' by @ccmvn in #659 openssl: update openssl to the latest 1.1.1t by @res0nance in #660 ceres-solver: per default disable CUDA support by @NeroBurner in #665 update range-v3 to version 0.12.0 by @alex-tdrn in #670 Update 'pybind11' to 2.10.4 by @hjmallon in #667
cli11: update cli11 to 2.3.2 by @res0nance in #669 openssl: update to v3 as 1.1.1 is almost eol by @res0nance in #668 Fix Hunter on Windows MSVC CMAKE_VS_PLATFORM_TOOLSET_HOST_ARCHITECTURE 'ARM64' by @ccmvn in #655 Boost: Fix building b2 (+ headers) on Apple tvOS with Xcode generator by @hjmallon in #647 assimp: add version 5.2.5 by @NovaSurfer in #640
SuiteSparse: update to v1.6.1 (SuiteSparse v5.4.0), with METIS and OpenBLAS by @NeroBurner in #642 OpenSSL: replace HUNTER_UWP_PLATFORM with CMAKE_SYSTEM_NAME check by @Dargun in #635 asio-grpc: Add version 2.3.0 by @Tradias in #636
Update OpenBLAS to v0.3.21 and add new BUILD_WITHOUT_LAPACK flag by @NeroBurner in #638 OpenBLAS: starting with 0.3.21 build with LAPACK support per default by @NeroBurner in #639 Update 'date' to v3.0.1 by @hjmallon in #615
Update 'SDL_net' package to v2.2.0-p0 by @drodin in #616 Update 'Jpeg' package to v9e-p0 by @drodin in #618 Update 'GTest' package to v1.12.1 by @drodin in #620 Update 'lcms' package to v2.13.1-p0 by @drodin in #621 Update 'giflib' package to v5.2.1-p0 by @drodin in #622 Update package 'WebP' to v1.2.4-p0 by @drodin in #623 Update 'Boost' to 1.80.0 by @tnixeu in #627
Update asio-grpc to 2.2.0 by @Tradias in #629
Update ZLIB to v1.2.13-p0 by @NeroBurner in #628
Add support for iOS simulator only builds by @hjmallon in #610 aws-sdk-cpp: Fix linking OpenSSL Crypto on Linux by @hjmallon in #630 and #631 OpenSSL: Fix build on universal windows platforms, add UWP job to global build matrix by @Dargun in #626 Update asio-grpc to v2.1.0 by @Tradias in #607
Update 'harfbuzz' package to v2.9.1-p0 by @drodin in #608 Update RocksDB to 7.5.3 by @twoentartian in #611
Fix CMAKE_IOS_INSTALL_COMBINED on Xcode 12+ by @hjmallon in #609 CI: Boost: update matrix.json to match general workflow by @NeroBurner in #612 Boost: update to v1.79.0 by @NeroBurner in #599