### PR TITLE
fix: KHR_materials_pbrSpecularGlossiness/diffuseFactor convert to pbr…

### DIFF
--- a/code/AssetLib/glTF2/glTF2Exporter.cpp
+++ b/code/AssetLib/glTF2/glTF2Exporter.cpp
@@ -912,6 +912,7 @@ void glTF2Exporter::ExportMaterials() {
                 if (GetMatSpecular(mat, specular)) {
                     mAsset->extensionsUsed.KHR_materials_specular = true;
                     m->materialSpecular = Nullable<MaterialSpecular>(specular);
+                    GetMatColor(mat, m->pbrMetallicRoughness.baseColorFactor, AI_MATKEY_COLOR_DIFFUSE);
                 }
 
                 MaterialSheen sheen;


### PR DESCRIPTION
When there is KHR_materials_pbrSpecularGlossiness and AI_CONFIG_USE_GLTF_PBR_SPECULAR_GLOSSINESS is false, Converting the KHR_materials_pbrSpecularGlossiness/diffuseFactor pbrMetallicRoughness/baseColorFactor