### PR TITLE
Fix copying private data when source pointer is NULL

### DIFF
--- a/code/Common/SceneCombiner.cpp
+++ b/code/Common/SceneCombiner.cpp
@@ -1057,7 +1057,7 @@ void SceneCombiner::CopyScene(aiScene **_dest, const aiScene *src, bool allocate
     dest->mFlags = src->mFlags;
 
     // source private data might be nullptr if the scene is user-allocated (i.e. for use with the export API)
-    if (dest->mPrivate != nullptr) {
+    if (src->mPrivate != nullptr) {
         ScenePriv(dest)->mPPStepsApplied = ScenePriv(src) ? ScenePriv(src)->mPPStepsApplied : 0;
     }
 }


### PR DESCRIPTION
When copying a scene, it was checking the *destination* for a NULL pointer instead of the *source*. The copy went ahead despite the source being a NULL pointer, causing random core dumps. 