### PR TITLE
Add DIFFUSE_ROUGHNESS_TEXTURE for gltf2 exporter

### DIFF
--- a/code/AssetLib/glTF2/glTF2Exporter.cpp
+++ b/code/AssetLib/glTF2/glTF2Exporter.cpp
@@ -838,6 +838,16 @@ void glTF2Exporter::ExportMaterials() {
 
         GetMatTex(mat, m->pbrMetallicRoughness.metallicRoughnessTexture, aiTextureType_DIFFUSE_ROUGHNESS);
 
+        if (!m->pbrMetallicRoughness.metallicRoughnessTexture.texture) {
+            //if there wasn't a aiTextureType_DIFFUSE_ROUGHNESS defined in the source, fallback to aiTextureType_METALNESS
+            GetMatTex(mat, m->pbrMetallicRoughness.metallicRoughnessTexture, aiTextureType_METALNESS);
+        }
+
+        if (!m->pbrMetallicRoughness.metallicRoughnessTexture.texture) {
+            //if there still wasn't a aiTextureType_METALNESS defined in the source, fallback to unknown texture
+            GetMatTex(mat, m->pbrMetallicRoughness.metallicRoughnessTexture, AI_MATKEY_GLTF_PBRMETALLICROUGHNESS_METALLICROUGHNESS_TEXTURE);
+        }
+
         if (GetMatColor(mat, m->pbrMetallicRoughness.baseColorFactor, AI_MATKEY_BASE_COLOR) != AI_SUCCESS) {
             // if baseColorFactor wasn't defined, then the source is likely not a metallic roughness material.
             //a fallback to any diffuse color should be used instead

--- a/code/AssetLib/glTF2/glTF2Exporter.cpp
+++ b/code/AssetLib/glTF2/glTF2Exporter.cpp
@@ -844,7 +844,7 @@ void glTF2Exporter::ExportMaterials() {
         }
 
         if (!m->pbrMetallicRoughness.metallicRoughnessTexture.texture) {
-            // if there still wasn't a aiTextureType_METALNESS defined in the source, fallback to unknown texture
+            // if there still wasn't a aiTextureType_METALNESS defined in the source, fallback to AI_MATKEY_GLTF_PBRMETALLICROUGHNESS_METALLICROUGHNESS_TEXTURE
             GetMatTex(mat, m->pbrMetallicRoughness.metallicRoughnessTexture, AI_MATKEY_GLTF_PBRMETALLICROUGHNESS_METALLICROUGHNESS_TEXTURE);
         }
 

--- a/code/AssetLib/glTF2/glTF2Exporter.cpp
+++ b/code/AssetLib/glTF2/glTF2Exporter.cpp
@@ -263,7 +263,7 @@ size_t NZDiff(void *data, void *dataBase, size_t count, unsigned int numCompsIn,
     for (short idx = 0; bufferData_ptr < bufferData_end; idx += 1, bufferData_ptr += numCompsIn) {
         bool bNonZero = false;
 
-        //for the data, check any component Non Zero
+        // for the data, check any component Non Zero
         for (unsigned int j = 0; j < numCompsOut; j++) {
             double valueData = bufferData_ptr[j];
             double valueBase = bufferBase_ptr ? bufferBase_ptr[j] : 0;
@@ -273,11 +273,11 @@ size_t NZDiff(void *data, void *dataBase, size_t count, unsigned int numCompsIn,
             }
         }
 
-        //all zeros, continue
+        // all zeros, continue
         if (!bNonZero)
             continue;
 
-        //non zero, store the data
+        // non zero, store the data
         for (unsigned int j = 0; j < numCompsOut; j++) {
             T valueData = bufferData_ptr[j];
             T valueBase = bufferBase_ptr ? bufferBase_ptr[j] : 0;
@@ -286,14 +286,14 @@ size_t NZDiff(void *data, void *dataBase, size_t count, unsigned int numCompsIn,
         vNZIdx.push_back(idx);
     }
 
-    //avoid all-0, put 1 item
+    // avoid all-0, put 1 item
     if (vNZDiff.size() == 0) {
         for (unsigned int j = 0; j < numCompsOut; j++)
             vNZDiff.push_back(0);
         vNZIdx.push_back(0);
     }
 
-    //process data
+    // process data
     outputNZDiff = new T[vNZDiff.size()];
     memcpy(outputNZDiff, vNZDiff.data(), vNZDiff.size() * sizeof(T));
 
@@ -361,7 +361,7 @@ inline Ref<Accessor> ExportDataSparse(Asset &a, std::string &meshName, Ref<Buffe
         acc->sparse.reset(new Accessor::Sparse);
         acc->sparse->count = nzCount;
 
-        //indices
+        // indices
         unsigned int bytesPerIdx = sizeof(unsigned short);
         size_t indices_offset = buffer->byteLength;
         size_t indices_padding = indices_offset % bytesPerIdx;
@@ -379,7 +379,7 @@ inline Ref<Accessor> ExportDataSparse(Asset &a, std::string &meshName, Ref<Buffe
         acc->sparse->indicesByteOffset = 0;
         acc->WriteSparseIndices(nzCount, nzIdx, 1 * bytesPerIdx);
 
-        //values
+        // values
         size_t values_offset = buffer->byteLength;
         size_t values_padding = values_offset % bytesPerComp;
         values_offset += values_padding;
@@ -395,9 +395,9 @@ inline Ref<Accessor> ExportDataSparse(Asset &a, std::string &meshName, Ref<Buffe
         acc->sparse->valuesByteOffset = 0;
         acc->WriteSparseValues(nzCount, nzDiff, numCompsIn * bytesPerComp);
 
-        //clear
-        delete[](char *) nzDiff;
-        delete[](char *) nzIdx;
+        // clear
+        delete[] (char *)nzDiff;
+        delete[] (char *)nzIdx;
     }
     return acc;
 }
@@ -599,7 +599,7 @@ void glTF2Exporter::GetMatTex(const aiMaterial &mat, Ref<Texture> &texture, unsi
                 if (curTex != nullptr) { // embedded
                     texture->source->name = curTex->mFilename.C_Str();
 
-                    //basisu: embedded ktx2, bu
+                    // basisu: embedded ktx2, bu
                     if (curTex->achFormatHint[0]) {
                         std::string mimeType = "image/";
                         if (memcmp(curTex->achFormatHint, "jpg", 3) == 0)
@@ -619,7 +619,7 @@ void glTF2Exporter::GetMatTex(const aiMaterial &mat, Ref<Texture> &texture, unsi
                     }
 
                     // The asset has its own buffer, see Image::SetData
-                    //basisu: "image/ktx2", "image/basis" as is
+                    // basisu: "image/ktx2", "image/basis" as is
                     texture->source->SetData(reinterpret_cast<uint8_t *>(curTex->pcData), curTex->mWidth, *mAsset);
                 } else {
                     texture->source->uri = path;
@@ -629,7 +629,7 @@ void glTF2Exporter::GetMatTex(const aiMaterial &mat, Ref<Texture> &texture, unsi
                     }
                 }
 
-                //basisu
+                // basisu
                 if (useBasisUniversal) {
                     mAsset->extensionsUsed.KHR_texture_basisu = true;
                     mAsset->extensionsRequired.KHR_texture_basisu = true;
@@ -652,7 +652,7 @@ void glTF2Exporter::GetMatTex(const aiMaterial &mat, NormalTextureInfo &prop, ai
     GetMatTex(mat, texture, prop.texCoord, tt, slot);
 
     if (texture) {
-        //GetMatTexProp(mat, prop.texCoord, "texCoord", tt, slot);
+        // GetMatTexProp(mat, prop.texCoord, "texCoord", tt, slot);
         GetMatTexProp(mat, prop.scale, "scale", tt, slot);
     }
 }
@@ -663,7 +663,7 @@ void glTF2Exporter::GetMatTex(const aiMaterial &mat, OcclusionTextureInfo &prop,
     GetMatTex(mat, texture, prop.texCoord, tt, slot);
 
     if (texture) {
-        //GetMatTexProp(mat, prop.texCoord, "texCoord", tt, slot);
+        // GetMatTexProp(mat, prop.texCoord, "texCoord", tt, slot);
         GetMatTexProp(mat, prop.strength, "strength", tt, slot);
     }
 }
@@ -832,30 +832,30 @@ void glTF2Exporter::ExportMaterials() {
         GetMatTex(mat, m->pbrMetallicRoughness.baseColorTexture, aiTextureType_BASE_COLOR);
 
         if (!m->pbrMetallicRoughness.baseColorTexture.texture) {
-            //if there wasn't a baseColorTexture defined in the source, fallback to any diffuse texture
+            // if there wasn't a baseColorTexture defined in the source, fallback to any diffuse texture
             GetMatTex(mat, m->pbrMetallicRoughness.baseColorTexture, aiTextureType_DIFFUSE);
         }
 
         GetMatTex(mat, m->pbrMetallicRoughness.metallicRoughnessTexture, aiTextureType_DIFFUSE_ROUGHNESS);
 
         if (!m->pbrMetallicRoughness.metallicRoughnessTexture.texture) {
-            //if there wasn't a aiTextureType_DIFFUSE_ROUGHNESS defined in the source, fallback to aiTextureType_METALNESS
+            // if there wasn't a aiTextureType_DIFFUSE_ROUGHNESS defined in the source, fallback to aiTextureType_METALNESS
             GetMatTex(mat, m->pbrMetallicRoughness.metallicRoughnessTexture, aiTextureType_METALNESS);
         }
 
         if (!m->pbrMetallicRoughness.metallicRoughnessTexture.texture) {
-            //if there still wasn't a aiTextureType_METALNESS defined in the source, fallback to unknown texture
+            // if there still wasn't a aiTextureType_METALNESS defined in the source, fallback to unknown texture
             GetMatTex(mat, m->pbrMetallicRoughness.metallicRoughnessTexture, AI_MATKEY_GLTF_PBRMETALLICROUGHNESS_METALLICROUGHNESS_TEXTURE);
         }
 
         if (GetMatColor(mat, m->pbrMetallicRoughness.baseColorFactor, AI_MATKEY_BASE_COLOR) != AI_SUCCESS) {
             // if baseColorFactor wasn't defined, then the source is likely not a metallic roughness material.
-            //a fallback to any diffuse color should be used instead
+            // a fallback to any diffuse color should be used instead
             GetMatColor(mat, m->pbrMetallicRoughness.baseColorFactor, AI_MATKEY_COLOR_DIFFUSE);
         }
 
         if (mat.Get(AI_MATKEY_METALLIC_FACTOR, m->pbrMetallicRoughness.metallicFactor) != AI_SUCCESS) {
-            //if metallicFactor wasn't defined, then the source is likely not a PBR file, and the metallicFactor should be 0
+            // if metallicFactor wasn't defined, then the source is likely not a PBR file, and the metallicFactor should be 0
             m->pbrMetallicRoughness.metallicFactor = 0;
         }
 
@@ -868,10 +868,10 @@ void glTF2Exporter::ExportMaterials() {
             if (mat.Get(AI_MATKEY_COLOR_SPECULAR, specularColor) == AI_SUCCESS && mat.Get(AI_MATKEY_SHININESS, shininess) == AI_SUCCESS) {
                 // convert specular color to luminance
                 float specularIntensity = specularColor[0] * 0.2125f + specularColor[1] * 0.7154f + specularColor[2] * 0.0721f;
-                //normalize shininess (assuming max is 1000) with an inverse exponentional curve
+                // normalize shininess (assuming max is 1000) with an inverse exponentional curve
                 float normalizedShininess = std::sqrt(shininess / 1000);
 
-                //clamp the shininess value between 0 and 1
+                // clamp the shininess value between 0 and 1
                 normalizedShininess = std::min(std::max(normalizedShininess, 0.0f), 1.0f);
                 // low specular intensity values should produce a rough material even if shininess is high.
                 normalizedShininess = normalizedShininess * specularIntensity;
@@ -1069,7 +1069,7 @@ void ExportSkin(Asset &mAsset, const aiMesh *aimesh, Ref<Mesh> &meshRef, Ref<Buf
                 if (boneIndexFitted != -1) {
                     vertexJointData[vertexId][boneIndexFitted] = static_cast<float>(jointNamesIndex);
                 }
-            }else {
+            } else {
                 vertexJointData[vertexId][jointsPerVertex[vertexId]] = static_cast<float>(jointNamesIndex);
                 vertexWeightData[vertexId][jointsPerVertex[vertexId]] = vertWeight;
 
@@ -1081,7 +1081,7 @@ void ExportSkin(Asset &mAsset, const aiMesh *aimesh, Ref<Mesh> &meshRef, Ref<Buf
 
     Mesh::Primitive &p = meshRef->primitives.back();
     Ref<Accessor> vertexJointAccessor = ExportData(mAsset, skinRef->id, bufferRef, aimesh->mNumVertices,
-        vertexJointData, AttribType::VEC4, AttribType::VEC4, ComponentType_FLOAT);
+            vertexJointData, AttribType::VEC4, AttribType::VEC4, ComponentType_FLOAT);
     if (vertexJointAccessor) {
         size_t offset = vertexJointAccessor->bufferView->byteOffset;
         size_t bytesLen = vertexJointAccessor->bufferView->byteLength;
@@ -1165,7 +1165,7 @@ void glTF2Exporter::ExportMeshes() {
 
         /******************* Vertices ********************/
         Ref<Accessor> v = ExportData(*mAsset, meshId, b, aim->mNumVertices, aim->mVertices, AttribType::VEC3,
-            AttribType::VEC3, ComponentType_FLOAT, BufferViewTarget_ARRAY_BUFFER);
+                AttribType::VEC3, ComponentType_FLOAT, BufferViewTarget_ARRAY_BUFFER);
         if (v) {
             p.attributes.position.push_back(v);
         }
@@ -1179,7 +1179,7 @@ void glTF2Exporter::ExportMeshes() {
         }
 
         Ref<Accessor> n = ExportData(*mAsset, meshId, b, aim->mNumVertices, aim->mNormals, AttribType::VEC3,
-            AttribType::VEC3, ComponentType_FLOAT, BufferViewTarget_ARRAY_BUFFER);
+                AttribType::VEC3, ComponentType_FLOAT, BufferViewTarget_ARRAY_BUFFER);
         if (n) {
             p.attributes.normal.push_back(n);
         }
@@ -1201,7 +1201,7 @@ void glTF2Exporter::ExportMeshes() {
                 AttribType::Value type = (aim->mNumUVComponents[i] == 2) ? AttribType::VEC2 : AttribType::VEC3;
 
                 Ref<Accessor> tc = ExportData(*mAsset, meshId, b, aim->mNumVertices, aim->mTextureCoords[i],
-                    AttribType::VEC3, type, ComponentType_FLOAT, BufferViewTarget_ARRAY_BUFFER);
+                        AttribType::VEC3, type, ComponentType_FLOAT, BufferViewTarget_ARRAY_BUFFER);
                 if (tc) {
                     p.attributes.texcoord.push_back(tc);
                 }
@@ -1211,7 +1211,7 @@ void glTF2Exporter::ExportMeshes() {
         /*************** Vertex colors ****************/
         for (unsigned int indexColorChannel = 0; indexColorChannel < aim->GetNumColorChannels(); ++indexColorChannel) {
             Ref<Accessor> c = ExportData(*mAsset, meshId, b, aim->mNumVertices, aim->mColors[indexColorChannel],
-                AttribType::VEC4, AttribType::VEC4, ComponentType_FLOAT, BufferViewTarget_ARRAY_BUFFER);
+                    AttribType::VEC4, AttribType::VEC4, ComponentType_FLOAT, BufferViewTarget_ARRAY_BUFFER);
             if (c) {
                 p.attributes.color.push_back(c);
             }
@@ -1229,7 +1229,7 @@ void glTF2Exporter::ExportMeshes() {
             }
 
             p.indices = ExportData(*mAsset, meshId, b, indices.size(), &indices[0], AttribType::SCALAR, AttribType::SCALAR,
-                ComponentType_UNSIGNED_INT, BufferViewTarget_ELEMENT_ARRAY_BUFFER);
+                    ComponentType_UNSIGNED_INT, BufferViewTarget_ELEMENT_ARRAY_BUFFER);
         }
 
         switch (aim->mPrimitiveTypes) {
@@ -1372,24 +1372,24 @@ void glTF2Exporter::MergeMeshes() {
 
         unsigned int nMeshes = static_cast<unsigned int>(node->meshes.size());
 
-        //skip if it's 1 or less meshes per node
+        // skip if it's 1 or less meshes per node
         if (nMeshes > 1) {
             Ref<Mesh> firstMesh = node->meshes.at(0);
 
-            //loop backwards to allow easy removal of a mesh from a node once it's merged
+            // loop backwards to allow easy removal of a mesh from a node once it's merged
             for (unsigned int m = nMeshes - 1; m >= 1; --m) {
                 Ref<Mesh> mesh = node->meshes.at(m);
 
-                //append this mesh's primitives to the first mesh's primitives
+                // append this mesh's primitives to the first mesh's primitives
                 firstMesh->primitives.insert(
                         firstMesh->primitives.end(),
                         mesh->primitives.begin(),
                         mesh->primitives.end());
 
-                //remove the mesh from the list of meshes
+                // remove the mesh from the list of meshes
                 unsigned int removedIndex = mAsset->meshes.Remove(mesh->id.c_str());
 
-                //find the presence of the removed mesh in other nodes
+                // find the presence of the removed mesh in other nodes
                 for (unsigned int nn = 0; nn < mAsset->nodes.Size(); ++nn) {
                     Ref<Node> curNode = mAsset->nodes.Get(nn);
 
@@ -1408,7 +1408,7 @@ void glTF2Exporter::MergeMeshes() {
                 }
             }
 
-            //since we were looping backwards, reverse the order of merged primitives to their original order
+            // since we were looping backwards, reverse the order of merged primitives to their original order
             std::reverse(firstMesh->primitives.begin() + 1, firstMesh->primitives.end());
         }
     }
@@ -1440,7 +1440,7 @@ unsigned int glTF2Exporter::ExportNodeHierarchy(const aiNode *n) {
     return node.GetIndex();
 }
 
- /*
+/*
  * Export node and recursively calls ExportNode for all children.
  * Since these nodes are not the root node, we also export the parent Ref<Node>
  */
@@ -1535,9 +1535,9 @@ inline void ExtractTranslationSampler(Asset &asset, std::string &animId, Ref<Buf
         const aiVectorKey &key = nodeChannel->mPositionKeys[i];
         // mTime is measured in ticks, but GLTF time is measured in seconds, so convert.
         times[i] = static_cast<float>(key.mTime / ticksPerSecond);
-        values[(i * 3) + 0] = (ai_real) key.mValue.x;
-        values[(i * 3) + 1] = (ai_real) key.mValue.y;
-        values[(i * 3) + 2] = (ai_real) key.mValue.z;
+        values[(i * 3) + 0] = (ai_real)key.mValue.x;
+        values[(i * 3) + 1] = (ai_real)key.mValue.y;
+        values[(i * 3) + 2] = (ai_real)key.mValue.z;
     }
 
     sampler.input = GetSamplerInputRef(asset, animId, buffer, times);
@@ -1554,9 +1554,9 @@ inline void ExtractScaleSampler(Asset &asset, std::string &animId, Ref<Buffer> &
         const aiVectorKey &key = nodeChannel->mScalingKeys[i];
         // mTime is measured in ticks, but GLTF time is measured in seconds, so convert.
         times[i] = static_cast<float>(key.mTime / ticksPerSecond);
-        values[(i * 3) + 0] = (ai_real) key.mValue.x;
-        values[(i * 3) + 1] = (ai_real) key.mValue.y;
-        values[(i * 3) + 2] = (ai_real) key.mValue.z;
+        values[(i * 3) + 0] = (ai_real)key.mValue.x;
+        values[(i * 3) + 1] = (ai_real)key.mValue.y;
+        values[(i * 3) + 2] = (ai_real)key.mValue.z;
     }
 
     sampler.input = GetSamplerInputRef(asset, animId, buffer, times);
@@ -1573,10 +1573,10 @@ inline void ExtractRotationSampler(Asset &asset, std::string &animId, Ref<Buffer
         const aiQuatKey &key = nodeChannel->mRotationKeys[i];
         // mTime is measured in ticks, but GLTF time is measured in seconds, so convert.
         times[i] = static_cast<float>(key.mTime / ticksPerSecond);
-        values[(i * 4) + 0] = (ai_real) key.mValue.x;
-        values[(i * 4) + 1] = (ai_real) key.mValue.y;
-        values[(i * 4) + 2] = (ai_real) key.mValue.z;
-        values[(i * 4) + 3] = (ai_real) key.mValue.w;
+        values[(i * 4) + 0] = (ai_real)key.mValue.x;
+        values[(i * 4) + 1] = (ai_real)key.mValue.y;
+        values[(i * 4) + 2] = (ai_real)key.mValue.z;
+        values[(i * 4) + 3] = (ai_real)key.mValue.w;
     }
 
     sampler.input = GetSamplerInputRef(asset, animId, buffer, times);

--- a/code/AssetLib/glTF2/glTF2Exporter.cpp
+++ b/code/AssetLib/glTF2/glTF2Exporter.cpp
@@ -870,6 +870,7 @@ void glTF2Exporter::ExportMaterials() {
             }
         }
 
+        GetMatTex(mat, m->normalTexture, aiTextureType_DIFFUSE_ROUGHNESS);
         GetMatTex(mat, m->normalTexture, aiTextureType_NORMALS);
         GetMatTex(mat, m->occlusionTexture, aiTextureType_LIGHTMAP);
         GetMatTex(mat, m->emissiveTexture, aiTextureType_EMISSIVE);

--- a/code/AssetLib/glTF2/glTF2Exporter.cpp
+++ b/code/AssetLib/glTF2/glTF2Exporter.cpp
@@ -836,7 +836,7 @@ void glTF2Exporter::ExportMaterials() {
             GetMatTex(mat, m->pbrMetallicRoughness.baseColorTexture, aiTextureType_DIFFUSE);
         }
 
-        GetMatTex(mat, m->pbrMetallicRoughness.metallicRoughnessTexture, AI_MATKEY_GLTF_PBRMETALLICROUGHNESS_METALLICROUGHNESS_TEXTURE);
+        GetMatTex(mat, m->pbrMetallicRoughness.metallicRoughnessTexture, aiTextureType_DIFFUSE_ROUGHNESS);
 
         if (GetMatColor(mat, m->pbrMetallicRoughness.baseColorFactor, AI_MATKEY_BASE_COLOR) != AI_SUCCESS) {
             // if baseColorFactor wasn't defined, then the source is likely not a metallic roughness material.
@@ -870,7 +870,6 @@ void glTF2Exporter::ExportMaterials() {
             }
         }
 
-        GetMatTex(mat, m->normalTexture, aiTextureType_DIFFUSE_ROUGHNESS);
         GetMatTex(mat, m->normalTexture, aiTextureType_NORMALS);
         GetMatTex(mat, m->occlusionTexture, aiTextureType_LIGHTMAP);
         GetMatTex(mat, m->emissiveTexture, aiTextureType_EMISSIVE);


### PR DESCRIPTION
I am using the assimp exporter and I have noticed that I can't add aiTextureType_DIFFUSE_ROUGHNESS when exporting to  glb2 format. Therefore, I would like to add it.