### PR TITLE
Fix double free in Video::~Video()

### DIFF
--- a/code/AssetLib/FBX/FBXMaterial.cpp
+++ b/code/AssetLib/FBX/FBXMaterial.cpp
@@ -367,7 +367,9 @@ Video::Video(uint64_t id, const Element &element, const Document &doc, const std
 }
 
 Video::~Video() {
-    delete[] content;
+    if (contentLength > 0) {
+        delete[] content;
+    }
 }
 
 } //!FBX


### PR DESCRIPTION
If `contentLength` is zero, then `content` was deallocated in `Video::Video()` or was not allocated at all. Thus, deleting `content` in destructor without a check resulted in double free.

Add a check in `Video::~Video()`.