### PR TITLE
Fixed a `heap-use-after-free` in `SortByPTypeProcess`.

### DIFF
--- a/code/PostProcessing/SortByPTypeProcess.cpp
+++ b/code/PostProcessing/SortByPTypeProcess.cpp
@@ -165,6 +165,7 @@ void SortByPTypeProcess::Execute(aiScene *pScene) {
             if (!(mConfigRemoveMeshes & mesh->mPrimitiveTypes)) {
                 *meshIdx = static_cast<unsigned int>(outMeshes.size());
                 outMeshes.emplace_back(mesh);
+                pScene->mMeshes[i] = nullptr; // Indicate ownership transfer
             } else {
                 delete mesh;
                 pScene->mMeshes[i] = nullptr;


### PR DESCRIPTION
The process incorrectly deleted original meshes from the scene when cleaning up after an error if those meshes had been added to its output list (`outMeshes`).
The fix ensures proper ownership transfer by nullifying the original mesh pointer in the scene (`pScene->mMeshes[i] = nullptr;`) when the mesh is moved to outMeshes. This prevents the scene destructor from attempting to delete the mesh again later, while allowing the error cleanup path in `SortByPTypeProcess` to correctly delete all meshes it owns (both newly created and transferred originals).