### PR TITLE
Docker: Optimize usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,17 @@
-FROM ubuntu:22.04
+FROM gcc:latest
 
-RUN apt-get update && apt-get install --no-install-recommends -y ninja-build \
-    git cmake build-essential software-properties-common
+RUN apt-get update && apt-get install --no-install-recommends -y ninja-build cmake 
 
-RUN add-apt-repository ppa:ubuntu-toolchain-r/test && apt-get update 
-
-WORKDIR /opt
+WORKDIR /app
 RUN apt install zlib1g-dev
 
-# Build Assimp
-RUN git clone https://github.com/assimp/assimp.git /opt/assimp
+COPY . .
 
-WORKDIR /opt/assimp
-
-RUN git checkout master \
-    && mkdir build && cd build && \
+RUN mkdir build && cd build && \
     cmake -G 'Ninja' \
     -DCMAKE_BUILD_TYPE=Release \
     -DASSIMP_BUILD_ASSIMP_TOOLS=ON \
     .. && \
     ninja -j4 && ninja install
+
+CMD ["/app/build/bin/unit"]

--- a/test/unit/utMetadata.cpp
+++ b/test/unit/utMetadata.cpp
@@ -229,7 +229,7 @@ TEST_F( utMetadata, copy_test ) {
 
     // bool test
     {
-        bool v;
+        bool v = true;
         EXPECT_TRUE( copy.Get( "bool", v ) );
         EXPECT_EQ( bv, v );
     }


### PR DESCRIPTION
- Copy source from local folder instead of checkit it out
- Use gcc image
- Directly run unittests