### PR TITLE
SetIOHandler delete previous handler when setting to nullptr

### DIFF
--- a/code/Common/Importer.cpp
+++ b/code/Common/Importer.cpp
@@ -298,13 +298,15 @@ void Importer::SetIOHandler( IOSystem* pIOHandler) {
     ai_assert(nullptr != pimpl);
 
     ASSIMP_BEGIN_EXCEPTION_REGION();
+    if (pimpl->mIOHandler) {
+        delete pimpl->mIOHandler;
+    }
     // If the new handler is zero, allocate a default IO implementation.
     if (!pIOHandler) {
         // Release pointer in the possession of the caller
         pimpl->mIOHandler = new DefaultIOSystem();
         pimpl->mIsDefaultHandler = true;
     } else if (pimpl->mIOHandler != pIOHandler) { // Otherwise register the custom handler
-        delete pimpl->mIOHandler;
         pimpl->mIOHandler = pIOHandler;
         pimpl->mIsDefaultHandler = false;
     }


### PR DESCRIPTION
If `nullptr` is passed, a default handler is created and set, but the previous one is not released. This looks like a bug, as it makes the function inconsistent and really hard to use without leaking.

I suspect this is the cause for https://github.com/assimp/assimp/issues/5913, but I have to be able to repro it yet to confirm.

A new `ImporterImpl` is created with a `nullptr` mIOHandler` initially, the `ReadFileFromMemory` would store that `nullptr` into `io`, changes it, then sets it back.

```
    IOSystem* io = pimpl->mIOHandler;

// ...
        // prevent deletion of the previous IOHandler
        pimpl->mIOHandler = nullptr;
        SetIOHandler(new MemoryIOSystem((const uint8_t*)pBuffer,pLength,io));
// ...
        SetIOHandler(io);
```

Notice that if `io` is `nullptr` this will leak.

A deeper question I am not sure I can ask is if the behavior of creating a default IOHandler is expected: when the class is created, the `mIOHandler` is `nullptr`, but after the final call to `SetIOHandler(nullptr)` the `mIOHandler` will actually be the default one. Is this change of state expected for the `ReadFileFromMemory` function?

EDIT: please let me know if I should add the case exposed in the referenced issue in some unit test somewhere for the address sanitizer in CI to catch it(?)