### PR TITLE
Fix use of uninitialized value.

### DIFF
--- a/code/Common/DefaultIOSystem.cpp
+++ b/code/Common/DefaultIOSystem.cpp
@@ -104,7 +104,9 @@ bool DefaultIOSystem::Exists(const char *pFile) const {
     }
 #else
 	struct stat statbuf;
-    stat(pFile, &statbuf);
+    if (stat(pFile, &statbuf) != 0) {
+        return false;
+    }
     // test for a regular file
     if (!S_ISREG(statbuf.st_mode)) {
         return false;


### PR DESCRIPTION
If the stat command fails, statbuf is uninitialized.