### PR TITLE
Fixes CVE-2025-2751: Out-of-bounds Read in Assimp::CSMImporter::InternReadFile (closes #6012)

### DIFF
--- a/code/AssetLib/CSM/CSMLoader.cpp
+++ b/code/AssetLib/CSM/CSMLoader.cpp
@@ -271,7 +271,13 @@ void CSMImporter::InternReadFile( const std::string& pFile,
         nd->mName   = anim->mChannels[i]->mNodeName;
         nd->mParent = pScene->mRootNode;
 
-        aiMatrix4x4::Translation(na->mPositionKeys[0].mValue, nd->mTransformation);
+        if (na->mPositionKeys != nullptr && na->mNumPositionKeys > 0) {
+            aiMatrix4x4::Translation(na->mPositionKeys[0].mValue, nd->mTransformation);
+        } else {
+            // Use identity matrix if no valid position data is available
+            nd->mTransformation = aiMatrix4x4();
+            DefaultLogger::get()->warn("CSM: No position keys available for node - using identity transformation");
+        }
     }
 
     // Store the one and only animation in the scene


### PR DESCRIPTION
Closes #6012 

description:
issue:
- https://github.com/assimp/assimp/blob/4ad1d2aa3086517816716a50aa122342806736f9/code/AssetLib/CSM/CSMLoader.cpp#L274C1-L275C1
- sometimes the code tried to construct a new 4x4 matrix from a nullptr, thus reading out of bounds

fix:
- added nullptr check
- added array count check
- added default fallback init to identity matrix

fuzz output after fixing:

> sh /home/ubuntu/assimp/test_exploits/CVE-2025-2751.sh
> -- Shared libraries disabled
> -- GCC13 detected disabling "-Wdangling-reference" in Cpp files as it appears to be a false positive
> -- compiling zlib from sources
> -- GCC13 detected disabling "-Warray-bounds and -Wstringop-overflow" for AssetLib/MDL/MDLLoader.cpp as it appears to be a false positive
> -- VRML disabled
> -- tinyusdz disabled
> -- Enabled importer formats: AMF 3DS AC ASE ASSBIN B3D BVH COLLADA DXF CSM HMP IRRMESH IQM IRR LWO LWS MD2 MD3 MD5 MDC MDL NFF NDO OFF OBJ OGRE OPENGEX PLY MS3D COB BLEND IFC XGL FBX Q3D Q3BSP RAW SIB SMD STL TERRAGEN 3D X X3D GLTF 3MF MMD
> -- Disabled importer formats: USD
> -- Enabled exporter formats: OBJ OPENGEX PLY 3DS ASSBIN ASSXML COLLADA FBX STL X X3D GLTF 3MF PBRT ASSJSON STEP
> -- Disabled exporter formats:
> -- Treating all warnings as errors (for assimp library only)
> -- Configuring done (0.0s)
> -- Generating done (0.0s)
> -- Build files have been written to: /home/ubuntu/assimp
> ninja: no work to do.
> INFO: Running with entropic power schedule (0xFF, 100).
> INFO: Seed: 595894660
> INFO: Loaded 1 modules   (7 inline 8-bit counters): 7 [0x5f958c8f0a30, 0x5f958c8f0a37), 
> INFO: Loaded 1 PC tables (7 PCs): 7 [0x5f958c8f0a38,0x5f958c8f0aa8), 
> ./assimp_fuzzer: Running 1 inputs 1 time(s) each.
> Running: ./crash
> Executed ./crash in 3 ms
>  NOTE: fuzzing was not performed, you have only
> *       executed the target code on a fixed set of inputs.*
