### PR TITLE
fixes potential memory leak on malformed obj file

### DIFF
--- a/code/AssetLib/Obj/ObjFileImporter.h
+++ b/code/AssetLib/Obj/ObjFileImporter.h
@@ -44,6 +44,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <assimp/BaseImporter.h>
 #include <assimp/material.h>
+#include <memory>
 #include <vector>
 
 struct aiMesh;
@@ -84,10 +85,10 @@ protected:
 
     //! \brief  Creates all nodes stored in imported content.
     aiNode *createNodes(const ObjFile::Model *pModel, const ObjFile::Object *pData,
-            aiNode *pParent, aiScene *pScene, std::vector<aiMesh *> &MeshArray);
+            aiNode *pParent, aiScene *pScene, std::vector<std::unique_ptr<aiMesh>> &MeshArray);
 
     //! \brief  Creates topology data like faces and meshes for the geometry.
-    aiMesh *createTopology(const ObjFile::Model *pModel, const ObjFile::Object *pData,
+    std::unique_ptr<aiMesh> createTopology(const ObjFile::Model *pModel, const ObjFile::Object *pData,
             unsigned int uiMeshIndex);
 
     //! \brief  Creates vertices from model.


### PR DESCRIPTION
Fixes memory leak detected by the fuzzer. 
Relevant Issue: https://github.com/assimp/assimp/issues/4131

Not sure, if I can change the protected interface in ObjFileImporter, in case someone inherits from it.  
If this interface change is not Ok, I can rewrite the fix.