### PR TITLE
Extend token search flag from alpha to graph.

### DIFF
--- a/code/Common/BaseImporter.cpp
+++ b/code/Common/BaseImporter.cpp
@@ -158,7 +158,7 @@ void BaseImporter::GetExtensionList(std::set<std::string> &extensions) {
         std::size_t numTokens,
         unsigned int searchBytes /* = 200 */,
         bool tokensSol /* false */,
-        bool noAlphaBeforeTokens /* false */) {
+        bool noGraphBeforeTokens /* false */) {
     ai_assert(nullptr != tokens);
     ai_assert(0 != numTokens);
     ai_assert(0 != searchBytes);
@@ -207,8 +207,9 @@ void BaseImporter::GetExtensionList(std::set<std::string> &extensions) {
                 continue;
             }
             // We need to make sure that we didn't accidentally identify the end of another token as our token,
-            // e.g. in a previous version the "gltf " present in some gltf files was detected as "f "
-            if (noAlphaBeforeTokens && (r != buffer && isalpha(static_cast<unsigned char>(r[-1])))) {
+            // e.g. in a previous version the "gltf " present in some gltf files was detected as "f ", or a
+            // Blender-exported glb file containing "Khronos glTF Blender I/O " was detected as "o "
+            if (noGraphBeforeTokens && (r != buffer && isgraph(static_cast<unsigned char>(r[-1])))) {
                 continue;
             }
             // We got a match, either we don't care where it is, or it happens to

--- a/include/assimp/BaseImporter.h
+++ b/include/assimp/BaseImporter.h
@@ -259,7 +259,7 @@ public: // static utilities
             std::size_t numTokens,
             unsigned int searchBytes = 200,
             bool tokensSol = false,
-            bool noAlphaBeforeTokens = false);
+            bool noGraphBeforeTokens = false);
 
     // -------------------------------------------------------------------
     /** @brief Check whether a file has a specific file extension


### PR DESCRIPTION
This way we can fix Blender exported files being wrongly detected as obj files, if the filename didn't contain any extension information, e.g. when loading a binary glb file named `blob`.