### PR TITLE
test/unit/utProfiler.cpp: fix `gcc-16` build failure

### DIFF
--- a/test/unit/utProfiler.cpp
+++ b/test/unit/utProfiler.cpp
@@ -70,6 +70,7 @@ TEST_F( utProfiler, addRegion_success ) {
     for ( int i=0; i<10; i++ ) {
         volatile int j=0;
         j++;
+        (void)j; /* avoid gcc-16 warnings about unused variable */
     }
     myProfiler.EndRegion( "t1" );
     //UTLogStream *stream( (UTLogStream*) m_stream );

--- a/test/unit/utProfiler.cpp
+++ b/test/unit/utProfiler.cpp
@@ -5,8 +5,6 @@ Open Asset Import Library (assimp)
 
 Copyright (c) 2006-2025, assimp team
 
-
-
 All rights reserved.
 
 Redistribution and use of this software in source and binary forms,
@@ -50,18 +48,7 @@ using namespace ::Assimp::Profiling;
 
 class utProfiler : public ::testing::Test {
 public:
-    LogStream *m_stream;
-
-    /*virtual void SetUp() {
-        m_stream = new UTLogStream;
-        DefaultLogger::create();
-        DefaultLogger::get()->attachStream( m_stream );
-    }
-
-    virtual void TearDown() {
-        DefaultLogger::get()->detatchStream( m_stream );
-        m_stream = nullptr;
-    }*/
+    LogStream *mStream = nullptr;
 };
 
 TEST_F( utProfiler, addRegion_success ) {
@@ -73,6 +60,4 @@ TEST_F( utProfiler, addRegion_success ) {
         (void)j; /* avoid gcc-16 warnings about unused variable */
     }
     myProfiler.EndRegion( "t1" );
-    //UTLogStream *stream( (UTLogStream*) m_stream );
-    //EXPECT_FALSE( stream->m_messages.empty() );
 }


### PR DESCRIPTION
Upcoming `gcc-16` improved detection of unused variables as:

    test/unit/utProfiler.cpp: In member function 'virtual void utProfiler_addRegion_success_Test::TestBody()':
    test/unit/utProfiler.cpp:71:22: error: variable 'j' set but not used [-Werror=unused-but-set-variable=]
       71 |         volatile int j=0;
          |                      ^

The change is intentional accoring to Andrew Pinski and is not a faalse positive.