### PR TITLE
Fixed missing config property lookup for removal of empty bones.

### DIFF
--- a/code/PostProcessing/LimitBoneWeightsProcess.cpp
+++ b/code/PostProcessing/LimitBoneWeightsProcess.cpp
@@ -81,6 +81,7 @@ void LimitBoneWeightsProcess::Execute( aiScene* pScene) {
 // Executes the post processing step on the given imported data.
 void LimitBoneWeightsProcess::SetupProperties(const Importer* pImp) {
     this->mMaxWeights = pImp->GetPropertyInteger(AI_CONFIG_PP_LBW_MAX_WEIGHTS,AI_LMW_MAX_WEIGHTS);
+    this->mRemoveEmptyBones = pImp->GetPropertyInteger(AI_CONFIG_IMPORT_REMOVE_EMPTY_BONES, 1) != 0;
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -172,9 +173,9 @@ void LimitBoneWeightsProcess::ProcessMesh(aiMesh* pMesh) {
     }
 
     // remove empty bones
-#ifdef AI_CONFIG_IMPORT_REMOVE_EMPTY_BONES 
-    pMesh->mNumBones = removeEmptyBones(pMesh);
-#endif // AI_CONFIG_IMPORT_REMOVE_EMPTY_BONES 
+    if (mRemoveEmptyBones) {
+        pMesh->mNumBones = removeEmptyBones(pMesh);
+    }
 
     if (!DefaultLogger::isNullLogger()) {
         ASSIMP_LOG_INFO("Removed ", removed, " weights. Input bones: ", old_bones, ". Output bones: ", pMesh->mNumBones);

--- a/code/PostProcessing/LimitBoneWeightsProcess.h
+++ b/code/PostProcessing/LimitBoneWeightsProcess.h
@@ -133,6 +133,7 @@ public:
 
     /** Maximum number of bones influencing any single vertex. */
     unsigned int mMaxWeights;
+    bool mRemoveEmptyBones;
 };
 
 } // end of namespace Assimp


### PR DESCRIPTION
The post processing step LimitBoneWeightsProcess currently always removes unused bones because the config property AI_CONFIG_IMPORT_REMOVE_EMPTY_BONES has not been used to toggle this behavior on and off.

This change adds a property look up so LimitBoneWeightsProcess won't remove unused bones anymore when the client doesn't want this behavior.