### PR TITLE
FBX Import - Restored Absolute Transform Calculation

### DIFF
--- a/code/AssetLib/FBX/FBXConverter.cpp
+++ b/code/AssetLib/FBX/FBXConverter.cpp
@@ -312,6 +312,8 @@ void FBXConverter::ConvertNodes(uint64_t id, aiNode *parent, aiNode *root_node) 
 
                 child->mParent = last_parent;
                 last_parent = child.mNode;
+
+                new_abs_transform *= child->mTransformation;
             }
 
             // attach geometry
@@ -334,6 +336,8 @@ void FBXConverter::ConvertNodes(uint64_t id, aiNode *parent, aiNode *root_node) 
 
                     postnode->mParent = last_parent;
                     last_parent = postnode.mNode;
+
+                    new_abs_transform *= postnode->mTransformation;
                 }
             } else {
                 // free the nodes we allocated as we don't need them


### PR DESCRIPTION
This fixes: https://github.com/assimp/assimp/issues/5449 and https://github.com/assimp/assimp/issues/5642 by restoring the absolute transformation calculation which is now required due to this change: https://github.com/assimp/assimp/pull/5349.

The original pull request: https://github.com/assimp/assimp/pull/5643 was not properly merged so I have created this pull request again to hopefully fix this ***critical*** issue in the FBX importer.  Please let me know if there are any concerns and I will address them as soon as possible.