### PR TITLE
Added missing scene extras properties for glTF2Importer

### DIFF
--- a/code/AssetLib/glTF2/glTF2Importer.cpp
+++ b/code/AssetLib/glTF2/glTF2Importer.cpp
@@ -1681,7 +1681,8 @@ void glTF2Importer::ImportCommonMetadata(glTF2::Asset &a) {
     const bool hasGenerator = !a.asset.generator.empty();
     const bool hasCopyright = !a.asset.copyright.empty();
     const bool hasSceneMetadata = a.scene->customExtensions;
-    if (hasVersion || hasGenerator || hasCopyright || hasSceneMetadata) {
+    const bool hasSceneExtras = a.scene->extras.HasExtras();
+    if (hasVersion || hasGenerator || hasCopyright || hasSceneMetadata || hasSceneExtras) {
         mScene->mMetaData = new aiMetadata;
         if (hasVersion) {
             mScene->mMetaData->Add(AI_METADATA_SOURCE_FORMAT_VERSION, aiString(a.asset.version));
@@ -1694,6 +1695,9 @@ void glTF2Importer::ImportCommonMetadata(glTF2::Asset &a) {
         }
         if (hasSceneMetadata) {
             ParseExtensions(mScene->mMetaData, a.scene->customExtensions);
+        }
+        if (hasSceneExtras) {
+            ParseExtras(mScene->mMetaData, a.scene->extras);
         }
     }
 }


### PR DESCRIPTION
Hi.
I wanted to import my custom scene properties via the glTF2 improter, but I found that the importer ignores them.