### PR TITLE
Remove Redundant `virtual`

### DIFF
--- a/code/AssetLib/OpenGEX/OpenGEXImporter.h
+++ b/code/AssetLib/OpenGEX/OpenGEXImporter.h
@@ -102,10 +102,10 @@ protected:
     void InternReadFile( const std::string &file, aiScene *pScene, IOSystem *pIOHandler ) override;
 
     /// BaseImporter override.
-    virtual const aiImporterDesc *GetInfo() const override;
+    const aiImporterDesc *GetInfo() const override;
 
     /// BaseImporter override.
-    virtual void SetupProperties( const Importer *pImp ) override;
+    void SetupProperties( const Importer *pImp ) override;
 
     void handleNodes( ODDLParser::DDLNode *node, aiScene *pScene );
     void handleMetricNode( ODDLParser::DDLNode *node, aiScene *pScene );

--- a/code/PostProcessing/EmbedTexturesProcess.h
+++ b/code/PostProcessing/EmbedTexturesProcess.h
@@ -74,7 +74,7 @@ public:
     void SetupProperties(const Importer* pImp) override;
 
     /// Overwritten, @see BaseProcess
-    virtual void Execute(aiScene* pScene) override;
+    void Execute(aiScene* pScene) override;
 
 private:
     // Try several ways to attempt to resolve the image path

--- a/code/PostProcessing/RemoveVCProcess.h
+++ b/code/PostProcessing/RemoveVCProcess.h
@@ -83,7 +83,7 @@ public:
     * The function is a request to the process to update its configuration
     * basing on the Importer's configuration property list.
     */
-    virtual void SetupProperties(const Importer* pImp) override;
+    void SetupProperties(const Importer* pImp) override;
 
     // -------------------------------------------------------------------
     /** Manually setup the configuration flags for the step

--- a/code/PostProcessing/ScaleProcess.h
+++ b/code/PostProcessing/ScaleProcess.h
@@ -74,13 +74,13 @@ public:
     ai_real getScale() const;
 
     /// Overwritten, @see BaseProcess
-    virtual bool IsActive( unsigned int pFlags ) const override;
+    bool IsActive( unsigned int pFlags ) const override;
 
     /// Overwritten, @see BaseProcess
-    virtual void SetupProperties( const Importer* pImp ) override;
+    void SetupProperties( const Importer* pImp ) override;
 
     /// Overwritten, @see BaseProcess
-    virtual void Execute( aiScene* pScene ) override;
+    void Execute( aiScene* pScene ) override;
 
 private:
     void traverseNodes( aiNode *currentNode, unsigned int nested_node_id = 0 );

--- a/code/PostProcessing/SplitByBoneCountProcess.h
+++ b/code/PostProcessing/SplitByBoneCountProcess.h
@@ -74,7 +74,7 @@ public:
     /// @brief Called prior to ExecuteOnScene().
     /// The function is a request to the process to update its configuration
     /// basing on the Importer's configuration property list.
-    virtual void SetupProperties(const Importer* pImp) override;
+    void SetupProperties(const Importer* pImp) override;
 
     /// @brief Will return the maximal number of bones.
     /// @return The maximal number of bones.

--- a/include/assimp/ZipArchiveIOSystem.h
+++ b/include/assimp/ZipArchiveIOSystem.h
@@ -62,7 +62,7 @@ public:
     //! Open a Zip using the proffered IOSystem
     ZipArchiveIOSystem(IOSystem* pIOHandler, const char *pFilename, const char* pMode = "r");
     ZipArchiveIOSystem(IOSystem* pIOHandler, const std::string& rFilename, const char* pMode = "r");
-    virtual ~ZipArchiveIOSystem() override;
+    ~ZipArchiveIOSystem() override;
     bool Exists(const char* pFilename) const override;
     char getOsSeparator() const override;
     IOStream* Open(const char* pFilename, const char* pMode = "rb") override;

--- a/test/unit/utImporter.cpp
+++ b/test/unit/utImporter.cpp
@@ -299,7 +299,7 @@ aiImporterDesc s_failingImporterDescription = {
 class FailingImporter : public Assimp::BaseImporter {
 public:
     virtual ~FailingImporter() = default;
-    virtual bool CanRead(const std::string &, Assimp::IOSystem *, bool) const override {
+    bool CanRead(const std::string &, Assimp::IOSystem *, bool) const override {
         return true;
     }
 


### PR DESCRIPTION
The `override` keyword only applies to virtual functions. Specifying `virtual` again is useless.