### PR TITLE
MDL/HL1: bounds-checked buffers and safer parsing

### DIFF
--- a/code/AssetLib/MDL/HalfLife/HL1DataBuffer.h
+++ b/code/AssetLib/MDL/HalfLife/HL1DataBuffer.h
@@ -1,0 +1,182 @@
+/*
+---------------------------------------------------------------------------
+Open Asset Import Library (assimp)
+---------------------------------------------------------------------------
+
+Copyright (c) 2006-2026, assimp team
+
+All rights reserved.
+
+Redistribution and use of this software in source and binary forms,
+with or without modification, are permitted provided that the following
+conditions are met:
+
+* Redistributions of source code must retain the above
+copyright notice, this list of conditions and the
+following disclaimer.
+
+* Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the
+following disclaimer in the documentation and/or other
+materials provided with the distribution.
+
+* Neither the name of the assimp team, nor the names of its
+contributors may be used to endorse or promote products
+derived from this software without specific prior
+written permission of the assimp team.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+---------------------------------------------------------------------------
+*/
+
+/** @file HL1DataBuffer.h
+ *  @brief Declaration of the Half-Life 1 data buffer.
+ */
+
+#ifndef AI_HL1DATABUFFER_INCLUDED
+#define AI_HL1DATABUFFER_INCLUDED
+
+#include <assimp/Exceptional.h>
+#include <assimp/defs.h>
+#include <cstddef>
+#include <memory>
+
+namespace Assimp {
+namespace MDL {
+namespace HalfLife {
+
+/**
+ * \brief Lightweight byte buffer wrapper for HL1 binary parsing.
+ *
+ * Acts as either:
+ *  - a non-owning view into external memory, or
+ *  - an owning buffer backed by a unique_ptr.
+ *
+ * Copy is disabled to avoid accidental double-ownership; move is supported.
+ */
+class HL1DataBuffer {
+public:
+    /** \brief Construct an empty buffer (null view). */
+    HL1DataBuffer() AI_NO_EXCEPT : data_(nullptr),
+                                   length_(0),
+                                   owner_(nullptr) {}
+
+    /** \brief Non-copyable (buffer may own memory). */
+    HL1DataBuffer(const HL1DataBuffer &) = delete;
+
+    /** \brief Non-copyable (buffer may own memory). */
+    HL1DataBuffer &operator=(const HL1DataBuffer &) = delete;
+
+    /** \brief Move-construct, transferring ownership/view state. */
+    HL1DataBuffer(HL1DataBuffer &&other) AI_NO_EXCEPT : data_(other.data_),
+                                                        length_(other.length_),
+                                                        owner_(std::move(other.owner_)) {
+        other.data_ = nullptr;
+        other.length_ = 0;
+        other.owner_ = nullptr;
+    }
+
+    /** \brief Move-assign, transferring ownership/view state. */
+    HL1DataBuffer &operator=(HL1DataBuffer &&other) AI_NO_EXCEPT {
+        if (this != &other) {
+            data_ = other.data_;
+            length_ = other.length_;
+            owner_ = std::move(other.owner_);
+
+            other.data_ = nullptr;
+            other.length_ = 0;
+            other.owner_ = nullptr;
+        }
+
+        return *this;
+    }
+
+    /**
+     * \brief Create a non-owning view into external bytes.
+     *
+     * \param[in] data Pointer to raw bytes (must outlive the view).
+     * \param[in] length Size in bytes.
+     */
+    static HL1DataBuffer view(const unsigned char *data, size_t length) {
+        HL1DataBuffer b;
+        b.data_ = data;
+        b.length_ = length;
+        b.owner_ = nullptr;
+        return b;
+    }
+
+    /**
+     * \brief Create a non-owning view of another buffer.
+     *
+     * \param[in] other Source buffer.
+     */
+    static HL1DataBuffer view(const HL1DataBuffer &other) {
+        HL1DataBuffer b;
+        b.data_ = other.data_;
+        b.length_ = other.length_;
+        b.owner_ = nullptr;
+        return b;
+    }
+
+    /**
+     * \brief Create an owning buffer by taking ownership of allocated storage.
+     *
+     * \param[in] buffer Unique buffer storage.
+     * \param[in] length Size in bytes.
+     */
+    static HL1DataBuffer owning(std::unique_ptr<unsigned char[]> buffer, size_t length) {
+        HL1DataBuffer b;
+        b.data_ = buffer.get();
+        b.length_ = length;
+        b.owner_ = std::move(buffer);
+        return b;
+    }
+
+    /**
+     * \brief Return a typed pointer into the buffer with bounds checks.
+     *
+     * \param[in] offset Byte offset from the start of the buffer.
+     * \param[in] elements Number of elements to access.
+     * \return Pointer to the requested typed data inside the buffer.
+     * \throws DeadlyImportError if the request is out of range.
+     */
+    template <typename DataType>
+    const DataType *get_data(int offset, int elements) const {
+        if (offset < 0 || elements < 0) {
+            throw DeadlyImportError("MDL file contains invalid data");
+        }
+
+        const size_t uoffset = static_cast<size_t>(offset);
+        const size_t uelements = static_cast<size_t>(elements);
+
+        if (uoffset > length_ || uelements > (length_ - uoffset) / sizeof(DataType)) {
+            throw DeadlyImportError("MDL file contains invalid data");
+        }
+
+        return reinterpret_cast<const DataType *>(data_ + uoffset);
+    }
+
+private:
+    /** Raw byte pointer (points to owner_.get() when owning, otherwise external). */
+    const unsigned char *data_;
+    /** Buffer length in bytes. */
+    size_t length_;
+    /** Owning storage (null for views). */
+    std::unique_ptr<unsigned char[]> owner_;
+};
+
+} // namespace HalfLife
+} // namespace MDL
+} // namespace Assimp
+
+#endif // AI_HL1DATABUFFER_INCLUDED

