### PR TITLE
Revert variable name

### DIFF
--- a/code/AssetLib/USD/USDLoaderImplTinyusdz.cpp
+++ b/code/AssetLib/USD/USDLoaderImplTinyusdz.cpp
@@ -72,7 +72,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "../../../contrib/tinyusdz/assimp_tinyusdz_logging.inc"
 
 namespace {
-    static constexpr char Tag[] = "tinyusdz loader";
+    static constexpr char TAG[] = "tinyusdz loader";
 }
 
 namespace Assimp {


### PR DESCRIPTION
Variable name `TAG` was changed to `Tag` during refactor, broke build on android; this PR reverts the name to fix the problem

Fixes #5714