### PR TITLE
Fix: add missing import for `AI_CONFIG_CHECK_IDENTITY_MATRIX_EPSILON_DEFAULT`

### DIFF
--- a/include/assimp/matrix4x4.h
+++ b/include/assimp/matrix4x4.h
@@ -53,6 +53,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <assimp/vector3.h>
 #include <assimp/defs.h>
+#include <assimp/config.h>
 
 #ifdef __cplusplus
 


### PR DESCRIPTION
`IsIdentity` would not compile on M1 macos due to missing import for `AI_CONFIG_CHECK_IDENTITY_MATRIX_EPSILON_DEFAULT`.