### PR TITLE
fix: write textures to folder of PBRT file

### DIFF
--- a/code/Pbrt/PbrtExporter.h
+++ b/code/Pbrt/PbrtExporter.h
@@ -74,7 +74,7 @@ class PbrtExporter {
 public:
     /// Constructor for a specific scene to export
     PbrtExporter(const aiScene *pScene, IOSystem *pIOSystem,
-            const std::string &path, const std::string &file);
+            const std::string &path, const std::string &file, const std::string &texturesPath);
 
     /// Destructor
     virtual ~PbrtExporter() = default;
@@ -113,6 +113,9 @@ private:
 
     /// Name of the file (without extension) where the scene will be exported
     const std::string mFile;
+
+    /// Path of the textures directory (inlcuding seperator)
+    const std::string mTexturesPath;
 
     //  A private set to keep track of which textures have been declared
     std::set<std::string> mTextureSet;


### PR DESCRIPTION
Previously, the textures folder was created in the current directory and not in the directory next to the PBRT file