### PR TITLE
FBX exporter - handle multiple vertex color channels

### DIFF
--- a/code/AssetLib/FBX/FBXExporter.cpp
+++ b/code/AssetLib/FBX/FBXExporter.cpp
@@ -1217,10 +1217,8 @@ void FBXExporter::WriteObjects ()
         }
 
         // colors, if any
-        // TODO only one color channel currently
-        const int32_t colorChannelIndex = 0;
-        if (m->HasVertexColors(colorChannelIndex)) {
-            FBX::Node vertexcolors("LayerElementColor", int32_t(colorChannelIndex));
+        for (size_t ci = 0; ci < m->GetNumColorChannels(); ++ci) {
+            FBX::Node vertexcolors("LayerElementColor", int32_t(ci));
             vertexcolors.Begin(outstream, binary, indent);
             vertexcolors.DumpProperties(outstream, binary, indent);
             vertexcolors.EndProperties(outstream, binary, indent);
@@ -1230,7 +1228,7 @@ void FBXExporter::WriteObjects ()
                 "Version", int32_t(101), outstream, binary, indent
             );
             char layerName[8];
-            snprintf(layerName, sizeof(layerName), "COLOR_%d", colorChannelIndex);
+            snprintf(layerName, sizeof(layerName), "COLOR_%d", int32_t(ci));
             FBX::Node::WritePropertyNode(
                 "Name", (const char*)layerName, outstream, binary, indent
             );
@@ -1247,7 +1245,7 @@ void FBXExporter::WriteObjects ()
             for (size_t fi = 0; fi < m->mNumFaces; ++fi) {
                 const aiFace &f = m->mFaces[fi];
                 for (size_t pvi = 0; pvi < f.mNumIndices; ++pvi) {
-                    const aiColor4D &c = m->mColors[colorChannelIndex][f.mIndices[pvi]];
+                    const aiColor4D &c = m->mColors[ci][f.mIndices[pvi]];
                     color_data.push_back(c.r);
                     color_data.push_back(c.g);
                     color_data.push_back(c.b);
@@ -1354,11 +1352,14 @@ void FBXExporter::WriteObjects ()
         le.AddChild("Type", "LayerElementNormal");
         le.AddChild("TypedIndex", int32_t(0));
         layer.AddChild(le);
-        // TODO only 1 color channel currently
-        le = FBX::Node("LayerElement");
-        le.AddChild("Type", "LayerElementColor");
-        le.AddChild("TypedIndex", int32_t(0));
-        layer.AddChild(le);
+
+        for (size_t ci = 0; ci < m->GetNumColorChannels(); ++ci) {
+            le = FBX::Node("LayerElement");
+            le.AddChild("Type", "LayerElementColor");
+            le.AddChild("TypedIndex", int32_t(ci));
+            layer.AddChild(le);
+        }
+
         le = FBX::Node("LayerElement");
         le.AddChild("Type", "LayerElementMaterial");
         le.AddChild("TypedIndex", int32_t(0));


### PR DESCRIPTION
The FBX exporter currently only handles one vertex color channel; this pull request changes it to support multiple color channels.
Tested with blender, all color channels are correctly visible as color attributes.