### PR TITLE
Refactoring: Some cleanups

### DIFF
--- a/code/AssetLib/3DS/3DSConverter.cpp
+++ b/code/AssetLib/3DS/3DSConverter.cpp
@@ -52,9 +52,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cctype>
 #include <memory>
 
-using namespace Assimp;
+namespace Assimp {
 
-static const unsigned int NotSet = 0xcdcdcdcd;
+static constexpr unsigned int NotSet = 0xcdcdcdcd;
 
 // ------------------------------------------------------------------------------------------------
 // Setup final material indices, generae a default material if necessary
@@ -68,7 +68,7 @@ void Discreet3DSImporter::ReplaceDefaultMaterial() {
     unsigned int idx(NotSet);
     for (unsigned int i = 0; i < mScene->mMaterials.size(); ++i) {
         std::string s = mScene->mMaterials[i].mName;
-        for (char & it : s) {
+        for (char &it : s) {
             it = static_cast<char>(::tolower(static_cast<unsigned char>(it)));
         }
 
@@ -262,7 +262,7 @@ void Discreet3DSImporter::ConvertMaterial(D3DS::Material &oldMat,
         unsigned int iWire = 1;
         mat.AddProperty<int>((int *)&iWire, 1, AI_MATKEY_ENABLE_WIREFRAME);
     }
-    [[fallthrough]];
+        [[fallthrough]];
 
     case D3DS::Discreet3DS::Gouraud:
         eShading = aiShadingMode_Gouraud;
@@ -804,5 +804,7 @@ void Discreet3DSImporter::ConvertScene(aiScene *pcOut) {
         ::memcpy(pcOut->mCameras, &mScene->mCameras[0], sizeof(void *) * pcOut->mNumCameras);
     }
 }
+
+} // namespace Assimp
 
 #endif // !! ASSIMP_BUILD_NO_3DS_IMPORTER

--- a/code/AssetLib/3DS/3DSExporter.h
+++ b/code/AssetLib/3DS/3DSExporter.h
@@ -4,7 +4,6 @@ Open Asset Import Library (assimp)
 
 Copyright (c) 2006-2022, assimp team
 
-
 All rights reserved.
 
 Redistribution and use of this software in source and binary forms,
@@ -57,8 +56,7 @@ struct aiNode;
 struct aiMaterial;
 struct aiMesh;
 
-namespace Assimp
-{
+namespace Assimp {
 
 // ------------------------------------------------------------------------------------------------
 /**
@@ -88,7 +86,7 @@ private:
 
     std::map<const aiNode*, aiMatrix4x4> trafos;
 
-    typedef std::multimap<const aiNode*, unsigned int> MeshesByNodeMap;
+    using MeshesByNodeMap = std::multimap<const aiNode*, unsigned int>;
     MeshesByNodeMap meshes;
 
 };

--- a/code/AssetLib/3DS/3DSLoader.cpp
+++ b/code/AssetLib/3DS/3DSLoader.cpp
@@ -56,7 +56,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using namespace Assimp;
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "Discreet 3DS Importer",
     "",
     "",

--- a/code/AssetLib/3DS/3DSLoader.cpp
+++ b/code/AssetLib/3DS/3DSLoader.cpp
@@ -54,7 +54,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/DefaultLogger.hpp>
 #include <assimp/IOSystem.hpp>
 
-using namespace Assimp;
+namespace Assimp {
 
 static constexpr aiImporterDesc desc = {
     "Discreet 3DS Importer",
@@ -1334,5 +1334,7 @@ void Discreet3DSImporter::ParseColorChunk(aiColor3D *out, bool acceptPercent) {
     };
     (void)bGamma;
 }
+
+} // namespace Assimp
 
 #endif // !! ASSIMP_BUILD_NO_3DS_IMPORTER

--- a/code/AssetLib/3MF/D3MFImporter.cpp
+++ b/code/AssetLib/3MF/D3MFImporter.cpp
@@ -81,10 +81,6 @@ static constexpr aiImporterDesc desc = {
     "3mf"
 };
 
-D3MFImporter::D3MFImporter() = default;
-
-D3MFImporter::~D3MFImporter() = default;
-
 bool D3MFImporter::CanRead(const std::string &filename, IOSystem *pIOHandler, bool /*checkSig*/) const {
     if (!ZipArchiveIOSystem::isZipArchive(pIOHandler, filename)) {
         return false;

--- a/code/AssetLib/3MF/D3MFImporter.cpp
+++ b/code/AssetLib/3MF/D3MFImporter.cpp
@@ -68,7 +68,7 @@ namespace Assimp {
 
 using namespace D3MF;
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "3mf Importer",
     "",
     "",

--- a/code/AssetLib/3MF/D3MFImporter.h
+++ b/code/AssetLib/3MF/D3MFImporter.h
@@ -56,10 +56,10 @@ namespace Assimp {
 class D3MFImporter : public BaseImporter {
 public:
     /// @brief The default class constructor.
-    D3MFImporter();
+    D3MFImporter() = default;
 
     ///	@brief  The class destructor.
-    ~D3MFImporter() override;
+    ~D3MFImporter() override = default;
 
     /// @brief Performs the data format detection.
     /// @param pFile        The filename to check.

--- a/code/AssetLib/3MF/D3MFOpcPackage.cpp
+++ b/code/AssetLib/3MF/D3MFOpcPackage.cpp
@@ -68,7 +68,7 @@ using OpcPackageRelationshipPtr = std::shared_ptr<OpcPackageRelationship>;
 class OpcPackageRelationshipReader {
 public:
     OpcPackageRelationshipReader(XmlParser &parser) :
-            m_relationShips() {
+            mRelations() {
         XmlNode root = parser.getRootNode();
         ParseRootNode(root);
     }
@@ -108,13 +108,13 @@ public:
                 relPtr->type = currentNode.attribute(XmlTag::RELS_ATTRIB_TYPE).as_string();
                 relPtr->target = currentNode.attribute(XmlTag::RELS_ATTRIB_TARGET).as_string();
                 if (validateRels(relPtr)) {
-                    m_relationShips.push_back(relPtr);
+                    mRelations.push_back(relPtr);
                 }
             }
         }
     }
 
-    std::vector<OpcPackageRelationshipPtr> m_relationShips;
+    std::vector<OpcPackageRelationshipPtr> mRelations;
 };
 
 static bool IsEmbeddedTexture( const std::string &filename ) {
@@ -217,11 +217,11 @@ std::string D3MFOpcPackage::ReadPackageRootRelationship(IOStream *stream) {
 
     OpcPackageRelationshipReader reader(xmlParser);
 
-    auto itr = std::find_if(reader.m_relationShips.begin(), reader.m_relationShips.end(), [](const OpcPackageRelationshipPtr &rel) {
+    auto itr = std::find_if(reader.mRelations.begin(), reader.mRelations.end(), [](const OpcPackageRelationshipPtr &rel) {
         return rel->type == XmlTag::PACKAGE_START_PART_RELATIONSHIP_TYPE;
     });
 
-    if (itr == reader.m_relationShips.end()) {
+    if (itr == reader.mRelations.end()) {
         throw DeadlyImportError("Cannot find ", XmlTag::PACKAGE_START_PART_RELATIONSHIP_TYPE);
     }
 

--- a/code/AssetLib/3MF/XmlSerializer.cpp
+++ b/code/AssetLib/3MF/XmlSerializer.cpp
@@ -49,12 +49,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace Assimp {
 namespace D3MF {
 
-static const int IdNotSet = -1;
+static constexpr int IdNotSet = -1;
 
 namespace {
 
-static const size_t ColRGBA_Len = 9;
-static const size_t ColRGB_Len = 7;
+static constexpr size_t ColRGBA_Len = 9;
+static constexpr size_t ColRGB_Len = 7;
 
 // format of the color string: #RRGGBBAA or #RRGGBB (3MF Core chapter 5.1.1)
 bool validateColorString(const char *color) {

--- a/code/AssetLib/AC/ACLoader.cpp
+++ b/code/AssetLib/AC/ACLoader.cpp
@@ -62,7 +62,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using namespace Assimp;
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "AC3D Importer",
     "",
     "",

--- a/code/AssetLib/AC/ACLoader.cpp
+++ b/code/AssetLib/AC/ACLoader.cpp
@@ -60,7 +60,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/Importer.hpp>
 #include <memory>
 
-using namespace Assimp;
+namespace Assimp {
 
 static constexpr aiImporterDesc desc = {
     "AC3D Importer",
@@ -861,5 +861,7 @@ void AC3DImporter::InternReadFile(const std::string &pFile,
         ::memcpy(pScene->mLights, &lights[0], lights.size() * sizeof(void *));
     }
 }
+
+} // namespace Assimp
 
 #endif //!defined ASSIMP_BUILD_NO_AC_IMPORTER

--- a/code/AssetLib/AMF/AMFImporter.cpp
+++ b/code/AssetLib/AMF/AMFImporter.cpp
@@ -53,7 +53,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 namespace Assimp {
 
-const aiImporterDesc AMFImporter::Description = {
+static constexpr aiImporterDesc Description = {
     "Additive manufacturing file format(AMF) Importer",
     "smalcom",
     "",

--- a/code/AssetLib/ASE/ASELoader.cpp
+++ b/code/AssetLib/ASE/ASELoader.cpp
@@ -66,7 +66,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using namespace Assimp;
 using namespace Assimp::ASE;
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "ASE Importer",
     "",
     "",

--- a/code/AssetLib/ASE/ASELoader.cpp
+++ b/code/AssetLib/ASE/ASELoader.cpp
@@ -63,7 +63,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // utilities
 #include <assimp/fast_atof.h>
 
-using namespace Assimp;
+namespace Assimp {
 using namespace Assimp::ASE;
 
 static constexpr aiImporterDesc desc = {
@@ -1260,6 +1260,8 @@ bool ASEImporter::GenerateNormals(ASE::Mesh &mesh) {
     // The array is reused.
     ComputeNormalsWithSmoothingsGroups<ASE::Face>(mesh);
     return false;
+}
+
 }
 
 #endif // ASSIMP_BUILD_NO_3DS_IMPORTER

--- a/code/AssetLib/ASE/ASEParser.cpp
+++ b/code/AssetLib/ASE/ASEParser.cpp
@@ -53,7 +53,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/fast_atof.h>
 #include <assimp/DefaultLogger.hpp>
 
-using namespace Assimp;
+namespace Assimp {
 using namespace Assimp::ASE;
 
 // ------------------------------------------------------------------------------------------------
@@ -1862,6 +1862,8 @@ void Parser::ParseLV4MeshLong(unsigned int &iOut) {
     }
     // parse the value
     iOut = strtoul10(filePtr, &filePtr);
+}
+
 }
 
 #endif // ASSIMP_BUILD_NO_3DS_IMPORTER

--- a/code/AssetLib/Assbin/AssbinLoader.cpp
+++ b/code/AssetLib/Assbin/AssbinLoader.cpp
@@ -65,7 +65,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using namespace Assimp;
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "Assimp Binary Importer",
     "Gargaj / Conspiracy",
     "",

--- a/code/AssetLib/B3D/B3DImporter.cpp
+++ b/code/AssetLib/B3D/B3DImporter.cpp
@@ -62,7 +62,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using namespace Assimp;
 using namespace std;
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "BlitzBasic 3D Importer",
     "",
     "",

--- a/code/AssetLib/B3D/B3DImporter.cpp
+++ b/code/AssetLib/B3D/B3DImporter.cpp
@@ -59,7 +59,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <memory>
 
-using namespace Assimp;
+namespace Assimp {
 using namespace std;
 
 static constexpr aiImporterDesc desc = {
@@ -79,9 +79,9 @@ static constexpr aiImporterDesc desc = {
 #pragma warning(disable : 4018)
 #endif
 
-//#define DEBUG_B3D
+// #define DEBUG_B3D
 
-template<typename T>
+template <typename T>
 void DeleteAllBarePointers(std::vector<T> &x) {
     for (auto p : x) {
         delete p;
@@ -329,7 +329,7 @@ void B3DImporter::ReadBRUS() {
             mat->AddProperty(&i, 1, AI_MATKEY_TWOSIDED);
         }
 
-        //Textures
+        // Textures
         for (int i = 0; i < n_texs; ++i) {
             int texid = ReadInt();
             if (texid < -1 || (texid >= 0 && texid >= static_cast<int>(_textures.size()))) {
@@ -372,7 +372,7 @@ void B3DImporter::ReadVRTS() {
         }
 
         if (_vflags & 2) {
-            ReadQuat(); //skip v 4bytes...
+            ReadQuat(); // skip v 4bytes...
         }
 
         for (int j = 0; j < _tcsets; ++j) {
@@ -704,22 +704,22 @@ void B3DImporter::ReadBB3D(aiScene *scene) {
         }
     }
 
-    //nodes
+    // nodes
     scene->mRootNode = _nodes[0];
     _nodes.clear(); // node ownership now belongs to scene
 
-    //material
+    // material
     if (!_materials.size()) {
         _materials.emplace_back(std::unique_ptr<aiMaterial>(new aiMaterial));
     }
     scene->mNumMaterials = static_cast<unsigned int>(_materials.size());
     scene->mMaterials = unique_to_array(_materials);
 
-    //meshes
+    // meshes
     scene->mNumMeshes = static_cast<unsigned int>(_meshes.size());
     scene->mMeshes = unique_to_array(_meshes);
 
-    //animations
+    // animations
     if (_animations.size() == 1 && _nodeAnims.size()) {
 
         aiAnimation *anim = _animations.back().get();
@@ -737,5 +737,7 @@ void B3DImporter::ReadBB3D(aiScene *scene) {
     FlipWindingOrderProcess flip;
     flip.Execute(scene);
 }
+
+} // namespace Assimp
 
 #endif // !! ASSIMP_BUILD_NO_B3D_IMPORTER

--- a/code/AssetLib/BVH/BVHLoader.cpp
+++ b/code/AssetLib/BVH/BVHLoader.cpp
@@ -58,7 +58,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using namespace Assimp;
 using namespace Assimp::Formatter;
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "BVH Importer (MoCap)",
     "",
     "",

--- a/code/AssetLib/BVH/BVHLoader.cpp
+++ b/code/AssetLib/BVH/BVHLoader.cpp
@@ -55,7 +55,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <map>
 #include <memory>
 
-using namespace Assimp;
+namespace Assimp {
+
 using namespace Assimp::Formatter;
 
 static constexpr aiImporterDesc desc = {
@@ -73,8 +74,8 @@ static constexpr aiImporterDesc desc = {
 
 // ------------------------------------------------------------------------------------------------
 // Aborts the file reading with an exception
-template<typename... T>
-AI_WONT_RETURN void BVHLoader::ThrowException(T&&... args) {
+template <typename... T>
+AI_WONT_RETURN void BVHLoader::ThrowException(T &&...args) {
     throw DeadlyImportError(mFileName, ":", mLine, " - ", args...);
 }
 
@@ -426,7 +427,7 @@ void BVHLoader::CreateAnimation(aiScene *pScene) {
         nodeAnim->mNodeName.Set(nodeName);
         std::map<BVHLoader::ChannelType, int> channelMap;
 
-        //Build map of channels
+        // Build map of channels
         for (unsigned int channel = 0; channel < node.mChannels.size(); ++channel) {
             channelMap[node.mChannels[channel]] = channel;
         }
@@ -441,7 +442,7 @@ void BVHLoader::CreateAnimation(aiScene *pScene) {
 
                 // Now compute all translations
                 for (BVHLoader::ChannelType channel = Channel_PositionX; channel <= Channel_PositionZ; channel = (BVHLoader::ChannelType)(channel + 1)) {
-                    //Find channel in node
+                    // Find channel in node
                     std::map<BVHLoader::ChannelType, int>::iterator mapIter = channelMap.find(channel);
 
                     if (mapIter == channelMap.end())
@@ -485,30 +486,27 @@ void BVHLoader::CreateAnimation(aiScene *pScene) {
             for (unsigned int fr = 0; fr < mAnimNumFrames; ++fr) {
                 aiMatrix4x4 temp;
                 aiMatrix3x3 rotMatrix;
-				for (unsigned int channelIdx = 0; channelIdx < node.mChannels.size(); ++ channelIdx) {
-					switch (node.mChannels[channelIdx]) {
-                    case Channel_RotationX:
-                        {
+                for (unsigned int channelIdx = 0; channelIdx < node.mChannels.size(); ++channelIdx) {
+                    switch (node.mChannels[channelIdx]) {
+                    case Channel_RotationX: {
                         const float angle = node.mChannelValues[fr * node.mChannels.size() + channelIdx] * float(AI_MATH_PI) / 180.0f;
-                        aiMatrix4x4::RotationX( angle, temp); rotMatrix *= aiMatrix3x3( temp);
-                        }
-                        break;
-                    case Channel_RotationY:
-                        {
+                        aiMatrix4x4::RotationX(angle, temp);
+                        rotMatrix *= aiMatrix3x3(temp);
+                    } break;
+                    case Channel_RotationY: {
                         const float angle = node.mChannelValues[fr * node.mChannels.size() + channelIdx] * float(AI_MATH_PI) / 180.0f;
-                        aiMatrix4x4::RotationY( angle, temp); rotMatrix *= aiMatrix3x3( temp);
-                        }
-                        break;
-                    case Channel_RotationZ:
-                        {
+                        aiMatrix4x4::RotationY(angle, temp);
+                        rotMatrix *= aiMatrix3x3(temp);
+                    } break;
+                    case Channel_RotationZ: {
                         const float angle = node.mChannelValues[fr * node.mChannels.size() + channelIdx] * float(AI_MATH_PI) / 180.0f;
-                        aiMatrix4x4::RotationZ( angle, temp); rotMatrix *= aiMatrix3x3( temp);
-                        }
-                        break;
+                        aiMatrix4x4::RotationZ(angle, temp);
+                        rotMatrix *= aiMatrix3x3(temp);
+                    } break;
                     default:
                         break;
-					}
-				}
+                    }
+                }
                 rotkey->mTime = double(fr);
                 rotkey->mValue = aiQuaternion(rotMatrix);
                 ++rotkey;
@@ -524,5 +522,7 @@ void BVHLoader::CreateAnimation(aiScene *pScene) {
         }
     }
 }
+
+} // namespace Assimp
 
 #endif // !! ASSIMP_BUILD_NO_BVH_IMPORTER

--- a/code/AssetLib/Blender/BlenderLoader.cpp
+++ b/code/AssetLib/Blender/BlenderLoader.cpp
@@ -69,11 +69,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // zlib is needed for compressed blend files
 #ifndef ASSIMP_BUILD_NO_COMPRESSED_BLEND
 #include "Common/Compression.h"
-/* #ifdef ASSIMP_BUILD_NO_OWN_ZLIB
-#    include <zlib.h>
-#  else
-#    include "../contrib/zlib/zlib.h"
-#  endif*/
 #endif
 
 namespace Assimp {
@@ -89,7 +84,7 @@ using namespace Assimp;
 using namespace Assimp::Blender;
 using namespace Assimp::Formatter;
 
-static const aiImporterDesc blenderDesc = {
+static constexpr aiImporterDesc blenderDesc = {
     "Blender 3D Importer (http://www.blender3d.org)",
     "",
     "",

--- a/code/AssetLib/COB/COBLoader.cpp
+++ b/code/AssetLib/COB/COBLoader.cpp
@@ -61,7 +61,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <memory>
 
-using namespace Assimp;
+namespace Assimp {
 using namespace Assimp::COB;
 using namespace Assimp::Formatter;
 
@@ -1162,6 +1162,8 @@ void COBImporter::ReadUnit_Binary(COB::Scene &out, StreamReaderLE &reader, const
         }
     }
     ASSIMP_LOG_WARN("`Unit` chunk ", nfo.id, " is a child of ", nfo.parent_id, " which does not exist");
+}
+
 }
 
 #endif // ASSIMP_BUILD_NO_COB_IMPORTER

--- a/code/AssetLib/COB/COBLoader.cpp
+++ b/code/AssetLib/COB/COBLoader.cpp
@@ -65,7 +65,7 @@ using namespace Assimp;
 using namespace Assimp::COB;
 using namespace Assimp::Formatter;
 
-static const float units[] = {
+static constexpr float units[] = {
     1000.f,
     100.f,
     1.f,
@@ -76,7 +76,7 @@ static const float units[] = {
     1.f / 1609.344f
 };
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "TrueSpace Object Importer",
     "",
     "",
@@ -88,14 +88,6 @@ static const aiImporterDesc desc = {
     0,
     "cob scn"
 };
-
-// ------------------------------------------------------------------------------------------------
-// Constructor to be privately used by Importer
-COBImporter::COBImporter() = default;
-
-// ------------------------------------------------------------------------------------------------
-// Destructor, private as well
-COBImporter::~COBImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/COB/COBLoader.h
+++ b/code/AssetLib/COB/COBLoader.h
@@ -56,16 +56,16 @@ class LineSplitter;
 
 // TinyFormatter.h
 namespace Formatter {
-template <typename T, typename TR, typename A>
-class basic_formatter;
-typedef class basic_formatter<char, std::char_traits<char>, std::allocator<char>> format;
+    template <typename T, typename TR, typename A>
+    class basic_formatter;
+    typedef class basic_formatter<char, std::char_traits<char>, std::allocator<char>> format;
 } // namespace Formatter
 
 // COBScene.h
 namespace COB {
-struct ChunkInfo;
-struct Node;
-struct Scene;
+    struct ChunkInfo;
+    struct Node;
+    struct Scene;
 } // namespace COB
 
 // -------------------------------------------------------------------------------------------
@@ -75,8 +75,8 @@ struct Scene;
 // -------------------------------------------------------------------------------------------
 class COBImporter : public BaseImporter {
 public:
-    COBImporter();
-    ~COBImporter() override;
+    COBImporter() = default;
+    ~COBImporter() override = default;
 
     // --------------------
     bool CanRead(const std::string &pFile, IOSystem *pIOHandler,

--- a/code/AssetLib/CSM/CSMLoader.cpp
+++ b/code/AssetLib/CSM/CSMLoader.cpp
@@ -44,9 +44,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /** @file  CSMLoader.cpp
  *  Implementation of the CSM importer class.
  */
-
-
-
 #ifndef ASSIMP_BUILD_NO_CSM_IMPORTER
 
 #include "CSMLoader.h"
@@ -63,7 +60,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using namespace Assimp;
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "CharacterStudio Motion Importer (MoCap)",
     "",
     "",
@@ -79,13 +76,9 @@ static const aiImporterDesc desc = {
 
 // ------------------------------------------------------------------------------------------------
 // Constructor to be privately used by Importer
-CSMImporter::CSMImporter()
-: noSkeletonMesh()
-{}
-
-// ------------------------------------------------------------------------------------------------
-// Destructor, private as well
-CSMImporter::~CSMImporter() = default;
+CSMImporter::CSMImporter() : noSkeletonMesh(){
+    // empty
+}
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/CSM/CSMLoader.h
+++ b/code/AssetLib/CSM/CSMLoader.h
@@ -61,7 +61,7 @@ namespace Assimp {
 class CSMImporter : public BaseImporter {
 public:
     CSMImporter();
-    ~CSMImporter() override;
+    ~CSMImporter() override = default;
 
     // -------------------------------------------------------------------
     bool CanRead(const std::string &pFile, IOSystem *pIOHandler,
@@ -81,9 +81,8 @@ protected:
 private:
     bool noSkeletonMesh;
 
-}; // end of class CSMImporter
+};
 
-} // end of namespace Assimp
+} // namespace Assimp
 
 #endif // AI_AC3DIMPORTER_H_INC
-

--- a/code/AssetLib/Collada/ColladaLoader.cpp
+++ b/code/AssetLib/Collada/ColladaLoader.cpp
@@ -64,7 +64,7 @@ namespace Assimp {
 using namespace Assimp::Formatter;
 using namespace Assimp::Collada;
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "Collada Importer",
     "",
     "",
@@ -100,10 +100,6 @@ ColladaLoader::ColladaLoader() :
         mNodeNameCounter(0) {
     // empty
 }
-
-// ------------------------------------------------------------------------------------------------
-// Destructor, private as well
-ColladaLoader::~ColladaLoader() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/Collada/ColladaLoader.h
+++ b/code/AssetLib/Collada/ColladaLoader.h
@@ -86,7 +86,7 @@ public:
     ColladaLoader();
 
     /// The class destructor.
-    ~ColladaLoader() override;
+    ~ColladaLoader() override = default;
 
     /// Returns whether the class can handle the format of the given file.
     /// @see BaseImporter::CanRead() for more details.

--- a/code/AssetLib/DXF/DXFLoader.cpp
+++ b/code/AssetLib/DXF/DXFLoader.cpp
@@ -70,7 +70,7 @@ static const aiColor4D AI_DXF_DEFAULT_COLOR(aiColor4D(0.6f, 0.6f, 0.6f, 0.6f));
 
 // color indices for DXF - 16 are supported, the table is
 // taken directly from the DXF spec.
-static aiColor4D g_aclrDxfIndexColors[] = {
+static const aiColor4D g_aclrDxfIndexColors[] = {
     aiColor4D(0.6f, 0.6f, 0.6f, 1.0f),
     aiColor4D (1.0f, 0.0f, 0.0f, 1.0f), // red
     aiColor4D (0.0f, 1.0f, 0.0f, 1.0f), // green
@@ -97,7 +97,7 @@ static const int GroupCode_XComp = 10;
 static const int GroupCode_YComp = 20;
 static const int GroupCode_ZComp = 30;
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "Drawing Interchange Format (DXF) Importer",
     "",
     "",

--- a/code/AssetLib/FBX/FBXImporter.cpp
+++ b/code/AssetLib/FBX/FBXImporter.cpp
@@ -72,24 +72,19 @@ using namespace Assimp::Formatter;
 using namespace Assimp::FBX;
 
 namespace {
-
-static const aiImporterDesc desc = {
-	"Autodesk FBX Importer",
-	"",
-	"",
-	"",
-	aiImporterFlags_SupportTextFlavour,
-	0,
-	0,
-	0,
-	0,
-	"fbx"
-};
+    static constexpr aiImporterDesc desc = {
+	    "Autodesk FBX Importer",
+	    "",
+	    "",
+	    "",
+	    aiImporterFlags_SupportTextFlavour,
+	    0,
+	    0,
+	    0,
+	    0,
+	    "fbx"
+    };
 }
-
-// ------------------------------------------------------------------------------------------------
-// Constructor to be privately used by #Importer
-FBXImporter::FBXImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/FBX/FBXImporter.h
+++ b/code/AssetLib/FBX/FBXImporter.h
@@ -70,7 +70,7 @@ typedef class basic_formatter<char, std::char_traits<char>, std::allocator<char>
 class FBXImporter : public BaseImporter, public LogFunctions<FBXImporter> {
 public:
     /// @brief The class constructor.
-    FBXImporter();
+    FBXImporter() = default;
 
     ///	@brief The class destructor, default implementation.
     ~FBXImporter() override = default;

--- a/code/AssetLib/HMP/HMPLoader.cpp
+++ b/code/AssetLib/HMP/HMPLoader.cpp
@@ -57,7 +57,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using namespace Assimp;
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "3D GameStudio Heightmap (HMP) Importer",
     "",
     "",

--- a/code/AssetLib/IFC/IFCLoader.cpp
+++ b/code/AssetLib/IFC/IFCLoader.cpp
@@ -103,7 +103,7 @@ void ConvertUnit(const ::Assimp::STEP::EXPRESS::DataType &dt, ConversionData &co
 
 } // namespace
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "Industry Foundation Classes (IFC) Importer",
     "",
     "",

--- a/code/AssetLib/IQM/IQMImporter.cpp
+++ b/code/AssetLib/IQM/IQMImporter.cpp
@@ -59,7 +59,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // http://sauerbraten.org/iqm/
 // https://github.com/lsalzman/iqm
 
-
 inline void swap_block( uint32_t *block, size_t size ){
     (void)block; // suppress 'unreferenced formal parameter' MSVC warning
     size >>= 2;
@@ -67,7 +66,7 @@ inline void swap_block( uint32_t *block, size_t size ){
         AI_SWAP4( block[ i ] );
 }
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "Inter-Quake Model Importer",
     "",
     "",

--- a/code/AssetLib/Irr/IRRLoader.cpp
+++ b/code/AssetLib/Irr/IRRLoader.cpp
@@ -66,7 +66,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using namespace Assimp;
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "Irrlicht Scene Reader",
     "",
     "",

--- a/code/AssetLib/Irr/IRRMeshLoader.cpp
+++ b/code/AssetLib/Irr/IRRMeshLoader.cpp
@@ -56,7 +56,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using namespace Assimp;
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "Irrlicht Mesh Reader",
     "",
     "",

--- a/code/AssetLib/LWO/LWOBLoader.cpp
+++ b/code/AssetLib/LWO/LWOBLoader.cpp
@@ -51,64 +51,56 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "LWOLoader.h"
 using namespace Assimp;
 
-
 // ------------------------------------------------------------------------------------------------
-void LWOImporter::LoadLWOBFile()
-{
+void LWOImporter::LoadLWOBFile() {
     LE_NCONST uint8_t* const end = mFileBuffer + fileSize;
     bool running = true;
-    while (running)
-    {
-        if (mFileBuffer + sizeof(IFF::ChunkHeader) > end)break;
+    while (running) {
+        if (mFileBuffer + sizeof(IFF::ChunkHeader) > end)
+            break;
         const IFF::ChunkHeader head = IFF::LoadChunk(mFileBuffer);
 
-        if (mFileBuffer + head.length > end)
-        {
+        if (mFileBuffer + head.length > end) {
             throw DeadlyImportError("LWOB: Invalid chunk length");
         }
         uint8_t* const next = mFileBuffer+head.length;
-        switch (head.type)
-        {
+        switch (head.type) {
             // vertex list
-        case AI_LWO_PNTS:
-            {
+            case AI_LWO_PNTS: {
                 if (!mCurLayer->mTempPoints.empty())
                     ASSIMP_LOG_WARN("LWO: PNTS chunk encountered twice");
-                else LoadLWOPoints(head.length);
-                break;
-            }
-            // face list
-        case AI_LWO_POLS:
-            {
+                else
+                    LoadLWOPoints(head.length);
+                } break;
+            case AI_LWO_POLS: {                 // face list
+                    if (!mCurLayer->mFaces.empty())
+                        ASSIMP_LOG_WARN("LWO: POLS chunk encountered twice");
+                    else
+                        LoadLWOBPolygons(head.length);
+                } break;
+                
+            case AI_LWO_SRFS: // list of tags
+                {
+                    if (!mTags->empty())
+                        ASSIMP_LOG_WARN("LWO: SRFS chunk encountered twice");
+                    else
+                        LoadLWOTags(head.length);
+                } break;
 
-                if (!mCurLayer->mFaces.empty())
-                    ASSIMP_LOG_WARN("LWO: POLS chunk encountered twice");
-                else LoadLWOBPolygons(head.length);
-                break;
-            }
-            // list of tags
-        case AI_LWO_SRFS:
-            {
-                if (!mTags->empty())
-                    ASSIMP_LOG_WARN("LWO: SRFS chunk encountered twice");
-                else LoadLWOTags(head.length);
-                break;
-            }
+            case AI_LWO_SURF: // surface chunk
+                {
+                    LoadLWOBSurface(head.length);
+                } break;
 
-            // surface chunk
-        case AI_LWO_SURF:
-            {
-                LoadLWOBSurface(head.length);
+            default:
                 break;
-            }
         }
         mFileBuffer = next;
     }
 }
 
 // ------------------------------------------------------------------------------------------------
-void LWOImporter::LoadLWOBPolygons(unsigned int length)
-{
+void LWOImporter::LoadLWOBPolygons(unsigned int length) {
     // first find out how many faces and vertices we'll finally need
     LE_NCONST uint16_t* const end   = (LE_NCONST uint16_t*)(mFileBuffer+length);
     LE_NCONST uint16_t* cursor      = (LE_NCONST uint16_t*)mFileBuffer;
@@ -123,8 +115,7 @@ void LWOImporter::LoadLWOBPolygons(unsigned int length)
     CountVertsAndFacesLWOB(iNumVertices,iNumFaces,cursor,end);
 
     // allocate the output array and copy face indices
-    if (iNumFaces)
-    {
+    if (iNumFaces) {
         cursor = (LE_NCONST uint16_t*)mFileBuffer;
 
         mCurLayer->mFaces.resize(iNumFaces);
@@ -135,10 +126,8 @@ void LWOImporter::LoadLWOBPolygons(unsigned int length)
 
 // ------------------------------------------------------------------------------------------------
 void LWOImporter::CountVertsAndFacesLWOB(unsigned int& verts, unsigned int& faces,
-    LE_NCONST uint16_t*& cursor, const uint16_t* const end, unsigned int max)
-{
-    while (cursor < end && max--)
-    {
+    LE_NCONST uint16_t*& cursor, const uint16_t* const end, unsigned int max) {
+    while (cursor < end && max--) {
         uint16_t numIndices;
         // must have 2 shorts left for numIndices and surface
         if (end - cursor < 2) {
@@ -154,8 +143,7 @@ void LWOImporter::CountVertsAndFacesLWOB(unsigned int& verts, unsigned int& face
         cursor += numIndices;
         int16_t surface;
         ::memcpy(&surface, cursor++, 2);
-        if (surface < 0)
-        {
+        if (surface < 0) {
             // there are detail polygons
             ::memcpy(&numIndices, cursor++, 2);
             CountVertsAndFacesLWOB(verts,faces,cursor,end,numIndices);
@@ -167,18 +155,14 @@ void LWOImporter::CountVertsAndFacesLWOB(unsigned int& verts, unsigned int& face
 void LWOImporter::CopyFaceIndicesLWOB(FaceList::iterator& it,
     LE_NCONST uint16_t*& cursor,
     const uint16_t* const end,
-    unsigned int max)
-{
-    while (cursor < end && max--)
-    {
+    unsigned int max) {
+    while (cursor < end && max--) {
         LWO::Face& face = *it;++it;
         uint16_t numIndices;
         ::memcpy(&numIndices, cursor++, 2);
         face.mNumIndices = numIndices;
-        if(face.mNumIndices)
-        {
-            if (cursor + face.mNumIndices >= end)
-            {
+        if(face.mNumIndices) {
+            if (cursor + face.mNumIndices >= end) {
                 break;
             }
             face.mIndices = new unsigned int[face.mNumIndices];
@@ -187,8 +171,7 @@ void LWOImporter::CopyFaceIndicesLWOB(FaceList::iterator& it,
                 uint16_t index;
                 ::memcpy(&index, cursor++, 2);
                 mi = index;
-                if (mi > mCurLayer->mTempPoints.size())
-                {
+                if (mi > mCurLayer->mTempPoints.size()) {
                     ASSIMP_LOG_WARN("LWOB: face index is out of range");
                     mi = (unsigned int)mCurLayer->mTempPoints.size()-1;
                 }
@@ -198,15 +181,13 @@ void LWOImporter::CopyFaceIndicesLWOB(FaceList::iterator& it,
         }
         int16_t surface;
         ::memcpy(&surface, cursor++, 2);
-        if (surface < 0)
-        {
+        if (surface < 0) {
             surface = -surface;
 
             // there are detail polygons.
             uint16_t numPolygons;
             ::memcpy(&numPolygons, cursor++, 2);
-            if (cursor < end)
-            {
+            if (cursor < end) {
                 CopyFaceIndicesLWOB(it,cursor,end,numPolygons);
             }
         }
@@ -215,8 +196,7 @@ void LWOImporter::CopyFaceIndicesLWOB(FaceList::iterator& it,
 }
 
 // ------------------------------------------------------------------------------------------------
-LWO::Texture* LWOImporter::SetupNewTextureLWOB(LWO::TextureList& list,unsigned int size)
-{
+LWO::Texture* LWOImporter::SetupNewTextureLWOB(LWO::TextureList& list,unsigned int size) {
     list.emplace_back();
     LWO::Texture* tex = &list.back();
 
@@ -224,8 +204,7 @@ LWO::Texture* LWOImporter::SetupNewTextureLWOB(LWO::TextureList& list,unsigned i
     GetS0(type,size);
     const char* s = type.c_str();
 
-    if(strstr(s, "Image Map"))
-    {
+    if(strstr(s, "Image Map")) {
         // Determine mapping type
         if(strstr(s, "Planar"))
             tex->mapMode = LWO::Texture::Planar;
@@ -237,9 +216,7 @@ LWO::Texture* LWOImporter::SetupNewTextureLWOB(LWO::TextureList& list,unsigned i
             tex->mapMode = LWO::Texture::Cubic;
         else if(strstr(s, "Front"))
             tex->mapMode = LWO::Texture::FrontProjection;
-    }
-    else
-    {
+    } else {
         // procedural or gradient, not supported
         ASSIMP_LOG_ERROR("LWOB: Unsupported legacy texture: ", type);
     }
@@ -248,8 +225,7 @@ LWO::Texture* LWOImporter::SetupNewTextureLWOB(LWO::TextureList& list,unsigned i
 }
 
 // ------------------------------------------------------------------------------------------------
-void LWOImporter::LoadLWOBSurface(unsigned int size)
-{
+void LWOImporter::LoadLWOBSurface(unsigned int size) {
     LE_NCONST uint8_t* const end = mFileBuffer + size;
 
     mSurfaces->push_back( LWO::Surface () );
@@ -277,148 +253,147 @@ void LWOImporter::LoadLWOBSurface(unsigned int size)
         }
 
         uint8_t* const next = mFileBuffer+head.length;
-        switch (head.type)
-        {
-        // diffuse color
-        case AI_LWO_COLR:
-            {
-                AI_LWO_VALIDATE_CHUNK_LENGTH(head.length,COLR,3);
-                surf.mColor.r = GetU1() / 255.0f;
-                surf.mColor.g = GetU1() / 255.0f;
-                surf.mColor.b = GetU1() / 255.0f;
-                break;
-            }
-        // diffuse strength ...
-        case AI_LWO_DIFF:
-            {
-                AI_LWO_VALIDATE_CHUNK_LENGTH(head.length,DIFF,2);
-                surf.mDiffuseValue = GetU2() / 255.0f;
-                break;
-            }
-        // specular strength ...
-        case AI_LWO_SPEC:
-            {
-                AI_LWO_VALIDATE_CHUNK_LENGTH(head.length,SPEC,2);
-                surf.mSpecularValue = GetU2() / 255.0f;
-                break;
-            }
-        // luminosity ...
-        case AI_LWO_LUMI:
-            {
-                AI_LWO_VALIDATE_CHUNK_LENGTH(head.length,LUMI,2);
-                surf.mLuminosity = GetU2() / 255.0f;
-                break;
-            }
-        // transparency
-        case AI_LWO_TRAN:
-            {
-                AI_LWO_VALIDATE_CHUNK_LENGTH(head.length,TRAN,2);
-                surf.mTransparency = GetU2() / 255.0f;
-                break;
-            }
-        // surface flags
-        case AI_LWO_FLAG:
-            {
-                AI_LWO_VALIDATE_CHUNK_LENGTH(head.length,FLAG,2);
-                uint16_t flag = GetU2();
-                if (flag & 0x4 )   surf.mMaximumSmoothAngle = 1.56207f;
-                if (flag & 0x8 )   surf.mColorHighlights = 1.f;
-                if (flag & 0x100)  surf.bDoubleSided = true;
-                break;
-            }
-        // maximum smoothing angle
-        case AI_LWO_SMAN:
-            {
-                AI_LWO_VALIDATE_CHUNK_LENGTH(head.length,SMAN,4);
-                surf.mMaximumSmoothAngle = std::fabs( GetF4() );
-                break;
-            }
-        // glossiness
-        case AI_LWO_GLOS:
-            {
-                AI_LWO_VALIDATE_CHUNK_LENGTH(head.length,GLOS,2);
-                surf.mGlossiness = (float)GetU2();
-                break;
-            }
-        // color texture
-        case AI_LWO_CTEX:
-            {
-                pTex = SetupNewTextureLWOB(surf.mColorTextures,
-                    head.length);
-                break;
-            }
-        // diffuse texture
-        case AI_LWO_DTEX:
-            {
-                pTex = SetupNewTextureLWOB(surf.mDiffuseTextures,
-                    head.length);
-                break;
-            }
-        // specular texture
-        case AI_LWO_STEX:
-            {
-                pTex = SetupNewTextureLWOB(surf.mSpecularTextures,
-                    head.length);
-                break;
-            }
-        // bump texture
-        case AI_LWO_BTEX:
-            {
-                pTex = SetupNewTextureLWOB(surf.mBumpTextures,
-                    head.length);
-                break;
-            }
-        // transparency texture
-        case AI_LWO_TTEX:
-            {
-                pTex = SetupNewTextureLWOB(surf.mOpacityTextures,
-                    head.length);
-                break;
-            }
-        // texture path
-        case AI_LWO_TIMG:
-            {
-                if (pTex)   {
-                    GetS0(pTex->mFileName,head.length);
-                } else {
-                    ASSIMP_LOG_WARN("LWOB: Unexpected TIMG chunk");
+        switch (head.type) {
+            // diffuse color
+            case AI_LWO_COLR:
+                {
+                    AI_LWO_VALIDATE_CHUNK_LENGTH(head.length,COLR,3);
+                    surf.mColor.r = GetU1() / 255.0f;
+                    surf.mColor.g = GetU1() / 255.0f;
+                    surf.mColor.b = GetU1() / 255.0f;
+                    break;
                 }
-                break;
-            }
-        // texture strength
-        case AI_LWO_TVAL:
-            {
-                AI_LWO_VALIDATE_CHUNK_LENGTH(head.length,TVAL,1);
-                if (pTex)   {
-                    pTex->mStrength = (float)GetU1()/ 255.f;
-                } else {
-                    ASSIMP_LOG_ERROR("LWOB: Unexpected TVAL chunk");
+            // diffuse strength ...
+            case AI_LWO_DIFF:
+                {
+                    AI_LWO_VALIDATE_CHUNK_LENGTH(head.length,DIFF,2);
+                    surf.mDiffuseValue = GetU2() / 255.0f;
+                    break;
                 }
-                break;
-            }
-        // texture flags
-        case AI_LWO_TFLG:
-            {
-                AI_LWO_VALIDATE_CHUNK_LENGTH(head.length,TFLG,2);
-
-                if (nullptr != pTex) {
-                    const uint16_t s = GetU2();
-                    if (s & 1)
-                        pTex->majorAxis = LWO::Texture::AXIS_X;
-                    else if (s & 2)
-                        pTex->majorAxis = LWO::Texture::AXIS_Y;
-                    else if (s & 4)
-                        pTex->majorAxis = LWO::Texture::AXIS_Z;
-
-                    if (s & 16) {
-                        ASSIMP_LOG_WARN("LWOB: Ignoring \'negate\' flag on texture");
+            // specular strength ...
+            case AI_LWO_SPEC:
+                {
+                    AI_LWO_VALIDATE_CHUNK_LENGTH(head.length,SPEC,2);
+                    surf.mSpecularValue = GetU2() / 255.0f;
+                    break;
+                }
+            // luminosity ...
+            case AI_LWO_LUMI:
+                {
+                    AI_LWO_VALIDATE_CHUNK_LENGTH(head.length,LUMI,2);
+                    surf.mLuminosity = GetU2() / 255.0f;
+                    break;
+                }
+            // transparency
+            case AI_LWO_TRAN:
+                {
+                    AI_LWO_VALIDATE_CHUNK_LENGTH(head.length,TRAN,2);
+                    surf.mTransparency = GetU2() / 255.0f;
+                    break;
+                }
+            // surface flags
+            case AI_LWO_FLAG:
+                {
+                    AI_LWO_VALIDATE_CHUNK_LENGTH(head.length,FLAG,2);
+                    uint16_t flag = GetU2();
+                    if (flag & 0x4 )   surf.mMaximumSmoothAngle = 1.56207f;
+                    if (flag & 0x8 )   surf.mColorHighlights = 1.f;
+                    if (flag & 0x100)  surf.bDoubleSided = true;
+                    break;
+                }
+            // maximum smoothing angle
+            case AI_LWO_SMAN:
+                {
+                    AI_LWO_VALIDATE_CHUNK_LENGTH(head.length,SMAN,4);
+                    surf.mMaximumSmoothAngle = std::fabs( GetF4() );
+                    break;
+                }
+            // glossiness
+            case AI_LWO_GLOS:
+                {
+                    AI_LWO_VALIDATE_CHUNK_LENGTH(head.length,GLOS,2);
+                    surf.mGlossiness = (float)GetU2();
+                    break;
+                }
+            // color texture
+            case AI_LWO_CTEX:
+                {
+                    pTex = SetupNewTextureLWOB(surf.mColorTextures,
+                        head.length);
+                    break;
+                }
+            // diffuse texture
+            case AI_LWO_DTEX:
+                {
+                    pTex = SetupNewTextureLWOB(surf.mDiffuseTextures,
+                        head.length);
+                    break;
+                }
+            // specular texture
+            case AI_LWO_STEX:
+                {
+                    pTex = SetupNewTextureLWOB(surf.mSpecularTextures,
+                        head.length);
+                    break;
+                }
+            // bump texture
+            case AI_LWO_BTEX:
+                {
+                    pTex = SetupNewTextureLWOB(surf.mBumpTextures,
+                        head.length);
+                    break;
+                }
+            // transparency texture
+            case AI_LWO_TTEX:
+                {
+                    pTex = SetupNewTextureLWOB(surf.mOpacityTextures,
+                        head.length);
+                    break;
+                }
+            // texture path
+            case AI_LWO_TIMG:
+                {
+                    if (pTex)   {
+                        GetS0(pTex->mFileName,head.length);
+                    } else {
+                        ASSIMP_LOG_WARN("LWOB: Unexpected TIMG chunk");
                     }
+                    break;
                 }
-                else {
-                    ASSIMP_LOG_WARN("LWOB: Unexpected TFLG chunk");
+            // texture strength
+            case AI_LWO_TVAL:
+                {
+                    AI_LWO_VALIDATE_CHUNK_LENGTH(head.length,TVAL,1);
+                    if (pTex)   {
+                        pTex->mStrength = (float)GetU1()/ 255.f;
+                    } else {
+                        ASSIMP_LOG_ERROR("LWOB: Unexpected TVAL chunk");
+                    }
+                    break;
                 }
-                break;
-            }
+            // texture flags
+            case AI_LWO_TFLG:
+                {
+                    AI_LWO_VALIDATE_CHUNK_LENGTH(head.length,TFLG,2);
+
+                    if (nullptr != pTex) {
+                        const uint16_t s = GetU2();
+                        if (s & 1)
+                            pTex->majorAxis = LWO::Texture::AXIS_X;
+                        else if (s & 2)
+                            pTex->majorAxis = LWO::Texture::AXIS_Y;
+                        else if (s & 4)
+                            pTex->majorAxis = LWO::Texture::AXIS_Z;
+
+                        if (s & 16) {
+                            ASSIMP_LOG_WARN("LWOB: Ignoring \'negate\' flag on texture");
+                        }
+                    }
+                    else {
+                        ASSIMP_LOG_WARN("LWOB: Unexpected TFLG chunk");
+                    }
+                    break;
+                }
         }
         mFileBuffer = next;
     }

--- a/code/AssetLib/LWS/LWSLoader.cpp
+++ b/code/AssetLib/LWS/LWSLoader.cpp
@@ -63,7 +63,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using namespace Assimp;
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "LightWave Scene Importer",
     "",
     "",
@@ -138,10 +138,6 @@ LWSImporter::LWSImporter() :
         noSkeletonMesh() {
     // nothing to do here
 }
-
-// ------------------------------------------------------------------------------------------------
-// Destructor, private as well
-LWSImporter::~LWSImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/LWS/LWSLoader.h
+++ b/code/AssetLib/LWS/LWSLoader.h
@@ -174,7 +174,7 @@ struct NodeDesc {
 class LWSImporter : public BaseImporter {
 public:
     LWSImporter();
-    ~LWSImporter() override;
+    ~LWSImporter() override = default;
 
     // -------------------------------------------------------------------
     // Check whether we can read a specific file

--- a/code/AssetLib/M3D/M3DImporter.cpp
+++ b/code/AssetLib/M3D/M3DImporter.cpp
@@ -85,7 +85,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
       are listed in aiScene->mRootNode->children, but all without meshes
 */
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "Model 3D Importer",
     "",
     "",

--- a/code/AssetLib/MD2/MD2Loader.cpp
+++ b/code/AssetLib/MD2/MD2Loader.cpp
@@ -5,8 +5,6 @@ Open Asset Import Library (assimp)
 
 Copyright (c) 2006-2022, assimp team
 
-
-
 All rights reserved.
 
 Redistribution and use of this software in source and binary forms,
@@ -41,7 +39,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ---------------------------------------------------------------------------
 */
 
-
 #ifndef ASSIMP_BUILD_NO_MD2_IMPORTER
 
 /** @file Implementation of the MD2 importer class */
@@ -65,7 +62,7 @@ using namespace Assimp::MD2;
 #   define ARRAYSIZE(_array) (int(sizeof(_array) / sizeof(_array[0])))
 #endif
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "Quake II Mesh Importer",
     "",
     "",
@@ -79,7 +76,7 @@ static const aiImporterDesc desc = {
 };
 
 // ------------------------------------------------------------------------------------------------
-// Helper function to lookup a normal in Quake 2's precalculated table
+// Helper function to lookup a normal in Quake 2's pre-calculated table
 void MD2::LookupNormalIndex(uint8_t iNormalIndex,aiVector3D& vOut)
 {
     // make sure the normal index has a valid value
@@ -99,10 +96,6 @@ MD2Importer::MD2Importer()
     mBuffer(),
     fileSize()
 {}
-
-// ------------------------------------------------------------------------------------------------
-// Destructor, private as well
-MD2Importer::~MD2Importer() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/MD2/MD2Loader.h
+++ b/code/AssetLib/MD2/MD2Loader.h
@@ -63,7 +63,7 @@ using namespace MD2;
 class MD2Importer : public BaseImporter {
 public:
     MD2Importer();
-    ~MD2Importer() override;
+    ~MD2Importer() override = default;
 
     // -------------------------------------------------------------------
     /** Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/MD3/MD3Loader.cpp
+++ b/code/AssetLib/MD3/MD3Loader.cpp
@@ -70,7 +70,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using namespace Assimp;
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "Quake III Mesh Importer",
     "",
     "",

--- a/code/AssetLib/MD5/MD5Loader.cpp
+++ b/code/AssetLib/MD5/MD5Loader.cpp
@@ -64,7 +64,7 @@ using namespace Assimp;
 // Minimum weight value. Weights inside [-n ... n] are ignored
 #define AI_MD5_WEIGHT_EPSILON Math::getEpsilon<float>()
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "Doom 3 / MD5 Mesh Importer",
     "",
     "",
@@ -91,10 +91,6 @@ MD5Importer::MD5Importer() :
         mCconfigNoAutoLoad(false) {
     // empty
 }
-
-// ------------------------------------------------------------------------------------------------
-// Destructor, private as well
-MD5Importer::~MD5Importer() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/MD5/MD5Loader.h
+++ b/code/AssetLib/MD5/MD5Loader.h
@@ -65,7 +65,7 @@ using namespace Assimp::MD5;
 class MD5Importer : public BaseImporter {
 public:
     MD5Importer();
-    ~MD5Importer() override;
+    ~MD5Importer() override = default;
 
     // -------------------------------------------------------------------
     /** Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/MDC/MDCLoader.cpp
+++ b/code/AssetLib/MDC/MDCLoader.cpp
@@ -60,7 +60,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using namespace Assimp;
 using namespace Assimp::MDC;
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "Return To Castle Wolfenstein Mesh Importer",
     "",
     "",
@@ -102,10 +102,6 @@ MDCImporter::MDCImporter() :
         fileSize() {
     // empty
 }
-
-// ------------------------------------------------------------------------------------------------
-// Destructor, private as well
-MDCImporter::~MDCImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/MDC/MDCLoader.h
+++ b/code/AssetLib/MDC/MDCLoader.h
@@ -62,7 +62,7 @@ using namespace MDC;
 class MDCImporter : public BaseImporter {
 public:
     MDCImporter();
-    ~MDCImporter() override;
+    ~MDCImporter() override = default;
 
     // -------------------------------------------------------------------
     /** Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/MDL/MDLLoader.cpp
+++ b/code/AssetLib/MDL/MDLLoader.cpp
@@ -65,7 +65,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using namespace Assimp;
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "Quake Mesh / 3D GameStudio Mesh Importer",
     "",
     "",
@@ -95,10 +95,6 @@ MDLImporter::MDLImporter() :
         configFrameID(), mBuffer(), iGSFileVersion(), mIOHandler(nullptr), pScene(), iFileSize() {
     // empty
 }
-
-// ------------------------------------------------------------------------------------------------
-// Destructor, private as well
-MDLImporter::~MDLImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/MDL/MDLLoader.h
+++ b/code/AssetLib/MDL/MDLLoader.h
@@ -39,10 +39,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------
 */
 
-
-/**  @file MDLLoader.h
- *   @brief Declaration of the loader for MDL files
- */
+/// @file MDLLoader.h
+/// @brief Declaration of the loader for MDL files
 #pragma once
 #ifndef AI_MDLLOADER_H_INCLUDED
 #define AI_MDLLOADER_H_INCLUDED
@@ -83,11 +81,10 @@ using namespace MDL;
  *  them all with a single 1000-line function-beast. However, it has been
  *  split into several code paths to make the code easier to read and maintain.
 */
-class MDLImporter : public BaseImporter
-{
+class MDLImporter : public BaseImporter {
 public:
     MDLImporter();
-    ~MDLImporter() override;
+    ~MDLImporter() override = default;
 
     // -------------------------------------------------------------------
     /** Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/MMD/MMDImporter.cpp
+++ b/code/AssetLib/MMD/MMDImporter.cpp
@@ -57,7 +57,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <memory>
 #include <sstream>
 
-static const aiImporterDesc desc = { "MMD Importer",
+static constexpr aiImporterDesc desc = { "MMD Importer",
     "",
     "",
     "surfaces supported?",
@@ -80,10 +80,6 @@ MMDImporter::MMDImporter() :
     DefaultIOSystem io;
     m_strAbsPath = io.getOsSeparator();
 }
-
-// ------------------------------------------------------------------------------------------------
-//  Destructor.
-MMDImporter::~MMDImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 //  Returns true, if file is an pmx file.

--- a/code/AssetLib/MMD/MMDImporter.h
+++ b/code/AssetLib/MMD/MMDImporter.h
@@ -50,46 +50,34 @@ struct aiMesh;
 namespace Assimp {
 
 // ------------------------------------------------------------------------------------------------
-/// \class  MMDImporter
-/// \brief  Imports MMD a pmx/pmd/vmd file
+/// @class  MMDImporter
+/// @brief  Imports MMD a pmx/pmd/vmd file
 // ------------------------------------------------------------------------------------------------
 class MMDImporter : public BaseImporter {
 public:
-    /// \brief  Default constructor
+    /// @brief  Default constructor
     MMDImporter();
 
-    /// \brief  Destructor
-    ~MMDImporter() override;
+    /// @brief  Destructor
+    ~MMDImporter() override = default;
 
 public:
-    /// \brief  Returns whether the class can handle the format of the given file.
-    /// \remark See BaseImporter::CanRead() for details.
+    /// @brief  Returns whether the class can handle the format of the given file.
+    /// @remark See BaseImporter::CanRead() for details.
     bool CanRead( const std::string& pFile, IOSystem* pIOHandler, bool checkSig) const override;
 
 private:
-    //! \brief  Appends the supported extension.
     const aiImporterDesc* GetInfo() const override;
-
-    //! \brief  File import implementation.
     void InternReadFile(const std::string& pFile, aiScene* pScene, IOSystem* pIOHandler) override;
-
-    //! \brief  Create the data from imported content.
     void CreateDataFromImport(const pmx::PmxModel* pModel, aiScene* pScene);
-
-    //! \brief Create the mesh
     aiMesh* CreateMesh(const pmx::PmxModel* pModel, const int indexStart, const int indexCount);
-
-    //! \brief Create the material
     aiMaterial* CreateMaterial(const pmx::PmxMaterial* pMat, const pmx::PmxModel* pModel);
 
 private:
-    //! Data buffer
     std::vector<char> m_Buffer;
-    //! Absolute pathname of model in file system
     std::string m_strAbsPath;
 };
 
-// ------------------------------------------------------------------------------------------------
 
 } // Namespace Assimp
 

--- a/code/AssetLib/MS3D/MS3DLoader.cpp
+++ b/code/AssetLib/MS3D/MS3DLoader.cpp
@@ -60,7 +60,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using namespace Assimp;
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "Milkshape 3D Importer",
     "",
     "",
@@ -84,9 +84,6 @@ MS3DImporter::MS3DImporter()
     : mScene()
 {}
 
-// ------------------------------------------------------------------------------------------------
-// Destructor, private as well
-MS3DImporter::~MS3DImporter() = default;
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.
 bool MS3DImporter::CanRead( const std::string& pFile, IOSystem* pIOHandler, bool /*checkSig*/) const

--- a/code/AssetLib/MS3D/MS3DLoader.h
+++ b/code/AssetLib/MS3D/MS3DLoader.h
@@ -48,6 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <assimp/BaseImporter.h>
 #include <assimp/StreamReader.h>
+
 struct aiNode;
 
 namespace Assimp {
@@ -58,7 +59,7 @@ namespace Assimp {
 class MS3DImporter : public BaseImporter {
 public:
     MS3DImporter();
-    ~MS3DImporter() override;
+    ~MS3DImporter() override = default;
 
     // -------------------------------------------------------------------
     /** Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/NDO/NDOLoader.cpp
+++ b/code/AssetLib/NDO/NDOLoader.cpp
@@ -43,8 +43,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *  Implementation of the NDO importer class.
  */
 
-
 #ifndef ASSIMP_BUILD_NO_NDO_IMPORTER
+
 #include "NDOLoader.h"
 #include <assimp/DefaultLogger.hpp>
 #include <assimp/IOSystem.hpp>
@@ -56,7 +56,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using namespace Assimp;
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "Nendo Mesh Importer",
     "",
     "",
@@ -68,14 +68,6 @@ static const aiImporterDesc desc = {
     0,
     "ndo"
 };
-
-// ------------------------------------------------------------------------------------------------
-// Constructor to be privately used by Importer
-NDOImporter::NDOImporter() = default;
-
-// ------------------------------------------------------------------------------------------------
-// Destructor, private as well
-NDOImporter::~NDOImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/NDO/NDOLoader.h
+++ b/code/AssetLib/NDO/NDOLoader.h
@@ -65,8 +65,8 @@ class Importer;
 */
 class NDOImporter : public BaseImporter {
 public:
-    NDOImporter();
-    ~NDOImporter() override;
+    NDOImporter() = default; 
+    ~NDOImporter() override = default;
 
     //! Represents a single edge
     struct Edge {

--- a/code/AssetLib/NFF/NFFLoader.cpp
+++ b/code/AssetLib/NFF/NFFLoader.cpp
@@ -56,9 +56,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/IOSystem.hpp>
 #include <memory>
 
-using namespace Assimp;
+namespace Assimp {
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "Neutral File Format Importer",
     "",
     "",
@@ -70,14 +70,6 @@ static const aiImporterDesc desc = {
     0,
     "enff nff"
 };
-
-// ------------------------------------------------------------------------------------------------
-// Constructor to be privately used by Importer
-NFFImporter::NFFImporter() = default;
-
-// ------------------------------------------------------------------------------------------------
-// Destructor, private as well
-NFFImporter::~NFFImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.
@@ -94,7 +86,7 @@ const aiImporterDesc *NFFImporter::GetInfo() const {
 // ------------------------------------------------------------------------------------------------
 #define AI_NFF_PARSE_FLOAT(f) \
     SkipSpaces(&sz);          \
-    if (!::IsLineEnd(*sz)) sz = fast_atoreal_move<ai_real>(sz, (ai_real &)f);
+    if (!IsLineEnd(*sz)) sz = fast_atoreal_move<ai_real>(sz, (ai_real &)f);
 
 // ------------------------------------------------------------------------------------------------
 #define AI_NFF_PARSE_TRIPLE(v) \
@@ -338,8 +330,8 @@ void NFFImporter::InternReadFile(const std::string &pFile,
                         break;
                 }
 
-                // read the numbr of vertices
-                unsigned int num = ::strtoul10(sz, &sz);
+                // read the number of vertices
+                unsigned int num = strtoul10(sz, &sz);
 
                 // temporary storage
                 std::vector<aiColor4D> tempColors;
@@ -365,7 +357,7 @@ void NFFImporter::InternReadFile(const std::string &pFile,
                         // color definition
                         if (TokenMatch(sz, "0x", 2)) {
                             hasColor = true;
-                            unsigned int numIdx = ::strtoul16(sz, &sz);
+                            unsigned int numIdx = strtoul16(sz, &sz);
                             aiColor4D clr;
                             clr.a = 1.f;
 
@@ -403,15 +395,16 @@ void NFFImporter::InternReadFile(const std::string &pFile,
                 }
 
                 AI_NFF2_GET_NEXT_TOKEN();
-                if (!num) throw DeadlyImportError("NFF2: There are zero vertices");
-                num = ::strtoul10(sz, &sz);
+                if (!num)
+                    throw DeadlyImportError("NFF2: There are zero vertices");
+                num = strtoul10(sz, &sz);
 
                 std::vector<unsigned int> tempIdx;
                 tempIdx.reserve(10);
                 for (unsigned int i = 0; i < num; ++i) {
                     AI_NFF2_GET_NEXT_TOKEN();
                     SkipSpaces(line, &sz);
-                    unsigned int numIdx = ::strtoul10(sz, &sz);
+                    unsigned int numIdx = strtoul10(sz, &sz);
 
                     // read all faces indices
                     if (numIdx) {
@@ -421,7 +414,7 @@ void NFFImporter::InternReadFile(const std::string &pFile,
 
                         for (unsigned int a = 0; a < numIdx; ++a) {
                             SkipSpaces(sz, &sz);
-                            unsigned int m = ::strtoul10(sz, &sz);
+                            unsigned int m = strtoul10(sz, &sz);
                             if (m >= (unsigned int)tempPositions.size()) {
                                 ASSIMP_LOG_ERROR("NFF2: Vertex index overflow");
                                 m = 0;
@@ -446,7 +439,7 @@ void NFFImporter::InternReadFile(const std::string &pFile,
                         if (TokenMatch(sz, "0x", 2)) {
                             hasColor = true;
                             const char *sz2 = sz;
-                            numIdx = ::strtoul16(sz, &sz);
+                            numIdx = strtoul16(sz, &sz);
                             const unsigned int diff = (unsigned int)(sz - sz2);
 
                             // 0xRRGGBB
@@ -518,7 +511,7 @@ void NFFImporter::InternReadFile(const std::string &pFile,
                         // Material ID?
                         else if (!materialTable.empty() && TokenMatch(sz, "matid", 5)) {
                             SkipSpaces(&sz);
-                            matIdx = ::strtoul10(sz, &sz);
+                            matIdx = strtoul10(sz, &sz);
                             if (matIdx >= materialTable.size()) {
                                 ASSIMP_LOG_ERROR("NFF2: Material index overflow.");
                                 matIdx = 0;
@@ -1164,5 +1157,7 @@ void NFFImporter::InternReadFile(const std::string &pFile,
     }
     pScene->mRootNode = root;
 }
+
+} // namespace Assimp
 
 #endif // !! ASSIMP_BUILD_NO_NFF_IMPORTER

--- a/code/AssetLib/NFF/NFFLoader.h
+++ b/code/AssetLib/NFF/NFFLoader.h
@@ -63,8 +63,8 @@ namespace Assimp {
 */
 class NFFImporter : public BaseImporter {
 public:
-    NFFImporter();
-    ~NFFImporter() override;
+    NFFImporter() = default;
+    ~NFFImporter() override = default;
 
     // -------------------------------------------------------------------
     /** Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/OFF/OFFLoader.cpp
+++ b/code/AssetLib/OFF/OFFLoader.cpp
@@ -43,7 +43,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *  @brief Implementation of the OFF importer class
  */
 
-
 #ifndef ASSIMP_BUILD_NO_OFF_IMPORTER
 
 // internal headers
@@ -56,9 +55,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/DefaultLogger.hpp>
 #include <assimp/importerdesc.h>
 
-using namespace Assimp;
+namespace Assimp {
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "OFF Importer",
     "",
     "",
@@ -72,98 +71,91 @@ static const aiImporterDesc desc = {
 };
 
 // ------------------------------------------------------------------------------------------------
-// Constructor to be privately used by Importer
-OFFImporter::OFFImporter() = default;
-
-// ------------------------------------------------------------------------------------------------
-// Destructor, private as well
-OFFImporter::~OFFImporter() = default;
-
-// ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.
-bool OFFImporter::CanRead( const std::string& pFile, IOSystem* pIOHandler, bool /*checkSig*/) const
-{
-    static const char* tokens[] = { "off" };
-    return SearchFileHeaderForToken(pIOHandler,pFile,tokens,AI_COUNT_OF(tokens),3);
+bool OFFImporter::CanRead(const std::string &pFile, IOSystem *pIOHandler, bool /*checkSig*/) const {
+    static const char *tokens[] = { "off" };
+    return SearchFileHeaderForToken(pIOHandler, pFile, tokens, AI_COUNT_OF(tokens), 3);
 }
 
 // ------------------------------------------------------------------------------------------------
-const aiImporterDesc* OFFImporter::GetInfo () const
-{
+const aiImporterDesc *OFFImporter::GetInfo() const {
     return &desc;
 }
 
-
 // skip blank space, lines and comments
-static void NextToken(const char **car, const char* end) {
-  SkipSpacesAndLineEnd(car);
-  while (*car < end && (**car == '#' || **car == '\n' || **car == '\r')) {
-    SkipLine(car);
+static void NextToken(const char **car, const char *end) {
     SkipSpacesAndLineEnd(car);
-  }
+    while (*car < end && (**car == '#' || **car == '\n' || **car == '\r')) {
+        SkipLine(car);
+        SkipSpacesAndLineEnd(car);
+    }
 }
 
 // ------------------------------------------------------------------------------------------------
 // Imports the given file into the given scene structure.
-void OFFImporter::InternReadFile( const std::string& pFile, aiScene* pScene, IOSystem* pIOHandler) {
-    std::unique_ptr<IOStream> file( pIOHandler->Open( pFile, "rb"));
+void OFFImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSystem *pIOHandler) {
+    std::unique_ptr<IOStream> file(pIOHandler->Open(pFile, "rb"));
 
     // Check whether we can read from the file
     if (file == nullptr) {
-      throw DeadlyImportError("Failed to open OFF file ", pFile, ".");
+        throw DeadlyImportError("Failed to open OFF file ", pFile, ".");
     }
 
     // allocate storage and copy the contents of the file to a memory buffer
     std::vector<char> mBuffer2;
-    TextFileToBuffer(file.get(),mBuffer2);
-    const char* buffer = &mBuffer2[0];
+    TextFileToBuffer(file.get(), mBuffer2);
+    const char *buffer = &mBuffer2[0];
 
     // Proper OFF header parser. We only implement normal loading for now.
     bool hasTexCoord = false, hasNormals = false, hasColors = false;
     bool hasHomogenous = false, hasDimension = false;
     unsigned int dimensions = 3;
-    const char* car = buffer;
-    const char* end = buffer + mBuffer2.size();
+    const char *car = buffer;
+    const char *end = buffer + mBuffer2.size();
     NextToken(&car, end);
 
     if (car < end - 2 && car[0] == 'S' && car[1] == 'T') {
-      hasTexCoord = true; car += 2;
+        hasTexCoord = true;
+        car += 2;
     }
     if (car < end - 1 && car[0] == 'C') {
-      hasColors = true; car++;
+        hasColors = true;
+        car++;
     }
-    if (car < end- 1 && car[0] == 'N') {
-      hasNormals = true; car++;
+    if (car < end - 1 && car[0] == 'N') {
+        hasNormals = true;
+        car++;
     }
     if (car < end - 1 && car[0] == '4') {
-      hasHomogenous = true; car++;
+        hasHomogenous = true;
+        car++;
     }
     if (car < end - 1 && car[0] == 'n') {
-      hasDimension = true; car++;
+        hasDimension = true;
+        car++;
     }
     if (car < end - 3 && car[0] == 'O' && car[1] == 'F' && car[2] == 'F') {
         car += 3;
-	NextToken(&car, end);
+        NextToken(&car, end);
     } else {
-      // in case there is no OFF header (which is allowed by the
-      // specification...), then we might have unintentionally read an
-      // additional dimension from the primitive count fields
-      dimensions = 3;
-      hasHomogenous = false;
-      NextToken(&car, end);
+        // in case there is no OFF header (which is allowed by the
+        // specification...), then we might have unintentionally read an
+        // additional dimension from the primitive count fields
+        dimensions = 3;
+        hasHomogenous = false;
+        NextToken(&car, end);
 
-      // at this point the next token should be an integer number
-      if (car >= end - 1 || *car < '0' || *car > '9') {
-	throw DeadlyImportError("OFF: Header is invalid");
-      }
+        // at this point the next token should be an integer number
+        if (car >= end - 1 || *car < '0' || *car > '9') {
+            throw DeadlyImportError("OFF: Header is invalid");
+        }
     }
     if (hasDimension) {
         dimensions = strtoul10(car, &car);
-	NextToken(&car, end);
+        NextToken(&car, end);
     }
     if (dimensions > 3) {
-        throw DeadlyImportError
-	  ("OFF: Number of vertex coordinates higher than 3 unsupported");
+        throw DeadlyImportError("OFF: Number of vertex coordinates higher than 3 unsupported");
     }
 
     NextToken(&car, end);
@@ -171,7 +163,7 @@ void OFFImporter::InternReadFile( const std::string& pFile, aiScene* pScene, IOS
     NextToken(&car, end);
     const unsigned int numFaces = strtoul10(car, &car);
     NextToken(&car, end);
-    strtoul10(car, &car);  // skip edge count
+    strtoul10(car, &car); // skip edge count
     NextToken(&car, end);
 
     if (!numVertices) {
@@ -182,13 +174,13 @@ void OFFImporter::InternReadFile( const std::string& pFile, aiScene* pScene, IOS
     }
 
     pScene->mNumMeshes = 1;
-    pScene->mMeshes = new aiMesh*[ pScene->mNumMeshes ];
+    pScene->mMeshes = new aiMesh *[pScene->mNumMeshes];
 
-    aiMesh* mesh = new aiMesh();
+    aiMesh *mesh = new aiMesh();
     pScene->mMeshes[0] = mesh;
 
     mesh->mNumFaces = numFaces;
-    aiFace* faces = new aiFace[mesh->mNumFaces];
+    aiFace *faces = new aiFace[mesh->mNumFaces];
     mesh->mFaces = faces;
 
     mesh->mNumVertices = numVertices;
@@ -206,100 +198,101 @@ void OFFImporter::InternReadFile( const std::string& pFile, aiScene* pScene, IOS
 
     // now read all vertex lines
     for (unsigned int i = 0; i < numVertices; ++i) {
-        if(!GetNextLine(buffer, line)) {
+        if (!GetNextLine(buffer, line)) {
             ASSIMP_LOG_ERROR("OFF: The number of verts in the header is incorrect");
             break;
         }
-        aiVector3D& v = mesh->mVertices[i];
+        aiVector3D &v = mesh->mVertices[i];
         sz = line;
 
-	// helper array to write a for loop over possible dimension values
-	ai_real* vec[3] = {&v.x, &v.y, &v.z};
+        // helper array to write a for loop over possible dimension values
+        ai_real *vec[3] = { &v.x, &v.y, &v.z };
 
-	// stop at dimensions: this allows loading 1D or 2D coordinate vertices
-        for (unsigned int dim = 0; dim < dimensions; ++dim ) {
-	    SkipSpaces(&sz);
-	    sz = fast_atoreal_move<ai_real>(sz, *vec[dim]);
-	}
+        // stop at dimensions: this allows loading 1D or 2D coordinate vertices
+        for (unsigned int dim = 0; dim < dimensions; ++dim) {
+            SkipSpaces(&sz);
+            sz = fast_atoreal_move<ai_real>(sz, *vec[dim]);
+        }
 
-	// if has homogeneous coordinate, divide others by this one
-	if (hasHomogenous) {
-	    SkipSpaces(&sz);
-	    ai_real w = 1.;
-	    sz = fast_atoreal_move<ai_real>(sz, w);
-            for (unsigned int dim = 0; dim < dimensions; ++dim ) {
-	        *(vec[dim]) /= w;
-	    }
-	}
+        // if has homogeneous coordinate, divide others by this one
+        if (hasHomogenous) {
+            SkipSpaces(&sz);
+            ai_real w = 1.;
+            sz = fast_atoreal_move<ai_real>(sz, w);
+            for (unsigned int dim = 0; dim < dimensions; ++dim) {
+                *(vec[dim]) /= w;
+            }
+        }
 
-	// read optional normals
-	if (hasNormals) {
-	    aiVector3D& n = mesh->mNormals[i];
-	    SkipSpaces(&sz);
-	    sz = fast_atoreal_move<ai_real>(sz,(ai_real&)n.x);
-	    SkipSpaces(&sz);
-	    sz = fast_atoreal_move<ai_real>(sz,(ai_real&)n.y);
-	    SkipSpaces(&sz);
-	    fast_atoreal_move<ai_real>(sz,(ai_real&)n.z);
-	}
+        // read optional normals
+        if (hasNormals) {
+            aiVector3D &n = mesh->mNormals[i];
+            SkipSpaces(&sz);
+            sz = fast_atoreal_move<ai_real>(sz, (ai_real &)n.x);
+            SkipSpaces(&sz);
+            sz = fast_atoreal_move<ai_real>(sz, (ai_real &)n.y);
+            SkipSpaces(&sz);
+            fast_atoreal_move<ai_real>(sz, (ai_real &)n.z);
+        }
 
-	// reading colors is a pain because the specification says it can be
-	// integers or floats, and any number of them between 1 and 4 included,
-	// until the next comment or end of line
-	// in theory should be testing type !
-	if (hasColors) {
-	    aiColor4D& c = mesh->mColors[0][i];
-	    SkipSpaces(&sz);
-	    sz = fast_atoreal_move<ai_real>(sz,(ai_real&)c.r);
+        // reading colors is a pain because the specification says it can be
+        // integers or floats, and any number of them between 1 and 4 included,
+        // until the next comment or end of line
+        // in theory should be testing type !
+        if (hasColors) {
+            aiColor4D &c = mesh->mColors[0][i];
+            SkipSpaces(&sz);
+            sz = fast_atoreal_move<ai_real>(sz, (ai_real &)c.r);
             if (*sz != '#' && *sz != '\n' && *sz != '\r') {
-	        SkipSpaces(&sz);
-	        sz = fast_atoreal_move<ai_real>(sz,(ai_real&)c.g);
+                SkipSpaces(&sz);
+                sz = fast_atoreal_move<ai_real>(sz, (ai_real &)c.g);
             } else {
-	        c.g = 0.;
-	    }
+                c.g = 0.;
+            }
             if (*sz != '#' && *sz != '\n' && *sz != '\r') {
-	        SkipSpaces(&sz);
-	        sz = fast_atoreal_move<ai_real>(sz,(ai_real&)c.b);
+                SkipSpaces(&sz);
+                sz = fast_atoreal_move<ai_real>(sz, (ai_real &)c.b);
             } else {
-	        c.b = 0.;
-	    }
+                c.b = 0.;
+            }
             if (*sz != '#' && *sz != '\n' && *sz != '\r') {
-	        SkipSpaces(&sz);
-	        sz = fast_atoreal_move<ai_real>(sz,(ai_real&)c.a);
+                SkipSpaces(&sz);
+                sz = fast_atoreal_move<ai_real>(sz, (ai_real &)c.a);
             } else {
-	        c.a = 1.;
-	    }
-	}
+                c.a = 1.;
+            }
+        }
         if (hasTexCoord) {
-	    aiVector3D& t = mesh->mTextureCoords[0][i];
-	    SkipSpaces(&sz);
-	    sz = fast_atoreal_move<ai_real>(sz,(ai_real&)t.x);
-	    SkipSpaces(&sz);
-	    fast_atoreal_move<ai_real>(sz,(ai_real&)t.y);
-	}
+            aiVector3D &t = mesh->mTextureCoords[0][i];
+            SkipSpaces(&sz);
+            sz = fast_atoreal_move<ai_real>(sz, (ai_real &)t.x);
+            SkipSpaces(&sz);
+            fast_atoreal_move<ai_real>(sz, (ai_real &)t.y);
+        }
     }
 
     // load faces with their indices
     faces = mesh->mFaces;
-    for (unsigned int i = 0; i < numFaces; ) {
-        if(!GetNextLine(buffer,line)) {
+    for (unsigned int i = 0; i < numFaces;) {
+        if (!GetNextLine(buffer, line)) {
             ASSIMP_LOG_ERROR("OFF: The number of faces in the header is incorrect");
             throw DeadlyImportError("OFF: The number of faces in the header is incorrect");
         }
         unsigned int idx;
-        sz = line; SkipSpaces(&sz);
-        idx = strtoul10(sz,&sz);
-        if(!idx || idx > 9) {
-	        ASSIMP_LOG_ERROR("OFF: Faces with zero indices aren't allowed");
+        sz = line;
+        SkipSpaces(&sz);
+        idx = strtoul10(sz, &sz);
+        if (!idx || idx > 9) {
+            ASSIMP_LOG_ERROR("OFF: Faces with zero indices aren't allowed");
             --mesh->mNumFaces;
             ++i;
             continue;
-	    }
-	    faces->mNumIndices = idx;
+        }
+        faces->mNumIndices = idx;
         faces->mIndices = new unsigned int[faces->mNumIndices];
-        for (unsigned int m = 0; m < faces->mNumIndices;++m) {
+        for (unsigned int m = 0; m < faces->mNumIndices; ++m) {
             SkipSpaces(&sz);
-            idx = strtoul10(sz,&sz);
+            idx = strtoul10(sz, &sz);
             if (idx >= numVertices) {
                 ASSIMP_LOG_ERROR("OFF: Vertex index is out of range");
                 idx = numVertices - 1;
@@ -314,20 +307,22 @@ void OFFImporter::InternReadFile( const std::string& pFile, aiScene* pScene, IOS
     pScene->mRootNode = new aiNode();
     pScene->mRootNode->mName.Set("<OFFRoot>");
     pScene->mRootNode->mNumMeshes = 1;
-    pScene->mRootNode->mMeshes = new unsigned int [pScene->mRootNode->mNumMeshes];
+    pScene->mRootNode->mMeshes = new unsigned int[pScene->mRootNode->mNumMeshes];
     pScene->mRootNode->mMeshes[0] = 0;
 
     // generate a default material
     pScene->mNumMaterials = 1;
-    pScene->mMaterials = new aiMaterial*[pScene->mNumMaterials];
-    aiMaterial* pcMat = new aiMaterial();
+    pScene->mMaterials = new aiMaterial *[pScene->mNumMaterials];
+    aiMaterial *pcMat = new aiMaterial();
 
-    aiColor4D clr( ai_real( 0.6 ), ai_real( 0.6 ), ai_real( 0.6 ), ai_real( 1.0 ) );
-    pcMat->AddProperty(&clr,1,AI_MATKEY_COLOR_DIFFUSE);
+    aiColor4D clr(ai_real(0.6), ai_real(0.6), ai_real(0.6), ai_real(1.0));
+    pcMat->AddProperty(&clr, 1, AI_MATKEY_COLOR_DIFFUSE);
     pScene->mMaterials[0] = pcMat;
 
     const int twosided = 1;
     pcMat->AddProperty(&twosided, 1, AI_MATKEY_TWOSIDED);
 }
+
+} // namespace Assimp
 
 #endif // !! ASSIMP_BUILD_NO_OFF_IMPORTER

--- a/code/AssetLib/OFF/OFFLoader.h
+++ b/code/AssetLib/OFF/OFFLoader.h
@@ -57,8 +57,8 @@ namespace Assimp {
 */
 class OFFImporter : public BaseImporter {
 public:
-    OFFImporter();
-    ~OFFImporter() override;
+    OFFImporter() = default;
+    ~OFFImporter() override = default;
 
     // -------------------------------------------------------------------
     /** Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/Obj/ObjFileImporter.cpp
+++ b/code/AssetLib/Obj/ObjFileImporter.cpp
@@ -54,7 +54,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/ObjMaterial.h>
 #include <memory>
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "Wavefront Object Importer",
     "",
     "",
@@ -103,6 +103,11 @@ const aiImporterDesc *ObjFileImporter::GetInfo() const {
 // ------------------------------------------------------------------------------------------------
 //  Obj-file import implementation
 void ObjFileImporter::InternReadFile(const std::string &file, aiScene *pScene, IOSystem *pIOHandler) {
+    if (m_pRootObject != nullptr) {
+        delete m_pRootObject;
+        m_pRootObject = nullptr;
+    }
+
     // Read file into memory
     static constexpr char mode[] = "rb";
     auto streamCloser = [&](IOStream *pStream) {

--- a/code/AssetLib/Ogre/OgreImporter.cpp
+++ b/code/AssetLib/Ogre/OgreImporter.cpp
@@ -48,7 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/Importer.hpp>
 #include <memory>
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "Ogre3D Mesh Importer",
     "",
     "",

--- a/code/AssetLib/OpenGEX/OpenGEXImporter.cpp
+++ b/code/AssetLib/OpenGEX/OpenGEXImporter.cpp
@@ -52,7 +52,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/scene.h>
 #include <openddlparser/OpenDDLParser.h>
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "Open Game Engine Exchange",
     "",
     "",
@@ -66,42 +66,42 @@ static const aiImporterDesc desc = {
 };
 
 namespace Grammar {
-    static const char* MetricType = "Metric";
-    static const char *Metric_DistanceType = "distance";
-    static const char *Metric_AngleType = "angle";
-    static const char *Metric_TimeType = "time";
-    static const char *Metric_UpType = "up";
-    static const char *NameType = "Name";
-    static const char *ObjectRefType = "ObjectRef";
-    static const char *MaterialRefType = "MaterialRef";
-    static const char *MetricKeyType = "key";
-    static const char *GeometryNodeType = "GeometryNode";
-    static const char *CameraNodeType = "CameraNode";
-    static const char *LightNodeType = "LightNode";
-    static const char *GeometryObjectType = "GeometryObject";
-    static const char *CameraObjectType = "CameraObject";
-    static const char *LightObjectType = "LightObject";
-    static const char *TransformType = "Transform";
-    static const char *MeshType = "Mesh";
-    static const char *VertexArrayType = "VertexArray";
-    static const char *IndexArrayType = "IndexArray";
-    static const char *MaterialType = "Material";
-    static const char *ColorType = "Color";
-    static const char *ParamType = "Param";
-    static const char *TextureType = "Texture";
-    static const char *AttenType = "Atten";
+    static constexpr char MetricType[] = "Metric";
+    static constexpr char Metric_DistanceType[] = "distance";
+    static constexpr char Metric_AngleType[] = "angle";
+    static constexpr char Metric_TimeType[] = "time";
+    static constexpr char Metric_UpType[] = "up";
+    static constexpr char NameType[] = "Name";
+    static constexpr char ObjectRefType[] = "ObjectRef";
+    static constexpr char MaterialRefType[] = "MaterialRef";
+    static constexpr char MetricKeyType[] = "key";
+    static constexpr char GeometryNodeType[] = "GeometryNode";
+    static constexpr char CameraNodeType[] = "CameraNode";
+    static constexpr char LightNodeType[] = "LightNode";
+    static constexpr char GeometryObjectType[] = "GeometryObject";
+    static constexpr char CameraObjectType[] = "CameraObject";
+    static constexpr char LightObjectType[] = "LightObject";
+    static constexpr char TransformType[] = "Transform";
+    static constexpr char MeshType[] = "Mesh";
+    static constexpr char VertexArrayType[] = "VertexArray";
+    static constexpr char IndexArrayType[] = "IndexArray";
+    static constexpr char MaterialType[] = "Material";
+    static constexpr char ColorType[] = "Color";
+    static constexpr char ParamType[] = "Param";
+    static constexpr char TextureType[] = "Texture";
+    static constexpr char AttenType[] = "Atten";
 
-    static const char *DiffuseColorToken = "diffuse";
-    static const char *SpecularColorToken = "specular";
-    static const char *EmissionColorToken = "emission";
+    static constexpr char DiffuseColorToken[] = "diffuse";
+    static constexpr char SpecularColorToken[] = "specular";
+    static constexpr char EmissionColorToken[] = "emission";
 
-    static const char *DiffuseTextureToken = "diffuse";
-    static const char *DiffuseSpecularTextureToken = "specular";
-    static const char *SpecularPowerTextureToken = "specular_power";
-    static const char *EmissionTextureToken = "emission";
-    static const char *OpacyTextureToken = "opacity";
-    static const char *TransparencyTextureToken = "transparency";
-    static const char *NormalTextureToken = "normal";
+    static constexpr char DiffuseTextureToken[] = "diffuse";
+    static constexpr char DiffuseSpecularTextureToken[] = "specular";
+    static constexpr char SpecularPowerTextureToken[] = "specular_power";
+    static constexpr char EmissionTextureToken[] = "emission";
+    static constexpr char OpacyTextureToken[] = "opacity";
+    static constexpr char TransparencyTextureToken[] = "transparency";
+    static constexpr char NormalTextureToken[] = "normal";
 
     enum TokenType {
         NoneType = -1,
@@ -139,7 +139,7 @@ namespace Grammar {
             return false;
         }
 
-        int idx(-1);
+        int idx = -1;
         for (size_t i = 0; i < 4; i++) {
             if (ValidMetricToken[i] == token) {
                 idx = (int)i;

--- a/code/AssetLib/Ply/PlyLoader.cpp
+++ b/code/AssetLib/Ply/PlyLoader.cpp
@@ -53,9 +53,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/IOSystem.hpp>
 #include <memory>
 
-using namespace ::Assimp;
+namespace Assimp {
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "Stanford Polygon Library (PLY) Importer",
     "",
     "",
@@ -71,16 +71,16 @@ static const aiImporterDesc desc = {
 // ------------------------------------------------------------------------------------------------
 // Internal stuff
 namespace {
-// ------------------------------------------------------------------------------------------------
-// Checks that property index is within range
-template <class T>
-inline const T &GetProperty(const std::vector<T> &props, int idx) {
-    if (static_cast<size_t>(idx) >= props.size()) {
-        throw DeadlyImportError("Invalid .ply file: Property index is out of range.");
-    }
+    // ------------------------------------------------------------------------------------------------
+    // Checks that property index is within range
+    template <class T>
+    inline const T &GetProperty(const std::vector<T> &props, int idx) {
+        if (static_cast<size_t>(idx) >= props.size()) {
+            throw DeadlyImportError("Invalid .ply file: Property index is out of range.");
+        }
 
-    return props[idx];
-}
+        return props[idx];
+    }
 } // namespace
 
 // ------------------------------------------------------------------------------------------------
@@ -91,10 +91,6 @@ PLYImporter::PLYImporter() :
         mGeneratedMesh(nullptr) {
     // empty
 }
-
-// ------------------------------------------------------------------------------------------------
-// Destructor, private as well
-PLYImporter::~PLYImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.
@@ -215,7 +211,7 @@ void PLYImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
         throw DeadlyImportError("Invalid .ply file: Missing format specification");
     }
 
-    //free the file buffer
+    // free the file buffer
     streamedBuffer.close();
 
     if (mGeneratedMesh == nullptr) {
@@ -376,7 +372,7 @@ void PLYImporter::LoadVertex(const PLY::Element *pcElement, const PLY::ElementIn
             haveNormal = true;
         }
 
-        //Colors
+        // Colors
         aiColor4D cOut;
         bool haveColor = false;
         if (0xFFFFFFFF != aiColors[0]) {
@@ -415,7 +411,7 @@ void PLYImporter::LoadVertex(const PLY::Element *pcElement, const PLY::ElementIn
             haveColor = true;
         }
 
-        //Texture coordinates
+        // Texture coordinates
         aiVector3D tOut;
         tOut.z = 0;
         bool haveTextureCoords = false;
@@ -431,7 +427,7 @@ void PLYImporter::LoadVertex(const PLY::Element *pcElement, const PLY::ElementIn
             haveTextureCoords = true;
         }
 
-        //create aiMesh if needed
+        // create aiMesh if needed
         if (nullptr == mGeneratedMesh) {
             mGeneratedMesh = new aiMesh();
             mGeneratedMesh->mMaterialIndex = 0;
@@ -512,8 +508,8 @@ void PLYImporter::LoadFace(const PLY::Element *pcElement, const PLY::ElementInst
     bool bIsTriStrip = false;
 
     // index of the material index property
-    //unsigned int iMaterialIndex = 0xFFFFFFFF;
-    //PLY::EDataType eType2 = EDT_Char;
+    // unsigned int iMaterialIndex = 0xFFFFFFFF;
+    // PLY::EDataType eType2 = EDT_Char;
 
     // texture coordinates
     unsigned int iTextureCoord = 0xFFFFFFFF;
@@ -595,7 +591,7 @@ void PLYImporter::LoadFace(const PLY::Element *pcElement, const PLY::ElementInst
             if (0xFFFFFFFF != iTextureCoord) {
                 const unsigned int iNum = (unsigned int)GetProperty(instElement->alProperties, iTextureCoord).avList.size();
 
-                //should be 6 coords
+                // should be 6 coords
                 std::vector<PLY::PropertyInstance::ValueUnion>::const_iterator p =
                         GetProperty(instElement->alProperties, iTextureCoord).avList.begin();
 
@@ -625,7 +621,7 @@ void PLYImporter::LoadFace(const PLY::Element *pcElement, const PLY::ElementInst
             // a value of -1 indicates a restart of the strip
             bool flip = false;
             const std::vector<PLY::PropertyInstance::ValueUnion> &quak = GetProperty(instElement->alProperties, iProperty).avList;
-            //pvOut->reserve(pvOut->size() + quak.size() + (quak.size()>>2u)); //Limits memory consumption
+            // pvOut->reserve(pvOut->size() + quak.size() + (quak.size()>>2u)); //Limits memory consumption
 
             int aiTable[2] = { -1, -1 };
             for (std::vector<PLY::PropertyInstance::ValueUnion>::const_iterator a = quak.begin(); a != quak.end(); ++a) {
@@ -863,7 +859,7 @@ void PLYImporter::LoadMaterial(std::vector<aiMaterial *> *pvOut, std::string &de
             const int two_sided = 1;
             pcHelper->AddProperty(&two_sided, 1, AI_MATKEY_TWOSIDED);
 
-            //default texture
+            // default texture
             if (!defaultTexture.empty()) {
                 const aiString name(defaultTexture.c_str());
                 pcHelper->AddProperty(&name, _AI_MATKEY_TEXTURE_BASE, aiTextureType_DIFFUSE, 0);
@@ -873,7 +869,7 @@ void PLYImporter::LoadMaterial(std::vector<aiMaterial *> *pvOut, std::string &de
                 pcHelper->AddProperty(&two_sided, 1, AI_MATKEY_TWOSIDED);
             }
 
-            //set to wireframe, so when using this material info we can switch to points rendering
+            // set to wireframe, so when using this material info we can switch to points rendering
             if (pointsOnly) {
                 const int wireframe = 1;
                 pcHelper->AddProperty(&wireframe, 1, AI_MATKEY_ENABLE_WIREFRAME);
@@ -890,7 +886,7 @@ void PLYImporter::LoadMaterial(std::vector<aiMaterial *> *pvOut, std::string &de
         int iMode = (int)aiShadingMode_Gouraud;
         pcHelper->AddProperty<int>(&iMode, 1, AI_MATKEY_SHADING_MODEL);
 
-        //generate white material most 3D engine just multiply ambient / diffuse color with actual ambient / light color
+        // generate white material most 3D engine just multiply ambient / diffuse color with actual ambient / light color
         aiColor3D clr;
         clr.b = clr.g = clr.r = 1.0f;
         pcHelper->AddProperty<aiColor3D>(&clr, 1, AI_MATKEY_COLOR_DIFFUSE);
@@ -906,13 +902,13 @@ void PLYImporter::LoadMaterial(std::vector<aiMaterial *> *pvOut, std::string &de
             pcHelper->AddProperty(&two_sided, 1, AI_MATKEY_TWOSIDED);
         }
 
-        //default texture
+        // default texture
         if (!defaultTexture.empty()) {
             const aiString name(defaultTexture.c_str());
             pcHelper->AddProperty(&name, _AI_MATKEY_TEXTURE_BASE, aiTextureType_DIFFUSE, 0);
         }
 
-        //set to wireframe, so when using this material info we can switch to points rendering
+        // set to wireframe, so when using this material info we can switch to points rendering
         if (pointsOnly) {
             const int wireframe = 1;
             pcHelper->AddProperty(&wireframe, 1, AI_MATKEY_ENABLE_WIREFRAME);
@@ -921,5 +917,7 @@ void PLYImporter::LoadMaterial(std::vector<aiMaterial *> *pvOut, std::string &de
         pvOut->push_back(pcHelper);
     }
 }
+
+} // namespace Assimp
 
 #endif // !! ASSIMP_BUILD_NO_PLY_IMPORTER

--- a/code/AssetLib/Ply/PlyLoader.h
+++ b/code/AssetLib/Ply/PlyLoader.h
@@ -65,7 +65,7 @@ using namespace PLY;
 class PLYImporter : public BaseImporter {
 public:
     PLYImporter();
-    ~PLYImporter() override;
+    ~PLYImporter() override = default;
 
     // -------------------------------------------------------------------
     /** Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/Q3BSP/Q3BSPFileImporter.cpp
+++ b/code/AssetLib/Q3BSP/Q3BSPFileImporter.cpp
@@ -65,7 +65,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <sstream>
 #include <vector>
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "Quake III BSP Importer",
     "",
     "",
@@ -146,7 +146,11 @@ Q3BSPFileImporter::Q3BSPFileImporter() :
 // ------------------------------------------------------------------------------------------------
 //  Destructor.
 Q3BSPFileImporter::~Q3BSPFileImporter() {
-    // Clear face-to-material map
+    clear();
+}
+
+// ------------------------------------------------------------------------------------------------
+void Q3BSPFileImporter::clear() {
     for (FaceMap::iterator it = m_MaterialLookupMap.begin(); it != m_MaterialLookupMap.end(); ++it) {
         const std::string &matName = it->first;
         if (!matName.empty()) {
@@ -173,6 +177,7 @@ const aiImporterDesc *Q3BSPFileImporter::GetInfo() const {
 // ------------------------------------------------------------------------------------------------
 //  Import method.
 void Q3BSPFileImporter::InternReadFile(const std::string &rFile, aiScene *scene, IOSystem *ioHandler) {
+    clear();
     ZipArchiveIOSystem Archive(ioHandler, rFile);
     if (!Archive.isOpen()) {
         throw DeadlyImportError("Failed to open file ", rFile, ".");

--- a/code/AssetLib/Q3BSP/Q3BSPFileImporter.h
+++ b/code/AssetLib/Q3BSP/Q3BSPFileImporter.h
@@ -81,6 +81,7 @@ protected:
     using FaceMapIt = std::map<std::string, std::vector<Q3BSP::sQ3BSPFace*>* >::iterator;
     using FaceMapConstIt = std::map<std::string, std::vector<Q3BSP::sQ3BSPFace*>*>::const_iterator;
 
+    void clear();
     const aiImporterDesc* GetInfo () const override;
     void InternReadFile(const std::string& pFile, aiScene* pScene, IOSystem* pIOHandler) override;
     void separateMapName( const std::string &rImportName, std::string &rArchiveName, std::string &rMapName );

--- a/code/AssetLib/Q3D/Q3DLoader.cpp
+++ b/code/AssetLib/Q3D/Q3DLoader.cpp
@@ -55,9 +55,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/DefaultLogger.hpp>
 #include <assimp/IOSystem.hpp>
 
-using namespace Assimp;
+namespace Assimp {
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "Quick3D Importer",
     "",
     "",
@@ -127,7 +127,7 @@ void Q3DImporter::InternReadFile(const std::string &pFile,
     std::vector<Material> materials;
     try {
         materials.reserve(numMats);
-    } catch(const std::bad_alloc&) {
+    } catch (const std::bad_alloc &) {
         ASSIMP_LOG_ERROR("Invalid alloc for materials.");
         throw DeadlyImportError("Invalid Quick3D-file, material allocation failed.");
     }
@@ -135,7 +135,7 @@ void Q3DImporter::InternReadFile(const std::string &pFile,
     std::vector<Mesh> meshes;
     try {
         meshes.reserve(numMeshes);
-    } catch(const std::bad_alloc&) {
+    } catch (const std::bad_alloc &) {
         ASSIMP_LOG_ERROR("Invalid alloc for meshes.");
         throw DeadlyImportError("Invalid Quick3D-file, mesh allocation failed.");
     }
@@ -237,7 +237,6 @@ void Q3DImporter::InternReadFile(const std::string &pFile,
                 if (minor > '0' && major == '3')
                     stream.IncPtr(mesh.faces.size());
             }
-            // stream.IncPtr(4); // unknown value here
         } break;
 
             // materials chunk
@@ -275,8 +274,6 @@ void Q3DImporter::InternReadFile(const std::string &pFile,
                 // read the transparency
                 mat.transparency = stream.GetF4();
 
-                // unknown value here
-                // stream.IncPtr(4);
                 // FIX: it could be the texture index ...
                 mat.texIdx = (unsigned int)stream.GetI4();
             }
@@ -425,7 +422,8 @@ outer:
     pScene->mMeshes = new aiMesh *[pScene->mNumMaterials];
 
     for (unsigned int i = 0, real = 0; i < (unsigned int)materials.size(); ++i) {
-        if (fidx[i].empty()) continue;
+        if (fidx[i].empty())
+            continue;
 
         // Allocate a mesh and a material
         aiMesh *mesh = pScene->mMeshes[real] = new aiMesh();
@@ -548,14 +546,9 @@ outer:
     // Now we need to attach the meshes to the root node of the scene
     pScene->mRootNode->mNumMeshes = pScene->mNumMeshes;
     pScene->mRootNode->mMeshes = new unsigned int[pScene->mNumMeshes];
-    for (unsigned int i = 0; i < pScene->mNumMeshes; ++i)
+    for (unsigned int i = 0; i < pScene->mNumMeshes; ++i) {
         pScene->mRootNode->mMeshes[i] = i;
-
-    /*pScene->mRootNode->mTransformation *= aiMatrix4x4(
-        1.f, 0.f, 0.f, 0.f,
-        0.f, -1.f,0.f, 0.f,
-        0.f, 0.f, 1.f, 0.f,
-        0.f, 0.f, 0.f, 1.f);*/
+    }
 
     // Add cameras and light sources to the scene root node
     pScene->mRootNode->mNumChildren = pScene->mNumLights + pScene->mNumCameras;
@@ -576,5 +569,7 @@ outer:
         nd->mTransformation = pScene->mRootNode->mChildren[0]->mTransformation;
     }
 }
+
+} // namespace Assimp
 
 #endif // !! ASSIMP_BUILD_NO_Q3D_IMPORTER

--- a/code/AssetLib/Raw/RawLoader.cpp
+++ b/code/AssetLib/Raw/RawLoader.cpp
@@ -55,9 +55,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/IOSystem.hpp>
 #include <memory>
 
-using namespace Assimp;
+namespace Assimp {
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "Raw Importer",
     "",
     "",
@@ -69,14 +69,6 @@ static const aiImporterDesc desc = {
     0,
     "raw"
 };
-
-// ------------------------------------------------------------------------------------------------
-// Constructor to be privately used by Importer
-RAWImporter::RAWImporter() = default;
-
-// ------------------------------------------------------------------------------------------------
-// Destructor, private as well
-RAWImporter::~RAWImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.
@@ -294,5 +286,7 @@ void RAWImporter::InternReadFile(const std::string &pFile,
         }
     }
 }
+
+} // namespace Assimp
 
 #endif // !! ASSIMP_BUILD_NO_RAW_IMPORTER

--- a/code/AssetLib/Raw/RawLoader.h
+++ b/code/AssetLib/Raw/RawLoader.h
@@ -57,8 +57,8 @@ namespace Assimp {
 */
 class RAWImporter : public BaseImporter {
 public:
-    RAWImporter();
-    ~RAWImporter() override;
+    RAWImporter() = default;
+    ~RAWImporter() override = default;
 
     // -------------------------------------------------------------------
     /** Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/SIB/SIBImporter.cpp
+++ b/code/AssetLib/SIB/SIBImporter.cpp
@@ -69,9 +69,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <map>
 
-using namespace Assimp;
+namespace Assimp {
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "Silo SIB Importer",
     "Richard Mitton (http://www.codersnotes.com/about)",
     "",
@@ -94,7 +94,7 @@ enum {
     N
 };
 
-typedef std::pair<uint32_t, uint32_t> SIBPair;
+using SIBPair = std::pair<uint32_t, uint32_t>;
 
 struct SIBEdge {
     uint32_t faceA, faceB;
@@ -199,15 +199,6 @@ static aiString ReadString(StreamReaderLE *stream, uint32_t numWChars) {
 
     return result;
 }
-
-// ------------------------------------------------------------------------------------------------
-// Constructor to be privately used by Importer
-SIBImporter::SIBImporter() = default;
-
-// ------------------------------------------------------------------------------------------------
-// Destructor, private as well
-SIBImporter::~SIBImporter() = default;
-
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.
 bool SIBImporter::CanRead(const std::string &filename, IOSystem * /*pIOHandler*/, bool /*checkSig*/) const {
@@ -881,5 +872,7 @@ void SIBImporter::InternReadFile(const std::string &pFile,
         }
     }
 }
+
+} // namespace Assimp
 
 #endif // !! ASSIMP_BUILD_NO_SIB_IMPORTER

--- a/code/AssetLib/SIB/SIBImporter.h
+++ b/code/AssetLib/SIB/SIBImporter.h
@@ -57,8 +57,8 @@ namespace Assimp {
 */
 class ASSIMP_API SIBImporter : public BaseImporter {
 public:
-    SIBImporter();
-    ~SIBImporter() override;
+    SIBImporter() = default;
+    ~SIBImporter() override = default;
 
     // -------------------------------------------------------------------
     /** Returns whether the class can handle the format of the given file.

--- a/code/AssetLib/SMD/SMDLoader.cpp
+++ b/code/AssetLib/SMD/SMDLoader.cpp
@@ -64,9 +64,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define strtok_s strtok_r
 #endif
 
-using namespace Assimp;
+namespace Assimp {
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "Valve SMD Importer",
     "",
     "",
@@ -1075,6 +1075,8 @@ void SMDImporter::ParseVertex(const char* szCurrent,
 
     // go to the beginning of the next line
     SMDI_PARSE_RETURN;
+}
+
 }
 
 #endif // !! ASSIMP_BUILD_NO_SMD_IMPORTER

--- a/code/AssetLib/STL/STLLoader.cpp
+++ b/code/AssetLib/STL/STLLoader.cpp
@@ -52,11 +52,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/IOSystem.hpp>
 #include <memory>
 
-using namespace Assimp;
+namespace Assimp {
 
 namespace {
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "Stereolithography (STL) Importer",
     "",
     "",
@@ -129,7 +129,7 @@ STLImporter::STLImporter() :
         mBuffer(),
         mFileSize(0),
         mScene() {
-   // empty
+    // empty
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -250,13 +250,13 @@ void STLImporter::LoadASCIIFile(aiNode *root) {
         sz += 5; // skip the "solid"
         SkipSpaces(&sz);
         const char *szMe = sz;
-        while (!::IsSpaceOrNewLine(*sz)) {
+        while (!IsSpaceOrNewLine(*sz)) {
             sz++;
         }
 
         size_t temp = (size_t)(sz - szMe);
         // setup the name of the node
-        if ( temp ) {
+        if (temp) {
             if (temp >= MAXLEN) {
                 throw DeadlyImportError("STL: Node name too long");
             }
@@ -303,7 +303,7 @@ void STLImporter::LoadASCIIFile(aiNode *root) {
                     normalBuffer.emplace_back(vn);
                     normalBuffer.emplace_back(vn);
                 }
-            } else if (!strncmp(sz, "vertex", 6) && ::IsSpaceOrNewLine(*(sz + 6))) { // vertex 1.50000 1.50000 0.00000
+            } else if (!strncmp(sz, "vertex", 6) && IsSpaceOrNewLine(*(sz + 6))) { // vertex 1.50000 1.50000 0.00000
                 if (faceVertexCounter >= 3) {
                     ASSIMP_LOG_ERROR("STL: a facet with more than 3 vertices has been found");
                     ++sz;
@@ -325,14 +325,14 @@ void STLImporter::LoadASCIIFile(aiNode *root) {
             } else if (!::strncmp(sz, "endsolid", 8)) {
                 do {
                     ++sz;
-                } while (!::IsLineEnd(*sz));
+                } while (!IsLineEnd(*sz));
                 SkipSpacesAndLineEnd(&sz);
                 // finished!
                 break;
             } else { // else skip the whole identifier
                 do {
                     ++sz;
-                } while (!::IsSpaceOrNewLine(*sz));
+                } while (!IsSpaceOrNewLine(*sz));
             }
         }
 
@@ -349,14 +349,14 @@ void STLImporter::LoadASCIIFile(aiNode *root) {
             throw DeadlyImportError("Normal buffer size does not match position buffer size");
         }
 
-        // only process positionbuffer when filled, else exception when accessing with index operator
+        // only process position buffer when filled, else exception when accessing with index operator
         // see line 353: only warning is triggered
-        // see line 373(now): access to empty positionbuffer with index operator forced exception
+        // see line 373(now): access to empty position buffer with index operator forced exception
         if (!positionBuffer.empty()) {
             pMesh->mNumFaces = static_cast<unsigned int>(positionBuffer.size() / 3);
             pMesh->mNumVertices = static_cast<unsigned int>(positionBuffer.size());
             pMesh->mVertices = new aiVector3D[pMesh->mNumVertices];
-            for (size_t i=0; i<pMesh->mNumVertices; ++i ) {
+            for (size_t i = 0; i < pMesh->mNumVertices; ++i) {
                 pMesh->mVertices[i].x = positionBuffer[i].x;
                 pMesh->mVertices[i].y = positionBuffer[i].y;
                 pMesh->mVertices[i].z = positionBuffer[i].z;
@@ -366,7 +366,7 @@ void STLImporter::LoadASCIIFile(aiNode *root) {
         // also only process normalBuffer when filled, else exception when accessing with index operator
         if (!normalBuffer.empty()) {
             pMesh->mNormals = new aiVector3D[pMesh->mNumVertices];
-            for (size_t i=0; i<pMesh->mNumVertices; ++i ) {
+            for (size_t i = 0; i < pMesh->mNumVertices; ++i) {
                 pMesh->mNormals[i].x = normalBuffer[i].x;
                 pMesh->mNormals[i].y = normalBuffer[i].y;
                 pMesh->mNormals[i].z = normalBuffer[i].z;
@@ -450,9 +450,8 @@ bool STLImporter::LoadBinaryFile() {
     aiVector3D *vp = pMesh->mVertices = new aiVector3D[pMesh->mNumVertices];
     aiVector3D *vn = pMesh->mNormals = new aiVector3D[pMesh->mNumVertices];
 
-    typedef aiVector3t<float> aiVector3F;
-    aiVector3F *theVec;
-    aiVector3F theVec3F;
+    aiVector3f *theVec;
+    aiVector3f theVec3F;
 
     for (unsigned int i = 0; i < pMesh->mNumFaces; ++i) {
         // NOTE: Blender sometimes writes empty normals ... this is not
@@ -460,8 +459,8 @@ bool STLImporter::LoadBinaryFile() {
 
         // There's one normal for the face in the STL; use it three times
         // for vertex normals
-        theVec = (aiVector3F *)sz;
-        ::memcpy(&theVec3F, theVec, sizeof(aiVector3F));
+        theVec = (aiVector3f *)sz;
+        ::memcpy(&theVec3F, theVec, sizeof(aiVector3f));
         vn->x = theVec3F.x;
         vn->y = theVec3F.y;
         vn->z = theVec3F.z;
@@ -471,7 +470,7 @@ bool STLImporter::LoadBinaryFile() {
         vn += 3;
 
         // vertex 1
-        ::memcpy(&theVec3F, theVec, sizeof(aiVector3F));
+        ::memcpy(&theVec3F, theVec, sizeof(aiVector3f));
         vp->x = theVec3F.x;
         vp->y = theVec3F.y;
         vp->z = theVec3F.z;
@@ -479,7 +478,7 @@ bool STLImporter::LoadBinaryFile() {
         ++vp;
 
         // vertex 2
-        ::memcpy(&theVec3F, theVec, sizeof(aiVector3F));
+        ::memcpy(&theVec3F, theVec, sizeof(aiVector3f));
         vp->x = theVec3F.x;
         vp->y = theVec3F.y;
         vp->z = theVec3F.z;
@@ -487,7 +486,7 @@ bool STLImporter::LoadBinaryFile() {
         ++vp;
 
         // vertex 3
-        ::memcpy(&theVec3F, theVec, sizeof(aiVector3F));
+        ::memcpy(&theVec3F, theVec, sizeof(aiVector3f));
         vp->x = theVec3F.x;
         vp->y = theVec3F.y;
         vp->z = theVec3F.z;
@@ -569,5 +568,7 @@ void STLImporter::pushMeshesToNode(std::vector<unsigned int> &meshIndices, aiNod
     }
     meshIndices.clear();
 }
+
+} // namespace Assimp
 
 #endif // !! ASSIMP_BUILD_NO_STL_IMPORTER

--- a/code/AssetLib/Terragen/TerragenLoader.cpp
+++ b/code/AssetLib/Terragen/TerragenLoader.cpp
@@ -51,9 +51,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/IOSystem.hpp>
 #include <assimp/Importer.hpp>
 
-using namespace Assimp;
+namespace Assimp {
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "Terragen Heightmap Importer",
     "",
     "",
@@ -72,10 +72,6 @@ TerragenImporter::TerragenImporter() :
         configComputeUVs(false) {
     // empty
 }
-
-// ------------------------------------------------------------------------------------------------
-// Destructor, private as well
-TerragenImporter::~TerragenImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.
@@ -243,5 +239,7 @@ void TerragenImporter::InternReadFile(const std::string &pFile,
     // Set the AI_SCENE_FLAGS_TERRAIN bit
     pScene->mFlags |= AI_SCENE_FLAGS_TERRAIN;
 }
+
+} // namespace Assimp
 
 #endif // !! ASSIMP_BUILD_NO_TERRAGEN_IMPORTER

--- a/code/AssetLib/Terragen/TerragenLoader.h
+++ b/code/AssetLib/Terragen/TerragenLoader.h
@@ -73,7 +73,7 @@ namespace Assimp {
 class TerragenImporter : public BaseImporter {
 public:
     TerragenImporter();
-    ~TerragenImporter() override;
+    ~TerragenImporter() override = default;
 
     // -------------------------------------------------------------------
     bool CanRead(const std::string &pFile, IOSystem *pIOHandler,

--- a/code/AssetLib/Unreal/UnrealLoader.cpp
+++ b/code/AssetLib/Unreal/UnrealLoader.cpp
@@ -152,7 +152,7 @@ inline void DecompressVertex(aiVector3D &v, int32_t in) {
 
 } // end namespace Unreal
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "Unreal Mesh Importer",
     "",
     "",

--- a/code/AssetLib/Unreal/UnrealLoader.cpp
+++ b/code/AssetLib/Unreal/UnrealLoader.cpp
@@ -63,7 +63,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cstdint>
 #include <memory>
 
-using namespace Assimp;
+namespace Assimp {
 
 namespace Unreal {
 
@@ -178,7 +178,7 @@ UnrealImporter::~UnrealImporter() = default;
 
 // ------------------------------------------------------------------------------------------------
 // Returns whether the class can handle the format of the given file.
-bool UnrealImporter::CanRead(const std::string & filename, IOSystem * /*pIOHandler*/, bool /*checkSig*/) const {
+bool UnrealImporter::CanRead(const std::string &filename, IOSystem * /*pIOHandler*/, bool /*checkSig*/) const {
     return SimpleExtensionCheck(filename, "3d", "uc");
 }
 
@@ -336,12 +336,12 @@ void UnrealImporter::InternReadFile(const std::string &pFile,
                         tempTextures.emplace_back();
                         std::pair<std::string, std::string> &me = tempTextures.back();
                         for (; !IsLineEnd(*data); ++data) {
-                            if (!::ASSIMP_strincmp(data, "NAME=", 5)) {
+                            if (!ASSIMP_strincmp(data, "NAME=", 5)) {
                                 const char *d = data += 5;
                                 for (; !IsSpaceOrNewLine(*data); ++data)
                                     ;
                                 me.first = std::string(d, (size_t)(data - d));
-                            } else if (!::ASSIMP_strincmp(data, "FILE=", 5)) {
+                            } else if (!ASSIMP_strincmp(data, "FILE=", 5)) {
                                 const char *d = data += 5;
                                 for (; !IsSpaceOrNewLine(*data); ++data)
                                     ;
@@ -363,10 +363,10 @@ void UnrealImporter::InternReadFile(const std::string &pFile,
                         std::pair<unsigned int, std::string> &me = textures.back();
 
                         for (; !IsLineEnd(*data); ++data) {
-                            if (!::ASSIMP_strincmp(data, "NUM=", 4)) {
+                            if (!ASSIMP_strincmp(data, "NUM=", 4)) {
                                 data += 4;
                                 me.first = strtoul10(data, &data);
-                            } else if (!::ASSIMP_strincmp(data, "TEXTURE=", 8)) {
+                            } else if (!ASSIMP_strincmp(data, "TEXTURE=", 8)) {
                                 data += 8;
                                 const char *d = data;
                                 for (; !IsSpaceOrNewLine(*data); ++data)
@@ -515,5 +515,7 @@ void UnrealImporter::InternReadFile(const std::string &pFile,
     FlipWindingOrderProcess flipper;
     flipper.Execute(pScene);
 }
+
+} // namespace Assimp
 
 #endif // !! ASSIMP_BUILD_NO_3D_IMPORTER

--- a/code/AssetLib/X/XFileImporter.cpp
+++ b/code/AssetLib/X/XFileImporter.cpp
@@ -61,7 +61,7 @@ namespace Assimp {
 
 using namespace Assimp::Formatter;
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "Direct3D XFile Importer",
     "",
     "",

--- a/code/AssetLib/XGL/XGLLoader.cpp
+++ b/code/AssetLib/XGL/XGLLoader.cpp
@@ -78,7 +78,7 @@ XGLImporter::XGLImporter() : mXmlParser(nullptr), m_scene(nullptr) {
 
 // ------------------------------------------------------------------------------------------------
 XGLImporter::~XGLImporter() {
-	delete mXmlParser;
+    clear();
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -94,7 +94,8 @@ const aiImporterDesc *XGLImporter::GetInfo() const {
 
 // ------------------------------------------------------------------------------------------------
 void XGLImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSystem *pIOHandler) {
- #ifndef ASSIMP_BUILD_NO_COMPRESSED_XGL
+    clear();
+#ifndef ASSIMP_BUILD_NO_COMPRESSED_XGL
 	std::vector<char> uncompressed;
 #endif
 
@@ -164,6 +165,13 @@ void XGLImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
 
 	scope.dismiss();
 }
+
+// ------------------------------------------------------------------------------------------------
+void XGLImporter::clear() {
+    delete mXmlParser;
+    mXmlParser = nullptr;
+}
+
 
 // ------------------------------------------------------------------------------------------------
 void XGLImporter::ReadWorld(XmlNode &node, TempScope &scope) {

--- a/code/AssetLib/XGL/XGLLoader.h
+++ b/code/AssetLib/XGL/XGLLoader.h
@@ -81,6 +81,8 @@ public:
             bool checkSig) const override;
 
 protected:
+    void clear();
+
     // -------------------------------------------------------------------
     /** Return importer meta information.
      * See #BaseImporter::GetInfo for the details  */

--- a/code/AssetLib/glTF/glTFImporter.cpp
+++ b/code/AssetLib/glTF/glTFImporter.cpp
@@ -62,11 +62,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using namespace Assimp;
 using namespace glTF;
 
-//
-// glTFImporter
-//
-
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "glTF Importer",
     "",
     "",

--- a/code/AssetLib/glTF2/glTF2Importer.cpp
+++ b/code/AssetLib/glTF2/glTF2Importer.cpp
@@ -82,7 +82,7 @@ struct Tangent {
 // glTF2Importer
 //
 
-static const aiImporterDesc desc = {
+static constexpr aiImporterDesc desc = {
     "glTF2 Importer",
     "",
     "",

--- a/include/assimp/BaseImporter.h
+++ b/include/assimp/BaseImporter.h
@@ -63,6 +63,7 @@ struct aiImporterDesc;
 
 namespace Assimp {
 
+// Forward declarations
 class Importer;
 class IOSystem;
 class BaseProcess;
@@ -72,6 +73,9 @@ class IOStream;
 // utility to do char4 to uint32 in a portable manner
 #define AI_MAKE_MAGIC(string) ((uint32_t)((string[0] << 24) + \
                                           (string[1] << 16) + (string[2] << 8) + string[3]))
+
+using UByteBuffer = std::vector<uint8_t>;
+using ByteBuffer = std::vector<int8_t>;
 
 // ---------------------------------------------------------------------------
 /** FOR IMPORTER PLUGINS ONLY: The BaseImporter defines a common interface

--- a/include/assimp/ParsingUtils.h
+++ b/include/assimp/ParsingUtils.h
@@ -70,7 +70,6 @@ namespace Assimp {
 
 static const unsigned int BufferSize = 4096;
 
-
 // ---------------------------------------------------------------------------------
 template <class char_t>
 AI_FORCE_INLINE bool IsUpper(char_t in) {

--- a/include/assimp/vector3.h
+++ b/include/assimp/vector3.h
@@ -151,6 +151,8 @@ public:
 
 
 typedef aiVector3t<ai_real> aiVector3D;
+typedef aiVector3t<float> aiVector3f;
+typedef aiVector3t<double> aiVector3d;
 
 #else
 


### PR DESCRIPTION
- Add constexpr
- Fix possible memory leaks when loading assets more than once without recreating the loader
- Use namespace in cpp-files instead of adding using statements (make this unique over the codebase)