### PR TITLE
[Fix issue 5823] Hotfix for broken lightwave normals

### DIFF
--- a/code/AssetLib/LWO/LWOLoader.cpp
+++ b/code/AssetLib/LWO/LWOLoader.cpp
@@ -527,6 +527,7 @@ void LWOImporter::ComputeNormals(aiMesh *mesh, const std::vector<unsigned int> &
                         continue;
                     vNormals += v;
                 }
+                mesh->mNormals[idx] = vNormals.Normalize();
             }
         }
     }
@@ -547,6 +548,7 @@ void LWOImporter::ComputeNormals(aiMesh *mesh, const std::vector<unsigned int> &
                     const aiVector3D &v = faceNormals[*a];
                     vNormals += v;
                 }
+                vNormals.Normalize();
                 for (std::vector<unsigned int>::const_iterator a = poResult.begin(); a != poResult.end(); ++a) {
                     mesh->mNormals[*a] = vNormals;
                     vertexDone[*a] = true;


### PR DESCRIPTION
Closes #5823

### Overview
Normals were inadvertently broken for Lightwave importer (lighting calculations failed and models rendered completely black)

### Details
Restore lines removed in commit cb22d53 of 4 May 2023 which caused the breakage