### PR TITLE
Fix a out of bound buffer access in ParsingUtils GetNextLine

### DIFF
--- a/include/assimp/ParsingUtils.h
+++ b/include/assimp/ParsingUtils.h
@@ -161,7 +161,7 @@ AI_FORCE_INLINE bool GetNextLine(const char_t *&buffer, char_t out[BufferSize]) 
     }
 
     char *_out = out;
-    char *const end = _out + BufferSize;
+    char *const end = _out + BufferSize - 1;
     while (!IsLineEnd(*buffer) && _out < end) {
         *_out++ = *buffer++;
     }


### PR DESCRIPTION
In the while loop, when `!IsLineEnd(*buffer)` is true, eventually `*_out++=*buffer++;` writes the last byte before `end` and sets `_out` to `end`. In the current implementation if end is `_out + BufferSize`, the next line `*out = (char_t)'\0';` writes out of bounds of `out[BufferSize]`. This change prevents this out of bounds error by setting `end `one byte before to preserve a byte for writing the trailing `'\0'` byte.