### PR TITLE
DXF: Support negative index in VERTEX

### DIFF
--- a/code/AssetLib/DXF/DXFLoader.cpp
+++ b/code/AssetLib/DXF/DXFLoader.cpp
@@ -731,7 +731,7 @@ void DXFImporter::ParsePolyLineVertex(DXF::LineReader& reader, DXF::PolyLine& li
                 if (index >= 0) {
                     indices[cnti++] = static_cast<unsigned int>(index);
                 } else {
-                    ASSIMP_LOG_WARN("DXF: Skip invisible face.");
+                    indices[cnti++] = static_cast<unsigned int>(-index);
                 }
             }
             break;


### PR DESCRIPTION
In DXF files, negative value is allowed for the "Polyface mesh vertex index" of the VERTEX entity.

https://help.autodesk.com/view/ACD/2024/ENU/?guid=GUID-0741E831-599E-4CBF-91E1-8ADBCFD6556D

> If the index is negative, the edge that begins with that vertex is invisible. 

However, the current implementation of `DXFImporter::ParsePolyLineVertex()` converts negative index to 0 and cannot handle them correctly.

This pull request ensures that negative index is handled correctly by reading their absolute value.