### PR TITLE
Fix bug introduced in commit 168ae22 of 27 Oct 2019

### DIFF
--- a/code/AssetLib/FBX/FBXConverter.cpp
+++ b/code/AssetLib/FBX/FBXConverter.cpp
@@ -247,7 +247,7 @@ struct FBXConverter::PotentialNode {
 /// todo: get bone from stack
 /// todo: make map of aiBone* to aiNode*
 /// then update convert clusters to the new format
-void FBXConverter::ConvertNodes(uint64_t id, aiNode *parent, aiNode *root_node) {
+void FBXConverter::ConvertNodes(uint64_t id, aiNode *parent, aiNode *root_node, const aiMatrix4x4& parent_transform) {
     const std::vector<const Connection *> &conns = doc.GetConnectionsByDestinationSequenced(id, "Model");
 
     std::vector<PotentialNode> nodes;
@@ -278,7 +278,7 @@ void FBXConverter::ConvertNodes(uint64_t id, aiNode *parent, aiNode *root_node) 
         if (nullptr != model) {
             nodes_chain.clear();
             post_nodes_chain.clear();
-            aiMatrix4x4 new_abs_transform = parent->mTransformation;
+            aiMatrix4x4 new_abs_transform = parent_transform;
             std::string node_name = FixNodeName(model->Name());
             // even though there is only a single input node, the design of
             // assimp (or rather: the complicated transformation chain that
@@ -345,7 +345,7 @@ void FBXConverter::ConvertNodes(uint64_t id, aiNode *parent, aiNode *root_node) 
             }
 
             // recursion call - child nodes
-            ConvertNodes(model->ID(), last_parent, root_node);
+            ConvertNodes(model->ID(), last_parent, root_node, new_abs_transform);
 
             if (doc.Settings().readLights) {
                 ConvertLights(*model, node_name);
@@ -1676,14 +1676,14 @@ void FBXConverter::ConvertCluster(std::vector<aiBone*> &local_mesh_bones, const 
 
         //bone->mOffsetMatrix = cluster->Transform();
         // store local transform link for post processing
-        
+
         bone->mOffsetMatrix = cluster->TransformLink();
         bone->mOffsetMatrix.Inverse();
 
         const aiMatrix4x4 matrix = (aiMatrix4x4)absolute_transform;
 
         bone->mOffsetMatrix = bone->mOffsetMatrix * matrix; // * mesh_offset
-        
+
         //
         // Now calculate the aiVertexWeights
         //

--- a/code/AssetLib/FBX/FBXConverter.h
+++ b/code/AssetLib/FBX/FBXConverter.h
@@ -134,7 +134,7 @@ private:
 
     // ------------------------------------------------------------------------------------------------
     // collect and assign child nodes
-    void ConvertNodes(uint64_t id, aiNode *parent, aiNode *root_node);
+    void ConvertNodes(uint64_t id, aiNode *parent, aiNode *root_node, const aiMatrix4x4& parent_transform = aiMatrix4x4());
 
     // ------------------------------------------------------------------------------------------------
     void ConvertLights(const Model& model, const std::string &orig_name );


### PR DESCRIPTION
Closes #5808

### Overview
FBX armature PR modified how transforms were obtained in recursive `ConvertNodes()` function; instead of passing reference to 4x4 matrix, an `aiNode` was passed and the transform read from that parameter.  But this broke animations on certain FBX 3D model files.  To fix this, the original approach from the commit just prior to `168ae22` has been restored.

## Before/after screenshots

### Models directly fixed or improved by this PR
<table>
<tr><th rowspan=2>Model</th><th colspan=2>Assimp commit or PR</th><th rowspan=2>Notes</th></tr>
<tr><th><a href="https://github.com/assimp/assimp/commit/9934a8d1cc58d9c5ddc6e0f39da0f86a7091e63b"><tt>9934a8d</tt></a><br>7 Oct 2024</th><th><a href="https://github.com/assimp/assimp/pull/5813"><tt>PR 5813</tt></a></th></tr>
<tr><td><a href="https://renderpeople.com/sample/free/renderpeople_free_animated_people_FBX.zip"><tt>35-rp_sophia_animated_003_idling_fbx</tt></a></td><td><img src="https://github.com/user-attachments/assets/6e541d97-0906-489c-af85-849cf3ccea44" alt="assimp_commit_2024-10-11_9934a8d_renderpeople_sophia" width=90/></td><td><img src="https://github.com/user-attachments/assets/f5292194-4b11-46a0-aa2d-07eabf53f4f3" alt="assimp_pr_5813_renderpeople_sophia_improved" width=90/></td><td>Obvious improvement</td></tr>
<tr><td><a href="https://renderpeople.com/sample/free/renderpeople_free_animated_people_FBX.zip"><tt>22-rp_manuel_animated_001_dancing_fbx</tt></a></td><td><img src="https://github.com/user-attachments/assets/d1af80a2-df01-4fee-9508-7c632f213b1b" alt="assimp_commit_2024-10-11_9934a8d_renderpeople_manuel" width=90 /></td><td><img src="https://github.com/user-attachments/assets/b588ede0-eb23-4d04-b146-554159b39ee3" alt="assimp_pr_5813_renderpeople_manuel_fixed" width=90 /></td><td>Appears completely fixed</td></tr>
</table>

### Models unaffected by this PR (i.e. no regressions for these models)

#### Models which were already correct and remain correct after this PR
<table>
<tr><th rowspan=2>Model</th><th colspan=2>Assimp commit or PR</th><th rowspan=2>Notes</th></tr>
<tr><th><a href="https://github.com/assimp/assimp/commit/9934a8d1cc58d9c5ddc6e0f39da0f86a7091e63b"><tt>9934a8d</tt></a><br>7 Oct 2024</th><th><a href="https://github.com/assimp/assimp/pull/5813"><tt>PR 5813</tt></a></th></tr>
<tr><td><a href="https://sketchfab.com/3d-models/silver-dragonkin-mir4-89ead4e87cdc4b70840f748383f0998f"><tt>silver-dragonkin-mir4</tt></a></td><td><img src="https://github.com/user-attachments/assets/0b081863-effa-4540-aa6a-fc3f66f38320" alt="assimp_commit_2024-10-11_9934a8d_silver_dragon" width=90 /></td><td><img src="https://github.com/user-attachments/assets/142c0780-8333-4e0b-a7d6-5af5263ac2da" alt="assimp_pr_5813_silver_dragon_no_effect" width=90 /></td><td rowspan=2>These models were fixed recently in earlier PR and remain correct</td></tr>
<tr><td><a href="https://sketchfab.com/3d-models/tarisland-dragon-high-poly-ecf63885166c40e2bbbcdf11cd14e65f"><tt>tarisland-dragon-high-poly</tt></a></td><td><img src="https://github.com/user-attachments/assets/8975e304-49c3-4543-93df-051c086a2716" alt="assimp_commit_2024-10-11_9934a8d_tarisland_dragon" width=90 /></td><td><img src="https://github.com/user-attachments/assets/dfd8c3ca-e06d-4acc-a0fa-b6a1b01401ef" alt="assimp_pr_5813_tarisland_dragon_no_effect" width=90 /></td></tr>
</table>

#### Models which were already broken and remain broken after this PR
<table>
<tr><th rowspan=2>Model</th><th colspan=2>Assimp commit or PR</th><th rowspan=2>Notes</th></tr>
<tr><th><a href="https://github.com/assimp/assimp/commit/9934a8d1cc58d9c5ddc6e0f39da0f86a7091e63b"><tt>9934a8d</tt></a><br>7 Oct 2024</th><th><a href="https://github.com/assimp/assimp/pull/5813"><tt>PR 5813</tt></a></th></tr>
<tr><td><a href="https://renderpeople.com/sample/free/renderpeople_free_animated_people_FBX.zip"><tt>55-rp_nathan_animated_003_walking_fbx</tt></a></td><td><img src="https://github.com/user-attachments/assets/8c127367-148a-46e5-85e2-a5af4d3dc07c" alt="assimp_commit_2024-10-11_9934a8d_renderpeople_nathan" width=90 /></td><td><img src="https://github.com/user-attachments/assets/6f580da2-d2b6-49a5-a75a-e2234a8ce92c" alt="assimp_pr_5813_renderpeople_nathan_no_effect" width=90 /></td><td rowspan=3>Models have been broken for a long time now, remain broken but no apparent regressions due to this PR</td></tr>
<tr><td><a href="https://github.com/assimp/assimp/files/2672388/robot_kyle_walking.zip"><tt>robot_kyle_walking</tt></a></td><td><img src="https://github.com/user-attachments/assets/6ca604d9-e548-4d38-b0b0-83c31b9c49c7" alt="assimp_commit_2024-10-11_9934a8d_kylie_robot" width=90 /></td><td><img src="https://github.com/user-attachments/assets/b3cc547a-91af-41e8-a893-d96d116b03f3" alt="assimp_pr_5813_kylie_robot_no_effect" width=90 /></td></tr>
<tr><td><a href="https://sketchfab.com/3d-models/mr-man-walking-98ccac2b0e2845789b6f789978ca06ed"><tt>mr-man-walking</tt></a></td><td><img src="https://github.com/user-attachments/assets/0ae1d305-cfbd-4b9a-b949-3a7a5cd1c9a0" alt="assimp_commit_2024-10-11_9934a8d_mr_man_walking" width=90 /></td><td><img src="https://github.com/user-attachments/assets/a18a9372-0cbb-4f89-b9ca-0e6372f75d7f" alt="assimp_pr_5813_mr_man_no_effect" width=90 /></td></tr>
</table>