### PR TITLE
Fix: StackAllocator Undefined Reference fix

### DIFF
--- a/code/Common/StackAllocator.h
+++ b/code/Common/StackAllocator.h
@@ -88,6 +88,11 @@ private:
 
 } // namespace Assimp
 
+/// @brief Fixes an undefined reference error when linking in certain build environments.
+//         May throw warnings about needing stdc++17, but should compile without issues on modern compilers.
+inline const size_t Assimp::StackAllocator::g_maxBytesPerBlock;
+inline const size_t Assimp::StackAllocator::g_startBytesPerBlock;
+
 #include "StackAllocator.inl"
 
 #endif // include guard


### PR DESCRIPTION
Hey there. This fix is very simple but leaves the ability to adjust the StackAllocator. On the BSDs and Mac, when building a static library and building the FBX Importer, on certain configurations, this error can appear: `/usr/local/bin/ld: ../engine/libengine-editor.so: undefined reference to Assimp::StackAllocator::g_maxBytesPerBlock`.

An alternative suggestion can be found here: https://github.com/thunder-engine/thunder/pull/771#discussion_r1661843671