### PR TITLE
Add CI to automatically build and attach binaries to releases

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,50 @@
+name: Build and Publish Prebuilt Binaries
+
+on:
+  release:
+    types: [created]
+    
+jobs:
+  build:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: windows-x64
+            os: windows-latest
+            arch: x64
+          - name: windows-x86
+            os: windows-latest
+            arch: x86
+            cmake_args: -A Win32
+          - name: macos-x64
+            os: macos-latest
+          - name: linux-x64
+            os: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: lukka/get-cmake@latest
+
+      - uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.arch }}
+      
+      - name: Build
+        run: |
+          cmake -B build -S . ${{ matrix.cmake_args }} -DCMAKE_BUILD_TYPE=Release -DASSIMP_BUILD_TESTS=OFF
+          cmake --build build --config Release
+
+      - uses: TheDoctor0/zip-release@0.7.6
+        with:
+          filename: ${{ matrix.name }}-${{ github.event.release.tag_name }}.zip
+          directory: build/bin/
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: build/bin/${{ matrix.name }}-${{ github.event.release.tag_name }}.zip
+          append_body: true
+          fail_on_unmatched_files: true

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -20,6 +20,8 @@ jobs:
             arch: x86
             cmake_args: -A Win32
           - name: macos-x64
+            os: macos-13
+          - name: macos-arm64
             os: macos-latest
           - name: linux-x64
             os: ubuntu-latest


### PR DESCRIPTION
I needed this for myself, so I thought I'd contribute it as well, it's also been requested in the past, see #4356.

Will automatically build and attach the binaries when a new release is created, see [an example release](https://github.com/Saalvage/assimp/releases/tag/0.0.0.1.0.0) and [an example CI run](https://github.com/Saalvage/assimp/actions/runs/11996636350).

New configurations can easily be added as requested.

Some considerations:
- Due to the way MSVC structures its builds, the windows binary archives contain a "Release" folder in which the actual DLL is found. There's also a .pdb file that is significantly larger than the DLL itself included as well. This may not be desirable, but it makes implementation somewhat easier (honestly just saves an extra step of extracting the file we want from that folder or making the files to zip conditional).
- I tried to get ccache/sccache to work, however, it seems there's some issues with caches being loaded when a new tag is created. Potentially relevant: https://github.com/hendrikmuhs/ccache-action/issues/108. Since releases get created so rarely this is probably of little to no concern.

If there's anything that should be adjusted/improved upon please let me know!