### PR TITLE
fix: missing OS separator in outfile

### DIFF
--- a/code/Pbrt/PbrtExporter.cpp
+++ b/code/Pbrt/PbrtExporter.cpp
@@ -93,7 +93,7 @@ void ExportScenePbrt(const char *pFile, IOSystem *pIOSystem, const aiScene *pSce
         const ExportProperties *) {
     std::string path = DefaultIOSystem::absolutePath(std::string(pFile));
     std::string file = DefaultIOSystem::completeBaseName(std::string(pFile));
-    path = path + file + ".pbrt";
+    
     // initialize the exporter
     PbrtExporter exporter(pScene, pIOSystem, path, file);
 }
@@ -174,7 +174,13 @@ PbrtExporter::PbrtExporter(
     WriteWorldDefinition();
 
     // And write the file to disk...
-    std::unique_ptr<IOStream> outfile(mIOSystem->Open(mPath,"wt"));
+    std::string outputFilePath = mPath;
+    if (!outputFilePath.empty()) {
+        outputFilePath = outputFilePath + mIOSystem->getOsSeparator();
+    }
+    outputFilePath = outputFilePath + mFile +".pbrt";
+
+    std::unique_ptr<IOStream> outfile(mIOSystem->Open(outputFilePath,"wt"));
     if (!outfile) {
         throw DeadlyExportError("could not open output .pbrt file: " + std::string(mFile));
     }


### PR DESCRIPTION
The outfile was missing an OS separator when a PBRT file was exported in a path that was not the current directory. Writing to /foo/bar.pbrt was writing to foobar.pbrt instead. mPath and mFile are now handled like it's described in PbrtExporter.h