### PR TITLE
Fix heap-buffer-overflow in OpenDDLParser

### DIFF
--- a/contrib/openddlparser/code/OpenDDLParser.cpp
+++ b/contrib/openddlparser/code/OpenDDLParser.cpp
@@ -74,12 +74,11 @@ const char *getTypeToken(Value::ValueType type) {
     return Grammar::PrimitiveTypeToken[(size_t)type];
 }
 
-static void logInvalidTokenError(const char *in, const std::string &exp, OpenDDLParser::logCallback callback) {
-    if (callback) {
-        std::string full(in);
-        std::string part(full.substr(0, 50));
+static void logInvalidTokenError(const std::string &in, const std::string &exp, OpenDDLParser::logCallback callback) {
+    if (callback) {\
+        std::string part(in.substr(0, 50));
         std::stringstream stream;
-        stream << "Invalid token \"" << *in << "\" "
+        stream << "Invalid token \"" << in << "\" "
                << "(expected \"" << exp << "\") "
                << "in: \"" << part << "\"";
         callback(ddl_error_msg, stream.str());
@@ -306,7 +305,7 @@ char *OpenDDLParser::parseHeader(char *in, char *end) {
                 }
 
                 if (*in != Grammar::CommaSeparator[0] && *in != Grammar::ClosePropertyToken[0]) {
-                    logInvalidTokenError(in, Grammar::ClosePropertyToken, m_logCallback);
+                    logInvalidTokenError(std::string(in, end), Grammar::ClosePropertyToken, m_logCallback);
                     return nullptr;
                 }
 
@@ -355,8 +354,7 @@ char *OpenDDLParser::parseStructure(char *in, char *end) {
                 ++in;
             }
         } else {
-            ++in;
-            logInvalidTokenError(in, std::string(Grammar::OpenBracketToken), m_logCallback);
+            logInvalidTokenError(std::string(in, end), std::string(Grammar::OpenBracketToken), m_logCallback);
             error = true;
             return nullptr;
         }
@@ -427,7 +425,7 @@ char *OpenDDLParser::parseStructureBody(char *in, char *end, bool &error) {
 
         in = lookForNextToken(in, end);
         if (in == end || *in != '}') {
-            logInvalidTokenError(in == end ? "" : in, std::string(Grammar::CloseBracketToken), m_logCallback);
+            logInvalidTokenError(std::string(in, end), std::string(Grammar::CloseBracketToken), m_logCallback);
             return nullptr;
         } else {
             //in++;


### PR DESCRIPTION
Fixes https://github.com/assimp/assimp/issues/5906, https://github.com/assimp/assimp/issues/5787

Use `std::string` instead of `const char*` to log not zero-terminated strings. ASAN report for reference:

```
=================================================================
==266231==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x50200000011f at pc 0x55d3f028a8e9 bp 0x7ffca243ab90 sp 0x7ffca243a358
READ of size 1 at 0x50200000011f thread T0
    #0 0x55d3f028a8e8 in strlen (assimp/myfuzzing/prefix/bin/assimp_fuzzer+0xb088e8) (BuildId: 13be78bd51af30c410e9d483a4f94497ad869dad)
    #1 0x55d3f0245eb8 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::basic_string<std::allocator<char>>(char const*, std::allocator<char> const&) (assimp/myfuzzing/prefix/bin/assimp_fuzzer+0xac3eb8) (BuildId: 13be78bd51af30c410e9d483a4f94497ad869dad)
    #2 0x55d3f24c79c9 in ODDLParser::logInvalidTokenError(char const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, std::function<void (ODDLParser::LogSeverity, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&)>) assimp/contrib/openddlparser/code/OpenDDLParser.cpp:79:21
    #3 0x55d3f24c4f68 in ODDLParser::OpenDDLParser::parseStructure(char*, char*) assimp/contrib/openddlparser/code/OpenDDLParser.cpp:359:13
    #4 0x55d3f24c300f in ODDLParser::OpenDDLParser::parseNextNode(char*, char*) assimp/contrib/openddlparser/code/OpenDDLParser.cpp:250:10
    #5 0x55d3f24c20e7 in ODDLParser::OpenDDLParser::parse() assimp/contrib/openddlparser/code/OpenDDLParser.cpp:230:19
    #6 0x55d3f1480ae8 in Assimp::OpenGEX::OpenGEXImporter::InternReadFile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, aiScene*, Assimp::IOSystem*) assimp/code/AssetLib/OpenGEX/OpenGEXImporter.cpp:304:27
    #7 0x55d3f0b22b65 in Assimp::BaseImporter::ReadFile(Assimp::Importer*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, Assimp::IOSystem*) assimp/code/Common/BaseImporter.cpp:131:9
    #8 0x55d3f035d697 in Assimp::Importer::ReadFile(char const*, unsigned int) assimp/code/Common/Importer.cpp:709:30
    #9 0x55d3f0359fa2 in Assimp::Importer::ReadFileFromMemory(void const*, unsigned long, unsigned int, char const*) assimp/code/Common/Importer.cpp:507:9
    #10 0x55d3f034fb4c in LLVMFuzzerTestOneInput assimp/myfuzzing/cmake-build/../../fuzz/assimp_fuzzer.cc:54:34
    #11 0x55d3f025bcd0 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (assimp/myfuzzing/prefix/bin/assimp_fuzzer+0xad9cd0) (BuildId: 13be78bd51af30c410e9d483a4f94497ad869dad)
    #12 0x55d3f0245e22 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (assimp/myfuzzing/prefix/bin/assimp_fuzzer+0xac3e22) (BuildId: 13be78bd51af30c410e9d483a4f94497ad869dad)
    #13 0x55d3f024b866 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (assimp/myfuzzing/prefix/bin/assimp_fuzzer+0xac9866) (BuildId: 13be78bd51af30c410e9d483a4f94497ad869dad)
    #14 0x55d3f02749d2 in main (assimp/myfuzzing/prefix/bin/assimp_fuzzer+0xaf29d2) (BuildId: 13be78bd51af30c410e9d483a4f94497ad869dad)
    #15 0x7f773b459d8f in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #16 0x7f773b459e3f in __libc_start_main csu/../csu/libc-start.c:392:3
    #17 0x55d3f0240e04 in _start (assimp/myfuzzing/prefix/bin/assimp_fuzzer+0xabee04) (BuildId: 13be78bd51af30c410e9d483a4f94497ad869dad)

0x50200000011f is located 0 bytes after 15-byte region [0x502000000110,0x50200000011f)
allocated by thread T0 here:
    #0 0x55d3f034d70d in operator new(unsigned long) (assimp/myfuzzing/prefix/bin/assimp_fuzzer+0xbcb70d) (BuildId: 13be78bd51af30c410e9d483a4f94497ad869dad)
    #1 0x55d3f09156fe in std::__new_allocator<char>::allocate(unsigned long, void const*) /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/new_allocator.h:147:27
    #2 0x55d3f0914a71 in std::allocator_traits<std::allocator<char>>::allocate(std::allocator<char>&, unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/alloc_traits.h:482:20
    #3 0x55d3f0914a71 in std::_Vector_base<char, std::allocator<char>>::_M_allocate(unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/stl_vector.h:378:20
    #4 0x55d3f0913f1f in std::vector<char, std::allocator<char>>::_M_default_append(unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/vector.tcc:663:34
    #5 0x55d3f09136ae in std::vector<char, std::allocator<char>>::resize(unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/stl_vector.h:1013:4
    #6 0x55d3f24c0146 in ODDLParser::OpenDDLParser::setBuffer(char const*, unsigned long) assimp/contrib/openddlparser/code/OpenDDLParser.cpp:171:14
    #7 0x55d3f1480ad7 in Assimp::OpenGEX::OpenGEXImporter::InternReadFile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, aiScene*, Assimp::IOSystem*) assimp/code/AssetLib/OpenGEX/OpenGEXImporter.cpp:303:14
    #8 0x55d3f0b22b65 in Assimp::BaseImporter::ReadFile(Assimp::Importer*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, Assimp::IOSystem*) assimp/code/Common/BaseImporter.cpp:131:9
    #9 0x55d3f035d697 in Assimp::Importer::ReadFile(char const*, unsigned int) assimp/code/Common/Importer.cpp:709:30
    #10 0x55d3f0359fa2 in Assimp::Importer::ReadFileFromMemory(void const*, unsigned long, unsigned int, char const*) assimp/code/Common/Importer.cpp:507:9
    #11 0x55d3f034fb4c in LLVMFuzzerTestOneInput assimp/myfuzzing/cmake-build/../../fuzz/assimp_fuzzer.cc:54:34
    #12 0x55d3f025bcd0 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (assimp/myfuzzing/prefix/bin/assimp_fuzzer+0xad9cd0) (BuildId: 13be78bd51af30c410e9d483a4f94497ad869dad)
    #13 0x55d3f0245e22 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) (assimp/myfuzzing/prefix/bin/assimp_fuzzer+0xac3e22) (BuildId: 13be78bd51af30c410e9d483a4f94497ad869dad)
    #14 0x55d3f024b866 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (assimp/myfuzzing/prefix/bin/assimp_fuzzer+0xac9866) (BuildId: 13be78bd51af30c410e9d483a4f94497ad869dad)
    #15 0x55d3f02749d2 in main (assimp/myfuzzing/prefix/bin/assimp_fuzzer+0xaf29d2) (BuildId: 13be78bd51af30c410e9d483a4f94497ad869dad)
    #16 0x7f773b459d8f in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16

SUMMARY: AddressSanitizer: heap-buffer-overflow (assimp/myfuzzing/prefix/bin/assimp_fuzzer+0xb088e8) (BuildId: 13be78bd51af30c410e9d483a4f94497ad869dad) in strlen
Shadow bytes around the buggy address:
  0x501ffffffe80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x501fffffff00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x501fffffff80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x502000000000: fa fa 00 06 fa fa 00 06 fa fa 00 fa fa fa fd fa
  0x502000000080: fa fa fd fd fa fa fd fa fa fa 00 00 fa fa 00 07
=>0x502000000100: fa fa 00[07]fa fa fd fa fa fa fd fa fa fa fd fa
  0x502000000180: fa fa fd fa fa fa fd fd fa fa 00 fa fa fa fd fa
  0x502000000200: fa fa fd fa fa fa fd fd fa fa 00 fa fa fa 00 00
  0x502000000280: fa fa 00 00 fa fa fa fa fa fa fa fa fa fa fa fa
  0x502000000300: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x502000000380: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==266231==ABORTING
```