### PR TITLE
ai_epsilon bug fixed in C

### DIFF
--- a/include/assimp/defs.h
+++ b/include/assimp/defs.h
@@ -292,7 +292,7 @@ typedef unsigned int ai_uint;
 #ifdef __cplusplus
 constexpr ai_real ai_epsilon = (ai_real) 1e-6;
 #else
-const ai_real ai_epsilon = (ai_real) 1e-6;
+#define ai_epsilon ((ai_real)1e-6)
 #endif
 
 /* Support for big-endian builds */


### PR DESCRIPTION
When I include `<assimp/scene.h>` in multiple translation units in C it doesn't compile.
```
duplicate symbol '_ai_epsilon' in:
...
```

The bug is been there at least few months. I don't wanna edit `<assimp/defs.h>` in line 295 everytime i create a new project using assimp. Please accept.