### PR TITLE
remove ASE parsing break

### DIFF
--- a/code/AssetLib/ASE/ASEParser.cpp
+++ b/code/AssetLib/ASE/ASEParser.cpp
@@ -513,7 +513,6 @@ void Parser::ParseLV1MaterialListBlock() {
                 if (iIndex >= iMaterialCount) {
                     LogWarning("Out of range: material index is too large");
                     iIndex = iMaterialCount - 1;
-                    return;
                 }
 
                 // get a reference to the material


### PR DESCRIPTION
remove ASE parsing break added in c1968823adfb8c997f98671becca51fc54614da7 : original intent was to keep parsing

crash case (iMaterialCount = 0) is handled by 47dbabadcd683724be26109c757ad86f4645d280
