### PR TITLE
Fix invalid access

### DIFF
--- a/code/PostProcessing/SortByPTypeProcess.cpp
+++ b/code/PostProcessing/SortByPTypeProcess.cpp
@@ -66,36 +66,46 @@ void SortByPTypeProcess::SetupProperties(const Importer *pImp) {
 }
 
 // ------------------------------------------------------------------------------------------------
+static void clearMeshesInNode(aiNode *node) {
+    delete[] node->mMeshes;
+    node->mNumMeshes = 0;
+    node->mMeshes = nullptr;
+}
+
+// ------------------------------------------------------------------------------------------------
 // Update changed meshes in all nodes
 void UpdateNodes(const std::vector<unsigned int> &replaceMeshIndex, aiNode *node) {
+    ai_assert(node != nullptr);
+    
     if (node->mNumMeshes) {
         unsigned int newSize = 0;
         for (unsigned int m = 0; m < node->mNumMeshes; ++m) {
             unsigned int add = node->mMeshes[m] << 2;
             for (unsigned int i = 0; i < 4; ++i) {
-                if (UINT_MAX != replaceMeshIndex[add + i]) ++newSize;
-            }
-        }
-        if (!newSize) {
-            delete[] node->mMeshes;
-            node->mNumMeshes = 0;
-            node->mMeshes = nullptr;
-        } else {
-            // Try to reuse the old array if possible
-            unsigned int *newMeshes = (newSize > node->mNumMeshes ? new unsigned int[newSize] : node->mMeshes);
-
-            for (unsigned int m = 0; m < node->mNumMeshes; ++m) {
-                unsigned int add = node->mMeshes[m] << 2;
-                for (unsigned int i = 0; i < 4; ++i) {
-                    if (UINT_MAX != replaceMeshIndex[add + i])
-                        *newMeshes++ = replaceMeshIndex[add + i];
+                if (UINT_MAX != replaceMeshIndex[add + i]) {
+                    ++newSize;
                 }
             }
-            if (newSize > node->mNumMeshes)
-                delete[] node->mMeshes;
-
-            node->mMeshes = newMeshes - (node->mNumMeshes = newSize);
         }
+        if (newSize == 0) {
+            clearMeshesInNode(node);
+            return;
+        }
+        
+        // Try to reuse the old array if possible
+        unsigned int *newMeshes = (newSize > node->mNumMeshes ? new unsigned int[newSize] : node->mMeshes);
+        for (unsigned int m = 0; m < node->mNumMeshes; ++m) {
+            unsigned int add = node->mMeshes[m] << 2;
+            for (unsigned int i = 0; i < 4; ++i) {
+                if (UINT_MAX != replaceMeshIndex[add + i]) {
+                    *newMeshes++ = replaceMeshIndex[add + i];
+                }
+            }
+        }
+        if (newSize > node->mNumMeshes) {
+            clearMeshesInNode(node);
+        }
+        node->mMeshes = newMeshes - (node->mNumMeshes = newSize);
     }
 
     // call all subnodes recursively

--- a/code/PostProcessing/SortByPTypeProcess.cpp
+++ b/code/PostProcessing/SortByPTypeProcess.cpp
@@ -177,7 +177,7 @@ void SortByPTypeProcess::Execute(aiScene *pScene) {
         // with the largest number of primitives
         unsigned int aiNumPerPType[4] = { 0, 0, 0, 0 };
         aiFace *pFirstFace = mesh->mFaces;
-        if (!pFirstFace) {
+        if (pFirstFace == nullptr) {
             continue;
         }
 

--- a/code/PostProcessing/SortByPTypeProcess.cpp
+++ b/code/PostProcessing/SortByPTypeProcess.cpp
@@ -167,6 +167,10 @@ void SortByPTypeProcess::Execute(aiScene *pScene) {
         // with the largest number of primitives
         unsigned int aiNumPerPType[4] = { 0, 0, 0, 0 };
         aiFace *pFirstFace = mesh->mFaces;
+        if (!pFirstFace) {
+            continue;
+        }
+
         aiFace *const pLastFace = pFirstFace + mesh->mNumFaces;
 
         unsigned int numPolyVerts = 0;


### PR DESCRIPTION
## Fix stack overflow
### Fixed Vulnerability
https://github.com/assimp/assimp/issues/5677

### Description
This patch should ensure that the pointers `pFirstFace`are valid and before dereferencing

### Sanitizer Report
```
=================================================================
==924513==ERROR: AddressSanitizer: SEGV on unknown address 0x1000fea90623 (pc 0x555556b374c7 bp 0x7fffffffca70 sp 0x7fffffffbba0 T0)
==924513==The signal is caused by a READ memory access.
    #0 0x555556b374c7 in Assimp::SortByPTypeProcess::Execute(aiScene*) /root/code/PostProcessing/SortByPTypeProcess.cpp:175:17
    #1 0x555556a9afdf in Assimp::BaseProcess::ExecuteOnScene(Assimp::Importer*) /root/code/Common/BaseProcess.cpp:82:9
    #2 0x5555558d79b2 in Assimp::Importer::ApplyPostProcessing(unsigned int) /root/code/Common/Importer.cpp:841:22
    #3 0x5555558d5321 in Assimp::Importer::ReadFile(char const*, unsigned int) /root/code/Common/Importer.cpp:751:13
    #4 0x5555558d1fd9 in Assimp::Importer::ReadFileFromMemory(void const*, unsigned long, unsigned int, char const*) /root/code/Common/Importer.cpp:507:9
    #5 0x555555861fa9 in LLVMFuzzerTestOneInput /root/fuzz/assimp_fuzzer.cc:54:34
    #6 0x555555847714 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (/root/assimp_fuzzer+0x2f3714) (BuildId: b530028a139e0edb5c3ad73425d63d1af6f65477)
    #7 0x555555830846 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (/root/assimp_fuzzer+0x2dc846) (BuildId: b530028a139e0edb5c3ad73425d63d1af6f65477)
    #8 0x5555558362fa in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (/root/assimp_fuzzer+0x2e22fa) (BuildId: b530028a139e0edb5c3ad73425d63d1af6f65477)
    #9 0x555555860ab6 in main (/root/assimp_fuzzer+0x30cab6) (BuildId: b530028a139e0edb5c3ad73425d63d1af6f65477)
    #10 0x7ffff6f1b1c9 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #11 0x7ffff6f1b28a in __libc_start_main csu/../csu/libc-start.c:360:3
    #12 0x55555582b414 in _start (/root/assimp_fuzzer+0x2d7414) (BuildId: b530028a139e0edb5c3ad73425d63d1af6f65477)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV /root/code/PostProcessing/SortByPTypeProcess.cpp:175:17 in Assimp::SortByPTypeProcess::Execute(aiScene*)
==924513==ABORTING

```