### PR TITLE
Fix Heap-buffer-overflow READ in ODDLParser::OpenDDLParser::parseFloatingLiteral

### DIFF
--- a/code/AssetLib/OpenGEX/OpenGEXImporter.cpp
+++ b/code/AssetLib/OpenGEX/OpenGEXImporter.cpp
@@ -301,13 +301,14 @@ void OpenGEXImporter::InternReadFile(const std::string &filename, aiScene *pScen
     OpenDDLParser myParser;
     myParser.setLogCallback(&logDDLParserMessage);
     myParser.setBuffer(&buffer[0], buffer.size());
-    bool success(myParser.parse());
-    if (success) {
-        m_ctx = myParser.getContext();
-        pScene->mRootNode = new aiNode;
-        pScene->mRootNode->mName.Set(filename);
-        handleNodes(m_ctx->m_root, pScene);
+    if (!myParser.parse()) {
+        throw DeadlyImportError("Failed to parse file ", filename);
     }
+
+    m_ctx = myParser.getContext();
+    pScene->mRootNode = new aiNode;
+    pScene->mRootNode->mName.Set(filename);
+    handleNodes(m_ctx->m_root, pScene);
 
     copyMeshes(pScene);
     copyCameras(pScene);


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=58766

Requires https://github.com/kimkulling/openddl-parser/pull/83.

If left as is, later it crashes because `pScene->mRootNode` is nullptr. I think it is better to throw if parsing has failed.