### PR TITLE
Fix for CanRead function for FBXImporter

### DIFF
--- a/code/AssetLib/FBX/FBXImporter.cpp
+++ b/code/AssetLib/FBX/FBXImporter.cpp
@@ -90,7 +90,7 @@ namespace {
 // Returns whether the class can handle the format of the given file.
 bool FBXImporter::CanRead(const std::string & pFile, IOSystem * pIOHandler, bool /*checkSig*/) const {
 	// at least ASCII-FBX files usually have a 'FBX' somewhere in their head
-	static const char *tokens[] = { " \n\r\n " };
+	static const char *tokens[] = { "fbx" };
 	return SearchFileHeaderForToken(pIOHandler, pFile, tokens, AI_COUNT_OF(tokens));
 }
 


### PR DESCRIPTION
I am having an issue where I cannot load FBX files from memory since upgrading to 5.4.3 (from 5.2.4). Having stepped through the code I think I've traced the problem back to the "CanRead" function in the FBXImporter.cpp. It looks like the problem was introduced in this commit:

https://github.com/assimp/assimp/commit/0b0ec713f67d75bfd26317cc3e064acc518fe209

It looked like some sort of typo to me - I'm not sure why that magic token would be switched out for newline characters. If this is incorrect then I'm open to other ways of solving it. I've verified that switching back to "fbx" does indeed allow my app to function correctly again. This effectively reverts the small part of that commit to allow reading of FBX from memory.
