### PR TITLE
Fixed bug in DefaultLogger::set

### DIFF
--- a/code/Common/DefaultLogger.cpp
+++ b/code/Common/DefaultLogger.cpp
@@ -221,13 +221,11 @@ void DefaultLogger::set(Logger *logger) {
 #endif
 
     if (nullptr == logger) {
-        logger = &s_pNullLogger;
+        m_pLogger = &s_pNullLogger;
     }
-    if (nullptr != m_pLogger && !isNullLogger()) {
-        delete m_pLogger;
+    else {
+        m_pLogger = logger;
     }
-
-    DefaultLogger::m_pLogger = logger;
 }
 
 // ----------------------------------------------------------------------------------

--- a/include/assimp/DefaultLogger.hpp
+++ b/include/assimp/DefaultLogger.hpp
@@ -103,6 +103,9 @@ public:
      *  your needs. If the provided message formatting is OK for you,
      *  it's much easier to use #create() and to attach your own custom
      *  output streams to it.
+     *  Since set is intended to be used for custom loggers, the user is
+     *  responsible for instantiation and destruction (new / delete).
+     *  Before deletion of the custom logger, set(nullptr); must be called.
      *  @param logger Pass NULL to setup a default NullLogger*/
     static void set(Logger *logger);
 
@@ -120,8 +123,8 @@ public:
     static bool isNullLogger();
 
     // ----------------------------------------------------------------------
-    /** @brief  Kills the current singleton logger and replaces it with a
-     *  #NullLogger instance. */
+    /** @brief  Kills and deletes the current singleton logger and replaces
+     *  it with a #NullLogger instance. */
     static void kill();
 
     // ----------------------------------------------------------------------


### PR DESCRIPTION
assigning s_pNullLogger to the parameter "logger" is definitely wrong. However, custom logger previously set from user must not be deleted. The user itself must handle allocation / deallocation.