### PR TITLE
Fix: Let OpenGEX accept color3 types

### DIFF
--- a/code/AssetLib/OpenGEX/OpenGEXImporter.cpp
+++ b/code/AssetLib/OpenGEX/OpenGEXImporter.cpp
@@ -783,10 +783,10 @@ static void fillColor4(aiColor4D *col4, Value *vals) {
     col4->b = next->getFloat();
     next = next->m_next;
     if (!next) {
-        throw DeadlyImportError("OpenGEX: Not enough values to fill 4-element color, only 3");
+        col4->a = 1.0f;
+    } else {
+        col4->a = next->getFloat();
     }
-
-    col4->a = next->getFloat();
 }
 
 //------------------------------------------------------------------------------------------------


### PR DESCRIPTION
- will set alpha channel to 1.0f, if no alpha channel was found.
- closes https://github.com/assimp/assimp/issues/6039