### PR TITLE
Some FBXs do not have "Materials" information, which can cause parsing errors

### DIFF
--- a/code/AssetLib/FBX/FBXMeshGeometry.cpp
+++ b/code/AssetLib/FBX/FBXMeshGeometry.cpp
@@ -644,10 +644,12 @@ void MeshGeometry::ReadVertexDataMaterials(std::vector<int>& materials_out, cons
         return;
     }
 
-    // materials are handled separately. First of all, they are assigned per-face
-    // and not per polyvert. Secondly, ReferenceInformationType=IndexToDirect
-    // has a slightly different meaning for materials.
-    ParseVectorDataArray(materials_out,GetRequiredElement(source,"Materials"));
+    if (source["Materials"]) {
+        // materials are handled separately. First of all, they are assigned per-face
+        // and not per polyvert. Secondly, ReferenceInformationType=IndexToDirect
+        // has a slightly different meaning for materials.
+        ParseVectorDataArray(materials_out, GetRequiredElement(source, "Materials"));
+    }
 
     if (MappingInformationType == "AllSame") {
         // easy - same material for all faces


### PR DESCRIPTION
Add a conditional judgment to prevent errors.

this test fbx file:
[pipe7.7_test1.fbx.zip](https://github.com/user-attachments/files/15865385/pipe7.7_test1.fbx.zip)
