### PR TITLE
Fix Cinema4D Import

### DIFF
--- a/code/AssetLib/C4D/C4DImporter.cpp
+++ b/code/AssetLib/C4D/C4DImporter.cpp
@@ -64,7 +64,7 @@ namespace {
 
 aiString aiStringFrom(cineware::String const & cinestring) {
     aiString result;
-    cinestring.GetCString(result.data, MAXLEN-1);
+    cinestring.GetCString(result.data, AI_MAXLEN - 1);
     result.length = static_cast<ai_uint32>(cinestring.GetLength());
     return result;
 }


### PR DESCRIPTION
#5623 broke the Cinema4D import by forgetting to rename a constant. This commit fixes the invalid name.