### PR TITLE
Fixed a heap-buffer-overflow in the Half-Life 1 MDL loader.

### DIFF
--- a/code/AssetLib/MDL/MDLLoader.cpp
+++ b/code/AssetLib/MDL/MDLLoader.cpp
@@ -51,6 +51,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "MDLLoader.h"
 #include "AssetLib/MD2/MD2FileData.h"
 #include "HalfLife/HL1MDLLoader.h"
+#include "HalfLife/HL1FileData.h"
 #include "MDLDefaultColorMap.h"
 
 #include <assimp/StringUtils.h>
@@ -1979,6 +1980,11 @@ void MDLImporter::InternReadFile_HL1(const std::string &pFile, const uint32_t iM
     // We can't correctly load an MDL from a MDL "sequence" file.
     if (iMagicWord == AI_MDL_MAGIC_NUMBER_BE_HL2b || iMagicWord == AI_MDL_MAGIC_NUMBER_LE_HL2b)
         throw DeadlyImportError("Impossible to properly load a model from an MDL sequence file.");
+
+    // Check if the buffer is large enough to hold the header
+    if (iFileSize < sizeof(HalfLife::Header_HL1)) {
+        throw DeadlyImportError("HL1 MDL file is too small to contain header.");
+    }
 
     // Read the MDL file.
     HalfLife::HL1MDLLoader loader(


### PR DESCRIPTION
The loader attempted to read the MDL header without verifying if the input buffer was large enough. Added a check in `MDLImporter::InternReadFile_HL1` to ensure the buffer size is sufficient before proceeding with loading.