### PR TITLE
Fix names of enum values in docstring of aiProcess_FindDegenerates

### DIFF
--- a/include/assimp/postprocess.h
+++ b/include/assimp/postprocess.h
@@ -379,7 +379,7 @@ enum aiPostProcessSteps
      *     point primitives to separate meshes.
      *   </li>
      *   <li>Set the <tt>#AI_CONFIG_PP_SBP_REMOVE</tt> importer property to
-     *       @code aiPrimitiveType_POINTS | aiPrimitiveType_LINES
+     *       @code aiPrimitiveType_POINT | aiPrimitiveType_LINE
      *       @endcode to cause SortByPType to reject point
      *       and line meshes from the scene.
      *   </li>

--- a/port/PyAssimp/pyassimp/postprocess.py
+++ b/port/PyAssimp/pyassimp/postprocess.py
@@ -270,7 +270,7 @@ aiProcess_SortByPType = 0x8000
 #     point primitives to separate meshes.
 #   <li>
 #   <li>Set the <tt>AI_CONFIG_PP_SBP_REMOVE<tt> option to 
-#       @code aiPrimitiveType_POINTS | aiPrimitiveType_LINES
+#       @code aiPrimitiveType_POINT | aiPrimitiveType_LINE
 #       @endcode to cause SortByPType to reject point
 #       and line meshes from the scene.
 #   <li>

--- a/port/dAssimp/assimp/postprocess.d
+++ b/port/dAssimp/assimp/postprocess.d
@@ -348,7 +348,7 @@ extern ( C ) {
        *   <li>Specify the <code>SortByPType</code> flag. This moves line and
        *      point primitives to separate meshes.</li>
        *   <li>Set the <code>AI_CONFIG_PP_SBP_REMOVE</codet> option to
-       *      <code>aiPrimitiveType_POINTS | aiPrimitiveType_LINES</code>
+       *      <code>aiPrimitiveType_POINT | aiPrimitiveType_LINE</code>
        *      to cause SortByPType to reject point and line meshes from the
        *      scene.</li>
        * </ul>

--- a/port/jassimp/jassimp/src/jassimp/AiPostProcessSteps.java
+++ b/port/jassimp/jassimp/src/jassimp/AiPostProcessSteps.java
@@ -349,7 +349,7 @@ public enum AiPostProcessSteps {
      *   <li>Specify the #SortByPType flag. This moves line and point 
      *       primitives to separate meshes.
      *   <li>Set the <tt>AI_CONFIG_PP_SBP_REMOVE</tt> option to
-     *       <code>aiPrimitiveType_POINTS | aiPrimitiveType_LINES</code>
+     *       <code>aiPrimitiveType_POINT | aiPrimitiveType_LINE</code>
      *       to cause SortByPType to reject point and line meshes from the 
      *       scene.
      * </ul>


### PR DESCRIPTION
The names of the `aiPrimitiveType` point and line are misspelled with a plural 's' in the docstring of the `aiProcess_FindDegenerates` flag. The enum values are defined in `include/assimp/mesh.h`

Also, I think the docstring for `mMeshes` in https://github.com/assimp/assimp/blob/cdf8394ccc4adac94aae9ac395d09eb03608ef2d/include/assimp/scene.h#L271 might not be correct; shouldnt the last sentence be "... there will always be at least ONE mesh.", since this is the docstring of `mMeshes` and materials are declared later in the file? If someone can confirm this, I will create a separate PR for this minor change.