### PR TITLE
Fix glTF2 occlusion strength import/export and normal scale export

### DIFF
--- a/code/AssetLib/glTF2/glTF2Exporter.cpp
+++ b/code/AssetLib/glTF2/glTF2Exporter.cpp
@@ -556,12 +556,6 @@ void glTF2Exporter::GetMatTexProp(const aiMaterial &mat, unsigned int &prop, con
     mat.Get(textureKey.c_str(), tt, slot, prop);
 }
 
-void glTF2Exporter::GetMatTexProp(const aiMaterial &mat, float &prop, const char *propName, aiTextureType tt, unsigned int slot) {
-    std::string textureKey = std::string(_AI_MATKEY_TEXTURE_BASE) + "." + propName;
-
-    mat.Get(textureKey.c_str(), tt, slot, prop);
-}
-
 void glTF2Exporter::GetMatTex(const aiMaterial &mat, Ref<Texture> &texture, unsigned int &texCoord, aiTextureType tt, unsigned int slot = 0) {
     if (mat.GetTextureCount(tt) == 0) {
         return;
@@ -652,7 +646,7 @@ void glTF2Exporter::GetMatTex(const aiMaterial &mat, NormalTextureInfo &prop, ai
 
     if (texture) {
         // GetMatTexProp(mat, prop.texCoord, "texCoord", tt, slot);
-        GetMatTexProp(mat, prop.scale, "scale", tt, slot);
+        mat.Get(AI_MATKEY_GLTF_TEXTURE_SCALE(tt, slot), prop.scale);
     }
 }
 
@@ -663,7 +657,7 @@ void glTF2Exporter::GetMatTex(const aiMaterial &mat, OcclusionTextureInfo &prop,
 
     if (texture) {
         // GetMatTexProp(mat, prop.texCoord, "texCoord", tt, slot);
-        GetMatTexProp(mat, prop.strength, "strength", tt, slot);
+        mat.Get(AI_MATKEY_GLTF_TEXTURE_STRENGTH(tt, slot), prop.strength);
     }
 }
 

--- a/code/AssetLib/glTF2/glTF2Exporter.h
+++ b/code/AssetLib/glTF2/glTF2Exporter.h
@@ -110,7 +110,6 @@ protected:
     void WriteBinaryData(IOStream *outfile, std::size_t sceneLength);
     void GetTexSampler(const aiMaterial &mat, glTFCommon::Ref<glTF2::Texture> texture, aiTextureType tt, unsigned int slot);
     void GetMatTexProp(const aiMaterial &mat, unsigned int &prop, const char *propName, aiTextureType tt, unsigned int idx);
-    void GetMatTexProp(const aiMaterial &mat, float &prop, const char *propName, aiTextureType tt, unsigned int idx);
     void GetMatTex(const aiMaterial &mat, glTFCommon::Ref<glTF2::Texture> &texture, unsigned int &texCoord, aiTextureType tt, unsigned int slot);
     void GetMatTex(const aiMaterial &mat, glTF2::TextureInfo &prop, aiTextureType tt, unsigned int slot);
     void GetMatTex(const aiMaterial &mat, glTF2::NormalTextureInfo &prop, aiTextureType tt, unsigned int slot);

--- a/code/AssetLib/glTF2/glTF2Importer.cpp
+++ b/code/AssetLib/glTF2/glTF2Importer.cpp
@@ -237,8 +237,7 @@ static void SetMaterialTextureProperty(std::vector<int> &embeddedTexIdxs, Asset 
     SetMaterialTextureProperty(embeddedTexIdxs, r, static_cast<TextureInfo>(prop), mat, texType, texSlot);
 
     if (prop.texture && prop.texture->source) {
-        std::string textureStrengthKey = std::string(_AI_MATKEY_TEXTURE_BASE) + "." + "strength";
-        mat->AddProperty(&prop.strength, 1, textureStrengthKey.c_str(), texType, texSlot);
+        mat->AddProperty(&prop.strength, 1, AI_MATKEY_GLTF_TEXTURE_STRENGTH(texType, texSlot));
     }
 }
 


### PR DESCRIPTION
When trying to use assimp to import glTF2 files I ran into some issues with a handful of glTF-specific property keys:
- Occlusion strength was being imported and exported with the custom property key `"$tex.file.strength"` rather than using the GLTF-specific key `AI_MATKEY_GLTF_TEXTURE_STRENGTH` defined as `"$tex.strength"` that already existed making it confusing and difficult to access this material property.
- Normal scale was being imported as the existing GLTF-specific key `AI_MATKEY_GLTF_TEXTURE_SCALE` defined as `"$tex.scale"` but exported by looking for the custom property key `"$tex.file.scale"` meaning round-trip import -> export would not retain this property.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized glTF2 texture property handling in export and import operations. Texture scale and strength values are now accessed more efficiently, improving the overall robustness of glTF2 asset processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->