### PR TITLE
Fix parsing of comments at the end of lines for tokens with variable number of elements. (#5890)

### DIFF
--- a/code/AssetLib/Obj/ObjFileParser.cpp
+++ b/code/AssetLib/Obj/ObjFileParser.cpp
@@ -303,6 +303,9 @@ size_t ObjFileParser::getNumComponentsInDataDefinition() {
         if (!SkipSpaces(&tmp, mEnd)) {
             break;
         }
+        if (*tmp == '#') {
+            break;
+        }
         const bool isNum(IsNumeric(*tmp) || isNanOrInf(tmp));
         SkipToken(tmp, mEnd);
         if (isNum) {
@@ -311,8 +314,11 @@ size_t ObjFileParser::getNumComponentsInDataDefinition() {
         if (!SkipSpaces(&tmp, mEnd)) {
             break;
         }
+        if (*tmp == '#') {
+            break;
+        }
     }
-    
+
     return numComponents;
 }
 
@@ -452,6 +458,9 @@ void ObjFileParser::getFace(aiPrimitiveType type) {
         int iStep = 1;
 
         if (IsLineEnd(*m_DataIt)) {
+            break;
+        }
+        if (*m_DataIt == '#') {
             break;
         }
 

--- a/include/assimp/ParsingUtils.h
+++ b/include/assimp/ParsingUtils.h
@@ -119,7 +119,7 @@ AI_FORCE_INLINE bool SkipSpaces(const char_t **inout, const char_t *end) {
 // ---------------------------------------------------------------------------------
 template <class char_t>
 AI_FORCE_INLINE bool SkipLine(const char_t *in, const char_t **out, const char_t *end) {
-    while ((*in != (char_t)'\r' && *in != (char_t)'\n' && *in != (char_t)'\0') && in != end) {
+    while ((*in != (char_t)'\r' && *in != (char_t)'\n' && *in != (char_t)'\0') && *in != (char_t)'#' && in != end) {
         ++in;
     }
 


### PR DESCRIPTION
This pull request should fix the problem described in issue #5890 by stopping the parsing/skipping the rest of a line when a `#` comment character is found.
Everything that follows after the `#` can be assumed to be part of the comment and should thus not be parsed.

I made sure to check that all currently existing unit tests are passing.

Looking forward to your feedback. 🙂