### PR TITLE
Fix UNKNOWN WRITE in Assimp::SortByPTypeProcess::Execute

### DIFF
--- a/code/AssetLib/OFF/OFFLoader.cpp
+++ b/code/AssetLib/OFF/OFFLoader.cpp
@@ -284,7 +284,7 @@ void OFFImporter::InternReadFile( const std::string& pFile, aiScene* pScene, IOS
     for (unsigned int i = 0; i < numFaces; ) {
         if(!GetNextLine(buffer,line)) {
             ASSIMP_LOG_ERROR("OFF: The number of faces in the header is incorrect");
-            break;
+            throw DeadlyImportError("OFF: The number of faces in the header is incorrect");
         }
         unsigned int idx;
         sz = line; SkipSpaces(&sz);


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=57001
Closes #5069

The crash occures in [SortByPTypeProcess::Execute](https://github.com/assimp/assimp/blob/4180b1fd080b2cab0a2d3a3149eff1f5163ee888/code/PostProcessing/SortByPTypeProcess.cpp#L175) when `pFirstFace->mNumIndices == 0`. The root cause is that the faces are not initialized and skipped (`break`) during the loading.