### PR TITLE
Add std::string_view overloads for exporting and importing

### DIFF
--- a/include/assimp/Exporter.hpp
+++ b/include/assimp/Exporter.hpp
@@ -502,6 +502,11 @@ inline aiReturn Exporter ::Export(const aiScene *pScene, const std::string &pFor
         const ExportProperties *pProperties) {
     return Export(pScene, pFormatId.c_str(), pPath.c_str(), pPreprocessing, pProperties);
 }
+inline aiReturn Exporter ::Export(const aiScene *pScene, const std::string &pFormatId,
+        std::string_view pPath, unsigned int pPreprocessing,
+        const ExportProperties *pProperties) {
+    return Export(pScene, pFormatId.c_str(), pPath.data(), pPreprocessing, pProperties);
+}
 
 } // namespace Assimp
 

--- a/include/assimp/Importer.hpp
+++ b/include/assimp/Importer.hpp
@@ -667,6 +667,9 @@ protected:
 AI_FORCE_INLINE const aiScene *Importer::ReadFile(const std::string &pFile, unsigned int pFlags) {
     return ReadFile(pFile.c_str(), pFlags);
 }
+AI_FORCE_INLINE const aiScene *Importer::ReadFile(std::string_view pFile, unsigned int pFlags) {
+    return ReadFile(pFile.data(), pFlags);
+}
 // ----------------------------------------------------------------------------
 AI_FORCE_INLINE void Importer::GetExtensionList(std::string &szOut) const {
     aiString s;

--- a/include/assimp/types.h
+++ b/include/assimp/types.h
@@ -76,6 +76,7 @@ typedef uint32_t ai_uint32;
 #include <cstring>
 #include <new>    // for std::nothrow_t
 #include <string> // for aiString::Set(const std::string&)
+#include <string_view>
 
 namespace Assimp {
 //! @cond never


### PR DESCRIPTION
This pull request adds overloads with `std::string_view` parameters instead of `std::string` for the export and import functions' paths. This improves flexibility for users who use `std::string_view` for their paths.