### PR TITLE
Fix draco build path

### DIFF
--- a/contrib/draco/CMakeLists.txt
+++ b/contrib/draco/CMakeLists.txt
@@ -21,7 +21,7 @@ endif()
 
 set(draco_root "${CMAKE_CURRENT_SOURCE_DIR}")
 set(draco_src_root "${draco_root}/src/draco")
-set(draco_build "${CMAKE_BINARY_DIR}")
+set(draco_build "${Assimp_BINARY_DIR}")
 
 if("${draco_root}" STREQUAL "${draco_build}")
   message(


### PR DESCRIPTION
Re-fixes the #3663 issue, this was caused by the recent update (https://github.com/assimp/assimp/commit/39efe4c832c02e8e6560b9922b0504716fd3c99c)
#4114 Could re-open this issue if draco is updated again without changing the cmake path to assimp's