### PR TITLE
Updated Material.cpp to Add Missing Texture Types to String

### DIFF
--- a/code/Common/material.cpp
+++ b/code/Common/material.cpp
@@ -90,6 +90,14 @@ const char *aiTextureTypeToString(aiTextureType in) {
         return "Clearcoat";
     case aiTextureType_TRANSMISSION:
         return "Transmission";
+    case aiTextureType_MAYA_BASE:
+        return "MayaBase";
+    case aiTextureType_MAYA_SPECULAR:
+        return "MayaSpecular";
+    case aiTextureType_MAYA_SPECULAR_COLOR: 
+        return "MayaSpecularColor";
+    case aiTextureType_MAYA_SPECULAR_ROUGHNESS:
+        return "MayaSpecularRoughness";
     case aiTextureType_UNKNOWN:
         return "Unknown";
     default:


### PR DESCRIPTION
In pull request #5101, user @Sanchikuuus added MayaTextures from the FBX Converter as a valid AiTextureType.

These same AiTextureTypes were not added to the material.cpp file which would result in 'Bug' string outputs when investigating Maya-exported FBXs.

Noticed whilst doing a code read-through.