### PR TITLE
Fix compiler warning

### DIFF
--- a/code/Common/SceneCombiner.cpp
+++ b/code/Common/SceneCombiner.cpp
@@ -2,8 +2,7 @@
 Open Asset Import Library (assimp)
 ----------------------------------------------------------------------
 
-Copyright (c) 2006-2024, assimp team
-
+Copyright (c) 2006-2025, assimp team
 
 All rights reserved.
 
@@ -53,7 +52,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   */
 // ----------------------------------------------------------------------------
 #include "ScenePrivate.h"
-#include "time.h"
 #include <assimp/Hash.h>
 #include <assimp/SceneCombiner.h>
 #include <assimp/StringUtils.h>
@@ -61,9 +59,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/mesh.h>
 #include <assimp/metadata.h>
 #include <assimp/scene.h>
-#include <stdio.h>
 #include <assimp/DefaultLogger.hpp>
+
 #include <unordered_set>
+#include <ctime>
+#include <cstdio>
 
 namespace Assimp {
 
@@ -985,7 +985,9 @@ inline void GetArrayCopy(Type *&dest, ai_uint num) {
     Type *old = dest;
 
     dest = new Type[num];
-    ::memcpy(dest, old, sizeof(Type) * num);
+    for (ai_uint i=0; i<num; ++i) {
+        dest[i] = old[i];
+    }
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/include/assimp/SceneCombiner.h
+++ b/include/assimp/SceneCombiner.h
@@ -190,12 +190,11 @@ struct SceneHelper {
  * and loaders (ie. LWS).
  */
 class ASSIMP_API SceneCombiner {
+public:
     // class cannot be instanced
     SceneCombiner() = delete;
-
     ~SceneCombiner() = delete;
 
-public:
     // -------------------------------------------------------------------
     /** Merges two or more scenes.
      *
@@ -275,8 +274,8 @@ public:
     /** Builds a list of uniquely named bones in a mesh list
      *
      *  @param asBones Receives the output list
-     *  @param it First mesh to be processed
-     *  @param end Last mesh to be processed
+     *  @param it      First mesh to be processed
+     *  @param end     Last mesh to be processed
      */
     static void BuildUniqueBoneList(std::list<BoneWithHash> &asBones,
             std::vector<aiMesh *>::const_iterator it,
@@ -285,9 +284,9 @@ public:
     // -------------------------------------------------------------------
     /** Add a name prefix to all nodes in a scene.
      *
-     *  @param Current node. This function is called recursively.
+     *  @param node   Current node. This function is called recursively.
      *  @param prefix Prefix to be added to all nodes
-     *  @param len STring length
+     *  @param len    String length
      */
     static void AddNodePrefixes(aiNode *node, const char *prefix,
             unsigned int len);
@@ -295,7 +294,7 @@ public:
     // -------------------------------------------------------------------
     /** Add an offset to all mesh indices in a node graph
      *
-     *  @param Current node. This function is called recursively.
+     *  @param node   Current node. This function is called recursively.
      *  @param offset Offset to be added to all mesh indices
      */
     static void OffsetNodeMeshIndices(aiNode *node, unsigned int offset);
@@ -310,7 +309,7 @@ public:
      *    the master graph), a scene is attached to the root of the master
      *    graph (as an additional child node)
      *  @duplicates List of duplicates. If elem[n] == n the scene is not
-     *    a duplicate. Otherwise elem[n] links scene n to its first occurrence.
+     *    a duplicate. Otherwise, elem[n] links scene n to its first occurrence.
      */
     static void AttachToGraph(aiScene *master,
             std::vector<NodeAttachmentInfo> &srcList);
@@ -321,8 +320,9 @@ public:
     // -------------------------------------------------------------------
     /** Get a deep copy of a scene
      *
-     *  @param dest Receives a pointer to the destination scene
-     *  @param src Source scene - remains unmodified.
+     *  @param dest     Receives a pointer to the destination scene
+     *  @param source   Source scene - remains unmodified.
+     *  @param allocate true for allocation a new scene
      */
     static void CopyScene(aiScene **dest, const aiScene *source, bool allocate = true);
 

--- a/test/unit/Main.cpp
+++ b/test/unit/Main.cpp
@@ -1,7 +1,6 @@
 #include "../../include/assimp/DefaultLogger.hpp"
 #include "UnitTestPCH.h"
-#include <math.h>
-#include <time.h>
+#include <ctime>
 
 int main(int argc, char *argv[]) {
     ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
- Use copy contructor instead of memcpy
- closes   git push --set-upstream origin bugfix_comopiler_warning_issue-5908