### PR TITLE
[OpenGEX] disable partial implementation of light import (causes model load failure)

### DIFF
--- a/code/AssetLib/OpenGEX/OpenGEXImporter.cpp
+++ b/code/AssetLib/OpenGEX/OpenGEXImporter.cpp
@@ -309,8 +309,10 @@ void OpenGEXImporter::InternReadFile(const std::string &filename, aiScene *pScen
     }
 
     copyMeshes(pScene);
-    copyCameras(pScene);
-    copyLights(pScene);
+    // TODO: cameras only partially implemented and breaking model import
+//    copyCameras(pScene);
+    // TODO: lights only partially implemented and breaking model import
+//    copyLights(pScene);
     copyMaterials(pScene);
     resolveReferences();
     createNodeTree(pScene);
@@ -362,11 +364,13 @@ void OpenGEXImporter::handleNodes(DDLNode *node, aiScene *pScene) {
             break;
 
         case Grammar::CameraNodeToken:
-            handleCameraNode(*it, pScene);
+            // TODO: cameras only partially implemented and breaking model import
+//            handleCameraNode(*it, pScene);
             break;
 
         case Grammar::LightNodeToken:
-            handleLightNode(*it, pScene);
+            // TODO: lights only partially implemented and breaking model import
+//            handleLightNode(*it, pScene);
             break;
 
         case Grammar::GeometryObjectToken:
@@ -374,11 +378,13 @@ void OpenGEXImporter::handleNodes(DDLNode *node, aiScene *pScene) {
             break;
 
         case Grammar::CameraObjectToken:
-            handleCameraObject(*it, pScene);
+            // TODO: cameras only partially implemented and breaking model import
+//            handleCameraObject(*it, pScene);
             break;
 
         case Grammar::LightObjectToken:
-            handleLightObject(*it, pScene);
+            // TODO: lights only partially implemented and breaking model import
+//            handleLightObject(*it, pScene);
             break;
 
         case Grammar::TransformToken:
@@ -468,7 +474,12 @@ void OpenGEXImporter::handleNameNode(DDLNode *node, aiScene * /*pScene*/) {
         }
 
         const std::string name(val->getString());
-        if (m_tokenType == Grammar::GeometryNodeToken || m_tokenType == Grammar::LightNodeToken || m_tokenType == Grammar::CameraNodeToken) {
+        if (m_tokenType == Grammar::GeometryNodeToken
+                // TODO: lights only partially implemented and breaking model import
+//                || m_tokenType == Grammar::LightNodeToken
+                // TODO: cameras only partially implemented and breaking model import
+//                || m_tokenType == Grammar::CameraNodeToken
+                ) {
             m_currentNode->mName.Set(name.c_str());
         } else if (m_tokenType == Grammar::MaterialToken) {
             aiString aiName;

--- a/code/AssetLib/OpenGEX/OpenGEXImporter.cpp
+++ b/code/AssetLib/OpenGEX/OpenGEXImporter.cpp
@@ -309,8 +309,7 @@ void OpenGEXImporter::InternReadFile(const std::string &filename, aiScene *pScen
     }
 
     copyMeshes(pScene);
-    // TODO: cameras only partially implemented and breaking model import
-//    copyCameras(pScene);
+    copyCameras(pScene);
     // TODO: lights only partially implemented and breaking model import
 //    copyLights(pScene);
     copyMaterials(pScene);
@@ -364,8 +363,7 @@ void OpenGEXImporter::handleNodes(DDLNode *node, aiScene *pScene) {
             break;
 
         case Grammar::CameraNodeToken:
-            // TODO: cameras only partially implemented and breaking model import
-//            handleCameraNode(*it, pScene);
+            handleCameraNode(*it, pScene);
             break;
 
         case Grammar::LightNodeToken:
@@ -378,8 +376,7 @@ void OpenGEXImporter::handleNodes(DDLNode *node, aiScene *pScene) {
             break;
 
         case Grammar::CameraObjectToken:
-            // TODO: cameras only partially implemented and breaking model import
-//            handleCameraObject(*it, pScene);
+            handleCameraObject(*it, pScene);
             break;
 
         case Grammar::LightObjectToken:
@@ -474,12 +471,10 @@ void OpenGEXImporter::handleNameNode(DDLNode *node, aiScene * /*pScene*/) {
         }
 
         const std::string name(val->getString());
-        if (m_tokenType == Grammar::GeometryNodeToken
+        if (m_tokenType == Grammar::GeometryNodeToken ||
                 // TODO: lights only partially implemented and breaking model import
-//                || m_tokenType == Grammar::LightNodeToken
-                // TODO: cameras only partially implemented and breaking model import
-//                || m_tokenType == Grammar::CameraNodeToken
-                ) {
+//                m_tokenType == Grammar::LightNodeToken ||
+                m_tokenType == Grammar::CameraNodeToken) {
             m_currentNode->mName.Set(name.c_str());
         } else if (m_tokenType == Grammar::MaterialToken) {
             aiString aiName;

--- a/code/AssetLib/OpenGEX/OpenGEXImporter.cpp
+++ b/code/AssetLib/OpenGEX/OpenGEXImporter.cpp
@@ -783,10 +783,10 @@ static void fillColor4(aiColor4D *col4, Value *vals) {
     col4->b = next->getFloat();
     next = next->m_next;
     if (!next) {
-        throw DeadlyImportError("OpenGEX: Not enough values to fill 4-element color, only 3");
+        col4->a = 1.0f;
+    } else {
+        col4->a = next->getFloat();
     }
-
-    col4->a = next->getFloat();
 }
 
 //------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #6043 

Disable partially implemented light import which is causing model load failure

With this fix, at least bundled [`collada.ogex`](https://github.com/assimp/assimp/blob/master/test/models/OpenGEX/collada.ogex) model able to successfully load (note that this model file contains multiple light and camera nodes/objects)
<img alt="collada.ogex" src="https://github.com/user-attachments/assets/6c916484-c25b-4429-a6b1-ea62200e8096" width=240 >
