### PR TITLE
MD5: Fix uninitialized pointer dereference for file with invalid vertex index

### DIFF
--- a/code/AssetLib/MD5/MD5Loader.cpp
+++ b/code/AssetLib/MD5/MD5Loader.cpp
@@ -361,19 +361,19 @@ void MD5Importer::LoadMD5MeshFile() {
 #else
 
     // FIX: MD5 files exported from Blender can have empty meshes
+    unsigned int numMaterials = 0;
     for (std::vector<MD5::MeshDesc>::const_iterator it = meshParser.mMeshes.begin(), end = meshParser.mMeshes.end(); it != end; ++it) {
         if (!(*it).mFaces.empty() && !(*it).mVertices.empty()) {
-            ++mScene->mNumMaterials;
+            ++numMaterials;
         }
     }
 
     // generate all meshes
-    mScene->mNumMeshes = mScene->mNumMaterials;
-    mScene->mMeshes = new aiMesh *[mScene->mNumMeshes];
-    mScene->mMaterials = new aiMaterial *[mScene->mNumMeshes];
+    mScene->mMeshes = new aiMesh *[numMaterials];
+    mScene->mMaterials = new aiMaterial *[numMaterials];
 
     //  storage for node mesh indices
-    pcNode->mNumMeshes = mScene->mNumMeshes;
+    pcNode->mNumMeshes = numMaterials;
     pcNode->mMeshes = new unsigned int[pcNode->mNumMeshes];
     for (unsigned int m = 0; m < pcNode->mNumMeshes; ++m) {
         pcNode->mMeshes[m] = m;
@@ -386,7 +386,10 @@ void MD5Importer::LoadMD5MeshFile() {
             continue;
         }
 
-        aiMesh *mesh = mScene->mMeshes[n] = new aiMesh();
+        aiMesh* mesh = new aiMesh();
+        mScene->mMeshes[n] = mesh;
+        ++mScene->mNumMeshes;
+
         mesh->mPrimitiveTypes = aiPrimitiveType_TRIANGLE;
 
         // generate unique vertices in our internal verbose format
@@ -508,6 +511,7 @@ void MD5Importer::LoadMD5MeshFile() {
         // generate a material for the mesh
         aiMaterial *mat = new aiMaterial();
         mScene->mMaterials[n] = mat;
+        ++mScene->mNumMaterials;
 
         // insert the typical doom3 textures:
         // nnn_local.tga  - normal map


### PR DESCRIPTION
A segmentation fault occurred while parsing an MD5 file that contains an invalid vertex index. ASAN report:

```
==371440==ERROR: AddressSanitizer: SEGV on unknown address (pc 0x0000006ee9cd bp 0x7fffe469c040 sp 0x7fffe469bfd0 T0)
==371440==The signal is caused by a READ memory access.
==371440==Hint: this fault was caused by a dereference of a high value address (see register values below).  Disassemble the provided pc to learn which register was used.
    #0 0x0000006ee9cd in aiMaterial::Clear() assimp/code/Material/MaterialSystem.cpp:447:34
    #1 0x0000006ee8a4 in aiMaterial::~aiMaterial() assimp/code/Material/MaterialSystem.cpp:432:5
    #2 0x00000060f60c in aiScene::~aiScene() assimp/code/Common/scene.cpp:84:13
    #3 0x00000065b13c in std::default_delete<aiScene>::operator()(aiScene*) const /usr/include/c++/15/bits/unique_ptr.h:92:2
    #4 0x00000062e35d in std::unique_ptr<aiScene, std::default_delete<aiScene>>::~unique_ptr() /usr/include/c++/15/bits/unique_ptr.h:398:4
    #5 0x000000cc06bc in Assimp::BaseImporter::ReadFile(Assimp::Importer*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, Assimp::IOSystem*) assimp/code/Common/BaseImporter.cpp:147:1
    #6 0x0000005abc56 in Assimp::Importer::ReadFile(char const*, unsigned int) assimp/code/Common/Importer.cpp:709:30
    #7 0x0000005a85c9 in Assimp::Importer::ReadFileFromMemory(void const*, unsigned long, unsigned int, char const*) assimp/code/Common/Importer.cpp:507:9
    #8 0x00000059ecd9 in LLVMFuzzerTestOneInput assimp/myfuzzing/cmake-build/../../fuzz/assimp_fuzzer.cc:62:34
    #9 0x00000043164f in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) fuzzer.o
    #10 0x00000041c076 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) fuzzer.o
    #11 0x000000421f49 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) fuzzer.o
    #12 0x00000044e186 in main (assimp_fuzzer+0x44e186)
    #13 0x7f063a1e35b4 in __libc_start_call_main (/lib64/libc.so.6+0x35b4)
    #14 0x7f063a1e3667 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x3667)
    #15 0x000000414f54 in _start (assimp_fuzzer+0x414f54)

```

The issue was caused by `mScene->mMaterials` not being kept in sync with `mScene->mNumMaterials`. As a result, the `aiScene` destructor could call `delete` on uninitialized pointers.

This patch ensures that `mScene->mNumMaterials` always matches the actual contents of the `mScene->mMaterials` array. That way, if an exception is thrown during file import, `delete` is only called for properly allocated `aiMaterial` objects.

Found by fuzzer: https://issues.oss-fuzz.com/issues/447262177

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of MD5 model files, particularly those exported from Blender, ensuring correct material and mesh indexing even when files contain empty meshes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->