### PR TITLE
Fix potential uninitialized variable in clipper

### DIFF
--- a/contrib/clipper/clipper.cpp
+++ b/contrib/clipper/clipper.cpp
@@ -1567,7 +1567,7 @@ bool Clipper::ExecuteInternal()
     m_SortedEdges = 0;
 
     succeeded = true;
-    cInt botY, topY = 0;
+    cInt botY = 0, topY = 0;
     if (!PopScanbeam(botY)) return false;
     InsertLocalMinimaIntoAEL(botY);
     while (PopScanbeam(topY) || LocalMinimaPending())

--- a/contrib/clipper/clipper.cpp
+++ b/contrib/clipper/clipper.cpp
@@ -1567,7 +1567,7 @@ bool Clipper::ExecuteInternal()
     m_SortedEdges = 0;
 
     succeeded = true;
-    cInt botY, topY;
+    cInt botY, topY = 0;
     if (!PopScanbeam(botY)) return false;
     InsertLocalMinimaIntoAEL(botY);
     while (PopScanbeam(topY) || LocalMinimaPending())


### PR DESCRIPTION
If `PopScanbeam` returns false, `topY` may not have been initialized in this function, which can cause a compiler warning/error:
```
/.../assimp/contrib/clipper/clipper.cpp: In member function ‘virtual bool ClipperLib::Clipper::ExecuteInternal()’:
/.../assimp/contrib/clipper/clipper.cpp:1577:32: error: ‘topY’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
 1577 |       if (!ProcessIntersections(topY))
      |            ~~~~~~~~~~~~~~~~~~~~^~~~~~
```