### PR TITLE
Fix stack overflow

### DIFF
--- a/code/AssetLib/LWS/LWSLoader.cpp
+++ b/code/AssetLib/LWS/LWSLoader.cpp
@@ -78,7 +78,15 @@ static constexpr aiImporterDesc desc = {
 
 // ------------------------------------------------------------------------------------------------
 // Recursive parsing of LWS files
-void LWS::Element::Parse(const char *&buffer, const char *end) {
+namespace {
+    constexpr int MAX_DEPTH = 1000; // Define the maximum depth allowed
+}
+
+void LWS::Element::Parse(const char *&buffer, const char *end, int depth) {
+    if (depth > MAX_DEPTH) {
+        throw std::runtime_error("Maximum recursion depth exceeded in LWS::Element::Parse");
+    }
+
     for (; SkipSpacesAndLineEnd(&buffer, end); SkipLine(&buffer, end)) {
 
         // begin of a new element with children
@@ -121,7 +129,7 @@ void LWS::Element::Parse(const char *&buffer, const char *end) {
 
         // parse more elements recursively
         if (sub) {
-            children.back().Parse(buffer, end);
+            children.back().Parse(buffer, end, depth + 1);
         }
     }
 }

--- a/code/AssetLib/LWS/LWSLoader.h
+++ b/code/AssetLib/LWS/LWSLoader.h
@@ -76,7 +76,7 @@ public:
     std::list<Element> children;
 
     //! Recursive parsing function
-    void Parse(const char *&buffer, const char *end);
+    void Parse(const char *&buffer, const char *end, int depth = 0);
 };
 
 #define AI_LWS_MASK (0xffffffff >> 4u)


### PR DESCRIPTION
## Fix stack overflow
### Fixed Vulnerability
Stack Overflow (https://github.com/assimp/assimp/issues/5464)

### Description
This patch will prevent the stack overflow by limiting the recursion depth.

### Sanitizer Report
```
=================================================================
==522887==ERROR: AddressSanitizer: stack-overflow on address 0x7fffff7feff8 (pc 0x7ffff731e9c5 bp 0xfffffffffffffff8 sp 0x7fffff7ff000 T0)
    #0 0x7ffff731e9c5  build-llvm/tools/clang/stage2-bins/runtimes/runtimes-bins/compiler-rt/lib/asan/asan_thread.cpp:423:45
    #1 0x7ffff72796c8 in Allocate build-llvm/tools/clang/stage2-bins/runtimes/runtimes-bins/compiler-rt/lib/asan/asan_allocator.cpp:578:21
    #2 0x7ffff72794c7 in asan_malloc build-llvm/tools/clang/stage2-bins/runtimes/runtimes-bins/compiler-rt/lib/asan/asan_allocator.cpp:1000:34
    #3 0x7ffff7311803 in malloc build-llvm/tools/clang/stage2-bins/runtimes/runtimes-bins/compiler-rt/lib/asan/asan_malloc_linux.cpp:69:10
    #4 0x7ffff7df05db in operator new(unsigned long) /build/gcc-14-OQFzmN/gcc-14-14-20240412/build/x86_64-linux-gnu/libstdc++-v3/libsupc++/../../../../src/libstdc++-v3/libsupc++/new_op.cc:50:22
    #5 0x555555c707a4 in std::__new_allocator<std::_List_node<Assimp::LWS::Element>>::allocate(unsigned long, void const*) /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/new_allocator.h:151:27
    #6 0x555555c7057c in std::allocator_traits<std::allocator<std::_List_node<Assimp::LWS::Element>>>::allocate(std::allocator<std::_List_node<Assimp::LWS::Element>>&, unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/alloc_traits.h:482:20
    #7 0x555555c7057c in std::__cxx11::_List_base<Assimp::LWS::Element, std::allocator<Assimp::LWS::Element>>::_M_get_node() /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/stl_list.h:518:16
    #8 0x555555c703e0 in std::_List_node<Assimp::LWS::Element>* std::__cxx11::list<Assimp::LWS::Element, std::allocator<Assimp::LWS::Element>>::_M_create_node<>() /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/stl_list.h:710:21
    #9 0x555555c702dc in void std::__cxx11::list<Assimp::LWS::Element, std::allocator<Assimp::LWS::Element>>::_M_insert<>(std::_List_iterator<Assimp::LWS::Element>) /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/stl_list.h:2005:18
    #10 0x555555c6cce9 in Assimp::LWS::Element& std::__cxx11::list<Assimp::LWS::Element, std::allocator<Assimp::LWS::Element>>::emplace_back<>() /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/stl_list.h:1321:10
    #11 0x555555c626a8 in Assimp::LWS::Element::Parse(char const*&, char const*) /root/code/AssetLib/LWS/LWSLoader.cpp:93:18
    #12 0x555555c62bb7 in Assimp::LWS::Element::Parse(char const*&, char const*) /root/code/AssetLib/LWS/LWSLoader.cpp:124:29
    #13 0x555555c62bb7 in Assimp::LWS::Element::Parse(char const*&, char const*) /root/code/AssetLib/LWS/LWSLoader.cpp:124:29
...
    #247 0x555555c62bb7 in Assimp::LWS::Element::Parse(char const*&, char const*) /root/code/AssetLib/LWS/LWSLoader.cpp:124:29

SUMMARY: AddressSanitizer: stack-overflow /build/gcc-14-OQFzmN/gcc-14-14-20240412/build/x86_64-linux-gnu/libstdc++-v3/libsupc++/../../../../src/libstdc++-v3/libsupc++/new_op.cc:50:22 in operator new(unsigned long)
==522887==ABORTING

```