### PR TITLE
glTF importers: Avoid strncpy truncating away the ' \0' character

### DIFF
--- a/code/AssetLib/glTF/glTFImporter.cpp
+++ b/code/AssetLib/glTF/glTFImporter.cpp
@@ -664,7 +664,7 @@ void glTFImporter::ImportEmbeddedTextures(glTF::Asset &r) {
 
                 const size_t len = strlen(ext);
                 if (len <= 3) {
-                    strncpy(tex->achFormatHint, ext, len);
+                    strncpy(tex->achFormatHint, ext, len + 1);
                 }
             }
         }

--- a/code/AssetLib/glTF/glTFImporter.cpp
+++ b/code/AssetLib/glTF/glTFImporter.cpp
@@ -664,6 +664,7 @@ void glTFImporter::ImportEmbeddedTextures(glTF::Asset &r) {
 
                 const size_t len = strlen(ext);
                 if (len <= 3) {
+                    static_assert(sizeof(tex->achFormatHint) > 3, "achFormatHint is expected to hold at least 4 bytes.");
                     strncpy(tex->achFormatHint, ext, len + 1);
                 }
             }

--- a/code/AssetLib/glTF2/glTF2Importer.cpp
+++ b/code/AssetLib/glTF2/glTF2Importer.cpp
@@ -1640,7 +1640,7 @@ void glTF2Importer::ImportEmbeddedTextures(glTF2::Asset &r) {
 
                 const size_t len = strlen(ext);
                 if (len <= 3) {
-                    strncpy(tex->achFormatHint, ext, len);
+                    strncpy(tex->achFormatHint, ext, len + 1);
                 }
             }
         }

--- a/code/AssetLib/glTF2/glTF2Importer.cpp
+++ b/code/AssetLib/glTF2/glTF2Importer.cpp
@@ -1640,6 +1640,7 @@ void glTF2Importer::ImportEmbeddedTextures(glTF2::Asset &r) {
 
                 const size_t len = strlen(ext);
                 if (len <= 3) {
+                    static_assert(sizeof(tex->achFormatHint) > 3, "achFormatHint is expected to hold at least 4 bytes.");
                     strncpy(tex->achFormatHint, ext, len + 1);
                 }
             }


### PR DESCRIPTION
In build https://github.com/assimp/assimp/actions/runs/12403918024/job/34628244451?pr=5928 I hit some building errors because this strncpy functions were copying using the string length, which would remove the null terminator character. I just added a `+1` to ensure the null character is accounted for.