### PR TITLE
Store current exception when caught in ASSIMP_CATCH_GLOBAL_EXCEPTIONS

### DIFF
--- a/code/Common/Importer.cpp
+++ b/code/Common/Importer.cpp
@@ -771,6 +771,7 @@ const aiScene* Importer::ReadFile( const char* _pFile, unsigned int pFlags) {
 #else
         pimpl->mErrorString = std::string("std::exception: ") + e.what();
 #endif
+        pimpl->mException = std::current_exception();
 
         ASSIMP_LOG_ERROR(pimpl->mErrorString);
         delete pimpl->mScene; pimpl->mScene = nullptr;


### PR DESCRIPTION
In all other instances where we set mErrorString inside a catch block we also set mException. I think that this was an oversight.