### PR TITLE
Fixed some library build lines in the MinGW C++ Compiler on Windows.

### DIFF
--- a/contrib/poly2tri/poly2tri/common/dll_symbol.h
+++ b/contrib/poly2tri/poly2tri/common/dll_symbol.h
@@ -32,7 +32,6 @@
 #pragma once
 
 #if defined(_WIN32)
-#  pragma warning( disable: 4273)
 #  define P2T_COMPILER_DLLEXPORT __declspec(dllexport)
 #  define P2T_COMPILER_DLLIMPORT __declspec(dllimport)
 #elif defined(__GNUC__)

--- a/contrib/poly2tri/poly2tri/common/shapes.h
+++ b/contrib/poly2tri/poly2tri/common/shapes.h
@@ -39,9 +39,6 @@
 #include <vector>
 
 
-#if defined(_WIN32)
-#  pragma warning( disable: 4251)
-#endif
 namespace p2t {
 
 struct Edge;


### PR DESCRIPTION
This parts was causing unnecessary errors when using the MinGW C++ Compiler on Windows