### PR TITLE
Build: Disable building zlib for non-windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,7 @@ IF (WIN32)
 ELSE()
   OPTION( ASSIMP_BUILD_ZLIB
     "Build your own zlib"
-    ON
+    OFF
   )
 ENDIF()
 


### PR DESCRIPTION
- closes https://github.com/assimp/assimp/issues/5340