### PR TITLE
Fixed GLTF read reference file

### DIFF
--- a/code/AssetLib/glTF/glTFAsset.inl
+++ b/code/AssetLib/glTF/glTFAsset.inl
@@ -242,7 +242,7 @@ inline bool Buffer::LoadFromStream(IOStream &stream, size_t length, size_t baseO
 
     mData.reset(new uint8_t[byteLength], std::default_delete<uint8_t[]>());
 
-    if (stream.Read(mData.get(), byteLength, 1) != 1) {
+    if (stream.Read(mData.get(), byteLength, 1) != byteLength) {
         return false;
     }
     return true;

--- a/code/AssetLib/glTF2/glTF2Asset.inl
+++ b/code/AssetLib/glTF2/glTF2Asset.inl
@@ -638,7 +638,7 @@ inline bool Buffer::LoadFromStream(IOStream &stream, size_t length, size_t baseO
 
     mData.reset(new uint8_t[byteLength], std::default_delete<uint8_t[]>());
 
-    if (stream.Read(mData.get(), byteLength, 1) != 1) {
+    if (stream.Read(mData.get(), byteLength, 1) != byteLength) {
         return false;
     }
     return true;


### PR DESCRIPTION
There is a bug in the GTLF reference file reader. 

`Read` uses [fread](https://www.tutorialspoint.com/c_standard_library/c_function_fread.htm), this function return the number of bytes readed. not really sure why this condition was compared with 1. 