### PR TITLE
Converted a size_t to mz_uint that was being treated as an error

### DIFF
--- a/contrib/zip/src/zip.c
+++ b/contrib/zip/src/zip.c
@@ -1239,7 +1239,7 @@ int zip_entry_openbyindex(struct zip_t *zip, size_t index) {
   if (!(pHeader = &MZ_ZIP_ARRAY_ELEMENT(
             &pZip->m_pState->m_central_dir, mz_uint8,
             MZ_ZIP_ARRAY_ELEMENT(&pZip->m_pState->m_central_dir_offsets,
-                                 mz_uint32, index)))) {
+                                 mz_uint32, (mz_uint)index)))) {
     // cannot find header in central directory
     return ZIP_ENOHDR;
   }


### PR DESCRIPTION
Original error during building 

```assimp\contrib\zip\src\zip.c(1239,20): error C2220: the following warning is treated as an error```

```assimp\contrib\zip\src\zip.c(1239,20): warning C4267: 'function': conversion from 'size_t' to 'mz_uint', possible loss of data```
