### PR TITLE
Fix UTF-8 flag check in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,7 +362,7 @@ ELSEIF(MSVC)
   elseif((GENERATOR_IS_MULTI_CONFIG) OR (CMAKE_BUILD_TYPE MATCHES Release))
     message("-- MSVC PDB generation disabled. Release binary will not be debuggable.")
   endif()
-  if(NOT /utf-8 IN_LIST CMAKE_CXX_FLAGS)
+  if(NOT CMAKE_CXX_FLAGS MATCHES "/utf-8")
     # Source code is encoded in UTF-8
     ADD_COMPILE_OPTIONS(/source-charset:utf-8)
   endif()


### PR DESCRIPTION
assimp’s MSVC UTF‑8 detection uses IN_LIST on CMAKE_CXX_FLAGS, which is a string, not a list. The condition always fails, so assimp adds /source-charset:utf-8 even when a parent project already sets /utf-8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for UTF-8 source charset handling in MSVC builds.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->