### PR TITLE
Require C++17 for public headers in CMakeLists

### DIFF
--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -1472,6 +1472,9 @@ ENDIF()
 # adds C_FLAGS required to compile zip.c on old GCC 4.x compiler
 TARGET_COMPILE_FEATURES(assimp PRIVATE c_std_99)
 
+# Public headers use inline constexpr that requires at least C++17
+TARGET_COMPILE_FEATURES(assimp PUBLIC cxx_std_17)
+
 TARGET_INCLUDE_DIRECTORIES ( assimp PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/../include>


### PR DESCRIPTION
Since https://github.com/assimp/assimp/pull/6592 that got released in assimp 6.0.5, `inline constexpr` is used in the public headers, that requires the downstream compilation units to be compiled with at least C++ standard 17 . 

Setting `TARGET_COMPILE_FEATURES(assimp PUBLIC cxx_std_17)` ensures that any downstream compilation unit that links `assimp::assimp` is aware of this, and raise if possible and necessary the C++ standard used for compilation to C++17, avoiding errors like:

~~~
[1/2] Building CXX object CMakeFiles\assimp_main.dir\assimp_main.cpp.obj
FAILED: [code=2] CMakeFiles/assimp_main.dir/assimp_main.cpp.obj 
C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\MSVC\1444~1.352\bin\Hostx64\x64\cl.exe  /nologo /TP  -external:I%PREFIX%\Library\include -external:W0 /DWIN32 /D_WINDOWS /W3 /GR /EHsc /MD /O2 /Ob2 /DNDEBUG /showIncludes /FoCMakeFiles\assimp_main.dir\assimp_main.cpp.obj /FdCMakeFiles\assimp_main.dir\ /FS -c %SRC_DIR%\test\assimp_main.cpp
%PREFIX%\Library\include\assimp/defs.h(302): error C7525: inline variables require at least '/std:c++17'
ninja: build stopped: subcommand failed.
~~~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build system to publicly declare C++17 as a minimum language requirement for the assimp library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->