### PR TITLE
Fix target names not being imported on some gLTF2 models

### DIFF
--- a/code/AssetLib/glTF2/glTF2Asset.inl
+++ b/code/AssetLib/glTF2/glTF2Asset.inl
@@ -1552,6 +1552,22 @@ inline void Mesh::Read(Value &pJSON_Object, Asset &pAsset_Root) {
                     }
                 }
             }
+
+            if(this->targetNames.empty())
+            {
+                Value *curExtras = FindObject(primitive, "extras");
+                if (nullptr != curExtras) {
+                    if (Value *curTargetNames = FindArray(*curExtras, "targetNames")) {
+                        this->targetNames.resize(curTargetNames->Size());
+                        for (unsigned int j = 0; j < curTargetNames->Size(); ++j) {
+                            Value &targetNameValue = (*curTargetNames)[j];
+                            if (targetNameValue.IsString()) {
+                                this->targetNames[j] = targetNameValue.GetString();
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This loads target names from the first primitive if available. Names from the mesh root will still overwrite the ones from the primitive.
- closes https://github.com/assimp/assimp/issues/5354