### PR TITLE
Fix: Add "preservePivots" condition when importing FBX animation

### DIFF
--- a/code/AssetLib/FBX/FBXConverter.cpp
+++ b/code/AssetLib/FBX/FBXConverter.cpp
@@ -2958,7 +2958,7 @@ void FBXConverter::GenerateNodeAnimations(std::vector<aiNodeAnim *> &node_anims,
     // be invoked _later_ (animations come first). If this node has only rotation,
     // scaling and translation _and_ there are no animated other components either,
     // we can use a single node and also a single node animation channel.
-    if( !has_complex && !NeedsComplexTransformationChain(target)) {
+    if (!doc.Settings().preservePivots || (!has_complex && !NeedsComplexTransformationChain(target))) {
         aiNodeAnim* const nd = GenerateSimpleNodeAnim(fixed_name, target, chain,
                 node_property_map.end(),
                 start, stop,


### PR DESCRIPTION
### Abstract

-  #6114

The animation importer part has no handling for the "preservePivots" setting.

This setting prevents dummy nodes when processing nodes in the model.

However, animations are not, so if you use this option, the animation will not work with the model.

See comments below.

https://github.com/assimp/assimp/blob/ac5988422a7f1898b25c13fb5fb068c646a4c544/code/AssetLib/FBX/FBXConverter.cpp#L2957C1-L2984C73


---

https://github.com/assimp/assimp/blob/ac5988422a7f1898b25c13fb5fb068c646a4c544/code/AssetLib/FBX/FBXConverter.cpp#L747C49-L747C51

`GenerateTransformationNodeChain`
- Processing in this function

https://github.com/assimp/assimp/blob/ac5988422a7f1898b25c13fb5fb068c646a4c544/code/AssetLib/FBX/FBXConverter.cpp#L870C4-L875C1


*Note: This function creates dummy node names.
- `NameTransformationChainNode`

