### PR TITLE
Fix compilation for MSVC14.

### DIFF
--- a/code/AssetLib/Obj/ObjFileParser.cpp
+++ b/code/AssetLib/Obj/ObjFileParser.cpp
@@ -52,7 +52,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cstdlib>
 #include <memory>
 #include <utility>
-#include <string_view>
 
 namespace Assimp {
 

--- a/code/Common/StackAllocator.inl
+++ b/code/Common/StackAllocator.inl
@@ -41,6 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "StackAllocator.h"
 #include <assimp/ai_assert.h>
+#include <algorithm>
 
 using namespace Assimp;
 
@@ -56,7 +57,7 @@ inline void *StackAllocator::Allocate(size_t byteSize) {
     {
         // double block size every time, up to maximum of g_maxBytesPerBlock.
         // Block size must be at least as large as byteSize, but we want to use this for small allocations anyway.
-        m_blockAllocationSize = std::max(std::min(m_blockAllocationSize * 2, g_maxBytesPerBlock), byteSize);
+        m_blockAllocationSize = std::max<std::size_t>(std::min<std::size_t>(m_blockAllocationSize * 2, g_maxBytesPerBlock), byteSize);
         uint8_t *data = new uint8_t[m_blockAllocationSize];
         m_storageBlocks.emplace_back(data);
         m_subIndex = byteSize;

--- a/code/PostProcessing/ProcessHelper.cpp
+++ b/code/PostProcessing/ProcessHelper.cpp
@@ -177,8 +177,8 @@ unsigned int GetMeshVFormatUnique(const aiMesh *pcMesh) {
     if (pcMesh->HasTangentsAndBitangents()) iRet |= 0x4;
 
 
-    static_assert(8 >= AI_MAX_NUMBER_OF_COLOR_SETS);
-    static_assert(8 >= AI_MAX_NUMBER_OF_TEXTURECOORDS);
+    static_assert(8 >= AI_MAX_NUMBER_OF_COLOR_SETS, "static_assert(8 >= AI_MAX_NUMBER_OF_COLOR_SETS)");
+    static_assert(8 >= AI_MAX_NUMBER_OF_TEXTURECOORDS, "static_assert(8 >= AI_MAX_NUMBER_OF_TEXTURECOORDS)");
 
     // texture coordinates
     unsigned int p = 0;


### PR DESCRIPTION
This PR fixes Assimp compilation for older compilers with lack of C++17 support such as MSVC14.

- `std::min`/`max` were not defined in *StackAllocator.inl*; Also added explicit template arguments to break macro expansion if *Windows.h* is included prior and `NOMINMAX` macro is not present.
- Made `static_assert` statements compatible with C++11 in *ProcessHelper.cpp*.
- Removed unused `string_view` include in *ObjFileParser.cpp*.