### PR TITLE
Fix memory leak for USD importer

### DIFF
--- a/code/AssetLib/USD/USDLoaderImplTinyusdz.cpp
+++ b/code/AssetLib/USD/USDLoaderImplTinyusdz.cpp
@@ -511,14 +511,6 @@ void USDImporterImplTinyusdz::uvsForMesh(
     }
 }
 
-static aiColor3D *ownedColorPtrFor(const std::array<float, 3> &color) {
-    aiColor3D *colorPtr = new aiColor3D();
-    colorPtr->r = color[0];
-    colorPtr->g = color[1];
-    colorPtr->b = color[2];
-    return colorPtr;
-}
-
 static std::string nameForTextureWithId(const RenderScene &render_scene, const int targetId) {
     std::stringstream ss;
     std::string texName;


### PR DESCRIPTION
Closes #5766 

This MR fixes memory leaks in the USD importer by removing heap allocations and using stack objects instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reduced dynamic memory usage in USD asset/material/texture loading, lowering peak memory and easing memory management during import.
  * Improves stability and reliability of material/texture handling and yields modestly faster load times without altering external behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->