### PR TITLE
Update Triangulate Process

### DIFF
--- a/code/Common/PolyTools.h
+++ b/code/Common/PolyTools.h
@@ -64,8 +64,14 @@ inline double GetArea2D(const T& v1, const T& v2, const T& v3) {
  *  The function accepts an unconstrained template parameter for use with
  *  both aiVector3D and aiVector2D, but generally ignores the third coordinate.*/
 template <typename T>
-inline bool OnLeftSideOfLine2D(const T& p0, const T& p1,const T& p2) {
-    return GetArea2D(p0,p2,p1) > 0;
+inline int OnLeftSideOfLine2D(const T& p0, const T& p1,const T& p2) {
+    double area = GetArea2D(p0,p2,p1);
+    if(std::abs(area) < ai_epsilon)
+        return 0;
+    else if(area > 0)
+        return 1;
+    else
+        return -1;
 }
 
 // -------------------------------------------------------------------------------
@@ -75,7 +81,10 @@ inline bool OnLeftSideOfLine2D(const T& p0, const T& p1,const T& p2) {
 template <typename T>
 inline bool PointInTriangle2D(const T& p0, const T& p1,const T& p2, const T& pp) {
     // pp should be left side of the three triangle side, by ccw arrow
-    return OnLeftSideOfLine2D(p0, p1, pp) && OnLeftSideOfLine2D(p1, p2, pp) && OnLeftSideOfLine2D(p2, p0, pp);
+    int c1 = OnLeftSideOfLine2D(p0, p1, pp);
+    int c2 = OnLeftSideOfLine2D(p1, p2, pp);
+    int c3 = OnLeftSideOfLine2D(p2, p0, pp);
+    return (c1 >= 0) && (c2 >= 0) && (c3 >= 0);
 }
 
 
@@ -110,7 +119,7 @@ inline bool IsCCW(T* in, size_t npoints) {
         c = std::sqrt(cc);
         theta = std::acos((bb + cc - aa) / (2 * b * c));
 
-        if (OnLeftSideOfLine2D(in[i],in[i+2],in[i+1])) {
+        if (OnLeftSideOfLine2D(in[i],in[i+2],in[i+1]) == 1) {
             //  if (convex(in[i].x, in[i].y,
             //      in[i+1].x, in[i+1].y,
             //      in[i+2].x, in[i+2].y)) {
@@ -140,7 +149,7 @@ inline bool IsCCW(T* in, size_t npoints) {
     //if (convex(in[npoints-2].x, in[npoints-2].y,
     //  in[0].x, in[0].y,
     //  in[1].x, in[1].y)) {
-    if (OnLeftSideOfLine2D(in[npoints-2],in[1],in[0])) {
+    if (OnLeftSideOfLine2D(in[npoints-2],in[1],in[0]) == 1) {
         convex_turn = AI_MATH_PI_F - theta;
         convex_sum += convex_turn;
     } else {

--- a/code/PostProcessing/TriangulateProcess.cpp
+++ b/code/PostProcessing/TriangulateProcess.cpp
@@ -451,7 +451,7 @@ bool TriangulateProcess::TriangulateMesh( aiMesh* pMesh) {
                         *pnt2 = &temp_verts[next];
 
                     // Must be a convex point. Assuming ccw winding, it must be on the right of the line between p-1 and p+1.
-                    if (OnLeftSideOfLine2D(*pnt0,*pnt2,*pnt1)) {
+                    if (OnLeftSideOfLine2D(*pnt0,*pnt2,*pnt1) == 1) {
                         continue;
                     }
 


### PR DESCRIPTION
![image](https://github.com/assimp/assimp/assets/43235864/e4e92efd-ec62-45a8-8c2e-8f5a910aeca4)

According to the current Ear Clipping algorithm, point 2 is not within triangle 5, 9, 11, But point 2 is on the edge of 5-11. In this case, the triangle generated will cover the hole on the right.

I modified the `OnLeftSideOfLine2D` function so that it can determine whether it is left or right or on the side.

Here are the results of the test.

![image](https://github.com/assimp/assimp/assets/43235864/4c7ab736-be18-4fcb-8348-32278baeb2bc)

And this is the FBX file that I tested.

[double_hold.zip](https://github.com/assimp/assimp/files/12343171/double_hold.zip)
