### PR TITLE
Fix FBX animation bug (issue 3390)

### DIFF
--- a/code/AssetLib/FBX/FBXConverter.cpp
+++ b/code/AssetLib/FBX/FBXConverter.cpp
@@ -717,8 +717,7 @@ bool FBXConverter::NeedsComplexTransformationChain(const Model &model) {
     for (size_t i = 0; i < TransformationComp_MAXIMUM; ++i) {
         const TransformationComp comp = static_cast<TransformationComp>(i);
 
-        if (comp == TransformationComp_Rotation || comp == TransformationComp_Scaling || comp == TransformationComp_Translation ||
-            comp == TransformationComp_PreRotation || comp == TransformationComp_PostRotation) {
+        if (comp == TransformationComp_Rotation || comp == TransformationComp_Scaling || comp == TransformationComp_Translation) {
             continue;
         }
 


### PR DESCRIPTION
Closes #3390 (FBX animation bug introduced with 24 Mar 2020 commit 14b8d12)
Closes #4487
Closes #5719

## Overview
(H/T @Frooxius for [isolating the commit where the bug was introduced and suggesting the fix](https://github.com/assimp/assimp/issues/3390#issuecomment-767290559))

Fix: remove conditions for pre- and post-rotation added in commit [`14b8d12`](https://github.com/assimp/assimp/commit/14b8d1242b0f32fef9dd8ace0a1d4e8cbd20d88c):
```
    if (comp == TransformationComp_Rotation || comp == TransformationComp_Scaling ||
        comp == TransformationComp_Translation ||
        comp == TransformationComp_PreRotation || comp == TransformationComp_PostRotation) {
```
to reflect state just prior to that commit:
```
    if (comp == TransformationComp_Rotation || comp == TransformationComp_Scaling ||
        comp == TransformationComp_Translation) {
```
## Before/after screenshots

### Models directly fixed by this PR
<table>
<tr><th rowspan=2>Model</th><th colspan=2>Assimp commit or PR</th><th rowspan=2>Notes</th></tr>
<tr><th><a href="https://github.com/assimp/assimp/commit/cb4e663138b4a806514106099ced678be8b09eb9"><tt>cb4e663</tt></a><br>12 Oct 2024</th><th><a href="https://github.com/assimp/assimp/pull/5815"><tt>PR 5815</tt></a></th></tr>
<tr><td><a href="https://renderpeople.com/sample/free/renderpeople_free_animated_people_FBX.zip"><tt>35-rp_sophia_animated_003_idling_fbx</tt></a></td><td><img src="https://github.com/user-attachments/assets/f5292194-4b11-46a0-aa2d-07eabf53f4f3" alt="assimp_pr_5813_renderpeople_sophia_improved" width=90/></td><td><img src="https://github.com/user-attachments/assets/a0702405-c75d-4bf9-bc7b-d0fbc2e7384e" alt="assimp_pr_5813_renderpeople_sophia_fixed" width=90/></td><td rowspan=4>Models had been broken for a long time,  now appear completely correct due to this PR</td></tr>
<tr><td><a href="https://renderpeople.com/sample/free/renderpeople_free_animated_people_FBX.zip"><tt>55-rp_nathan_animated_003_walking_fbx</tt></a></td><td><img src="https://github.com/user-attachments/assets/6f580da2-d2b6-49a5-a75a-e2234a8ce92c" alt="assimp_pr_5813_renderpeople_nathan_no_effect" width=90 /></td><td><img src="https://github.com/user-attachments/assets/3211cf4e-4dd5-4d8d-ab3d-a4093c9a7fbe" alt="assimp_pr_5813_renderpeople_nathan_fixed" width=90 /></td></tr>
<tr><td><a href="https://github.com/assimp/assimp/files/2672388/robot_kyle_walking.zip"><tt>robot_kyle_walking</tt></a></td><td><img src="https://github.com/user-attachments/assets/b3cc547a-91af-41e8-a893-d96d116b03f3" alt="assimp_pr_5813_kylie_robot_no_effect" width=90 /></td><td><img src="https://github.com/user-attachments/assets/508ff93e-4d76-4fed-a5fb-8e3ab97ca810" alt="assimp_pr_5813_kylie_robot_fixed" width=90 /></td></tr>
<tr><td><a href="https://sketchfab.com/3d-models/mr-man-walking-98ccac2b0e2845789b6f789978ca06ed"><tt>mr-man-walking</tt></a></td><td><img src="https://github.com/user-attachments/assets/a18a9372-0cbb-4f89-b9ca-0e6372f75d7f" alt="assimp_pr_5813_mr_man_no_effect" width=90 /></td><td><img src="https://github.com/user-attachments/assets/ef770b41-b48a-433f-8a06-a40b9acfc8dd" alt="assimp_pr_5813_mr_man_walking_fixed" width=90 /></td></tr>
<tr><td><a href="https://github.com/user-attachments/files/16633300/hello.fbx.zip"><tt>hello.fbx.zip</tt></a></td><td><img src="https://github.com/user-attachments/assets/bf82179b-5e38-4a42-a257-a6005b6e7875" alt="assimp_issue_4487_hello_fbx_at_assimp_commit_2024-10-11_9934a8d" width=90 /></td><td><img src="https://github.com/user-attachments/assets/64abcbac-c7f5-421a-8c79-acfd8df1a2c0" alt="assimp_pr_5813_hello.fbx"  width=90 /></td><td>Screenshot of "twisted" model actually from assimp commit <a href="https://github.com/assimp/assimp/commit/9934a8d1cc58d9c5ddc6e0f39da0f86a7091e63b"><tt>9934a8d</tt></a></td></tr>
</table>

### Models which were already correct and remain correct after this PR
<table>
<tr><th rowspan=2>Model</th><th colspan=2>Assimp commit or PR</th><th rowspan=2>Notes</th></tr>
<tr><th><a href="https://github.com/assimp/assimp/commit/cb4e663138b4a806514106099ced678be8b09eb9"><tt>cb4e663</tt></a><br>12 Oct 2024</th><th><a href="https://github.com/assimp/assimp/pull/5815"><tt>PR 5815</tt></a></th></tr>
<tr><td><a href="https://sketchfab.com/3d-models/silver-dragonkin-mir4-89ead4e87cdc4b70840f748383f0998f"><tt>silver-dragonkin-mir4</tt></a></td><td><img src="https://github.com/user-attachments/assets/142c0780-8333-4e0b-a7d6-5af5263ac2da" alt="assimp_pr_5813_silver_dragon_no_effect" width=90 /></td><td><img src="https://github.com/user-attachments/assets/b9cfb50c-650c-47fd-bcd9-0376398646f9" alt="assimp_pr_5813_silver_dragon_no_effect" width=90 /></td><td rowspan=3>These models were already working correctly, and remain correct</td></tr>
<tr><td><a href="https://sketchfab.com/3d-models/tarisland-dragon-high-poly-ecf63885166c40e2bbbcdf11cd14e65f"><tt>tarisland-dragon-high-poly</tt></a></td><td><img src="https://github.com/user-attachments/assets/dfd8c3ca-e06d-4acc-a0fa-b6a1b01401ef" alt="assimp_pr_5813_tarisland_dragon_no_effect" width=90 /></td><td><img src="https://github.com/user-attachments/assets/7695c5bf-9de3-4e17-813c-18dbddd0e69d" alt="assimp_pr_5813_tarisland_dragon_no_effect" width=90 /></td></tr>
<tr><td><a href="https://renderpeople.com/sample/free/renderpeople_free_animated_people_FBX.zip"><tt>22-rp_manuel_animated_001_dancing_fbx</tt></a></td><td><img src="https://github.com/user-attachments/assets/b588ede0-eb23-4d04-b146-554159b39ee3" alt="assimp_pr_5813_renderpeople_manuel_fixed" width=90 /></td><td><img src="https://github.com/user-attachments/assets/319306cd-ce5b-40f5-bed1-47efa21e4166" alt="assimp_pr_5813_renderpeople_manuel_no_effect" width=90 /></td></tr>
</table>
