### PR TITLE
Added ADD condition in poly2tri dll_symbol.h to only define macros fo…

### DIFF
--- a/contrib/poly2tri/poly2tri/common/dll_symbol.h
+++ b/contrib/poly2tri/poly2tri/common/dll_symbol.h
@@ -31,11 +31,11 @@
 
 #pragma once
 
-#if defined(_WIN32)
+#if defined(_WIN32) && defined(ASSIMP_BUILD_DLL_EXPORT)
 #  pragma warning( disable: 4273)
 #  define P2T_COMPILER_DLLEXPORT __declspec(dllexport)
 #  define P2T_COMPILER_DLLIMPORT __declspec(dllimport)
-#elif defined(__GNUC__)
+#elif defined(__GNUC__) && defined(ASSIMP_BUILD_DLL_EXPORT)
 #  define P2T_COMPILER_DLLEXPORT __attribute__ ((visibility ("default")))
 #  define P2T_COMPILER_DLLIMPORT __attribute__ ((visibility ("default")))
 #else


### PR DESCRIPTION
I found out that the issue #5689 was caused by the recent update of poly2tri library in #5682,  the added [dll_symbol.h](https://github.com/assimp/assimp/commit/571ba09dc779e453d0074bfa169aa46003e15296#diff-e72e15e95c897b107e2f693545f2656e72b7164728708fc52b817cc2d8d2971b) file defines the macro P2T_COMPILER_DLLEXPORT to allow to exporting/importing functions for DLL but the only check that it performs to define those is the platform, this causes even when building assimp as a static-link library to still have the DLL exports. I made this change to also check if ASSIMP_BUILD_DLL_EXPORT, I'm not sure if this would be an acceptable change to solve this issue or if would be better to create a different macro for poly2tri or even open an issue to get a specific macro defined in the library.