### PR TITLE
Use std::copy to copy array and remove user destructor to make sure is_trivially_copyable in order to avoid -Wno-error=nontrivial-memcall

### DIFF
--- a/code/Common/SceneCombiner.cpp
+++ b/code/Common/SceneCombiner.cpp
@@ -1095,10 +1095,6 @@ void SceneCombiner::Copy(aiMesh **_dest, const aiMesh *src) {
 
     // make a deep copy of all faces
     GetArrayCopy(dest->mFaces, dest->mNumFaces);
-    for (unsigned int i = 0; i < dest->mNumFaces; ++i) {
-        aiFace &f = dest->mFaces[i];
-        GetArrayCopy(f.mIndices, f.mNumIndices);
-    }
 
     // make a deep copy of all blend shapes
     CopyPtrArray(dest->mAnimMeshes, dest->mAnimMeshes, dest->mNumAnimMeshes);

--- a/code/Common/SceneCombiner.cpp
+++ b/code/Common/SceneCombiner.cpp
@@ -985,7 +985,7 @@ inline void GetArrayCopy(Type *&dest, ai_uint num) {
     Type *old = dest;
 
     dest = new Type[num];
-    ::memcpy((void*)dest, old, sizeof(Type) * num);
+    std::copy(old, old+num, dest);
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/code/Common/SceneCombiner.cpp
+++ b/code/Common/SceneCombiner.cpp
@@ -985,7 +985,7 @@ inline void GetArrayCopy(Type *&dest, ai_uint num) {
     Type *old = dest;
 
     dest = new Type[num];
-    ::memcpy(dest, old, sizeof(Type) * num);
+    ::memcpy((void*)dest, old, sizeof(Type) * num);
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/contrib/Open3DGC/o3dgcCommon.h
+++ b/contrib/Open3DGC/o3dgcCommon.h
@@ -164,7 +164,7 @@ namespace o3dgc
     public: 
                                     SC3DMCStats(void)
                                     {
-                                        memset(this, 0, sizeof(SC3DMCStats));
+                                        memset((void*)this, 0, sizeof(SC3DMCStats));
                                     };
                                     ~SC3DMCStats(void){};
         

--- a/contrib/Open3DGC/o3dgcCommon.h
+++ b/contrib/Open3DGC/o3dgcCommon.h
@@ -164,9 +164,8 @@ namespace o3dgc
     public: 
                                     SC3DMCStats(void)
                                     {
-                                        memset((void*)this, 0, sizeof(SC3DMCStats));
+                                        memset(this, 0, sizeof(SC3DMCStats));
                                     };
-                                    ~SC3DMCStats(void){};
         
         double                      m_timeCoord;
         double                      m_timeNormal;
@@ -409,4 +408,3 @@ namespace o3dgc
     }
 }
 #endif // O3DGC_COMMON_H
-

--- a/contrib/Open3DGC/o3dgcIndexedFaceSet.h
+++ b/contrib/Open3DGC/o3dgcIndexedFaceSet.h
@@ -36,7 +36,7 @@ namespace o3dgc
         //! Constructor.
                                          IndexedFaceSet(void)
                                          {
-                                             memset(this, 0, sizeof(IndexedFaceSet));
+                                             memset((void*)this, 0, sizeof(IndexedFaceSet));
                                              m_ccw              = true;
                                              m_solid            = true;
                                              m_convex           = true;

--- a/contrib/Open3DGC/o3dgcIndexedFaceSet.h
+++ b/contrib/Open3DGC/o3dgcIndexedFaceSet.h
@@ -36,15 +36,13 @@ namespace o3dgc
         //! Constructor.
                                          IndexedFaceSet(void)
                                          {
-                                             memset((void*)this, 0, sizeof(IndexedFaceSet));
+                                             memset(this, 0, sizeof(IndexedFaceSet));
                                              m_ccw              = true;
                                              m_solid            = true;
                                              m_convex           = true;
                                              m_isTriangularMesh = true;
                                              m_creaseAngle      = 30;
                                          };
-        //! Destructor.
-                                         ~IndexedFaceSet(void) {};
         
         unsigned long                    GetNCoordIndex() const { return m_nCoordIndex     ;}
         // only coordIndex is supported
@@ -260,4 +258,3 @@ namespace o3dgc
 }
 #include "o3dgcIndexedFaceSet.inl"    // template implementation
 #endif // O3DGC_INDEXED_FACE_SET_H
-

--- a/contrib/Open3DGC/o3dgcSC3DMCEncodeParams.h
+++ b/contrib/Open3DGC/o3dgcSC3DMCEncodeParams.h
@@ -35,7 +35,7 @@ namespace o3dgc
         //! Constructor.
                                     SC3DMCEncodeParams(void)
                                     {
-                                        memset(this, 0, sizeof(SC3DMCEncodeParams));
+                                        memset((void*)this, 0, sizeof(SC3DMCEncodeParams));
                                         m_encodeMode        = O3DGC_SC3DMC_ENCODE_MODE_TFAN;
                                         m_streamTypeMode    = O3DGC_STREAM_TYPE_ASCII;
                                         m_coordQuantBits    = 14;

--- a/contrib/Open3DGC/o3dgcSC3DMCEncodeParams.h
+++ b/contrib/Open3DGC/o3dgcSC3DMCEncodeParams.h
@@ -35,7 +35,7 @@ namespace o3dgc
         //! Constructor.
                                     SC3DMCEncodeParams(void)
                                     {
-                                        memset((void*)this, 0, sizeof(SC3DMCEncodeParams));
+                                        memset(this, 0, sizeof(SC3DMCEncodeParams));
                                         m_encodeMode        = O3DGC_SC3DMC_ENCODE_MODE_TFAN;
                                         m_streamTypeMode    = O3DGC_STREAM_TYPE_ASCII;
                                         m_coordQuantBits    = 14;
@@ -51,8 +51,6 @@ namespace o3dgc
                                             m_intAttributePredMode[a] = O3DGC_SC3DMC_NO_PREDICTION;
                                         }
                                     };
-        //! Destructor.
-                                    ~SC3DMCEncodeParams(void) {};
 
         O3DGCStreamType             GetStreamType()    const { return m_streamTypeMode;}
         O3DGCSC3DMCEncodingMode     GetEncodeMode()    const { return m_encodeMode;}
@@ -137,4 +135,3 @@ namespace o3dgc
     };
 }
 #endif // O3DGC_SC3DMC_ENCODE_PARAMS_H
-

--- a/contrib/Open3DGC/o3dgcTimer.h
+++ b/contrib/Open3DGC/o3dgcTimer.h
@@ -111,7 +111,7 @@ namespace o3dgc
     public: 
         Timer(void)
         {
-            memset(this, 0, sizeof(Timer));
+            memset((void*)this, 0, sizeof(Timer));
         };
         ~Timer(void){};
         void Tic() 

--- a/contrib/Open3DGC/o3dgcTimer.h
+++ b/contrib/Open3DGC/o3dgcTimer.h
@@ -111,9 +111,8 @@ namespace o3dgc
     public: 
         Timer(void)
         {
-            memset((void*)this, 0, sizeof(Timer));
+            memset(this, 0, sizeof(Timer));
         };
-        ~Timer(void){};
         void Tic() 
         {
             clock_gettime(CLOCK_REALTIME, &m_start);


### PR DESCRIPTION
Addresses https://github.com/assimp/assimp/issues/5908. Tested locally using 20.1.0 RC.

@danoli3 

----

@kimkulling The error message suggests casting to void, but I really don't know it is correct fix.