### PR TITLE
Fix AC3DImporter heap-buffer-overflow by validating mesh vertex bounds

### DIFF
--- a/code/AssetLib/AC/ACLoader.cpp
+++ b/code/AssetLib/AC/ACLoader.cpp
@@ -607,6 +607,10 @@ aiNode *AC3DImporter::ConvertObjectSection(Object &object,
                                 const Surface::SurfaceEntry &entry1 = src.entries[i];
                                 const Surface::SurfaceEntry &entry2 = src.entries[i + 1];
                                 const Surface::SurfaceEntry &entry3 = src.entries[i + 2];
+                                const unsigned int verticesNeeded = isDoubleSided ? 6 : 3;
+                                if (static_cast<unsigned>(vertices - mesh->mVertices) + verticesNeeded > mesh->mNumVertices) {
+                                    throw DeadlyImportError("AC3D: Invalid number of vertices");
+                                }
 
                                 aiFace &face = *faces++;
                                 face.mNumIndices = 3;
@@ -661,6 +665,10 @@ aiNode *AC3DImporter::ConvertObjectSection(Object &object,
                             unsigned int tmp = (unsigned int)(*it).entries.size();
                             if (Surface::OpenLine == type) --tmp;
                             for (unsigned int m = 0; m < tmp; ++m) {
+                                if (static_cast<unsigned>(vertices - mesh->mVertices) + 2 > mesh->mNumVertices) {
+                                    throw DeadlyImportError("AC3D: Invalid number of vertices");
+                                }
+
                                 aiFace &face = *faces++;
 
                                 face.mNumIndices = 2;


### PR DESCRIPTION
Add validations check in AC3DImporter::ConvertObjectSection to ensure that writing TriangleStrip vertex data does not exceed mesh->mNumVertices allocation. 
Fixes #6015 (CVE-2025-2754)
Fixes #6018 (CVE-2025-2756)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced AC3D file import stability through improved validation during geometry processing. The importer now includes additional safety checks when handling certain model configurations, reducing the likelihood of import failures and application crashes. These improvements provide more reliable and stable loading of AC3D format files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->