### PR TITLE
OBJ: avoid extra scanning while reading faces in ObjFileParser.cpp

### DIFF
--- a/code/AssetLib/Obj/ObjFileParser.cpp
+++ b/code/AssetLib/Obj/ObjFileParser.cpp
@@ -471,7 +471,7 @@ void ObjFileParser::getFace(aiPrimitiveType type) {
             iPos = 0;
         } else {
             //OBJ USES 1 Base ARRAYS!!!!
-            const int iVal = ::atoi(std::to_address(m_DataIt));
+            const int iVal = ::atoi(&(*m_DataIt));
 
             // increment iStep position based off of the sign and # of digits
             int tmp = iVal;


### PR DESCRIPTION
The code in `ObjFileParser::getFace()` tries to be smart about end of buffer and scans for it for every face index it reads. This takes us to something close to `O(N^2)` where `N` is the file size, so I wonder if we really need that there.

This patch replaces the whole thing with a simpler `atoi()` call that passes all my internal tests. If there is a file that fails we might consider scan ahead, but limit that scan to something like 10 symbols or so as otherwise we do a lot of unnecessary work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified OBJ face-index parsing for a more direct extraction approach, reducing internal complexity while preserving existing behavior.
* **Chores**
  * Updated copyright year in source headers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->