### PR TITLE
Fix a bug where string erases throws out of range

### DIFF
--- a/code/AssetLib/Ply/PlyParser.cpp
+++ b/code/AssetLib/Ply/PlyParser.cpp
@@ -300,7 +300,9 @@ bool PLY::Element::ParseElement(IOStreamBuffer<char> &streamBuffer, std::vector<
         // the original string identifier
         pOut->szName = std::string(&buffer[0], &buffer[0] + strlen(&buffer[0]));
         auto pos = pOut->szName.find_last_of(' ');
-        pOut->szName.erase(pos, pOut->szName.size());
+        if (pos != std::string::npos) {
+            pOut->szName.erase(pos, pOut->szName.size());
+        }
     }
 
     if (!PLY::DOM::SkipSpaces(buffer))


### PR DESCRIPTION
Currently when there isn't any `' '` character inside `pOut->szName`, pos will be `std::string::npos` according to [`find_last_of` documentation](https://en.cppreference.com/w/cpp/string/basic_string/find_last_of). Calling `erase` with  `std::string::npos` throws according to [`erase` documentation](https://en.cppreference.com/w/cpp/string/basic_string/erase).

This PR adds a check before calling erase.