--- a/code/AssetLib/MDL/HalfLife/HL1MDLLoader.h
+++ b/code/AssetLib/MDL/HalfLife/HL1MDLLoader.h
@@ -47,6 +47,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define AI_HL1MDLLOADER_INCLUDED
 
 #include "HL1FileData.h"
+#include "HL1DataBuffer.h"
 #include "HL1ImportSettings.h"
 #include "UniqueNameGenerator.h"
 
@@ -74,6 +75,7 @@ public:
         aiScene *scene,
         IOSystem *io,
         const unsigned char *buffer,
+        size_t buffer_length,
         const std::string &file_path,
         const HL1ImportSettings &import_settings);
 
@@ -109,10 +111,32 @@ private:
 
     /** \brief Load a file and copy it's content to a buffer.
      * \param file_path The path to the file to be loaded.
-     * \param buffer A pointer to a buffer to receive the data.
+     * \param buffer A buffer to receive the data.
      */
     template <typename MDLFileHeader>
-    void load_file_into_buffer(const std::string &file_path, unsigned char *&buffer);
+    void load_file_into_buffer(const std::string &file_path, HL1DataBuffer &buffer);
+
+    /** \brief Get a pointer to the specified data type in texture buffer.
+     * \param offset Offset in bytes.
+     * \param elements Elements count.
+     */
+    template <typename DataType>
+    const DataType *get_texture_buffer_data(int offset, int elements);
+
+    /** \brief Get a pointer to the specified data type in animation buffer.
+     * \param animation Animation index.
+     * \param offset Offset in bytes.
+     * \param elements Elements count.
+     */
+    template <typename DataType>
+    const DataType *get_anim_buffer_data(int animation, int offset, int elements);
+
+    /** \brief Get a pointer to the specified data type in MDL buffer.
+     * \param offset Offset in bytes.
+     * \param elements Elements count.
+     */
+    template <typename DataType>
+    const DataType *get_buffer_data(int offset, int elements);
 
     /** \brief Read an MDL texture.
      * \param[in] ptexture A pointer to an MDL texture.
@@ -122,7 +146,7 @@ private:
      * \param[in,out] last_palette_color The last color from the image palette.
      */
     void read_texture(const Texture_HL1 *ptexture,
-            uint8_t *data, uint8_t *pal, aiTexture *pResult,
+            const uint8_t *data, const uint8_t *pal, aiTexture *pResult,
             aiColor3D &last_palette_color);
 
     /** \brief This method reads a compressed anim value.
@@ -158,7 +182,7 @@ private:
     IOSystem *io_;
 
     /** Buffer from MDLLoader class. */
-    const unsigned char *buffer_;
+    const HL1DataBuffer buffer_;
 
     /** The full file path to the MDL file we are trying to load.
      * Used to locate other MDL files since MDL may store resources
@@ -176,13 +200,13 @@ private:
 
     /** External MDL animation headers.
      * One for each loaded animation file. */
-    SequenceHeader_HL1 **anim_headers_;
+    std::vector<const SequenceHeader_HL1*> anim_headers_;
 
     /** Texture file data. */
-    unsigned char *texture_buffer_;
+    HL1DataBuffer texture_buffer_;
 
     /** Animation files data. */
-    unsigned char **anim_buffers_;
+    std::vector<HL1DataBuffer> anim_buffers_;
 
     /** The number of sequence groups. */
     int num_sequence_groups_;
@@ -226,7 +250,7 @@ private:
 
 // ------------------------------------------------------------------------------------------------
 template <typename MDLFileHeader>
