### PR TITLE
Renamed and inlined hasSkeletons() to HasSkeletons() for API consistency

### DIFF
--- a/include/assimp/scene.h
+++ b/include/assimp/scene.h
@@ -421,7 +421,8 @@ struct ASSIMP_API aiScene {
         return mAnimations != nullptr && mNumAnimations > 0;
     }
 
-    bool hasSkeletons() const {
+    //! Check whether the scene contains skeletons
+    inline bool HasSkeletons() const {
         return mSkeletons != nullptr && mNumSkeletons > 0;
     }
 


### PR DESCRIPTION
Renamed and inlined `hasSkeletons()` to `HasSkeletons()` to match the other `Has*()` methods
Added comments to the method.