### PR TITLE
Obj: Fix heap-buffer-overflow in getFace via vertical tabs

### DIFF
--- a/code/AssetLib/Obj/ObjFileParser.cpp
+++ b/code/AssetLib/Obj/ObjFileParser.cpp
@@ -467,7 +467,7 @@ void ObjFileParser::getFace(aiPrimitiveType type) {
                 ASSIMP_LOG_ERROR("Obj: Separator unexpected in point statement");
             }
             iPos++;
-        } else if (IsSpaceOrNewLine(*m_DataIt)) {
+        } else if (IsSpaceOrNewLine(*m_DataIt) || *m_DataIt == '\v') {
             iPos = 0;
         } else {
             //OBJ USES 1 Base ARRAYS!!!!


### PR DESCRIPTION
The `ObjFileParser::getFace` method failed to recognize the vertical tab character (`\v`, 0x0b) as a separator. While the `IsSpaceOrNewLine` utility handles most whitespace (space, tab, CR, LF, FF), it excludes `\v`.

When encountering a vertical tab, the parser fell through to an `else` block that calls `::atoi(&(*m_DataIt))`. Because `atoi` treats `\v` as whitespace per the C standard, it skips the character and continues reading. If `\v` is located at the end of the buffer (e.g., followed by a newline at the buffer boundary), `atoi` can read past the allocated memory, triggering a heap-buffer-overflow.

This fix explicitly checks for `\v` and treats it as a separator, resetting the position counter and preventing the invalid `atoi` call.

Verified with AddressSanitizer and confirmed that all 584 existing unit tests pass.

Fixes: https://issues.oss-fuzz.com/issues/476180586

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where OBJ model files containing certain whitespace characters would fail to parse correctly during face index processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->