### PR TITLE
contrib/zip/src/zip.h:  correct 2 spelling errors in comments

### DIFF
--- a/contrib/zip/src/zip.h
+++ b/contrib/zip/src/zip.h
@@ -83,9 +83,9 @@ typedef long ssize_t; /* byte count or error */
 #define ZIP_EFWRITE -29     // fwrite error
 
 /**
- * Looks up the error message string coresponding to an error number.
+ * Looks up the error message string corresponding to an error number.
  * @param errnum error number
- * @return error message string coresponding to errnum or NULL if error is not
+ * @return error message string corresponding to errnum or NULL if error is not
  * found.
  */
 extern const char *zip_strerror(int errnum);


### PR DESCRIPTION
This pull request corrects the spelling of the word "corresponding" in 2 comments in the file contrib/zip/src/zip.h