### PR TITLE
Reverts the changes introduced by commit ad766cb in February 2022.

### DIFF
--- a/code/PostProcessing/CalcTangentsProcess.cpp
+++ b/code/PostProcessing/CalcTangentsProcess.cpp
@@ -195,7 +195,7 @@ bool CalcTangentsProcess::ProcessMesh(aiMesh *pMesh, unsigned int meshIndex) {
 
             // project tangent and bitangent into the plane formed by the vertex' normal
             aiVector3D localTangent = tangent - meshNorm[p] * (tangent * meshNorm[p]);
-            aiVector3D localBitangent = bitangent - meshNorm[p] * (bitangent * meshNorm[p])
+            aiVector3D localBitangent = bitangent - meshNorm[p] * (bitangent * meshNorm[p]);
             localTangent.NormalizeSafe();
             localBitangent.NormalizeSafe();
 

--- a/code/PostProcessing/CalcTangentsProcess.cpp
+++ b/code/PostProcessing/CalcTangentsProcess.cpp
@@ -185,9 +185,9 @@ bool CalcTangentsProcess::ProcessMesh(aiMesh *pMesh, unsigned int meshIndex) {
         tangent.x = (w.x * sy - v.x * ty) * dirCorrection;
         tangent.y = (w.y * sy - v.y * ty) * dirCorrection;
         tangent.z = (w.z * sy - v.z * ty) * dirCorrection;
-        bitangent.x = (- w.x * sx + v.x * tx) * dirCorrection;
-        bitangent.y = (- w.y * sx + v.y * tx) * dirCorrection;
-        bitangent.z = (- w.z * sx + v.z * tx) * dirCorrection;
+        bitangent.x = (w.x * sx - v.x * tx) * dirCorrection;
+        bitangent.y = (w.y * sx - v.y * tx) * dirCorrection;
+        bitangent.z = (w.z * sx - v.z * tx) * dirCorrection;
 
         // store for every vertex of that face
         for (unsigned int b = 0; b < face.mNumIndices; ++b) {
@@ -195,7 +195,7 @@ bool CalcTangentsProcess::ProcessMesh(aiMesh *pMesh, unsigned int meshIndex) {
 
             // project tangent and bitangent into the plane formed by the vertex' normal
             aiVector3D localTangent = tangent - meshNorm[p] * (tangent * meshNorm[p]);
-            aiVector3D localBitangent = bitangent - meshNorm[p] * (bitangent * meshNorm[p]) - localTangent * (bitangent * localTangent);
+            aiVector3D localBitangent = bitangent - meshNorm[p] * (bitangent * meshNorm[p])
             localTangent.NormalizeSafe();
             localBitangent.NormalizeSafe();
 


### PR DESCRIPTION
ASSIMP's way of calculating bitangents before commit ad766cb was just fine, but unfortunately it was changed by that commit in February 2022, breaking compatibility to previous code.

It introduces two problems:
- It orthogonalizes bitangents w.r.t. tangents (which is generally wrong for texture-mapped meshes).
- It changes the handedness, which is arguably not totally wrong, but breaks compatibility to previous code which uses ASSIMP.

More detailed explanation why the old code was just fine is given in Q&A #5512 

**Suggestion: Just revert to the old code, which this pull request suggests.**