### PR TITLE
Add aiProcess_ValidateDataStructure flag to the fuzzer

### DIFF
--- a/fuzz/assimp_fuzzer.cc
+++ b/fuzz/assimp_fuzzer.cc
@@ -53,8 +53,8 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t dataSize) {
 #endif
 
     Importer importer;
-    const aiScene *sc = importer.ReadFileFromMemory(data, dataSize,
-        aiProcessPreset_TargetRealtime_Quality, nullptr );
+    unsigned int flags = aiProcessPreset_TargetRealtime_Quality | aiProcess_ValidateDataStructure;
+    const aiScene *sc = importer.ReadFileFromMemory(data, dataSize, flags, nullptr);
 
     if (sc == nullptr) {
         return 0;


### PR DESCRIPTION
This is a continuation of https://github.com/assimp/assimp/pull/5944#issuecomment-2572952400

The current fuzzer calls `Exporter::ExportToBlob` right after `Importer::ReadFileFromMemory`, which is invoked with the flag `aiProcessPreset_TargetRealtime_Quality`. This flag doesn't include the `aiProcess_ValidateDataStructure` value, which means that aiScene::mRootNode might be NULL. At least, this is what I can conclude after reading the code and documentation.

```
ai_assert failure in /src/assimp/code/Common/SceneCombiner.cpp(1293): nullptr != src
==74== ERROR: libFuzzer: deadly signal
    #0 0x56323fdc6b34 in __sanitizer_print_stack_trace /src/llvm-project/compiler-rt/lib/ubsan/ubsan_diag_standalone.cpp:31:3
    #1 0x56323fd45b88 in fuzzer::PrintStackTrace() /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerUtil.cpp:210:5
    #2 0x56323fd28f23 in fuzzer::Fuzzer::CrashCallback() /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:231:3
    #3 0x7f0045f3541f  (/lib/x86_64-linux-gnu/libpthread.so.0+0x1441f) (BuildId: 9a65bb469e45a1c6fbcffae5b82a2fd7a69eb479)
    #4 0x7f0045d2f00a in raise (/lib/x86_64-linux-gnu/libc.so.6+0x4300a) (BuildId: 0702430aef5fa3dda43986563e9ffcc47efbd75e)
    #5 0x7f0045d0e858 in abort (/lib/x86_64-linux-gnu/libc.so.6+0x22858) (BuildId: 0702430aef5fa3dda43986563e9ffcc47efbd75e)
    #6 0x56323fde1bef in Assimp::defaultAiAssertHandler(char const*, char const*, int) /src/assimp/code/Common/AssertHandler.cpp:53:5
    #7 0x56323fffd80f in Assimp::SceneCombiner::Copy(aiNode**, aiNode const*) /src/assimp/code/Common/SceneCombiner.cpp:1293:5
    #8 0x563240000700 in Assimp::SceneCombiner::CopyScene(aiScene**, aiScene const*, bool) /src/assimp/code/Common/SceneCombiner.cpp:1055:5
    #9 0x56323fde4756 in Assimp::Exporter::Export(aiScene const*, char const*, char const*, unsigned int, Assimp::ExportProperties const*) /src/assimp/code/Common/Exporter.cpp:385:17
    #10 0x56323fde43c5 in Assimp::Exporter::ExportToBlob(aiScene const*, char const*, unsigned int, Assimp::ExportProperties const*) /src/assimp/code/Common/Exporter.cpp:353:23
    #11 0x56323fdc7eab in LLVMFuzzerTestOneInput /src/assimp/fuzz/assimp_fuzzer.cc:64:14
    #12 0x56323fd2a430 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerLoop.cpp:614:13
    #13 0x56323fd33a00 in fuzzer::Fuzzer::CrashResistantMergeInternalStep(std::__Fuzzer::basic_string<char, std::__Fuzzer::char_traits<char>, std::__Fuzzer::allocator<char>> const&, bool) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMerge.cpp:239:5
    #14 0x56323fd1afb5 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerDriver.cpp:887:8
    #15 0x56323fd463e2 in main /src/llvm-project/compiler-rt/lib/fuzzer/FuzzerMain.cpp:20:10
    #16 0x7f0045d10082 in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x24082) (BuildId: 0702430aef5fa3dda43986563e9ffcc47efbd75e)
    #17 0x56323fd0d88d in _start (out/libfuzzer-coverage-x86_64/assimp_fuzzer+0x1cc88d)

DEDUP_TOKEN: __sanitizer_print_stack_trace--fuzzer::PrintStackTrace()--fuzzer::Fuzzer::CrashCallback()
NOTE: libFuzzer has rudimentary signal handlers.
      Combine libFuzzer with AddressSanitizer or similar for better crash reports.
SUMMARY: libFuzzer: deadly signal
MS: 0 ; base unit: 0000000000000000000000000000000000000000
0xff,0xff,0xe9,0x47,0xff,0xff,0xfb,0xff,0xff,0xff,0xff,0x1,0x0,0x0,0x72,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x24,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x5d,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x0,0x0,0xff,0xff,0xff,0xff,0xff,0xff,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0x95,0xff,0xff,0x69,0x6e,0x64,0x65,0x78,0x61,0x72,0x72,0x61,0x79,0xff,0xff,0xff,0xff,0xff,0xff,0x1,0x0,0x0,0x0,0x0,0x0,0x0,0x4,0xff,0xff,0xff,0x7b,0xff,0xff,0xff,0xfa,0xff,0xff,0x5d,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x0,0x0,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x69,0x6e,0x64,0x65,0x78,0x61,0x72,0x72,0x61,0x79,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0x78,0x4d,0x3c,0xff,0xff,0xf7,
\377\377\351G\377\377\373\377\377\377\377\001\000\000r\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377$\377\377\377\377\377\377\377\377\377\377\377\377]\377\377\377\377\377\377\377\377\377\377\377\377\377\377\000\000\377\377\377\377\377\377\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\225\377\377indexarray\377\377\377\377\377\377\001\000\000\000\000\000\000\004\377\377\377{\377\377\377\372\377\377]\377\377\377\377\377\377\377\377\377\377\377\377\377\377\000\000\377\377\377\377\377\377\377\377indexarray\377\377\377\377\377\377\377\377\377\377\377\377\377\377xM<\377\377\367
artifact_prefix='./'; Test unit written to ./crash-bd2f107f367a6031134660397189630225a530d9
Base64: ///pR///+/////8BAABy//////////////////////8k////////////////Xf//////////////////AAD///////+VlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZWVlZX//2luZGV4YXJyYXn///////8BAAAAAAAABP///3v////6//9d//////////////////8AAP//////////aW5kZXhhcnJhef//////////////////eE08///3
```
As a result, an aiScene with an empty `mRootNode` might be passed to `Exporter::ExportToBlob`, causing crashes due to attempts to dereference a null pointer. I'm not sure if this is a bug in the library or intended behavior, please share your thoughts with me.