### PR TITLE
Fix to check both types of slashes in GetShortFilename

### DIFF
--- a/include/assimp/scene.h
+++ b/include/assimp/scene.h
@@ -401,8 +401,9 @@ struct ASSIMP_API aiScene {
     //! Returns a short filename from a full path
     static const char* GetShortFilename(const char* filename) {
         const char* lastSlash = strrchr(filename, '/');
-        if (lastSlash == nullptr) {
-            lastSlash = strrchr(filename, '\\');
+        const char* lastBackSlash = strrchr(filename, '\\');
+        if (lastSlash < lastBackSlash) {
+            lastSlash = lastBackSlash;
         }
         const char* shortFilename = lastSlash != nullptr ? lastSlash + 1 : filename;
         return shortFilename;


### PR DESCRIPTION
when blender export fbx then embedded texture path have slash and back slash. so GetShortFilename have to check both types of slashes