### PR TITLE
Work In Progress: USD Referencing

### DIFF
--- a/code/AssetLib/Step/STEPFile.h
+++ b/code/AssetLib/Step/STEPFile.h
@@ -920,6 +920,10 @@ private:
 #pragma warning(pop)
 #endif // _MSC_VER
 
+#if _MSC_VER > 1920
+#pragma warning(pop)
+#endif
+
 } // namespace STEP
 } // namespace Assimp
 

--- a/code/AssetLib/USD/USDLoaderImplTinyusdz.h
+++ b/code/AssetLib/USD/USDLoaderImplTinyusdz.h
@@ -123,17 +123,20 @@ public:
     void setupNodes(
             const tinyusdz::tydra::RenderScene &render_scene,
             aiScene *pScene,
+            const tinyusdz::Stage &usdStage,
             std::map<size_t, tinyusdz::tydra::Node> &meshNodes,
             const std::string &nameWExt
             );
 
     aiNode *nodes(
             const tinyusdz::tydra::RenderScene &render_scene,
+            const tinyusdz::Stage &usdStage,
             std::map<size_t, tinyusdz::tydra::Node> &meshNodes,
             const std::string &nameWExt);
 
     aiNode *nodesRecursive(
             aiNode *pNodeParent,
+            const tinyusdz::Prim &prim,
             const tinyusdz::tydra::Node &node,
             std::map<size_t, tinyusdz::tydra::Node> &meshNodes);
 


### PR DESCRIPTION
Passing USD prims along with render nodes to search for USD references. 
Saving reference path inside node->metaData['ref']

_Looking for feedback on starting to implementing USD references... not sure if this is even the correct approach.
Instead of loading reference geometry directly into the scene, I want the end user to decide what to do with the reference. 
In my case, O3DE will load each usd separately, create a procedural prefab for each, and then create a hierarchy of nested prefabs for USDs which reference other USDs._
