### PR TITLE
pragma warning bug fix when using g++ on windows

### DIFF
--- a/contrib/poly2tri/poly2tri/common/shapes.h
+++ b/contrib/poly2tri/poly2tri/common/shapes.h
@@ -38,8 +38,7 @@
 #include <stdexcept>
 #include <vector>
 
-
-#if defined(_WIN32)
+#if defined(_WIN32) && defined(_MSC_VER) && !defined(__INTEL_COMPILER)
 #  pragma warning( disable: 4251)
 #endif
 namespace p2t {


### PR DESCRIPTION
Added additional check if it is MSVC, because g++ will raise "unknown-pragmas" warning when used on windows, which will stop build process if warnings are treated as errors. Additionally, intel compiler is excluded since it also defines __MSC_VER, but doesn't support #pragma warning(...) syntax.
One thing to note is that clang also defines _MSC_VER, but I can't find if it has support for MSVC #pragma warning(...), and if yes, which versions of clang support it. Currently, I don't have clang, so I can't directly test this.