### PR TITLE
Fix conditional check in `SkipSpaces` function to prevent out-of-bound access

### DIFF
--- a/include/assimp/ParsingUtils.h
+++ b/include/assimp/ParsingUtils.h
@@ -103,7 +103,7 @@ AI_FORCE_INLINE bool IsSpaceOrNewLine(char_t in) {
 // ---------------------------------------------------------------------------------
 template <class char_t>
 AI_FORCE_INLINE bool SkipSpaces(const char_t *in, const char_t **out, const char_t *end) {
-    while ((*in == (char_t)' ' || *in == (char_t)'\t') && in != end) {
+    while (in != end && (*in == (char_t)' ' || *in == (char_t)'\t')) {
         ++in;
     }
     *out = in;


### PR DESCRIPTION
#### Description:
This PR resolves a potential out-of-bound access issue in the `SkipSpaces` function within the `ParsingUtils.h` file. Previously, the condition that checked for whitespace (`' '` or `'\t'`) was evaluated before verifying whether the pointer `in` had reached the end. This could lead to dereferencing the pointer when it is already at the boundary, resulting in undefined behavior.

The update reorders the condition so that the boundary check `in != end` is evaluated before accessing the value of `*in`. This ensures the function operates safely when processing input up to the boundary.

#### Changes:
- Modified `SkipSpaces` function to check for `in != end` before dereferencing `*in`.