### PR TITLE
Fixed regression that scrambled FBX blendshape order

### DIFF
--- a/code/AssetLib/FBX/FBXDeformer.cpp
+++ b/code/AssetLib/FBX/FBXDeformer.cpp
@@ -45,6 +45,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef ASSIMP_BUILD_NO_FBX_IMPORTER
 
+#include <algorithm>
+
 #include "FBXParser.h"
 #include "FBXDocument.h"
 #include "FBXMeshGeometry.h"
@@ -144,8 +146,10 @@ BlendShape::BlendShape(uint64_t id, const Element& element, const Document& doc,
     for (const Connection* con : conns) {
         const BlendShapeChannel* const bspc = ProcessSimpleConnection<BlendShapeChannel>(*con, false, "BlendShapeChannel -> BlendShape", element);
         if (bspc) {
-            auto pr = blendShapeChannels.insert(bspc);
-            if (!pr.second) {
+            // Only add a channel if it doesn't exist already
+            if (std::find(blendShapeChannels.begin(), blendShapeChannels.end(), bspc) == blendShapeChannels.end()) {
+                blendShapeChannels.push_back(bspc);
+            } else {
                 FBXImporter::LogWarn("there is the same blendShapeChannel id ", bspc->ID());
             }
         }
@@ -170,8 +174,10 @@ BlendShapeChannel::BlendShapeChannel(uint64_t id, const Element& element, const 
     for (const Connection* con : conns) {
         const ShapeGeometry* const sg = ProcessSimpleConnection<ShapeGeometry>(*con, false, "Shape -> BlendShapeChannel", element);
         if (sg) {
-            auto pr = shapeGeometries.insert(sg);
-            if (!pr.second) {
+            // Only add a geometry if it doesn't exist already
+            if (std::find(shapeGeometries.begin(), shapeGeometries.end(), sg) == shapeGeometries.end()) {
+                shapeGeometries.push_back(sg);
+            } else {
                 FBXImporter::LogWarn("there is the same shapeGeometrie id ", sg->ID());
             }
         }

--- a/code/AssetLib/FBX/FBXDocument.h
+++ b/code/AssetLib/FBX/FBXDocument.h
@@ -865,14 +865,14 @@ public:
         return fullWeights;
     }
 
-    const std::unordered_set<const ShapeGeometry*>& GetShapeGeometries() const {
+    const std::vector<const ShapeGeometry*>& GetShapeGeometries() const {
         return shapeGeometries;
     }
 
 private:
     float percent;
     WeightArray fullWeights;
-    std::unordered_set<const ShapeGeometry*> shapeGeometries;
+    std::vector<const ShapeGeometry*> shapeGeometries;
 };
 
 /** DOM class for BlendShape deformers */
@@ -882,12 +882,12 @@ public:
 
     virtual ~BlendShape() = default;
 
-    const std::unordered_set<const BlendShapeChannel*>& BlendShapeChannels() const {
+    const std::vector<const BlendShapeChannel*>& BlendShapeChannels() const {
         return blendShapeChannels;
     }
 
 private:
-    std::unordered_set<const BlendShapeChannel*> blendShapeChannels;
+    std::vector<const BlendShapeChannel*> blendShapeChannels;
 };
 
 /** DOM class for skin deformer clusters (aka sub-deformers) */

--- a/code/AssetLib/FBX/FBXMeshGeometry.cpp
+++ b/code/AssetLib/FBX/FBXMeshGeometry.cpp
@@ -45,6 +45,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef ASSIMP_BUILD_NO_FBX_IMPORTER
 
+#include <algorithm>
 #include <functional>
 
 #include "FBXMeshGeometry.h"
@@ -69,8 +70,10 @@ Geometry::Geometry(uint64_t id, const Element& element, const std::string& name,
         }
         const BlendShape* const bsp = ProcessSimpleConnection<BlendShape>(*con, false, "BlendShape -> Geometry", element);
         if (bsp) {
-            auto pr = blendShapes.insert(bsp);
-            if (!pr.second) {
+            // Only add a blendshape if it doesn't exist already
+            if (std::find(blendShapes.begin(), blendShapes.end(), bsp) == blendShapes.end()) {
+                blendShapes.push_back(bsp);
+            } else {
                 FBXImporter::LogWarn("there is the same blendShape id ", bsp->ID());
             }
         }
@@ -78,7 +81,7 @@ Geometry::Geometry(uint64_t id, const Element& element, const std::string& name,
 }
 
 // ------------------------------------------------------------------------------------------------
-const std::unordered_set<const BlendShape*>& Geometry::GetBlendShapes() const {
+const std::vector<const BlendShape*>& Geometry::GetBlendShapes() const {
     return blendShapes;
 }
 

--- a/code/AssetLib/FBX/FBXMeshGeometry.h
+++ b/code/AssetLib/FBX/FBXMeshGeometry.h
@@ -72,11 +72,11 @@ public:
 
     /// @brief Get the BlendShape attached to this geometry or nullptr
     /// @return The blendshape arrays.
-    const std::unordered_set<const BlendShape*>& GetBlendShapes() const;
+    const std::vector<const BlendShape*>& GetBlendShapes() const;
 
 private:
     const Skin* skin;
-    std::unordered_set<const BlendShape*> blendShapes;
+    std::vector<const BlendShape*> blendShapes;
 
 };
 


### PR DESCRIPTION
At some point the default data type of blendshape data in FBX data changed from `std::vector` to `std::unordered_set` which scrambles the order of blendshapes when imported/exported.

This pull request reverts the datatype back to `std::vector` to preserve the order properly.