### PR TITLE
Fix an invalid offsetof warning-as-error

### DIFF
--- a/code/AssetLib/Blender/BlenderTessellator.cpp
+++ b/code/AssetLib/Blender/BlenderTessellator.cpp
@@ -381,7 +381,14 @@ inline PointP2T& BlenderTessellatorP2T::GetActualPointStructure( p2t::Point& poi
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Winvalid-offsetof"
 #endif // __clang__
+#if defined __GNUC__
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Winvalid-offsetof"
+#endif // __GNUC__
     unsigned int pointOffset = offsetof( PointP2T, point2D );
+#if defined __GNUC__
+#    pragma GCC diagnostic pop
+#endif // __GNUC__
 #if defined __clang__
 #    pragma clang diagnostic pop
 #endif


### PR DESCRIPTION
The code already disables the warning on clang. It's also caused on GCC in some circumstances (particularly when building with `-D_GLIBCXX_DEBUG`).