### PR TITLE
use size in order to be compatible with float and double

### DIFF
--- a/code/AssetLib/Irr/IRRLoader.cpp
+++ b/code/AssetLib/Irr/IRRLoader.cpp
@@ -575,8 +575,8 @@ void SetupMapping(aiMaterial *mat, aiTextureMapping mode, const aiVector3D &axis
                 m->mSemantic = prop->mSemantic;
                 m->mType = aiPTI_Float;
 
-                m->mDataLength = 12;
-                m->mData = new char[12];
+                m->mDataLength = sizeof(aiVector3D);
+                m->mData = new char[m->mDataLength];
                 *((aiVector3D *)m->mData) = axis;
                 p.push_back(m);
             }


### PR DESCRIPTION
This fixes a compilation error of the lib when `ASSIMP_DOUBLE_PRECISION` is set to `ON`