### PR TITLE
Disable logs for fuzzer by default

### DIFF
--- a/fuzz/assimp_fuzzer.cc
+++ b/fuzz/assimp_fuzzer.cc
@@ -47,8 +47,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 using namespace Assimp;
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t dataSize) {
+#ifdef _DEBUG
     aiLogStream stream = aiGetPredefinedLogStream(aiDefaultLogStream_STDOUT, nullptr);
     aiAttachLogStream(&stream);
+#endif
 
     Importer importer;
     const aiScene *sc = importer.ReadFileFromMemory(data, dataSize,
@@ -61,7 +63,9 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t dataSize) {
     Exporter exporter;
     exporter.ExportToBlob(sc, "fbx");
     
+#ifdef _DEBUG
     aiDetachLogStream(&stream);
+#endif
 
     return 0;
 }


### PR DESCRIPTION
Using a logger in the fuzzer generates a large amount of output in the OSS-Fuzz project. For instance, [the latest run](https://oss-fuzz-build-logs.storage.googleapis.com/log-ae10e9c1-7390-4e01-a26d-6533a51a4529.txt) produced approximately 5 GB of output, which is generally not very useful This patch disables logging by default (`_DEBUG` is not set in the OSS-Fuzz environment).