### PR TITLE
Fix collada animation clips

### DIFF
--- a/code/AssetLib/Collada/ColladaParser.cpp
+++ b/code/AssetLib/Collada/ColladaParser.cpp
@@ -590,7 +590,7 @@ void ColladaParser::ReadStructure(XmlNode &node) {
         } else if (currentName == "library_animations") {
             ReadAnimationLibrary(currentNode);
         } else if (currentName == "library_animation_clips") {
-            (currentNode);
+            ReadAnimationClipLibrary(currentNode);
         } else if (currentName == "library_controllers") {
             ReadControllerLibrary(currentNode);
         } else if (currentName == "library_images") {

--- a/code/AssetLib/Collada/ColladaParser.cpp
+++ b/code/AssetLib/Collada/ColladaParser.cpp
@@ -673,10 +673,8 @@ void ColladaParser::ReadAnimationClipLibrary(XmlNode &node /*NODE: library_anima
 		}
 		
 	    std::string animName;
-	    if (!XmlParser::getStdStrAttribute(animationClip, "name", animName)) {
-		    if (!XmlParser::getStdStrAttribute(animationClip, "id", animName)) {
-			    animName = std::string("animation_") + ai_to_string(mAnimationClipLibrary.size());
-		    }
+	    if (!XmlParser::getStdStrAttribute(animationClip, "name", animName) && !XmlParser::getStdStrAttribute(animationClip, "id", animName)) {
+            animName = std::string("animation_") + ai_to_string(mAnimationClipLibrary.size());
 	    }
 
 	    std::pair<std::string, std::vector<std::string>> clip;

--- a/code/AssetLib/Collada/ColladaParser.cpp
+++ b/code/AssetLib/Collada/ColladaParser.cpp
@@ -668,30 +668,32 @@ void ColladaParser::ReadAnimationClipLibrary(XmlNode &node /*NODE: library_anima
     }
     for (XmlNode &animationClip : node.children()) {
         const std::string& currentNodeName = currentNode.name();
-        if (currentNodeName == "animation_clip") {
-	        std::string animName;
-	        if (!XmlParser::getStdStrAttribute(animationClip, "name", animName)) {
-		        if (!XmlParser::getStdStrAttribute(animationClip, "id", animName)) {
-			        animName = std::string("animation_") + ai_to_string(mAnimationClipLibrary.size());
-		        }
-	        }
+        if (currentNodeName != "animation_clip") {
+            continue;
+		}
+		
+	    std::string animName;
+	    if (!XmlParser::getStdStrAttribute(animationClip, "name", animName)) {
+		    if (!XmlParser::getStdStrAttribute(animationClip, "id", animName)) {
+			    animName = std::string("animation_") + ai_to_string(mAnimationClipLibrary.size());
+		    }
+	    }
 
-	        std::pair<std::string, std::vector<std::string>> clip;
-	        clip.first = animName;
+	    std::pair<std::string, std::vector<std::string>> clip;
+	    clip.first = animName;
 
-	        for (XmlNode &instanceAnimation : animationClip.children()) {
-		        const std::string &currentName = instanceAnimation.name();
-		        if (currentName == "instance_animation") {
-			        std::string url;
-			        readUrlAttribute(instanceAnimation, url);
-			        clip.second.push_back(url);
-		        }	
-	        }
+	    for (XmlNode &instanceAnimation : animationClip.children()) {
+		    const std::string &currentName = instanceAnimation.name();
+		    if (currentName == "instance_animation") {
+			    std::string url;
+			    readUrlAttribute(instanceAnimation, url);
+			    clip.second.push_back(url);
+		    }	
+	    }
 
-	        if (clip.second.size() > 0) {
-		        mAnimationClipLibrary.push_back(clip);
-	        }
-        }
+	    if (clip.second.size() > 0) {
+		    mAnimationClipLibrary.push_back(clip);
+	    }
     }
 }
 

--- a/code/AssetLib/Collada/ColladaParser.cpp
+++ b/code/AssetLib/Collada/ColladaParser.cpp
@@ -662,32 +662,34 @@ void ColladaParser::ReadAssetInfo(XmlNode &node) {
 
 // ------------------------------------------------------------------------------------------------
 // Reads the animation clips
-void ColladaParser::ReadAnimationClipLibrary(XmlNode &node) {
+void ColladaParser::ReadAnimationClipLibrary(XmlNode &node /*NODE: library_animation_clips*/) {
     if (node.empty()) {
         return;
     }
+    for (XmlNode &animationClip : node.children()) {
 
-    std::string animName;
-    if (!XmlParser::getStdStrAttribute(node, "name", animName)) {
-        if (!XmlParser::getStdStrAttribute(node, "id", animName)) {
-            animName = std::string("animation_") + ai_to_string(mAnimationClipLibrary.size());
-        }
-    }
+	    std::string animName;
+	    if (!XmlParser::getStdStrAttribute(animationClip, "name", animName)) {
+		    if (!XmlParser::getStdStrAttribute(animationClip, "id", animName)) {
+			    animName = std::string("animation_") + ai_to_string(mAnimationClipLibrary.size());
+		    }
+	    }
 
-    std::pair<std::string, std::vector<std::string>> clip;
-    clip.first = animName;
+	    std::pair<std::string, std::vector<std::string>> clip;
+	    clip.first = animName;
 
-    for (XmlNode &currentNode : node.children()) {
-        const std::string &currentName = currentNode.name();
-        if (currentName == "instance_animation") {
-            std::string url;
-            readUrlAttribute(currentNode, url);
-            clip.second.push_back(url);
-        }
+	    for (XmlNode &instanceAnimation : animationClip.children()) {
+		    const std::string &currentName = instanceAnimation.name();
+		    if (currentName == "instance_animation") {
+			    std::string url;
+			    readUrlAttribute(instanceAnimation, url);
+			    clip.second.push_back(url);
+		    }	
+	    }
 
-        if (clip.second.size() > 0) {
-            mAnimationClipLibrary.push_back(clip);
-        }
+	    if (clip.second.size() > 0) {
+		    mAnimationClipLibrary.push_back(clip);
+	    }
     }
 }
 

--- a/code/AssetLib/Collada/ColladaParser.cpp
+++ b/code/AssetLib/Collada/ColladaParser.cpp
@@ -666,21 +666,21 @@ void ColladaParser::ReadAnimationClipLibrary(XmlNode &node /*NODE: library_anima
     if (node.empty()) {
         return;
     }
-    for (XmlNode &animationClip : node.children()) {
+    for (XmlNode &currentNode : node.children()) {
         const std::string& currentNodeName = currentNode.name();
         if (currentNodeName != "animation_clip") {
             continue;
 		}
 		
 	    std::string animName;
-	    if (!XmlParser::getStdStrAttribute(animationClip, "name", animName) && !XmlParser::getStdStrAttribute(animationClip, "id", animName)) {
+	    if (!XmlParser::getStdStrAttribute(currentNode, "name", animName) && !XmlParser::getStdStrAttribute(currentNode, "id", animName)) {
             animName = std::string("animation_") + ai_to_string(mAnimationClipLibrary.size());
 	    }
 
 	    std::pair<std::string, std::vector<std::string>> clip;
 	    clip.first = animName;
 
-	    for (XmlNode &instanceAnimation : animationClip.children()) {
+	    for (XmlNode &instanceAnimation : currentNode.children()) {
 		    const std::string &currentName = instanceAnimation.name();
 		    if (currentName == "instance_animation") {
 			    std::string url;

--- a/code/AssetLib/Collada/ColladaParser.cpp
+++ b/code/AssetLib/Collada/ColladaParser.cpp
@@ -590,7 +590,7 @@ void ColladaParser::ReadStructure(XmlNode &node) {
         } else if (currentName == "library_animations") {
             ReadAnimationLibrary(currentNode);
         } else if (currentName == "library_animation_clips") {
-            ReadAnimationClipLibrary(currentNode);
+            (currentNode);
         } else if (currentName == "library_controllers") {
             ReadControllerLibrary(currentNode);
         } else if (currentName == "library_images") {
@@ -667,29 +667,31 @@ void ColladaParser::ReadAnimationClipLibrary(XmlNode &node /*NODE: library_anima
         return;
     }
     for (XmlNode &animationClip : node.children()) {
+        const std::string& currentNodeName = currentNode.name();
+        if (currentNodeName == "animation_clip") {
+	        std::string animName;
+	        if (!XmlParser::getStdStrAttribute(animationClip, "name", animName)) {
+		        if (!XmlParser::getStdStrAttribute(animationClip, "id", animName)) {
+			        animName = std::string("animation_") + ai_to_string(mAnimationClipLibrary.size());
+		        }
+	        }
 
-	    std::string animName;
-	    if (!XmlParser::getStdStrAttribute(animationClip, "name", animName)) {
-		    if (!XmlParser::getStdStrAttribute(animationClip, "id", animName)) {
-			    animName = std::string("animation_") + ai_to_string(mAnimationClipLibrary.size());
-		    }
-	    }
+	        std::pair<std::string, std::vector<std::string>> clip;
+	        clip.first = animName;
 
-	    std::pair<std::string, std::vector<std::string>> clip;
-	    clip.first = animName;
+	        for (XmlNode &instanceAnimation : animationClip.children()) {
+		        const std::string &currentName = instanceAnimation.name();
+		        if (currentName == "instance_animation") {
+			        std::string url;
+			        readUrlAttribute(instanceAnimation, url);
+			        clip.second.push_back(url);
+		        }	
+	        }
 
-	    for (XmlNode &instanceAnimation : animationClip.children()) {
-		    const std::string &currentName = instanceAnimation.name();
-		    if (currentName == "instance_animation") {
-			    std::string url;
-			    readUrlAttribute(instanceAnimation, url);
-			    clip.second.push_back(url);
-		    }	
-	    }
-
-	    if (clip.second.size() > 0) {
-		    mAnimationClipLibrary.push_back(clip);
-	    }
+	        if (clip.second.size() > 0) {
+		        mAnimationClipLibrary.push_back(clip);
+	        }
+        }
     }
 }
 


### PR DESCRIPTION
This fix is realted to the issue https://github.com/assimp/assimp/issues/4746 and should fix them :).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Animation-clip parsing now processes each clip individually, resolving per-clip names/IDs correctly.
  * Instance animations are collected only for their respective clips, preventing cross-clip aggregation.
  * Unnamed clips receive a stable fallback name to avoid missing or mislabelled animations during import.
  * Improved overall import accuracy for animation clips and their associated animations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->