### PR TITLE
Fix memory leak in OpenGEXImporter

### DIFF
--- a/code/AssetLib/OpenGEX/OpenGEXImporter.cpp
+++ b/code/AssetLib/OpenGEX/OpenGEXImporter.cpp
@@ -289,14 +289,13 @@ bool OpenGEXImporter::CanRead(const std::string &file, IOSystem *pIOHandler, boo
 //------------------------------------------------------------------------------------------------
 void OpenGEXImporter::InternReadFile(const std::string &filename, aiScene *pScene, IOSystem *pIOHandler) {
     // open source file
-    IOStream *file = pIOHandler->Open(filename, "rb");
+    std::unique_ptr<IOStream> file(pIOHandler->Open(filename, "rb"));
     if (!file) {
         throw DeadlyImportError("Failed to open file ", filename);
     }
 
     std::vector<char> buffer;
-    TextFileToBuffer(file, buffer);
-    pIOHandler->Close(file);
+    TextFileToBuffer(file.get(), buffer);
 
     OpenDDLParser myParser;
     myParser.setLogCallback(&logDDLParserMessage);


### PR DESCRIPTION
This patch fixes the memory leak in OpenGEXImporter

In OpenGEXIImporter. cpp, OpenGEXIImporter: The file in the InternReadFile function is the IOStream object generated by new, but pIOHandler ->Close (file); Not necessarily deleting files requires manual deletion of files;, Otherwise, there may be memory leaks. Use std:: Unique_ptr<IOStream>Automatically manages file streams to ensure that files are automatically released at the end of the function

==22910==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 40 byte(s) in 1 object(s) allocated from:
    #0 0x7fc3a60ead30 in operator new(unsigned long) (/lib/x86_64-linux-gnu/libasan.so.5+0xead30)
    #1 0x5136e9 in Assimp::Intern::AllocateFromAssimpHeap::operator new(unsigned long) /home/UOS/wfuzz/assimp-PoC/assimp/code/Common/Importer.cpp:115
    #2 0x53a476 in Assimp::MemoryIOSystem::Open(char const*, char const*) /home/UOS/wfuzz/assimp-PoC/assimp/include/assimp/MemoryIOWrapper.h:170
    #3 0x4ce0f8 in Assimp::FileSystemFilter::Open(char const*, char const*) /home/UOS/wfuzz/assimp-PoC/assimp/code/Common/FileSystemFilter.h:132
    #4 0x4c9128 in Assimp::IOSystem::Open(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /home/UOS/wfuzz/assimp-PoC/assimp/include/assimp/IOSystem.hpp:250
    #5 0xfc8769 in Assimp::OpenGEX::OpenGEXImporter::InternReadFile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, aiScene*, Assimp::IOSystem*) /home/UOS/wfuzz/assimp-PoC/assimp/code/AssetLib/OpenGEX/OpenGEXImporter.cpp:292
    #6 0x4be67d in Assimp::BaseImporter::ReadFile(Assimp::Importer*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, Assimp::IOSystem*) /home/UOS/wfuzz/assimp-PoC/assimp/code/Common/BaseImporter.cpp:131
    #7 0x51fb32 in Assimp::Importer::ReadFile(char const*, unsigned int) /home/UOS/wfuzz/assimp-PoC/assimp/code/Common/Importer.cpp:709
    #8 0x51a794 in Assimp::Importer::ReadFileFromMemory(void const*, unsigned long, unsigned int, char const*) /home/UOS/wfuzz/assimp-PoC/assimp/code/Common/Importer.cpp:507
    #9 0x420d8d in LLVMFuzzerTestOneInput fuzz/assimp_fuzzer.cc:57
    #10 0x420936 in main main.cc:47
    #11 0x7fc3a5b671fa in __libc_start_main ../csu/libc-start.c:308

SUMMARY: AddressSanitizer: 40 byte(s) leaked in 1 allocation(s).