### PR TITLE
Fix utDefaultIOStream test under MinGW

### DIFF
--- a/test/unit/UnitTestFileGenerator.h
+++ b/test/unit/UnitTestFileGenerator.h
@@ -44,9 +44,14 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cstdlib>
 #include <gtest/gtest.h>
 
+#if defined(_MSC_VER) || defined(__MINGW64__) || defined(__MINGW32__)
+#define TMP_PATH "./"
+#elif defined(__GNUC__) || defined(__clang__)
+#define TMP_PATH "/tmp/"
+#endif
+
 #if defined(_MSC_VER)
 #include <io.h>
-#define TMP_PATH "./"
 inline FILE* MakeTmpFile(char* tmplate)
 {
     auto pathtemplate = _mktemp(tmplate);
@@ -60,7 +65,6 @@ inline FILE* MakeTmpFile(char* tmplate)
     return fs;
 }
 #elif defined(__GNUC__) || defined(__clang__)
-#define TMP_PATH "/tmp/"
 inline FILE* MakeTmpFile(char* tmplate)
 {
     auto fd = mkstemp(tmplate);


### PR DESCRIPTION
`utDefaultIOStream.FileSizeTest` fails on MinGW's GCC, since it assumes a *nix OS and tries to [create a temporary file](https://github.com/assimp/assimp/blob/feb861f17bf937fd42e0591b3347b95009033eec/test/unit/utDefaultIOStream.cpp#L63) at `/tmp/rndfp.XXXXXX`. There're many other places which checks for MINGW macros, so I guess it wasn't intentional.

```
[==========] 574 tests from 115 test suites ran. (16450 ms total)
[  PASSED  ] 573 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] utDefaultIOStream.FileSizeTest

 1 FAILED TEST
```

[Similar logic](https://github.com/assimp/assimp/blob/master/test/unit/utIOStreamBuffer.cpp#L89) is used in `utIOStreamBuffer.cpp`, although there it just creates the files in the cwd without any `TMP_PATH`.

