### PR TITLE
KHR_materials_specular fixes

### DIFF
--- a/code/AssetLib/glTF2/glTF2Asset.h
+++ b/code/AssetLib/glTF2/glTF2Asset.h
@@ -720,7 +720,7 @@ const vec4 defaultBaseColor = { 1, 1, 1, 1 };
 const vec3 defaultEmissiveFactor = { 0, 0, 0 };
 const vec4 defaultDiffuseFactor = { 1, 1, 1, 1 };
 const vec3 defaultSpecularFactor = { 1, 1, 1 };
-const vec3 defaultSpecularColorFactor = { 0, 0, 0 };
+const vec3 defaultSpecularColorFactor = { 1, 1, 1 };
 const vec3 defaultSheenFactor = { 0, 0, 0 };
 const vec3 defaultAttenuationColor = { 1, 1, 1 };
 

--- a/code/AssetLib/glTF2/glTF2Asset.inl
+++ b/code/AssetLib/glTF2/glTF2Asset.inl
@@ -1392,7 +1392,7 @@ inline void PbrSpecularGlossiness::SetDefaults() {
 inline void MaterialSpecular::SetDefaults() {
     //KHR_materials_specular properties
     SetVector(specularColorFactor, defaultSpecularColorFactor);
-    specularFactor = 0.f;
+    specularFactor = 1.f;
 }
 
 inline void MaterialSheen::SetDefaults() {

--- a/code/AssetLib/glTF2/glTF2AssetWriter.inl
+++ b/code/AssetLib/glTF2/glTF2AssetWriter.inl
@@ -426,12 +426,13 @@ namespace glTF2 {
 
             if (specular.specularFactor != 0.0f) {
                 WriteFloat(materialSpecular, specular.specularFactor, "specularFactor", w.mAl);
-                WriteTex(materialSpecular, specular.specularTexture, "specularTexture", w.mAl);
             }
             if (specular.specularColorFactor[0] != defaultSpecularColorFactor[0] && specular.specularColorFactor[1] != defaultSpecularColorFactor[1] && specular.specularColorFactor[2] != defaultSpecularColorFactor[2]) {
                 WriteVec(materialSpecular, specular.specularColorFactor, "specularColorFactor", w.mAl);
-                WriteTex(materialSpecular, specular.specularColorTexture, "specularColorTexture", w.mAl);
             }
+
+            WriteTex(materialSpecular, specular.specularTexture, "specularTexture", w.mAl);
+            WriteTex(materialSpecular, specular.specularColorTexture, "specularColorTexture", w.mAl);
 
             if (!materialSpecular.ObjectEmpty()) {
                 exts.AddMember("KHR_materials_specular", materialSpecular, w.mAl);

--- a/code/AssetLib/glTF2/glTF2Exporter.cpp
+++ b/code/AssetLib/glTF2/glTF2Exporter.cpp
@@ -730,8 +730,8 @@ bool glTF2Exporter::GetMatSpecular(const aiMaterial &mat, glTF2::MaterialSpecula
     } else if (colorFactorIsZero) {
         specular.specularColorFactor[0] = specular.specularColorFactor[1] = specular.specularColorFactor[2] = 1.0f;
     }
-    GetMatTex(mat, specular.specularColorTexture, aiTextureType_SPECULAR);
-    GetMatTex(mat, specular.specularTexture, aiTextureType_SPECULAR);
+    GetMatTex(mat, specular.specularTexture, aiTextureType_SPECULAR, 0);
+    GetMatTex(mat, specular.specularColorTexture, aiTextureType_SPECULAR, 1);
     return true;
 }
 

--- a/code/AssetLib/glTF2/glTF2Importer.cpp
+++ b/code/AssetLib/glTF2/glTF2Importer.cpp
@@ -288,8 +288,8 @@ static aiMaterial *ImportMaterial(std::vector<int> &embeddedTexIdxs, Asset &r, M
             if (std::memcmp(specular.specularColorFactor, defaultSpecularColorFactor, sizeof(glTFCommon::vec3)) != 0 || specular.specularFactor != 0.0f) {
                 SetMaterialColorProperty(r, specular.specularColorFactor, aimat, AI_MATKEY_COLOR_SPECULAR);
                 aimat->AddProperty(&specular.specularFactor, 1, AI_MATKEY_SPECULAR_FACTOR);
-                SetMaterialTextureProperty(embeddedTexIdxs, r, specular.specularTexture, aimat, aiTextureType_SPECULAR);
-                SetMaterialTextureProperty(embeddedTexIdxs, r, specular.specularColorTexture, aimat, aiTextureType_SPECULAR);
+                SetMaterialTextureProperty(embeddedTexIdxs, r, specular.specularTexture, aimat, aiTextureType_SPECULAR, 0);
+                SetMaterialTextureProperty(embeddedTexIdxs, r, specular.specularColorTexture, aimat, aiTextureType_SPECULAR, 1);
             }
         }
         // pbrSpecularGlossiness


### PR DESCRIPTION
I found 2 issues while exporting the official assets ( https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/SpecularTest)
1. It doesn't provide proper properties for an extension, default values are different in the spec
2. It overrides the Specular texture type (specular and specularColor by the spec are separate)