### PR TITLE
Fixing static builds on Windows

### DIFF
--- a/contrib/poly2tri/poly2tri/common/dll_symbol.h
+++ b/contrib/poly2tri/poly2tri/common/dll_symbol.h
@@ -53,7 +53,9 @@
 #    define P2T_DLL_SYMBOL
 #  elif defined(P2T_SHARED_EXPORTS)
 #    define P2T_DLL_SYMBOL P2T_COMPILER_DLLEXPORT
-#  else
+#  elif defined(BUILD_SHARED_LIBS)
 #    define P2T_DLL_SYMBOL P2T_COMPILER_DLLIMPORT
+#  else
+#    define P2T_DLL_SYMBOL
 #  endif
 #endif


### PR DESCRIPTION
It seems that even with `BUILD_SHARED_LIBS` set to "OFF", this line here emits dlimports: https://github.com/assimp/assimp/blob/48c3a0ec46d2d67ad355b2ab727f503f67d9d7ce/contrib/poly2tri/poly2tri/common/dll_symbol.h#L57

I've added a check to see if BUILD_SHARED_LIBS is ON before defining `P2T_DLL_SYMBOL` as `P2T_COMPILER_DLLIMPORT`, and now for static builds this symbol is correctly undefined. 