### PR TITLE
Fixes some uninit bool loads

### DIFF
--- a/code/PostProcessing/LimitBoneWeightsProcess.cpp
+++ b/code/PostProcessing/LimitBoneWeightsProcess.cpp
@@ -53,7 +53,8 @@ namespace Assimp {
 
 // ------------------------------------------------------------------------------------------------
 // Constructor to be privately used by Importer
-LimitBoneWeightsProcess::LimitBoneWeightsProcess() : mMaxWeights(AI_LMW_MAX_WEIGHTS) {
+LimitBoneWeightsProcess::LimitBoneWeightsProcess() :
+        mMaxWeights(AI_LMW_MAX_WEIGHTS), mRemoveEmptyBones(true) {
     // empty
 }
 

--- a/include/assimp/metadata.h
+++ b/include/assimp/metadata.h
@@ -113,19 +113,19 @@ struct aiMetadata;
   */
 // -------------------------------------------------------------------------------
 
-inline aiMetadataType GetAiType(bool) {
+inline aiMetadataType GetAiType(const bool &) {
     return AI_BOOL;
 }
 inline aiMetadataType GetAiType(int32_t) {
     return AI_INT32;
 }
-inline aiMetadataType GetAiType(uint64_t) {
+inline aiMetadataType GetAiType(const uint64_t &) {
     return AI_UINT64;
 }
-inline aiMetadataType GetAiType(float) {
+inline aiMetadataType GetAiType(const float &) {
     return AI_FLOAT;
 }
-inline aiMetadataType GetAiType(double) {
+inline aiMetadataType GetAiType(const double &) {
     return AI_DOUBLE;
 }
 inline aiMetadataType GetAiType(const aiString &) {
@@ -137,10 +137,10 @@ inline aiMetadataType GetAiType(const aiVector3D &) {
 inline aiMetadataType GetAiType(const aiMetadata &) {
     return AI_AIMETADATA;
 }
-inline aiMetadataType GetAiType(int64_t) {
+inline aiMetadataType GetAiType(const int64_t &) {
     return AI_INT64;
 }
-inline aiMetadataType GetAiType(uint32_t) {
+inline aiMetadataType GetAiType(const uint32_t &) {
     return AI_UINT32;
 }
 

--- a/test/unit/utMetadata.cpp
+++ b/test/unit/utMetadata.cpp
@@ -242,6 +242,22 @@ TEST_F( utMetadata, copy_test ) {
         EXPECT_EQ( i32v, v );
     }
 
+    // uint32_t test
+    {
+        uint32_t v = 0;
+        bool ok = copy.Get("uint32_t", v);
+        EXPECT_TRUE(ok);
+        EXPECT_EQ( ui32, v );
+    }
+
+    // int64_t test
+    {
+        int64_t v = -1;
+        bool ok = copy.Get("int64_t", v);
+        EXPECT_TRUE(ok);
+        EXPECT_EQ( i64, v );
+    }
+
     // uint64_t test
     {
         uint64_t v = 255;
@@ -264,14 +280,14 @@ TEST_F( utMetadata, copy_test ) {
         EXPECT_EQ( dv, v );
     }
 
-    // bool test
+    // string test
     {
         aiString v;
         EXPECT_TRUE( copy.Get( "aiString", v ) );
         EXPECT_EQ( strVal, v );
     }
 
-    // bool test
+    // vector test
     {
         aiVector3D v;
         EXPECT_TRUE( copy.Get( "aiVector3D", v ) );


### PR DESCRIPTION
This PR fixes some bool loads which are not initialized. With ubsan and the "option -fsanitize=bool", this results in a runtime error during test execution.

When running the unittest suite with activated UBSan with Clang 17.0.6, I get 2 runtime errors.

- `mRemoveEmptyBones` is not initialized when running the test "LimitBoneWeightTest". It is not initialized due to missing `SetupProperties` call. I decided to initialize the option with default off, in case someone else calls "processMesh" without setting up the properties first. I decided for default true value, is this seems to be the default value in SetupProperties, when it is not defined
```
this->mRemoveEmptyBones = pImp->GetPropertyInteger(AI_CONFIG_IMPORT_REMOVE_EMPTY_BONES, 1) != 0;
```

- uninit load in "utMetadata.copy_test". Here, in the "bool" test case, the recieving bool is not initialized. It gets theoretically loaded in the "GetAiType" overloaded function (due to call-by-copy) and is never used. In Release mode, it probably just get optimized away, but in Debug mode, a false warning of UBSan can be annoying. I also added call-by-ref functions for the other pod types, in case UBSan adds these checks for the other types.


I hope you like it.

edit: [1] reference to ubsan with "-fsanitize=bool" option: https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html