### PR TITLE
glTF2: Fix extracting interleaved buffer data

### DIFF
--- a/code/AssetLib/glTF2/glTF2Asset.inl
+++ b/code/AssetLib/glTF2/glTF2Asset.inl
@@ -1042,22 +1042,23 @@ size_t Accessor::ExtractData(T *&outData, const std::vector<unsigned int> *remap
         throw DeadlyImportError("GLTF: elemSize ", elemSize, " > maxSize ", maxSize, " in ", getContextForErrorMessages(id, name));
     }
 
-    const unsigned int maxCount = static_cast<unsigned int>((maxSize - elemSize) / stride + 1);
+    const size_t maxCount = (maxSize - elemSize) / stride + 1;
+
+    if (count > maxCount) {
+        throw DeadlyImportError("GLTF: count ", count, " > maxCount ", maxCount, " in ", getContextForErrorMessages(id, name));
+    }
 
     outData = new T[usedCount];
 
     if (remappingIndices != nullptr) {
         for (size_t i = 0; i < usedCount; ++i) {
             size_t srcIdx = (*remappingIndices)[i];
-            if (srcIdx >= maxCount) {
-                throw DeadlyImportError("GLTF: index ", srcIdx, " >= maxCount ", maxCount, " in ", getContextForErrorMessages(id, name));
+            if (srcIdx >= count) {
+                throw DeadlyImportError("GLTF: index ", srcIdx, " >= count ", count, " in ", getContextForErrorMessages(id, name));
             }
             memcpy(outData + i, data + srcIdx * stride, elemSize);
         }
     } else { // non-indexed cases
-        if (usedCount > maxCount) {
-            throw DeadlyImportError("GLTF: count ", usedCount, " > maxCount ", maxCount, " in ", getContextForErrorMessages(id, name));
-        }
         if (stride == elemSize && targetElemSize == elemSize) {
             memcpy(outData, data, totalSize);
         } else {

--- a/code/AssetLib/glTF2/glTF2Asset.inl
+++ b/code/AssetLib/glTF2/glTF2Asset.inl
@@ -1038,20 +1038,25 @@ size_t Accessor::ExtractData(T *&outData, const std::vector<unsigned int> *remap
 
     const size_t maxSize = GetMaxByteSize();
 
+    if (elemSize > maxSize) {
+        throw DeadlyImportError("GLTF: elemSize ", elemSize, " > maxSize ", maxSize, " in ", getContextForErrorMessages(id, name));
+    }
+
+    const unsigned int maxCount = static_cast<unsigned int>((maxSize - elemSize) / stride + 1);
+
     outData = new T[usedCount];
 
     if (remappingIndices != nullptr) {
-        const unsigned int maxIndexCount = static_cast<unsigned int>(maxSize / stride);
         for (size_t i = 0; i < usedCount; ++i) {
             size_t srcIdx = (*remappingIndices)[i];
-            if (srcIdx >= maxIndexCount) {
-                throw DeadlyImportError("GLTF: index*stride ", (srcIdx * stride), " > maxSize ", maxSize, " in ", getContextForErrorMessages(id, name));
+            if (srcIdx >= maxCount) {
+                throw DeadlyImportError("GLTF: index ", srcIdx, " >= maxCount ", maxCount, " in ", getContextForErrorMessages(id, name));
             }
             memcpy(outData + i, data + srcIdx * stride, elemSize);
         }
     } else { // non-indexed cases
-        if (usedCount * stride > maxSize) {
-            throw DeadlyImportError("GLTF: count*stride ", (usedCount * stride), " > maxSize ", maxSize, " in ", getContextForErrorMessages(id, name));
+        if (usedCount > maxCount) {
+            throw DeadlyImportError("GLTF: count ", usedCount, " > maxCount ", maxCount, " in ", getContextForErrorMessages(id, name));
         }
         if (stride == elemSize && targetElemSize == elemSize) {
             memcpy(outData, data, totalSize);


### PR DESCRIPTION
The previous calculation of `maxIndexCount` was not accounting for the interaction between `stride` and the fact that `maxSize` was already reduced by the accessor's byte offset into the buffer view. This would cause `maxIndexCount` to be 1 less than it should be leading to erroneous failed imports.

For example, when loading the 8-byte element of a 48-byte interleaved buffer with a 4-byte element, 8-byte element, and 12-byte element streams for 24-byte stride:
- `maxSize=48-4=44` (total size - offset of the 8-byte element)
- `stride=24`
- `const unsigned int maxIndexCount = static_cast<unsigned int>(maxSize / stride);` = __1__ (should be 2)

The new approach calculates where the last element would start in the buffer (`maxSize - elemSize`) and thus the max index available (`... / stride`) then adds 1 for the max number of elements. The extra `throw` was added to prevent an underflow in the calculation of `maxCount`.
- `maxSize=48-4=44` (total size - offset of the 8-byte element)
- `stride=24`
- `const unsigned int maxCount = static_cast<unsigned int>((maxSize - elemSize) / stride + 1);` = __2__

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation during glTF2 asset import to prevent oversized data reads.
  * Improved bounds checking to catch and report out-of-range accessor counts earlier.
  * Clarified diagnostic messages for import failures to make root causes easier to identify.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->