### PR TITLE
Only build collada test when importer/exporter is build

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -147,8 +147,6 @@ SET( IMPORTERS
   unit/utBlendImportMaterials.cpp
   unit/utBlenderWork.cpp
   unit/utBVHImportExport.cpp
-  unit/utColladaExport.cpp
-  unit/utColladaImportExport.cpp
   unit/utCSMImportExport.cpp
   unit/utB3DImportExport.cpp
   #unit/utM3DImportExport.cpp
@@ -177,6 +175,18 @@ SET( IMPORTERS
 if(ASSIMP_BUILD_USD_IMPORTER)
   list( APPEND IMPORTERS
     unit/utUSDImport.cpp
+  )
+endif()
+
+if(ASSIMP_BUILD_COLLADA_EXPORTER)
+  list( APPEND IMPORTERS
+    unit/utColladaExport.cpp
+  )
+endif()
+
+if(ASSIMP_BUILD_COLLADA_IMPORTER)
+  list( APPEND IMPORTERS
+    unit/utColladaImportExport.cpp
   )
 endif()
 


### PR DESCRIPTION
The collada export/import tests are build even if `ASSIMP_BUILD_COLLADA_IMPORTER` and/or `ASSIMP_BUILD_COLLADA_EXPORTER` are disabled causing tests to fail.

A similar check already exists for `ASSIMP_BUILD_USD_IMPORTER` and should probably also be done for others.

See-also: https://bugs.gentoo.org/962559

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build configuration to conditionally run tests based on enabled features, enhancing build efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->