### PR TITLE
Potential fix for code scanning alert no. 63: Potential use after free

### DIFF
--- a/code/AssetLib/glTF/glTFImporter.cpp
+++ b/code/AssetLib/glTF/glTFImporter.cpp
@@ -153,6 +153,7 @@ void glTFImporter::ImportMaterials(Asset &r) {
         mScene->mNumMaterials = 1;
         // Delete the array of length zero created above.
         delete[] mScene->mMaterials;
+        mScene->mMaterials = nullptr;
         mScene->mMaterials = new aiMaterial *[1];
         mScene->mMaterials[0] = new aiMaterial();
     }


### PR DESCRIPTION
Potential fix for [https://github.com/assimp/assimp/security/code-scanning/63](https://github.com/assimp/assimp/security/code-scanning/63)

To fix the potential use-after-free error, we should set the `mMaterials` pointer to `nullptr` immediately after deleting it. This ensures that any accidental access to `mMaterials` after it has been freed will be caught as a null pointer dereference, which is easier to debug and less dangerous than a use-after-free error.

- Modify the code in the `ImportMaterials` method of the `glTFImporter` class.
- After the `delete[] mScene->mMaterials;` statement on line 155, set `mScene->mMaterials` to `nullptr`.
- This change ensures that any accidental access to `mMaterials` after it has been freed will result in a null pointer dereference.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
