### PR TITLE
Fix some recently implemented comparisons of token strings

### DIFF
--- a/code/AssetLib/Obj/ObjFileMtlImporter.cpp
+++ b/code/AssetLib/Obj/ObjFileMtlImporter.cpp
@@ -253,7 +253,7 @@ void ObjFileMtlImporter::load() {
             {
                 // Save start of token (after 'm')
                 auto tokenStart = m_DataIt;  // points to 'm'
-                auto tokenEnd = getEndOfToken(m_DataIt, m_DataItEnd); // move iterator to end of token
+                auto tokenEnd = getNextDelimiter(m_DataIt, m_DataItEnd); // move iterator to end of token
 
                 std::string keyword(tokenStart, tokenEnd);
                 m_DataIt = getNextWord(tokenEnd, m_DataItEnd); // advance iterator
@@ -279,7 +279,7 @@ void ObjFileMtlImporter::load() {
             case 'r': // refl (map) or roughness (float)
             {
                 auto tokenStart = m_DataIt;  // points to 'r'
-                auto tokenEnd = getEndOfToken(m_DataIt, m_DataItEnd);
+                auto tokenEnd = getNextDelimiter(m_DataIt, m_DataItEnd);
                 std::string keyword(tokenStart, tokenEnd);
                 m_DataIt = getNextWord(tokenEnd, m_DataItEnd);
 
@@ -303,7 +303,7 @@ void ObjFileMtlImporter::load() {
 
             case 'a': {
                 auto tokenStart = m_DataIt;
-                auto tokenEnd = getEndOfToken(m_DataIt, m_DataItEnd);
+                auto tokenEnd = getNextDelimiter(m_DataIt, m_DataItEnd);
                 std::string keyword(tokenStart, tokenEnd);
                 m_DataIt = getNextWord(tokenEnd, m_DataItEnd);
 
@@ -322,7 +322,7 @@ void ObjFileMtlImporter::load() {
 
             case 's': {
                 auto tokenStart = m_DataIt;
-                auto tokenEnd = getEndOfToken(m_DataIt, m_DataItEnd);
+                auto tokenEnd = getNextDelimiter(m_DataIt, m_DataItEnd);
                 std::string keyword(tokenStart, tokenEnd);
                 m_DataIt = getNextWord(tokenEnd,m_DataItEnd);
 
@@ -343,7 +343,7 @@ void ObjFileMtlImporter::load() {
 
             case 'c': {
                 auto tokenStart = m_DataIt;
-                auto tokenEnd = getEndOfToken(m_DataIt, m_DataItEnd);
+                auto tokenEnd = getNextDelimiter(m_DataIt, m_DataItEnd);
                 std::string keyword(tokenStart, tokenEnd);
                 m_DataIt = getNextWord(tokenEnd, m_DataItEnd);
 

--- a/code/AssetLib/Obj/ObjTools.h
+++ b/code/AssetLib/Obj/ObjTools.h
@@ -86,13 +86,13 @@ inline Char_T getNextWord(Char_T pBuffer, Char_T pEnd) {
 }
 
 /**
- *  @brief  Returns pointer to end of the current token
+ *  @brief  Returns next space
  *  @param[in] pBuffer  Pointer to data buffer
  *  @param[in] pEnd     Pointer to end of buffer
- *  @return Pointer to last character of current token
+ *  @return Pointer to next space
  */
 template <class Char_T>
-inline Char_T getEndOfToken(Char_T pBuffer, Char_T pEnd) {
+inline Char_T getNextDelimiter(Char_T pBuffer, Char_T pEnd) {
     while (!isEndOfBuffer(pBuffer, pEnd)) {
         if (IsSpaceOrNewLine(*pBuffer)) {
             break;
@@ -110,7 +110,7 @@ inline Char_T getEndOfToken(Char_T pBuffer, Char_T pEnd) {
  */
 template <class Char_T>
 inline Char_T getNextToken(Char_T pBuffer, Char_T pEnd) {
-    pBuffer = getEndOfToken(pBuffer, pEnd);
+    pBuffer = getNextDelimiter(pBuffer, pEnd);
     return getNextWord(pBuffer, pEnd);
 }
 


### PR DESCRIPTION
Previously, the `keyword` included the following space along with the token, which broke the string comparison using the equality operator.
This is an addition to https://github.com/assimp/assimp/commit/709fe3c3d0209cd180b239b21be80c43b4c07b80 which (partly) addressed issues #6253 and #5635.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Internal parsing for OBJ/MTL import was reworked to clarify token boundary detection vs. advancement. This improves consistency across keyword and texture parsing paths, reducing ambiguity in how keywords and their arguments are interpreted while preserving existing behavior and public interfaces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->