### PR TITLE
Fixed a `container-overflow` error

### DIFF
--- a/contrib/openddlparser/code/OpenDDLParser.cpp
+++ b/contrib/openddlparser/code/OpenDDLParser.cpp
@@ -688,7 +688,7 @@ char *OpenDDLParser::parseIntegerLiteral(char *in, char *end, Value **integer, V
 
     in = lookForNextToken(in, end);
     char *start(in);
-    while (in != end && !isSeparator(P0+r\P0+r\P0+r\P0+r\P0+r\*in)) {
+    while (in != end && !isSeparator(*in)) {
         ++in;
     }
 

--- a/contrib/openddlparser/code/OpenDDLParser.cpp
+++ b/contrib/openddlparser/code/OpenDDLParser.cpp
@@ -655,7 +655,7 @@ char *OpenDDLParser::parseBooleanLiteral(char *in, char *end, Value **boolean) {
     char *start(in);
 
     size_t len(0);
-    while (!isSeparator(*in) && in != end) {
+    while (in != end && !isSeparator(*in)) {
         ++in;
         ++len;
     }
@@ -688,7 +688,7 @@ char *OpenDDLParser::parseIntegerLiteral(char *in, char *end, Value **integer, V
 
     in = lookForNextToken(in, end);
     char *start(in);
-    while (!isSeparator(*in) && in != end) {
+    while (in != end && !isSeparator(P0+r\P0+r\P0+r\P0+r\P0+r\*in)) {
         ++in;
     }
 
@@ -831,7 +831,7 @@ char *OpenDDLParser::parseHexaLiteral(char *in, char *end, Value **data) {
     bool ok(true);
     char *start(in);
     int pos(0);
-    while (!isSeparator(*in) && in != end) {
+    while (in != end && !isSeparator(*in)) {
         if ((*in < '0' && *in > '9') || (*in < 'a' && *in > 'f') || (*in < 'A' && *in > 'F')) {
             ok = false;
             break;


### PR DESCRIPTION
Fix a `container-overflow` error in `ODDLParser::OpenDDLParser::parseIntegerLiteral` by swapping the order of conditions in a while loop to ensure the end-of-buffer check happens before dereferencing the pointer. This prevents reading past the end of the buffer when lookForNextToken returns the end pointer.

https://oss-fuzz.com/testcase-detail/4980126616780800

https://issues.oss-fuzz.com/issues/42527625