### PR TITLE
Fixing PyAssimp misalignment errors with certain structures

### DIFF
--- a/port/PyAssimp/pyassimp/postprocess.py
+++ b/port/PyAssimp/pyassimp/postprocess.py
@@ -232,6 +232,15 @@ aiProcess_RemoveRedundantMaterials = 0x1000
 #
 aiProcess_FixInfacingNormals = 0x2000
 
+## This step generically populates aiBone->mArmature and aiBone->mNode generically
+#  The point of these is it saves you later having to calculate these elements
+#  This is useful when handling rest information or skin information
+#  If you have multiple armatures on your models we strongly recommend enabling this
+#  Instead of writing your own multi-root, multi-armature lookups we have done the
+#  hard work for you :)
+
+aiProcess_PopulateArmatureData = 0x4000
+
 ## <hr>This step splits meshes with more than one primitive type in 
 #  homogeneous sub-meshes. 
 #

--- a/port/PyAssimp/pyassimp/structs.py
+++ b/port/PyAssimp/pyassimp/structs.py
@@ -555,6 +555,10 @@ class Bone(Structure):
             #  The maximum value for this member is
             #AI_MAX_BONE_WEIGHTS.
             ("mNumWeights", c_uint),
+            
+            ("mArmature", POINTER(Node)),
+
+            ("mNode", POINTER(Node)),
 
             #  The vertices affected by this bone
             ("mWeights", POINTER(VertexWeight)),
@@ -857,6 +861,9 @@ class QuatKey(Structure):
 
             # The value of this key
             ("mValue", Quaternion),
+
+            # The interpolation setting of this key
+            ("mInterpolation", c_uint32)
         ]
 
 class MeshMorphKey(Structure):

--- a/port/PyAssimp/pyassimp/structs.py
+++ b/port/PyAssimp/pyassimp/structs.py
@@ -556,8 +556,12 @@ class Bone(Structure):
             #AI_MAX_BONE_WEIGHTS.
             ("mNumWeights", c_uint),
             
+            # The bone armature node - used for skeleton conversion
+            # you must enable aiProcess_PopulateArmatureData to populate this
             ("mArmature", POINTER(Node)),
-
+            
+            # The bone node in the scene - used for skeleton conversion
+            # you must enable aiProcess_PopulateArmatureData to populate this
             ("mNode", POINTER(Node)),
 
             #  The vertices affected by this bone


### PR DESCRIPTION
QuatKey and Bone structures are missing certain fields, thus causing corruptions such as grabbing rotation frame data for animations. I have also included the "aiProcess_PopulateArmatureData" bit flag as it was missing from the current PyAssimp distribution.
