### PR TITLE
Fix SplitByBoneCount.

### DIFF
--- a/code/PostProcessing/SplitByBoneCountProcess.cpp
+++ b/code/PostProcessing/SplitByBoneCountProcess.cpp
@@ -394,7 +394,7 @@ void SplitByBoneCountProcess::SplitMesh( const aiMesh* pMesh, std::vector<aiMesh
 // Recursively updates the node's mesh list to account for the changed mesh list
 void SplitByBoneCountProcess::UpdateNode( aiNode* pNode) const {
     // rebuild the node's mesh index list
-    if( pNode->mNumMeshes == 0 ) {
+    if( pNode->mNumMeshes > 0 ) {
         IndexArray newMeshList;
         for( unsigned int a = 0; a < pNode->mNumMeshes; ++a) {
             unsigned int srcIndex = pNode->mMeshes[a];


### PR DESCRIPTION
Broken in 1147f0c8bde73b8e86adf24d1ef986cd841e80f1. Nodes' mesh index lists were not updated properly.