### PR TITLE
Cleanup: Fix review findings

### DIFF
--- a/code/Common/BaseImporter.cpp
+++ b/code/Common/BaseImporter.cpp
@@ -93,10 +93,6 @@ BaseImporter::BaseImporter() AI_NO_EXCEPT
     // empty
 }
 
-// ------------------------------------------------------------------------------------------------
-// Destructor, private as well
-BaseImporter::~BaseImporter() = default;
-
 void BaseImporter::UpdateImporterScale(Importer *pImp) {
     ai_assert(pImp != nullptr);
     ai_assert(importerScale != 0.0);

--- a/code/Common/BaseProcess.cpp
+++ b/code/Common/BaseProcess.cpp
@@ -58,10 +58,6 @@ BaseProcess::BaseProcess() AI_NO_EXCEPT
 }
 
 // ------------------------------------------------------------------------------------------------
-// Destructor, private as well
-BaseProcess::~BaseProcess() = default;
-
-// ------------------------------------------------------------------------------------------------
 void BaseProcess::ExecuteOnScene(Importer *pImp) {
     ai_assert( nullptr != pImp );
     if (pImp == nullptr) {

--- a/code/Common/BaseProcess.h
+++ b/code/Common/BaseProcess.h
@@ -179,11 +179,11 @@ class ASSIMP_API BaseProcess {
     friend class Importer;
 
 public:
-    /** @brief onstructor to be privately used by Importer */
+    /** @brief Constructor to be privately used by Importer */
     BaseProcess() AI_NO_EXCEPT;
 
-    /** @brief Destructor, private as well */
-    virtual ~BaseProcess();
+    /** @brief Destructor */
+    virtual ~BaseProcess() = default;
 
     // -------------------------------------------------------------------
     /**

--- a/code/Common/Importer.h
+++ b/code/Common/Importer.h
@@ -74,11 +74,11 @@ public:
     typedef unsigned int KeyType;
 
     // typedefs for our configuration maps.
-    typedef std::map<KeyType, int> IntPropertyMap;
-    typedef std::map<KeyType, ai_real> FloatPropertyMap;
-    typedef std::map<KeyType, std::string> StringPropertyMap;
-    typedef std::map<KeyType, aiMatrix4x4> MatrixPropertyMap;
-    typedef std::map<KeyType, void*> PointerPropertyMap;
+    using IntPropertyMap = std::map<KeyType, int>;
+    using FloatPropertyMap = std::map<KeyType, ai_real>;
+    using StringPropertyMap = std::map<KeyType, std::string>;
+    using MatrixPropertyMap = std::map<KeyType, aiMatrix4x4>;
+    using PointerPropertyMap = std::map<KeyType, void*>;
 
     /** IO handler to use for all file accesses. */
     IOSystem* mIOHandler;
@@ -128,10 +128,12 @@ public:
 
     /// The default class constructor.
     ImporterPimpl() AI_NO_EXCEPT;
+
+    /// The class destructor.
+    ~ImporterPimpl() = default;
 };
 
-inline
-ImporterPimpl::ImporterPimpl() AI_NO_EXCEPT :
+inline ImporterPimpl::ImporterPimpl() AI_NO_EXCEPT :
         mIOHandler( nullptr ),
         mIsDefaultHandler( false ),
         mProgressHandler( nullptr ),

--- a/code/Common/SGSpatialSort.cpp
+++ b/code/Common/SGSpatialSort.cpp
@@ -5,8 +5,6 @@ Open Asset Import Library (assimp)
 
 Copyright (c) 2006-2024, assimp team
 
-
-
 All rights reserved.
 
 Redistribution and use of this software in source and binary forms,
@@ -50,16 +48,13 @@ the 3ds loader handling smooth groups correctly  */
 using namespace Assimp;
 
 // ------------------------------------------------------------------------------------------------
-SGSpatialSort::SGSpatialSort()
-{
+SGSpatialSort::SGSpatialSort() {
     // define the reference plane. We choose some arbitrary vector away from all basic axes
     // in the hope that no model spreads all its vertices along this plane.
     mPlaneNormal.Set( 0.8523f, 0.34321f, 0.5736f);
     mPlaneNormal.Normalize();
 }
-// ------------------------------------------------------------------------------------------------
-// Destructor
-SGSpatialSort::~SGSpatialSort() = default;
+
 // ------------------------------------------------------------------------------------------------
 void SGSpatialSort::Add(const aiVector3D& vPosition, unsigned int index,
     unsigned int smoothingGroup)

--- a/code/Common/ScenePreprocessor.h
+++ b/code/Common/ScenePreprocessor.h
@@ -4,7 +4,6 @@ Open Asset Import Library (assimp)
 
 Copyright (c) 2006-2024, assimp team
 
-
 All rights reserved.
 
 Redistribution and use of this software in source and binary forms,
@@ -56,7 +55,7 @@ class ScenePreprocessorTest;
 namespace Assimp {
 
 // ----------------------------------------------------------------------------------
-/** ScenePreprocessor: Preprocess a scene before any post-processing
+/** ScenePreprocessor: Pre-process a scene before any post-processing
  *  steps are executed.
  *
  *  The step computes data that needn't necessarily be provided by the
@@ -78,6 +77,9 @@ public:
      */
     ScenePreprocessor(aiScene *_scene) :
             scene(_scene) {}
+
+    /// @brief The class destructor.
+    ~ScenePreprocessor() = default;
 
     // ----------------------------------------------------------------
     /** Assign a (new) scene to the object.

--- a/code/Common/StackAllocator.h
+++ b/code/Common/StackAllocator.h
@@ -61,9 +61,10 @@ namespace Assimp {
 class StackAllocator {
 public:
     /// @brief Constructs the allocator
-    inline StackAllocator();
+    StackAllocator();
+
     /// @brief Destructs the allocator and frees all memory
-    inline ~StackAllocator();
+    ~StackAllocator();
 
     // non copyable
     StackAllocator(const StackAllocator &) = delete;

--- a/code/Common/StackAllocator.inl
+++ b/code/Common/StackAllocator.inl
@@ -45,8 +45,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using namespace Assimp;
 
-inline StackAllocator::StackAllocator() {
-}
+inline StackAllocator::StackAllocator() : m_storageBlocks() {}
 
 inline StackAllocator::~StackAllocator() {
     FreeAll();

--- a/code/Common/Subdivision.cpp
+++ b/code/Common/Subdivision.cpp
@@ -4,7 +4,6 @@ Open Asset Import Library (assimp)
 
 Copyright (c) 2006-2024, assimp team
 
-
 All rights reserved.
 
 Redistribution and use of this software in source and binary forms,

--- a/code/Common/TargetAnimation.cpp
+++ b/code/Common/TargetAnimation.cpp
@@ -4,7 +4,6 @@ Open Asset Import Library (assimp)
 
 Copyright (c) 2006-2024, assimp team
 
-
 All rights reserved.
 
 Redistribution and use of this software in source and binary forms,

--- a/code/Common/TargetAnimation.h
+++ b/code/Common/TargetAnimation.h
@@ -4,7 +4,6 @@ Open Asset Import Library (assimp)
 
 Copyright (c) 2006-2024, assimp team
 
-
 All rights reserved.
 
 Redistribution and use of this software in source and binary forms,
@@ -119,11 +118,15 @@ private:
  * look-at target */
 class TargetAnimationHelper {
 public:
+    ///	@brief The class constructor.
     TargetAnimationHelper() :
             targetPositions(nullptr),
             objectPositions(nullptr) {
         // empty
     }
+
+    ///	@brief The class destructor.
+    ~TargetAnimationHelper() = default;
 
     // ------------------------------------------------------------------
     /** Sets the target animation channel

--- a/code/Common/VertexTriangleAdjacency.cpp
+++ b/code/Common/VertexTriangleAdjacency.cpp
@@ -5,8 +5,6 @@ Open Asset Import Library (assimp)
 
 Copyright (c) 2006-2024, assimp team
 
-
-
 All rights reserved.
 
 Redistribution and use of this software in source and binary forms,

--- a/code/Common/ZipArchiveIOSystem.cpp
+++ b/code/Common/ZipArchiveIOSystem.cpp
@@ -62,13 +62,13 @@ namespace Assimp {
 // ----------------------------------------------------------------
 // A read-only file inside a ZIP
 
-class ZipFile : public IOStream {
+class ZipFile final : public IOStream {
     friend class ZipFileInfo;
     explicit ZipFile(std::string &filename, size_t size);
 
 public:
     std::string m_Filename;
-    virtual ~ZipFile() override;
+    ~ZipFile() override = default;
 
     // IOStream interface
     size_t Read(void *pvBuffer, size_t pSize, size_t pCount) override;
@@ -89,6 +89,8 @@ private:
 // Wraps an existing Assimp::IOSystem for unzip
 class IOSystem2Unzip {
 public:
+    IOSystem2Unzip() = default;
+    ~IOSystem2Unzip() = default;
     static voidpf open(voidpf opaque, const char *filename, int mode);
     static voidpf opendisk(voidpf opaque, voidpf stream, uint32_t number_disk, int mode);
     static uLong read(voidpf opaque, voidpf stream, void *buf, uLong size);
@@ -100,6 +102,7 @@ public:
     static zlib_filefunc_def get(IOSystem *pIOHandler);
 };
 
+// ----------------------------------------------------------------
 voidpf IOSystem2Unzip::open(voidpf opaque, const char *filename, int mode) {
     IOSystem *io_system = reinterpret_cast<IOSystem *>(opaque);
 
@@ -119,6 +122,7 @@ voidpf IOSystem2Unzip::open(voidpf opaque, const char *filename, int mode) {
     return (voidpf)io_system->Open(filename, mode_fopen);
 }
 
+// ----------------------------------------------------------------
 voidpf IOSystem2Unzip::opendisk(voidpf opaque, voidpf stream, uint32_t number_disk, int mode) {
     ZipFile *io_stream = (ZipFile *)stream;
     voidpf ret = nullptr;
@@ -141,24 +145,28 @@ voidpf IOSystem2Unzip::opendisk(voidpf opaque, voidpf stream, uint32_t number_di
     return ret;
 }
 
+// ----------------------------------------------------------------
 uLong IOSystem2Unzip::read(voidpf /*opaque*/, voidpf stream, void *buf, uLong size) {
     IOStream *io_stream = (IOStream *)stream;
 
     return static_cast<uLong>(io_stream->Read(buf, 1, size));
 }
 
+// ----------------------------------------------------------------
 uLong IOSystem2Unzip::write(voidpf /*opaque*/, voidpf stream, const void *buf, uLong size) {
     IOStream *io_stream = (IOStream *)stream;
 
     return static_cast<uLong>(io_stream->Write(buf, 1, size));
 }
 
+// ----------------------------------------------------------------
 long IOSystem2Unzip::tell(voidpf /*opaque*/, voidpf stream) {
     IOStream *io_stream = (IOStream *)stream;
 
     return static_cast<long>(io_stream->Tell());
 }
 
+// ----------------------------------------------------------------
 long IOSystem2Unzip::seek(voidpf /*opaque*/, voidpf stream, uLong offset, int origin) {
     IOStream *io_stream = (IOStream *)stream;
 
@@ -179,6 +187,7 @@ long IOSystem2Unzip::seek(voidpf /*opaque*/, voidpf stream, uLong offset, int or
     return (io_stream->Seek(offset, assimp_origin) == aiReturn_SUCCESS ? 0 : -1);
 }
 
+// ----------------------------------------------------------------
 int IOSystem2Unzip::close(voidpf opaque, voidpf stream) {
     IOSystem *io_system = (IOSystem *)opaque;
     IOStream *io_stream = (IOStream *)stream;
@@ -188,10 +197,12 @@ int IOSystem2Unzip::close(voidpf opaque, voidpf stream) {
     return 0;
 }
 
+// ----------------------------------------------------------------
 int IOSystem2Unzip::testerror(voidpf /*opaque*/, voidpf /*stream*/) {
     return 0;
 }
 
+// ----------------------------------------------------------------
 zlib_filefunc_def IOSystem2Unzip::get(IOSystem *pIOHandler) {
     zlib_filefunc_def mapping;
 
@@ -213,9 +224,10 @@ zlib_filefunc_def IOSystem2Unzip::get(IOSystem *pIOHandler) {
 
 // ----------------------------------------------------------------
 // Info about a read-only file inside a ZIP
-class ZipFileInfo {
+class ZipFileInfo final {
 public:
     explicit ZipFileInfo(unzFile zip_handle, size_t size);
+    ~ZipFileInfo() = default;
 
     // Allocate and Extract data from the ZIP
     ZipFile *Extract(std::string &filename, unzFile zip_handle) const;
@@ -225,6 +237,7 @@ private:
     unz_file_pos_s m_ZipFilePos;
 };
 
+// ----------------------------------------------------------------
 ZipFileInfo::ZipFileInfo(unzFile zip_handle, size_t size) :
         m_Size(size) {
     ai_assert(m_Size != 0);
@@ -234,6 +247,7 @@ ZipFileInfo::ZipFileInfo(unzFile zip_handle, size_t size) :
     unzGetFilePos(zip_handle, &(m_ZipFilePos));
 }
 
+// ----------------------------------------------------------------
 ZipFile *ZipFileInfo::Extract(std::string &filename, unzFile zip_handle) const {
     // Find in the ZIP. This cannot fail
     unz_file_pos_s *filepos = const_cast<unz_file_pos_s *>(&(m_ZipFilePos));
@@ -273,14 +287,14 @@ ZipFile *ZipFileInfo::Extract(std::string &filename, unzFile zip_handle) const {
     return zip_file;
 }
 
+// ----------------------------------------------------------------
 ZipFile::ZipFile(std::string &filename, size_t size) :
         m_Filename(filename), m_Size(size) {
     ai_assert(m_Size != 0);
     m_Buffer = std::unique_ptr<uint8_t[]>(new uint8_t[m_Size]);
 }
 
-ZipFile::~ZipFile() = default;
-
+// ----------------------------------------------------------------
 size_t ZipFile::Read(void *pvBuffer, size_t pSize, size_t pCount) {
     // Should be impossible
     ai_assert(m_Buffer != nullptr);
@@ -305,10 +319,12 @@ size_t ZipFile::Read(void *pvBuffer, size_t pSize, size_t pCount) {
     return pCount;
 }
 
+// ----------------------------------------------------------------
 size_t ZipFile::FileSize() const {
     return m_Size;
 }
 
+// ----------------------------------------------------------------
 aiReturn ZipFile::Seek(size_t pOffset, aiOrigin pOrigin) {
     switch (pOrigin) {
         case aiOrigin_SET: {
@@ -334,6 +350,7 @@ aiReturn ZipFile::Seek(size_t pOffset, aiOrigin pOrigin) {
     return aiReturn_FAILURE;
 }
 
+// ----------------------------------------------------------------
 size_t ZipFile::Tell() const {
     return m_SeekPtr;
 }
@@ -365,6 +382,7 @@ private:
     ZipFileInfoMap m_ArchiveMap;
 };
 
+// ----------------------------------------------------------------
 ZipArchiveIOSystem::Implement::Implement(IOSystem *pIOHandler, const char *pFilename, const char *pMode) {
     ai_assert(strcmp(pMode, "r") == 0);
     ai_assert(pFilename != nullptr);
@@ -376,12 +394,14 @@ ZipArchiveIOSystem::Implement::Implement(IOSystem *pIOHandler, const char *pFile
     m_ZipFileHandle = unzOpen2(pFilename, &mapping);
 }
 
+// ----------------------------------------------------------------
 ZipArchiveIOSystem::Implement::~Implement() {
     if (m_ZipFileHandle != nullptr) {
         unzClose(m_ZipFileHandle);
     }
 }
 
+// ----------------------------------------------------------------
 void ZipArchiveIOSystem::Implement::MapArchive() {
     if (m_ZipFileHandle == nullptr)
         return;
@@ -408,10 +428,12 @@ void ZipArchiveIOSystem::Implement::MapArchive() {
     } while (unzGoToNextFile(m_ZipFileHandle) != UNZ_END_OF_LIST_OF_FILE);
 }
 
+// ----------------------------------------------------------------
 bool ZipArchiveIOSystem::Implement::isOpen() const {
     return (m_ZipFileHandle != nullptr);
 }
 
+// ----------------------------------------------------------------
 void ZipArchiveIOSystem::Implement::getFileList(std::vector<std::string> &rFileList) {
     MapArchive();
     rFileList.clear();
@@ -421,6 +443,7 @@ void ZipArchiveIOSystem::Implement::getFileList(std::vector<std::string> &rFileL
     }
 }
 
+// ----------------------------------------------------------------
 void ZipArchiveIOSystem::Implement::getFileListExtension(std::vector<std::string> &rFileList, const std::string &extension) {
     MapArchive();
     rFileList.clear();
@@ -431,6 +454,7 @@ void ZipArchiveIOSystem::Implement::getFileListExtension(std::vector<std::string
     }
 }
 
+// ----------------------------------------------------------------
 bool ZipArchiveIOSystem::Implement::Exists(std::string &filename) {
     MapArchive();
 
@@ -438,6 +462,7 @@ bool ZipArchiveIOSystem::Implement::Exists(std::string &filename) {
     return (it != m_ArchiveMap.end());
 }
 
+// ----------------------------------------------------------------
 IOStream *ZipArchiveIOSystem::Implement::OpenFile(std::string &filename) {
     MapArchive();
 
@@ -452,6 +477,7 @@ IOStream *ZipArchiveIOSystem::Implement::OpenFile(std::string &filename) {
     return zip_file.Extract(filename, m_ZipFileHandle);
 }
 
+// ----------------------------------------------------------------
 inline void ReplaceAll(std::string &data, const std::string &before, const std::string &after) {
     size_t pos = data.find(before);
     while (pos != std::string::npos) {
@@ -460,6 +486,7 @@ inline void ReplaceAll(std::string &data, const std::string &before, const std::
     }
 }
 
+// ----------------------------------------------------------------
 inline void ReplaceAllChar(std::string &data, const char before, const char after) {
     size_t pos = data.find(before);
     while (pos != std::string::npos) {
@@ -468,6 +495,7 @@ inline void ReplaceAllChar(std::string &data, const char before, const char afte
     }
 }
 
+// ----------------------------------------------------------------
 void ZipArchiveIOSystem::Implement::SimplifyFilename(std::string &filename) {
     ReplaceAllChar(filename, '\\', '/');
 
@@ -492,6 +520,7 @@ void ZipArchiveIOSystem::Implement::SimplifyFilename(std::string &filename) {
     }
 }
 
+// ----------------------------------------------------------------
 ZipArchiveIOSystem::ZipArchiveIOSystem(IOSystem *pIOHandler, const char *pFilename, const char *pMode) :
         pImpl(new Implement(pIOHandler, pFilename, pMode)) {
 }
@@ -502,10 +531,12 @@ ZipArchiveIOSystem::ZipArchiveIOSystem(IOSystem *pIOHandler, const std::string &
         pImpl(new Implement(pIOHandler, rFilename.c_str(), pMode)) {
 }
 
+// ----------------------------------------------------------------
 ZipArchiveIOSystem::~ZipArchiveIOSystem() {
     delete pImpl;
 }
 
+// ----------------------------------------------------------------
 bool ZipArchiveIOSystem::Exists(const char *pFilename) const {
     ai_assert(pFilename != nullptr);
 
@@ -517,11 +548,13 @@ bool ZipArchiveIOSystem::Exists(const char *pFilename) const {
     return pImpl->Exists(filename);
 }
 
+// ----------------------------------------------------------------
 // This is always '/' in a ZIP
 char ZipArchiveIOSystem::getOsSeparator() const {
     return '/';
 }
 
+// ----------------------------------------------------------------
 // Only supports Reading
 IOStream *ZipArchiveIOSystem::Open(const char *pFilename, const char *pMode) {
     ai_assert(pFilename != nullptr);
@@ -536,22 +569,27 @@ IOStream *ZipArchiveIOSystem::Open(const char *pFilename, const char *pMode) {
     return pImpl->OpenFile(filename);
 }
 
+// ----------------------------------------------------------------
 void ZipArchiveIOSystem::Close(IOStream *pFile) {
     delete pFile;
 }
 
+// ----------------------------------------------------------------
 bool ZipArchiveIOSystem::isOpen() const {
     return (pImpl->isOpen());
 }
 
+// ----------------------------------------------------------------
 void ZipArchiveIOSystem::getFileList(std::vector<std::string> &rFileList) const {
     return pImpl->getFileList(rFileList);
 }
 
+// ----------------------------------------------------------------
 void ZipArchiveIOSystem::getFileListExtension(std::vector<std::string> &rFileList, const std::string &extension) const {
     return pImpl->getFileListExtension(rFileList, extension);
 }
 
+// ----------------------------------------------------------------
 bool ZipArchiveIOSystem::isZipArchive(IOSystem *pIOHandler, const char *pFilename) {
     Implement tmp(pIOHandler, pFilename, "r");
     return tmp.isOpen();

--- a/include/assimp/BaseImporter.h
+++ b/include/assimp/BaseImporter.h
@@ -95,7 +95,7 @@ public:
     BaseImporter() AI_NO_EXCEPT;
 
     /** Destructor, private as well */
-    virtual ~BaseImporter();
+    virtual ~BaseImporter() = default;
 
     // -------------------------------------------------------------------
     /** Returns whether the class can handle the format of the given file.

--- a/include/assimp/ByteSwapper.h
+++ b/include/assimp/ByteSwapper.h
@@ -4,7 +4,6 @@ Open Asset Import Library (assimp)
 
 Copyright (c) 2006-2024, assimp team
 
-
 All rights reserved.
 
 Redistribution and use of this software in source and binary forms,
@@ -66,10 +65,10 @@ namespace Assimp    {
  * and vice versa. Direct use of this class is DEPRECATED. Use #StreamReader instead. */
 // --------------------------------------------------------------------------------------
 class ByteSwap {
-    ByteSwap() AI_NO_EXCEPT {}
+    ByteSwap() AI_NO_EXCEPT = default;
+    ~ByteSwap() = default;
 
 public:
-
     // ----------------------------------------------------------------------
     /** Swap two bytes of data
      *  @param[inout] _szOut A void* to save the reintcasts for the caller. */
@@ -89,8 +88,7 @@ public:
     // ----------------------------------------------------------------------
     /** Swap four bytes of data
      *  @param[inout] _szOut A void* to save the reintcasts for the caller. */
-    static inline void Swap4(void* _szOut)
-    {
+    static inline void Swap4(void* _szOut) {
         ai_assert(_szOut);
 
 #if _MSC_VER >= 1400

--- a/include/assimp/IOStream.hpp
+++ b/include/assimp/IOStream.hpp
@@ -73,14 +73,14 @@ class ASSIMP_API IOStream
 {
 protected:
     /** Constructor protected, use IOSystem::Open() to create an instance. */
-    IOStream() AI_NO_EXCEPT;
+    IOStream() AI_NO_EXCEPT = default;
 
 public:
     // -------------------------------------------------------------------
     /** @brief Destructor. Deleting the object closes the underlying file,
      * alternatively you may use IOSystem::Close() to release the file.
      */
-    virtual ~IOStream();
+    virtual ~IOStream() = default;
 
     // -------------------------------------------------------------------
     /** @brief Read from the file
@@ -125,15 +125,6 @@ public:
      */
     virtual void Flush() = 0;
 }; //! class IOStream
-
-// ----------------------------------------------------------------------------------
-AI_FORCE_INLINE
-IOStream::IOStream() AI_NO_EXCEPT = default;
-
-// ----------------------------------------------------------------------------------
-AI_FORCE_INLINE
-IOStream::~IOStream() = default;
-// ----------------------------------------------------------------------------------
 
 } //!namespace Assimp
 

--- a/include/assimp/IOStreamBuffer.h
+++ b/include/assimp/IOStreamBuffer.h
@@ -66,7 +66,7 @@ public:
     IOStreamBuffer(size_t cache = 4096 * 4096);
 
     /// @brief  The class destructor.
-    ~IOStreamBuffer();
+    ~IOStreamBuffer() = default;
 
     /// @brief  Will open the cached access for a given stream.
     /// @param  stream      The stream to cache.
@@ -139,9 +139,6 @@ AI_FORCE_INLINE IOStreamBuffer<T>::IOStreamBuffer(size_t cache) :
     m_cache.resize(cache);
     std::fill(m_cache.begin(), m_cache.end(), '\n');
 }
-
-template <class T>
-AI_FORCE_INLINE IOStreamBuffer<T>::~IOStreamBuffer() = default;
 
 template <class T>
 AI_FORCE_INLINE bool IOStreamBuffer<T>::open(IOStream *stream) {

--- a/include/assimp/Importer.hpp
+++ b/include/assimp/Importer.hpp
@@ -5,8 +5,6 @@ Open Asset Import Library (assimp)
 
 Copyright (c) 2006-2024, assimp team
 
-
-
 All rights reserved.
 
 Redistribution and use of this software in source and binary forms,

--- a/include/assimp/LineSplitter.h
+++ b/include/assimp/LineSplitter.h
@@ -86,7 +86,7 @@ public:
     */
     LineSplitter(StreamReaderLE& stream, bool skip_empty_lines = true, bool trim = true);
 
-    ~LineSplitter();
+    ~LineSplitter() = default;
 
     // -----------------------------------------
     /** pseudo-iterator increment */
@@ -159,8 +159,6 @@ AI_FORCE_INLINE LineSplitter::LineSplitter(StreamReaderLE& stream, bool skip_emp
     operator++();
     mIdx = 0;
 }
-
-AI_FORCE_INLINE LineSplitter::~LineSplitter() = default;
 
 AI_FORCE_INLINE LineSplitter& LineSplitter::operator++() {
     if (mSwallow) {

--- a/include/assimp/SGSpatialSort.h
+++ b/include/assimp/SGSpatialSort.h
@@ -4,7 +4,6 @@ Open Asset Import Library (assimp)
 
 Copyright (c) 2006-2024, assimp team
 
-
 All rights reserved.
 
 Redistribution and use of this software in source and binary forms,
@@ -63,10 +62,8 @@ namespace Assimp    {
  *  implementation to handle all details of its file format correctly.
  */
 // ----------------------------------------------------------------------------------
-class ASSIMP_API SGSpatialSort
-{
+class ASSIMP_API SGSpatialSort {
 public:
-
     SGSpatialSort();
 
     // -------------------------------------------------------------------
@@ -90,7 +87,7 @@ public:
     void Prepare();
 
     /** Destructor */
-    ~SGSpatialSort();
+    ~SGSpatialSort() = default;
 
     // -------------------------------------------------------------------
     /** Returns an iterator for all positions close to the given position.

--- a/include/assimp/aabb.h
+++ b/include/assimp/aabb.h
@@ -59,18 +59,12 @@ struct aiAABB {
 
 #ifdef __cplusplus
     /// @brief The default class constructor.
-    aiAABB() :
-            mMin(), mMax() {
-        // empty
-    }
+    aiAABB() = default;
 
     /// @brief The class constructor with the minimum and maximum.
     /// @param min  The minimum dimension.
     /// @param max  The maximum dimension.
-    aiAABB(const aiVector3D &min, const aiVector3D &max) :
-            mMin(min), mMax(max) {
-        // empty
-    }
+    aiAABB(const aiVector3D &min, const aiVector3D &max) : mMin(min), mMax(max) {}
 
     ///	@brief  The class destructor.
     ~aiAABB() = default;

--- a/include/assimp/anim.h
+++ b/include/assimp/anim.h
@@ -90,6 +90,7 @@ struct aiVectorKey {
     bool operator==(const aiVectorKey &rhs) const {
         return rhs.mValue == this->mValue;
     }
+
     bool operator!=(const aiVectorKey &rhs) const {
         return rhs.mValue != this->mValue;
     }


### PR DESCRIPTION
- Remove default marked destructors from cpp files
- Unify importer doc
- Make importers final
- Replace typedefs by using statements