### PR TITLE
Fix: Implicit Conversion Error

### DIFF
--- a/code/AssetLib/IFC/IFCLoader.cpp
+++ b/code/AssetLib/IFC/IFCLoader.cpp
@@ -185,7 +185,7 @@ void IFCImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
                 size_t total = 0;
                 int read = 0;
                 do {
-                    int bufferSize = fileInfo.uncompressed_size < INT16_MAX ? fileInfo.uncompressed_size : INT16_MAX;
+                    unsigned bufferSize = fileInfo.uncompressed_size < INT16_MAX ? static_cast<unsigned>(fileInfo.uncompressed_size) : INT16_MAX;
                     void *buffer = malloc(bufferSize);
                     read = unzReadCurrentFile(zip, buffer, bufferSize);
                     if (read > 0) {


### PR DESCRIPTION
In latest versions of XCode when building Assimp for ARM processor `Implicit conversion loses integer precision` warning is treated as error.
It happens when we try to assign `unsigned long` value (which is 8 bytes sized) to `int` variable (which is 4 bytes). `static_cast` covers this problem here and it is safe because length check before conversion already exists.