-void HL1MDLLoader::load_file_into_buffer(const std::string &file_path, unsigned char *&buffer) {
+void HL1MDLLoader::load_file_into_buffer(const std::string &file_path, HL1DataBuffer &buffer) {
     if (!io_->Exists(file_path))
         throw DeadlyImportError("Missing file ", DefaultIOSystem::fileName(file_path), ".");
 
@@ -241,9 +265,30 @@ void HL1MDLLoader::load_file_into_buffer(const std::string &file_path, unsigned 
         throw DeadlyImportError("MDL file is too small.");
     }
 
-    buffer = new unsigned char[1 + file_size];
-    file->Read((void *)buffer, 1, file_size);
-    buffer[file_size] = '\0';
+    std::unique_ptr<unsigned char[]> data(new unsigned char[1 + file_size]);
+    file->Read(data.get(), 1, file_size);
+    data[file_size] = '\0';
+
+    buffer = HL1DataBuffer::owning(std::move(data), file_size);
+}
+
+template <typename DataType>
+const DataType *HL1MDLLoader::get_texture_buffer_data(int offset, int elements) {
+    return texture_buffer_.get_data<DataType>(offset, elements);
+}
+
+template <typename DataType>
+const DataType *HL1MDLLoader::get_anim_buffer_data(int animation, int offset, int elements) {
+    if (animation < 0 || animation >= num_sequence_groups_) {
+        throw DeadlyImportError("MDL file contains invalid sequence group index (", animation, ")");
+    }
+
+    return anim_buffers_[animation].get_data<DataType>(offset, elements);
+}
+
+template <typename DataType>
+const DataType *HL1MDLLoader::get_buffer_data(int offset, int elements) {
+    return buffer_.get_data<DataType>(offset, elements);
 }
 
 } // namespace HalfLife

