### PR TITLE
`Blendshape`->`Geometry` in FBX Export

### DIFF
--- a/code/AssetLib/FBX/FBXExporter.cpp
+++ b/code/AssetLib/FBX/FBXExporter.cpp
@@ -1748,7 +1748,7 @@ void FBXExporter::WriteObjects ()
         int64_t blendshape_uid = generate_uid();
         mesh_uids.push_back(blendshape_uid);
         bsnode.AddProperty(blendshape_uid);
-        bsnode.AddProperty(blendshape_name + FBX::SEPARATOR + "Blendshape");
+        bsnode.AddProperty(blendshape_name + FBX::SEPARATOR + "Geometry");
         bsnode.AddProperty("Shape");
         bsnode.AddChild("Version", int32_t(100));
         bsnode.Begin(outstream, binary, indent);


### PR DESCRIPTION
When loading a mesh exported from assimp into Blender, it warns that it has an incorrect class. While debugging, I traced it back to this being `Blendshape` where `Geometry` was expected. This is likely because this node describes a `Geometry`, which is used as a blendshape. I'm not sure if any other DCC tools or places to import it expect `Blendshape` instead (i.e. was this code ever tested?), but it fixes its use in Blender.

Fixes #5418 

Test Mesh:
[headblendshape.zip](https://github.com/assimp/assimp/files/13899594/headblendshape.zip)
Note this is actually not the mesh I originally tested on, but the original was proprietary.