### PR TITLE
Add compile option /source-charset:utf-8 for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,6 +306,8 @@ ELSEIF(MSVC)
   elseif((GENERATOR_IS_MULTI_CONFIG) OR (CMAKE_BUILD_TYPE MATCHES Release))
     message("-- MSVC PDB generation disabled. Release binary will not be debuggable.")
   endif()
+  # Source code is encoded in UTF-8
+  ADD_COMPILE_OPTIONS(/source-charset:utf-8)
 ELSEIF (CMAKE_CXX_COMPILER_ID MATCHES "Clang" )
   IF(NOT ASSIMP_HUNTER_ENABLED)
     SET(CMAKE_POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
### Probrem
The following warning occurs when using cmake to build on Windows.

> assimp\contrib\poly2tri\poly2tri\sweep\sweep.h(1,1): warning C4819: The file contains a character that cannot be represented in the current code page (932). Save the file in Unicode format to prevent data loss

The build will fail because warnings are treated as errors.

### Cause
The cause of the error is that the following line in `contrib/poly2tri/poly2tri/sweep/sweep.h` contains non-ASCII characters.

https://github.com/assimp/assimp/blob/d95a5c60ef4948f52b5bd25de69a6896394a4660/contrib/poly2tri/poly2tri/sweep/sweep.h#L36

### Solution
This PR solves the problem by adding `/source-charset:utf-8` to the MSVC compile options.

* [/source-charset](https://learn.microsoft.com/en-us/cpp/build/reference/source-charset-set-source-character-set?view=msvc-170)

### Comman line
The command line that results in a build error is shown below.

```
c:\Users\kenic\Documents\dev\assimp>mkdir build

c:\Users\kenic\Documents\dev\assimp>cd build

c:\Users\kenic\Documents\dev\assimp\build>cmake ..
-- Building for: Visual Studio 17 2022
-- Selecting Windows SDK version 10.0.22621.0 to target Windows 10.0.22631.
-- The C compiler identification is MSVC 19.41.34120.0
-- The CXX compiler identification is MSVC 19.41.34120.0
<<snip>>
-- Treating all warnings as errors (for assimp library only)
-- Configuring done (6.5s)
-- Generating done (0.1s)
-- Build files have been written to: C:/Users/kenic/Documents/dev/assimp/build

c:\Users\kenic\Documents\dev\assimp\build>cmake --build .
MSBuild version 17.11.2+c078802d4 for .NET Framework

  1>Checking Build System
<<snip>>
  BlenderBMesh.cpp
  BlenderTessellator.cpp
  BlenderCustomData.cpp
  IFCLoader.cpp
  IFCReaderGen1_2x3.cpp
  IFCReaderGen2_2x3.cpp
  IFCUtil.cpp
  IFCGeometry.cpp
C:\Users\kenic\Documents\dev\assimp\contrib\poly2tri\poly2tri\sweep\sweep.h(1,1): error C2220: the follow
ing warning is treated as an error [C:\Users\kenic\Documents\dev\assimp\build\code\assimp.vcxproj]
  IFCMaterial.cpp
  IFCProfile.cpp
  (compiling source file '../../code/AssetLib/Blender/BlenderBMesh.cpp')

C:\Users\kenic\Documents\dev\assimp\contrib\poly2tri\poly2tri\sweep\sweep.h(1,1): warning C4819: The file
 contains a character that cannot be represented in the current code page (932). Save the file in Unicode
 format to prevent data loss [C:\Users\kenic\Documents\dev\assimp\build\code\assimp.vcxproj]
<<snip>>
```