--- a/code/AssetLib/MDL/MDLLoader.cpp
+++ b/code/AssetLib/MDL/MDLLoader.cpp
@@ -2001,6 +2001,7 @@ void MDLImporter::InternReadFile_HL1(const std::string &pFile, const uint32_t iM
             pScene,
             mIOHandler,
             mBuffer,
+            iFileSize,
             pFile,
             mHL1ImportSettings);
 }

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -457,6 +457,7 @@ ADD_ASSIMP_IMPORTER( MDL
   AssetLib/MDL/MDLLoader.h
   AssetLib/MDL/MDLMaterialLoader.cpp
   AssetLib/MDL/HalfLife/HalfLifeMDLBaseHeader.h
+  AssetLib/MDL/HalfLife/HL1DataBuffer.h
   AssetLib/MDL/HalfLife/HL1FileData.h
   AssetLib/MDL/HalfLife/HL1MDLLoader.cpp
   AssetLib/MDL/HalfLife/HL1MDLLoader.h


### PR DESCRIPTION
This MR is a security-oriented refactoring of the Half-Life 1 MDL loader.

It replaces raw byte pointers and manual `new[]` / `delete[]` handling with a small buffer wrapper that makes ownership and bounds explicit. All (or almost all) binary access now goes through bounds-checked helpers for the main MDL buffer, texture data, and animation (sequence group) files.

The main buffer size is now passed into HL1MDLLoader, so offsets are validated instead of blindly trusted. This fixes several out-of-bounds read cases visible under ASAN.

Offsets and element counts intentionally use `int`, matching HL1 MDL structures and avoiding signed/unsigned issues. Texture/material counters are incremented only when objects are successfully created, as in https://github.com/assimp/assimp/pull/6439 .

NOTE: This change does not try to fix all possible HL1 MDL issues. The scope is intentionally limited to reduce risk and review complexity, while improving safety in the most error-prone areas.

Examples of ASAN reports before the fix:

Found by fuzzer https://issues.oss-fuzz.com/issues/439645317:

```
==379073==ERROR: AddressSanitizer: SEGV on unknown address 0x7d905a007ae9 (pc 0x000001394202 bp 0x7ffc2eb57070 sp 0x7ffc2eb56da0 T0)
==379073==The signal is caused by a READ memory access.
    #0 0x000001394202 in Assimp::MDL::HalfLife::HL1MDLLoader::read_texture(Assimp::MDL::HalfLife::Texture_HL1 const*, unsigned char*, unsigned char*, aiTexture*, aiColor3D&) assimp/code/AssetLib/MDL/HalfLife/HL1MDLLoader.cpp:377:28
    #1 0x000001374662 in Assimp::MDL::HalfLife::HL1MDLLoader::read_textures() assimp/code/AssetLib/MDL/HalfLife/HL1MDLLoader.cpp:395:9
    #2 0x00000136efaa in Assimp::MDL::HalfLife::HL1MDLLoader::load_file() assimp/code/AssetLib/MDL/HalfLife/HL1MDLLoader.cpp:162:9
    #3 0x00000136e866 in Assimp::MDL::HalfLife::HL1MDLLoader::HL1MDLLoader(aiScene*, Assimp::IOSystem*, unsigned char const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, Assimp::MDL::HalfLife::HL1ImportSettings const&) assimp/code/AssetLib/MDL/HalfLife/HL1MDLLoader.cpp:101:5
    #4 0x00000133c073 in Assimp::MDLImporter::InternReadFile_HL1(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, unsigned int) assimp/code/AssetLib/MDL/MDLLoader.cpp:2000:28
    #5 0x00000132e852 in Assimp::MDLImporter::InternReadFile(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, aiScene*, Assimp::IOSystem*) assimp/code/AssetLib/MDL/MDLLoader.cpp:254:17
    #6 0x000000cc033c in Assimp::BaseImporter::ReadFile(Assimp::Importer*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, Assimp::IOSystem*) assimp/code/Common/BaseImporter.cpp:131:9
    #7 0x0000005abc56 in Assimp::Importer::ReadFile(char const*, unsigned int) assimp/code/Common/Importer.cpp:709:30
    #8 0x0000005a85c9 in Assimp::Importer::ReadFileFromMemory(void const*, unsigned long, unsigned int, char const*) assimp/code/Common/Importer.cpp:507:9
    #9 0x00000059ecd9 in LLVMFuzzerTestOneInput assimp/myfuzzing/cmake-build/../../fuzz/assimp_fuzzer.cc:62:34
    #10 0x00000043164f in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) fuzzer.o
    #11 0x00000041c076 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) fuzzer.o
    #12 0x000000421f49 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) fuzzer.o
    #13 0x00000044e186 in main (assimp_fuzzer+0x44e186)
    #14 0x7fe03a71b5b4 in __libc_start_call_main (/lib64/libc.so.6+0x35b4)
    #15 0x7fe03a71b667 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x3667)
    #16 0x000000414f54 in _start (assimp_fuzzer+0x414f54)
```

As in https://github.com/assimp/assimp/pull/6439:
```
==474839==ERROR: AddressSanitizer: SEGV on unknown address (pc 0x0000006ea37d bp 0x7ffea1b34aa0 sp 0x7ffea1b34a40 T0)
==474839==The signal is caused by a READ memory access.
==474839==Hint: this fault was caused by a dereference of a high value address (see register values below).  Disassemble the provided pc to learn which register was used.
    #0 0x0000006ea37d in aiMaterial::Clear() assimp/code/Material/MaterialSystem.cpp:447:34
    #1 0x0000006ea254 in aiMaterial::~aiMaterial() assimp/code/Material/MaterialSystem.cpp:432:5
    #2 0x00000060d26c in aiScene::~aiScene() assimp/code/Common/scene.cpp:84:13
    #3 0x000000657e9c in std::default_delete<aiScene>::operator()(aiScene*) const /usr/include/c++/15/bits/unique_ptr.h:92:2
    #4 0x00000062b66d in std::unique_ptr<aiScene, std::default_delete<aiScene>>::~unique_ptr() /usr/include/c++/15/bits/unique_ptr.h:398:4
    #5 0x000000cafc92 in Assimp::BaseImporter::ReadFile(Assimp::Importer*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, Assimp::IOSystem*) assimp/code/Common/BaseImporter.cpp:147:1
    #6 0x0000005aafb2 in Assimp::Importer::ReadFile(char const*, unsigned int) assimp/code/Common/Importer.cpp:709:30
    #7 0x0000005a7913 in Assimp::Importer::ReadFileFromMemory(void const*, unsigned long, unsigned int, char const*) assimp/code/Common/Importer.cpp:507:9
    #8 0x00000059ecc9 in LLVMFuzzerTestOneInput assimp/myfuzzing/cmake-build/../../fuzz/assimp_fuzzer.cc:62:34
    #9 0x00000043163f in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) fuzzer.o
    #10 0x00000041c066 in fuzzer::RunOneTest(fuzzer::Fuzzer*, char const*, unsigned long) fuzzer.o
    #11 0x000000421f39 in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) fuzzer.o
    #12 0x00000044e176 in main (assimp_fuzzer+0x44e176)
    #13 0x7f68bc80f5b4 in __libc_start_call_main (/lib64/libc.so.6+0x35b4)
    #14 0x7f68bc80f667 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x3667)
    #15 0x000000414f44 in _start (assimp_fuzzer+0x414f44)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added buffered, bounds-checked data handling to the Half‑Life MDL import path for safer parsing.

* **Refactor**
  * Replaced ad‑hoc raw pointer access with centralized, type‑safe buffer accessors across texture, animation, mesh and related loading paths, improving memory safety and reliability.

* **Chores**
  * Updated public headers and build configuration to expose the new buffer handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->