### PR TITLE
correct grammar/typographic errors in comments (8 files)

### DIFF
--- a/code/AssetLib/3DS/3DSConverter.cpp
+++ b/code/AssetLib/3DS/3DSConverter.cpp
@@ -593,7 +593,7 @@ void Discreet3DSImporter::AddNodeToGraph(aiScene *pcSOut, aiNode *pcOut,
 
         // Cameras or lights define their transformation in their parent node and in the
         // corresponding light or camera chunks. However, we read and process the latter
-        // to to be able to return valid cameras/lights even if no scenegraph is given.
+        // to be able to return valid cameras/lights even if no scenegraph is given.
         for (unsigned int n = 0; n < pcSOut->mNumCameras; ++n) {
             if (pcSOut->mCameras[n]->mName == pcOut->mName) {
                 pcSOut->mCameras[n]->mLookAt = aiVector3D(0.f, 0.f, 1.f);

--- a/code/AssetLib/3DS/3DSLoader.cpp
+++ b/code/AssetLib/3DS/3DSLoader.cpp
@@ -365,7 +365,7 @@ void Discreet3DSImporter::ParseChunk(const char *name, unsigned int num) {
     // IMPLEMENTATION NOTE;
     // Cameras or lights define their transformation in their parent node and in the
     // corresponding light or camera chunks. However, we read and process the latter
-    // to to be able to return valid cameras/lights even if no scenegraph is given.
+    // to be able to return valid cameras/lights even if no scenegraph is given.
 
     // get chunk type
     switch (chunk.Flag) {

--- a/code/AssetLib/ASE/ASELoader.cpp
+++ b/code/AssetLib/ASE/ASELoader.cpp
@@ -904,7 +904,7 @@ void ASEImporter::ConvertMeshes(ASE::Mesh &mesh, std::vector<aiMesh *> &avOutMes
         ASSIMP_LOG_WARN("Material index is out of range");
     }
 
-    // If the material the mesh is assigned to is consisting of submeshes, split it
+    // If the material the mesh is assigned to consists of submeshes, split it
     if (!mParser->m_vMaterials[mesh.iMaterialIndex].avSubMaterials.empty()) {
         std::vector<ASE::Material> vSubMaterials = mParser->m_vMaterials[mesh.iMaterialIndex].avSubMaterials;
 

--- a/code/AssetLib/Blender/BlenderScene.cpp
+++ b/code/AssetLib/Blender/BlenderScene.cpp
@@ -297,7 +297,7 @@ void Structure ::Convert<Base>(
         const FileDatabase &db) const {
     // note: as per https://github.com/assimp/assimp/issues/128,
     // reading the Object linked list recursively is prone to stack overflow.
-    // This structure converter is therefore an hand-written exception that
+    // This structure converter is therefore a hand-written exception that
     // does it iteratively.
 
     const int initial_pos = db.reader->GetCurrentPos();

--- a/code/AssetLib/Collada/ColladaParser.cpp
+++ b/code/AssetLib/Collada/ColladaParser.cpp
@@ -1867,7 +1867,7 @@ size_t ColladaParser::ReadPrimitives(XmlNode &node, Mesh &pMesh, std::vector<Inp
 
 ///@note This function won't work correctly if both PerIndex and PerVertex channels have same channels.
 ///For example if TEXCOORD present in both <vertices> and <polylist> tags this function will create wrong uv coordinates.
-///It's not clear from COLLADA documentation is this allowed or not. For now only exporter fixed to avoid such behavior
+///It's not clear from COLLADA documentation whether this is allowed or not. For now only exporter fixed to avoid such behavior
 void ColladaParser::CopyVertex(size_t currentVertex, size_t numOffsets, size_t numPoints, size_t perVertexOffset, Mesh &pMesh,
         std::vector<InputChannel> &pPerIndexChannels, size_t currentPrimitive, const std::vector<size_t> &indices) {
     // calculate the base offset of the vertex whose attributes we ant to copy

--- a/code/AssetLib/FBX/FBXConverter.cpp
+++ b/code/AssetLib/FBX/FBXConverter.cpp
@@ -1206,7 +1206,7 @@ unsigned int FBXConverter::ConvertMeshSingleMaterial(const MeshGeometry &mesh, c
                 const auto &curNormals = shapeGeometry->GetNormals();
                 const auto &curIndices = shapeGeometry->GetIndices();
                 //losing channel name if using shapeGeometry->Name()
-                // if blendShapeChannel Name is empty or don't have a ".", add geoMetryName;
+                // if blendShapeChannel Name is empty or doesn't have a ".", add geoMetryName;
                 auto aniName = FixAnimMeshName(blendShapeChannel->Name());
                 auto geoMetryName = FixAnimMeshName(shapeGeometry->Name());
                 if (aniName.empty()) {

--- a/code/AssetLib/FBX/FBXDeformer.cpp
+++ b/code/AssetLib/FBX/FBXDeformer.cpp
@@ -84,7 +84,7 @@ Cluster::Cluster(uint64_t id, const Element& element, const Document& doc, const
     transform = ReadMatrix(Transform);
     transformLink = ReadMatrix(TransformLink);
 
-    // it is actually possible that there be Deformer's with no weights
+    // it is actually possible that there are Deformer's with no weights
     if (!!Indexes != !!Weights) {
         DOMError("either Indexes or Weights are missing from Cluster",&element);
     }

--- a/tools/assimp_view/assimp_view.cpp
+++ b/tools/assimp_view/assimp_view.cpp
@@ -291,7 +291,7 @@ int LoadAsset() {
 
 //-------------------------------------------------------------------------------
 // Delete the loaded asset
-// The function does nothing is no asset is loaded
+// The function does nothing if no asset is loaded
 //-------------------------------------------------------------------------------
 int DeleteAsset(void) {
     if (!g_pcAsset) {


### PR DESCRIPTION
Similar to #5248, this pull request consists entirely of small corrections to comments in C++ source files.
