### PR TITLE
glTF2: Fix heap-buffer-overflow in GetVertexColorsForType

### DIFF
--- a/code/AssetLib/glTF2/glTF2Importer.cpp
+++ b/code/AssetLib/glTF2/glTF2Importer.cpp
@@ -462,9 +462,9 @@ template <typename T>
 aiColor4D *GetVertexColorsForType(Ref<Accessor> input, std::vector<unsigned int> *vertexRemappingTable) {
     constexpr float max = std::numeric_limits<T>::max();
     aiColor4t<T> *colors;
-    input->ExtractData(colors, vertexRemappingTable);
-    auto output = new aiColor4D[input->count];
-    for (size_t i = 0; i < input->count; i++) {
+    size_t count = input->ExtractData(colors, vertexRemappingTable);
+    auto output = new aiColor4D[count];
+    for (size_t i = 0; i < count; i++) {
         output[i] = aiColor4D(
                 colors[i].r / max, colors[i].g / max,
                 colors[i].b / max, colors[i].a / max);


### PR DESCRIPTION
The `GetVertexColorsForType` function previously used `input->count`
(the total number of elements in the accessor) to allocate the output
array and bound the conversion loop. However, when a
`vertexRemappingTable` is provided, `ExtractData` extracts a subset of
elements matching the size of the remapping table rather than the full
accessor count.

In cases where the remapping table was smaller than the accessor count
(including empty tables), the subsequent loop would perform
out-of-bounds reads on the `colors` buffer allocated by `ExtractData`.

This fix captures the actual number of elements extracted by
`ExtractData` and uses this value for the output allocation and loop
iteration, ensuring memory safety when vertex remapping is active.

Verified with ASan and existing unit tests.

Fixes https://issues.oss-fuzz.com/issues/486378385

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected vertex color extraction during glTF2 imports to use actual extracted counts for allocation and iteration.
  * Improved memory management by ensuring temporary color data is properly released after processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->