### PR TITLE
fix-CVE-2025-3158: closes #6023 Fixes CVE-2025-3158: Heap-based Buffer Overflow in Assimp::LWO::AnimResolver::UpdateAnimRangeSetup

### DIFF
--- a/code/AssetLib/LWO/LWOAnimation.cpp
+++ b/code/AssetLib/LWO/LWOAnimation.cpp
@@ -212,7 +212,7 @@ void AnimResolver::UpdateAnimRangeSetup() {
             unsigned int tt = 1;
             for (const double tmp = delta * (num + 1); cur_minus <= tmp; cur_minus += delta, ++tt) {
                 m = (delta == tmp ? (*it).keys.begin() : n - (old_size + 1));
-                for (; m != n; --n) {
+                for (; m < n; --n) {
                     (*n).time -= cur_minus;
 
                     // offset repeat? add delta offset to key value


### PR DESCRIPTION

- changed loop-condition to reflect the fact that m must be smaller than n

Fuzz results after changes
>  sh /home/ubuntu/assimp/test_exploits/CVE-2025-3158.sh
> -- Shared libraries disabled
> -- GCC13 detected disabling "-Wdangling-reference" in Cpp files as it appears to be a false positive
> -- compiling zlib from sources
> -- GCC13 detected disabling "-Warray-bounds and -Wstringop-overflow" for AssetLib/MDL/MDLLoader.cpp as it appears to be a false positive
> -- VRML disabled
> -- tinyusdz disabled
> -- Enabled importer formats: AMF 3DS AC ASE ASSBIN B3D BVH COLLADA DXF CSM HMP IRRMESH IQM IRR LWO LWS MD2 MD3 MD5 MDC MDL NFF NDO OFF OBJ OGRE OPENGEX PLY MS3D COB BLEND IFC XGL FBX Q3D Q3BSP RAW SIB SMD STL TERRAGEN 3D X X3D GLTF 3MF MMD
> -- Disabled importer formats: USD
> -- Enabled exporter formats: OBJ OPENGEX PLY 3DS ASSBIN ASSXML COLLADA FBX STL X X3D GLTF 3MF PBRT ASSJSON STEP
> -- Disabled exporter formats:
> -- Treating all warnings as errors (for assimp library only)
> -- Configuring done (0.0s)
> -- Generating done (0.0s)
> -- Build files have been written to: /home/ubuntu/assimp
> [2/2] Linking CXX static library lib/libassimp.a
> INFO: Running with entropic power schedule (0xFF, 100).
> INFO: Seed: 2891564261
> INFO: Loaded 1 modules   (7 inline 8-bit counters): 7 [0x5c7667a49a30, 0x5c7667a49a37), 
> INFO: Loaded 1 PC tables (7 PCs): 7 [0x5c7667a49a38,0x5c7667a49aa8), 
> ./assimp_fuzzer: Running 1 inputs 1 time(s) each.
> Running: ./crash
> Executed ./crash in 23 ms
>  NOTE: fuzzing was not performed, you have only
> *       executed the target code on a fixed set of inputs.*
