### PR TITLE
MDL: Fix synctype validation in MDLImporter to prevent OOB

### DIFF
--- a/code/AssetLib/MDL/MDLLoader.cpp
+++ b/code/AssetLib/MDL/MDLLoader.cpp
@@ -3,7 +3,7 @@
 Open Asset Import Library (assimp)
 ---------------------------------------------------------------------------
 
-Copyright (c) 2006-2025, assimp team
+Copyright (c) 2006-2026, assimp team
 
 All rights reserved.
 
@@ -602,7 +602,7 @@ void MDLImporter::SetupMaterialProperties_3DGS_MDL5_Quake1() {
 // Read a MDL 3,4,5 file
 void MDLImporter::InternReadFile_3DGS_MDL345() {
     ai_assert(nullptr != pScene);
-    if (pSene == nullptr) {
+    if (pScene == nullptr) {
         throw DeadlyImportError("INvalid scene pointer detected.");
     }
 


### PR DESCRIPTION
Validate synctype > 0 in MDL 3/4/5 loader to prevent OOB access (#6170)

Reject MDL files with invalid (<=0) synctype value in InternReadFile_3DGS_MDL345 to prevent possible buffer overflows. 
Fixes CVE-2025-5168.

### Verification

After applying this patch, the following fuzz test input no longer triggers a crash or out-of-bounds access:

```
[root@localhost assimp]# ./assimp_fuzzer ./crash-e7aab3eceac3345540f4ef8d2b75ba1c534464ff
INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 1751347426
INFO: Loaded 1 modules   (7 inline 8-bit counters): 7 [0x55974db308c8, 0x55974db308cf), 
INFO: Loaded 1 PC tables (7 PCs): 7 [0x55974db308d0,0x55974db30940), 
./assimp_fuzzer: Running 1 inputs 1 time(s) each.
Running: ./crash-e7aab3eceac3345540f4ef8d2b75ba1c534464ff
Executed ./crash-e7aab3eceac3345540f4ef8d2b75ba1c534464ff in 8 ms
***
*** NOTE: fuzzing was not performed, you have only
***       executed the target code on a fixed set of inputs.
***
[root@localhost assimp]#
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Importer now detects an invalid header field in MDL files earlier and aborts with a clearer error to prevent parsing corrupt files.
  * Added a guard against a missing/invalid scene reference to prevent crashes and confusing failures during import.

* **Refactor**
  * Internal cleanup of import logic for more consistent handling (no behavioral changes).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->