### PR TITLE
Replace C# port with maintained fork

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -44,7 +44,7 @@ Start by reading [our build instructions](https://github.com/assimp/assimp/blob/
 ### Ports ###
 * [Android](port/AndroidJNI/README.md)
 * [Python](port/PyAssimp/README.md)
-* [.NET](https://bitbucket.org/Starnick/assimpnet/src/master/)
+* [.NET](https://github.com/Saalvage/AssimpNetter)
 * [Pascal](port/AssimpPascal/Readme.md)
 * [Javascript (Alpha)](https://github.com/makc/assimp2json)
 * [Javascript/Node.js Interface](https://github.com/kovacsv/assimpjs)


### PR DESCRIPTION
There have been no updates to AssimpNet in over two years, which means it is stuck on an old version of Assimp and fails to take advantage of some more modern additions to .NET (namely the built-in math types). I've created a fork of the project that updates it to the latest Assimp release, adds better interop with modern C# and includes ARM64 binaries for MacOS. I'm also looking to maintain this fork for the foreseeable future with bug fixes and updates to the latest Assimp versions.