### PR TITLE
Fix: StackAllocator.h linkage fix

### DIFF
--- a/code/Common/StackAllocator.h
+++ b/code/Common/StackAllocator.h
@@ -88,6 +88,11 @@ private:
 
 } // namespace Assimp
 
+/// @brief Fixes an undefined reference error when linking in certain build environments.
+//         May throw warnings about needing stdc++17, but should compile without issues on modern compilers.
+inline const size_t Assimp::StackAllocator::g_maxBytesPerBlock;
+inline const size_t Assimp::StackAllocator::g_startBytesPerBlock;
+
 #include "StackAllocator.inl"
 
 #endif // include guard


### PR DESCRIPTION
I'm currently porting over the Thunder game engine to work on the BSD platforms (with its developer's help) and ran into a peculiar issue (see number 8 here: https://github.com/thunder-engine/thunder/issues/770). This fix will require std:c++17 set for certain build environments, so if there's a better way to go about it, I'm all ears.