### PR TITLE
Fix stack overflow in LWS loader

### DIFF
--- a/code/AssetLib/LWS/LWSLoader.cpp
+++ b/code/AssetLib/LWS/LWSLoader.cpp
@@ -585,6 +585,15 @@ void LWSImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
             // and add the file to the import list
             SkipSpaces(&c, end);
             std::string path = FindLWOFile(c);
+
+            if (path.empty()) {
+                throw DeadlyImportError("LWS: Invalid LoadObjectLayer: empty path.");
+            }
+
+            if (path == pFile) {
+                throw DeadlyImportError("LWS: Invalid LoadObjectLayer: self reference.");
+            }
+
             d.path = path;
             d.id = batch.AddLoadRequest(path, 0, &props);
 
@@ -602,6 +611,15 @@ void LWSImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
                 d.number = cur_object++;
             }
             std::string path = FindLWOFile(c);
+
+            if (path.empty()) {
+                throw DeadlyImportError("LWS: Invalid LoadObject: empty path.");
+            }
+
+            if (path == pFile) {
+                throw DeadlyImportError("LWS: Invalid LoadObject: self reference.");
+            }
+
             d.id = batch.AddLoadRequest(path, 0, nullptr);
 
             d.path = path;


### PR DESCRIPTION
The fuzzing test found this issue. Stack overflow can happen if an LWS file contains LoadObject or LoadObjectLayer command with the same file path as the current file.

OSS-Fuzz log (search by `stack-overflow`): https://oss-fuzz-build-logs.storage.googleapis.com/log-64548938-c33e-4161-9cfd-61fe8f85b562.txt

```
UndefinedBehaviorSanitizer:DEADLYSIGNAL
==81==ERROR: UndefinedBehaviorSanitizer: stack-overflow on address 0x7ffeff60afd8 (pc 0x561aef606873 bp 0x7ffeff60b030 sp 0x7ffeff60afe0 T81)
    #0 0x561aef606873 in Assimp::FileSystemFilter::Open(char const*, char const*) /src/assimp/code/Common/FileSystemFilter.h:132:33
    #1 0x561aef606875 in Assimp::FileSystemFilter::Open(char const*, char const*) /src/assimp/code/Common/FileSystemFilter.h:132:33
    #2 0x561aef606875 in Assimp::FileSystemFilter::Open(char const*, char const*) /src/assimp/code/Common/FileSystemFilter.h:132:33
    #3 0x561aef606875 in Assimp::FileSystemFilter::Open(char const*, char const*) /src/assimp/code/Common/FileSystemFilter.h:132:33
    #4 0x561aef606875 in Assimp::FileSystemFilter::Open(char const*, char const*) /src/assimp/code/Common/FileSystemFilter.h:132:33
    #5 0x561aef606875 in Assimp::FileSystemFilter::Open(char const*, char const*) /src/assimp/code/Common/FileSystemFilter.h:132:33
    #6 0x561aef606875 in Assimp::FileSystemFilter::Open(char const*, char const*) /src/assimp/code/Common/FileSystemFilter.h:132:33
    #7 0x561aef606875 in Assimp::FileSystemFilter::Open(char const*, char const*) /src/assimp/code/Common/FileSystemFilter.h:132:33
    #8 0x561aef606875 in Assimp::FileSystemFilter::Open(char const*, char const*) /src/assimp/code/Common/FileSystemFilter.h:132:33
    #9 0x561aef606875 in Assimp::FileSystemFilter::Open(char const*, char const*) /src/assimp/code/Common/FileSystemFilter.h:132:33
    #10 0x561aef606875 in Assimp::FileSystemFilter::Open(char const*, char const*) /src/assimp/code/Common/FileSystemFilter.h:132:33
    #11 0x561aef606875 in Assimp::FileSystemFilter::Open(char const*, char const*) /src/assimp/code/Common/FileSystemFilter.h:132:33
    #12 0x561aef606875 in Assimp::FileSystemFilter::Open(char const*, char const*) /src/assimp/code/Common/FileSystemFilter.h:132:33
    #13 0x561aef606875 in Assimp::FileSystemFilter::Open(char const*, char const*) /src/assimp/code/Common/FileSystemFilter.h:132:33
    #14 0x561aef606875 in Assimp::FileSystemFilter::Open(char const*, char const*) /src/assimp/code/Common/FileSystemFilter.h:132:33
    ...
    #248 0x561aef606875 in Assimp::FileSystemFilter::Open(char const*, char const*) /src/assimp/code/Common/FileSystemFilter.h:132:33

DEDUP_TOKEN: Assimp::FileSystemFilter::Open(char const*, char const*)--Assimp::FileSystemFilter::Open(char const*, char const*)--Assimp::FileSystemFilter::Open(char const*, char const*)
SUMMARY: UndefinedBehaviorSanitizer: stack-overflow /src/assimp/code/Common/FileSystemFilter.h:132:33 in Assimp::FileSystemFilter::Open(char const*, char const*)
==81==ABORTING
MS: 0 ; base unit: 0000000000000000000000000000000000000000
0x4c,0x57,0x4d,0x4f,0xa,0xff,0xd0,0xd9,0xd1,0x4d,0xd6,0x6f,0x4f,0xa,0x28,0x39,0x34,0x20,0xc,0x53,0xa,0xd3,0x30,0x76,0xd,0x4c,0x6f,0x61,0x64,0x4f,0x62,0x6a,0x65,0x63,0x74,0x9,0x24,0x24,0x24,0x5f,0x5f,0x5f,0x6d,0x61,0x67,0x69,0x63,0x5f,0x5f,0x5f,0x24,0x24,0x24,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x31,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x4d,0x44,0x4c,0x33,0x72,0x61,0x67,0x65,0x4f,0x4e,0xd,0x32,0xd,0x45,0x4e,0x54,0x49,0x54,0x49,0x45,0x53,0xa,0x3b,0xd,0x49,0x4e,0x53,0x45,0x52,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,0xcb,
LWMO\012\377\320\331\321M\326oO\012(94 \014S\012\3230v\015LoadObject\011$$$___magic___$$$\377\377\377\377\377\377\377\377\377\377\377\3771\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377MDL3rageON\0152\015ENTITIES\012;\015INSER\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313\313
artifact_prefix='./'; Test unit written to ./crash-c9060ffc548bdde465474064251166c12d8ea94b
Base64: TFdNTwr/0NnRTdZvTwooOTQgDFMK0zB2DUxvYWRPYmplY3QJJCQkX19fbWFnaWNfX18kJCT///////////////8x////////////////////////////////TURMM3JhZ2VPTg0yDUVOVElUSUVTCjsNSU5TRVLLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8vLy8s=
```

I'm not sure my approach is correct, please let me know if there is a better solution.