### PR TITLE
Add unit tests for X3D models which were broken at 5 Oct 2020 commit 3b9d4cf

### DIFF
--- a/test/unit/utX3DImportExport.cpp
+++ b/test/unit/utX3DImportExport.cpp
@@ -84,12 +84,12 @@ TEST_F(utX3DImportExport, importX3DComputerKeyboard) {
     ASSERT_EQ(scene->mNumMeshes, 4u);
 }
 
-TEST_F(utX3DImportExport, importX3DChevyTahoe) {
-    Assimp::Importer importer;
-    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_NONBSD_DIR "/X3D/Chevy/ChevyTahoe.x3d", aiProcess_ValidateDataStructure);
-    ASSERT_NE(nullptr, scene);
-    // TODO: CHANGE INCORRECT VALUE WHEN IMPORTER FIXED
-    //   As noted in assimp issue 4992, X3D importer was severely broken with 5 Oct 2020 commit 3b9d4cf.
-    //   ChevyTahoe.x3d should have 19 meshes but broken importer only has 18
-    ASSERT_EQ(scene->mNumMeshes, 18u);
-}
+//TEST_F(utX3DImportExport, importX3DChevyTahoe) {
+//    Assimp::Importer importer;
+//    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_NONBSD_DIR "/X3D/Chevy/ChevyTahoe.x3d", aiProcess_ValidateDataStructure);
+//    ASSERT_NE(nullptr, scene);
+//    // TODO: CHANGE INCORRECT VALUE WHEN IMPORTER FIXED
+//    //   As noted in assimp issue 4992, X3D importer was severely broken with 5 Oct 2020 commit 3b9d4cf.
+//    //   ChevyTahoe.x3d should have 19 meshes but broken importer only has 18
+//    ASSERT_EQ(scene->mNumMeshes, 18u);
+//}

--- a/test/unit/utX3DImportExport.cpp
+++ b/test/unit/utX3DImportExport.cpp
@@ -73,3 +73,23 @@ TEST_F(utX3DImportExport, importX3DIndexedLineSet) {
         ASSERT_EQ(scene->mMeshes[0]->mFaces[i].mNumIndices, 2u);
     }
 }
+
+TEST_F(utX3DImportExport, importX3DComputerKeyboard) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/X3D/ComputerKeyboard.x3d", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+    // TODO: CHANGE INCORRECT VALUE WHEN IMPORTER FIXED
+    //   As noted in assimp issue 4992, X3D importer was severely broken with 5 Oct 2020 commit 3b9d4cf.
+    //   ComputerKeyboard.x3d should have 99 meshes but broken importer only has 4
+    ASSERT_EQ(scene->mNumMeshes, 4u);
+}
+
+TEST_F(utX3DImportExport, importX3DChevyTahoe) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_NONBSD_DIR "/X3D/Chevy/ChevyTahoe.x3d", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+    // TODO: CHANGE INCORRECT VALUE WHEN IMPORTER FIXED
+    //   As noted in assimp issue 4992, X3D importer was severely broken with 5 Oct 2020 commit 3b9d4cf.
+    //   ChevyTahoe.x3d should have 19 meshes but broken importer only has 18
+    ASSERT_EQ(scene->mNumMeshes, 18u);
+}

