### PR TITLE
SplitLargeMeshes: Fix crash

### DIFF
--- a/code/PostProcessing/SplitLargeMeshes.cpp
+++ b/code/PostProcessing/SplitLargeMeshes.cpp
@@ -100,6 +100,11 @@ void SplitLargeMeshesProcess_Triangle::SetupProperties( const Importer* pImp) {
 // ------------------------------------------------------------------------------------------------
 // Update a node after some meshes have been split
 void SplitLargeMeshesProcess_Triangle::UpdateNode(aiNode* pcNode, const std::vector<std::pair<aiMesh*, unsigned int> >& avList) {
+    if (pcNode == nullptr) {
+        ASSIMP_LOG_WARN("UpdateNode skipped, nullptr detected.");
+        return; 
+    }
+    
     // for every index in out list build a new entry
     std::vector<unsigned int> aiEntries;
     aiEntries.reserve(pcNode->mNumMeshes + 1);


### PR DESCRIPTION
- Fix nullptr access when rootnode of the scene is a nullptr. This can happen even if the scene stores any kind of meshes.
- closes https://github.com/assimp/assimp/issues/5791