### PR TITLE
Collada: added import property to disable unit size scaling

### DIFF
--- a/code/AssetLib/Collada/ColladaLoader.cpp
+++ b/code/AssetLib/Collada/ColladaLoader.cpp
@@ -95,6 +95,7 @@ ColladaLoader::ColladaLoader() :
         noSkeletonMesh(false),
         removeEmptyBones(false),
         ignoreUpDirection(false),
+        ignoreUnitSize(false),
         useColladaName(false),
         mNodeNameCounter(0) {
     // empty
@@ -122,6 +123,7 @@ void ColladaLoader::SetupProperties(const Importer *pImp) {
     noSkeletonMesh = pImp->GetPropertyInteger(AI_CONFIG_IMPORT_NO_SKELETON_MESHES, 0) != 0;
     removeEmptyBones = pImp->GetPropertyInteger(AI_CONFIG_IMPORT_REMOVE_EMPTY_BONES, true) != 0;
     ignoreUpDirection = pImp->GetPropertyInteger(AI_CONFIG_IMPORT_COLLADA_IGNORE_UP_DIRECTION, 0) != 0;
+    ignoreUnitSize = pImp->GetPropertyInteger(AI_CONFIG_IMPORT_COLLADA_IGNORE_UNIT_SIZE, 0) != 0;
     useColladaName = pImp->GetPropertyInteger(AI_CONFIG_IMPORT_COLLADA_USE_COLLADA_NAMES, 0) != 0;
 }
 
@@ -170,12 +172,15 @@ void ColladaLoader::InternReadFile(const std::string &pFile, aiScene *pScene, IO
     // ... then fill the materials with the now adjusted settings
     FillMaterials(parser, pScene);
 
-    // Apply unit-size scale calculation
-
-    pScene->mRootNode->mTransformation *= aiMatrix4x4(parser.mUnitSize, 0, 0, 0,
-            0, parser.mUnitSize, 0, 0,
-            0, 0, parser.mUnitSize, 0,
-            0, 0, 0, 1);
+    if (!ignoreUnitSize) {
+        // Apply unit-size scale calculation
+        pScene->mRootNode->mTransformation *= aiMatrix4x4(
+                parser.mUnitSize, 0, 0, 0,
+                0, parser.mUnitSize, 0, 0,
+                0, 0, parser.mUnitSize, 0,
+                0, 0, 0, 1);
+    }
+    
     if (!ignoreUpDirection) {
         // Convert to Y_UP, if different orientation
         if (parser.mUpDirection == ColladaParser::UP_X) {

--- a/code/AssetLib/Collada/ColladaLoader.h
+++ b/code/AssetLib/Collada/ColladaLoader.h
@@ -239,6 +239,7 @@ protected:
     bool noSkeletonMesh;
     bool removeEmptyBones;
     bool ignoreUpDirection;
+    bool ignoreUnitSize;
     bool useColladaName;
 
     /** Used by FindNameForNode() to generate unique node names */

--- a/include/assimp/config.h.in
+++ b/include/assimp/config.h.in
@@ -1036,6 +1036,15 @@ enum aiComponent
 #define AI_CONFIG_IMPORT_COLLADA_IGNORE_UP_DIRECTION "IMPORT_COLLADA_IGNORE_UP_DIRECTION"
 
 // ---------------------------------------------------------------------------
+/** @brief Specifies whether the Collada loader will ignore the provided unit size.
+ *
+ * If this property is set to true, the unit size provided in the file header will
+ * be ignored and the file will be loaded without scaling the assets.
+ * Property type: Bool. Default value: false.
+ */
+#define AI_CONFIG_IMPORT_COLLADA_IGNORE_UNIT_SIZE "IMPORT_COLLADA_IGNORE_UNIT_SIZE"
+
+// ---------------------------------------------------------------------------
 /** @brief Specifies whether the Collada loader should use Collada names.
  *
  * If this property is set to true, the Collada names will be used as the node and


### PR DESCRIPTION
I needed the option to ignore the unit size scaling for Collada imports.

This PR adds a property `AI_CONFIG_IMPORT_COLLADA_IGNORE_UNIT_SIZE` which controls if the unit size scaling is applied to the root node's transform or not. It works similar to the existing `AI_CONFIG_IMPORT_COLLADA_IGNORE_UP_DIRECTION` property.

The default value is false, so the behavior for Collada imports will not change unless explicitly requested.