--- a/test/unit/utX3DImportExport.cpp
+++ b/test/unit/utX3DImportExport.cpp
@@ -80,9 +80,9 @@ TEST_F(utX3DImportExport, importX3DComputerKeyboard) {
     ASSERT_NE(nullptr, scene);
     // TODO: CHANGE INCORRECT VALUE WHEN IMPORTER FIXED
     //   As noted in assimp issue 4992, X3D importer was severely broken with 5 Oct 2020 commit 3b9d4cf.
-    //   ComputerKeyboard.x3d should have 99 meshes but broken importer only has 4
+    //   ComputerKeyboard.x3d should have 100 meshes but broken importer only has 4
     ASSERT_EQ(4u, scene->mNumMeshes);  // Incorrect value from currently broken importer
-    ASSERT_NE(99u, scene->mNumMeshes); // Correct value, to be restored when importer fixed
+    ASSERT_NE(100u, scene->mNumMeshes); // Correct value, to be restored when importer fixed
 }
 
 TEST_F(utX3DImportExport, importX3DChevyTahoe) {

--- a/test/unit/utX3DImportExport.cpp
+++ b/test/unit/utX3DImportExport.cpp
@@ -81,7 +81,8 @@ TEST_F(utX3DImportExport, importX3DComputerKeyboard) {
     // TODO: CHANGE INCORRECT VALUE WHEN IMPORTER FIXED
     //   As noted in assimp issue 4992, X3D importer was severely broken with 5 Oct 2020 commit 3b9d4cf.
     //   ComputerKeyboard.x3d should have 99 meshes but broken importer only has 4
-    ASSERT_EQ(scene->mNumMeshes, 4u);
+    ASSERT_EQ(4u, scene->mNumMeshes);  // Incorrect value from currently broken importer
+    ASSERT_NE(99u, scene->mNumMeshes); // Correct value, to be restored when importer fixed
 }
 
 TEST_F(utX3DImportExport, importX3DChevyTahoe) {
@@ -91,5 +92,6 @@ TEST_F(utX3DImportExport, importX3DChevyTahoe) {
     // TODO: CHANGE INCORRECT VALUE WHEN IMPORTER FIXED
     //   As noted in assimp issue 4992, X3D importer was severely broken with 5 Oct 2020 commit 3b9d4cf.
     //   ChevyTahoe.x3d should have 20 meshes but broken importer only has 19
-    ASSERT_EQ(scene->mNumMeshes, 19u);
+    ASSERT_EQ(19u, scene->mNumMeshes); // Incorrect value from currently broken importer
+    ASSERT_NE(20u, scene->mNumMeshes); // Correct value, to be restored when importer fixed
 }

--- a/test/unit/utX3DImportExport.cpp
+++ b/test/unit/utX3DImportExport.cpp
@@ -84,12 +84,12 @@ TEST_F(utX3DImportExport, importX3DComputerKeyboard) {
     ASSERT_EQ(scene->mNumMeshes, 4u);
 }
 
-//TEST_F(utX3DImportExport, importX3DChevyTahoe) {
-//    Assimp::Importer importer;
-//    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_NONBSD_DIR "/X3D/Chevy/ChevyTahoe.x3d", aiProcess_ValidateDataStructure);
-//    ASSERT_NE(nullptr, scene);
-//    // TODO: CHANGE INCORRECT VALUE WHEN IMPORTER FIXED
-//    //   As noted in assimp issue 4992, X3D importer was severely broken with 5 Oct 2020 commit 3b9d4cf.
-//    //   ChevyTahoe.x3d should have 19 meshes but broken importer only has 18
-//    ASSERT_EQ(scene->mNumMeshes, 18u);
-//}
+TEST_F(utX3DImportExport, importX3DChevyTahoe) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_NONBSD_DIR "/X3D/Chevy/ChevyTahoe.x3d", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+    // TODO: CHANGE INCORRECT VALUE WHEN IMPORTER FIXED
+    //   As noted in assimp issue 4992, X3D importer was severely broken with 5 Oct 2020 commit 3b9d4cf.
+    //   ChevyTahoe.x3d should have 20 meshes but broken importer only has 19
+    ASSERT_EQ(scene->mNumMeshes, 19u);
+}


### PR DESCRIPTION
Closes #5829

Add unit tests for keyboard and "chevy" models.  The currently broken importer provides incorrect number of meshes for these models; the tests reflect the _incorrect_ mesh count, with `TODO`s so that when the importer is fixed and the tests begin failing, it will be obvious how to restore working test values