### PR TITLE
Fix .ply triangle strip winding order problem

### DIFF
--- a/code/AssetLib/Ply/PlyLoader.cpp
+++ b/code/AssetLib/Ply/PlyLoader.cpp
@@ -682,13 +682,12 @@ namespace Assimp {
             face.mIndices[0] = aiTable[0];
             face.mIndices[1] = aiTable[1];
             face.mIndices[2] = p;
-            cache.push_back(face);
-
-            // every second pass swap the indices.
-            flip = !flip;
             if (flip) {
                 std::swap(face.mIndices[0], face.mIndices[1]);
             }
+            cache.push_back(face);
+            // every second pass swap the indices.
+            flip = !flip;
 
             aiTable[0] = aiTable[1];
             aiTable[1] = p;


### PR DESCRIPTION
Apply codeRabbit suggested fix from assimp PR #6548 (.ply triangle strip winding order problem)

Fixes #2337 (screenshot attached)

<img width="240" alt="lucy_triangle_strip_winding_order_fixed" src="https://github.com/user-attachments/assets/1957458f-13fb-46b1-8653-5055d9ac0fd7" />

### Notes
- IIUC #6554 does not have this change
- there are additional codeRabbit suggestions on PR #6548 that should probably be applied as well

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PLY file loading to ensure correct vertex ordering during triangle processing, enhancing the accuracy of 3D model imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->