### PR TITLE
Prevent Heap Buffer Overflow in MaterialSystem String Assignments

### DIFF
--- a/code/Material/MaterialSystem.cpp
+++ b/code/Material/MaterialSystem.cpp
@@ -513,7 +513,10 @@ aiReturn aiMaterial::AddBinaryProperty(const void *pInput,
 
     const size_t keyLen = ::strlen(pKey);
     pcNew->mKey.length = static_cast<ai_uint32>(std::min<size_t>(keyLen, AI_MAXLEN - 1));
-    memcpy(pcNew->mKey.data, pKey, pcNew->mKey.length);
+    if (keyLen >= AI_MAXLEN) {
+        ASSIMP_LOG_WARN("aiMaterial: property key '", pKey, "' exceeds AI_MAXLEN and will be truncated.");
+    }
+	memcpy(pcNew->mKey.data, pKey, pcNew->mKey.length);
     pcNew->mKey.data[pcNew->mKey.length] = '\0';
 
     if (UINT_MAX != iOutIndex) {

--- a/code/Material/MaterialSystem.cpp
+++ b/code/Material/MaterialSystem.cpp
@@ -511,9 +511,10 @@ aiReturn aiMaterial::AddBinaryProperty(const void *pInput,
     pcNew->mData = new char[pSizeInBytes];
     memcpy(pcNew->mData, pInput, pSizeInBytes);
 
-    pcNew->mKey.length = static_cast<ai_uint32>(::strlen(pKey));
-    ai_assert(AI_MAXLEN > pcNew->mKey.length);
-    strcpy(pcNew->mKey.data, pKey);
+    const size_t keyLen = ::strlen(pKey);
+    pcNew->mKey.length = static_cast<ai_uint32>(std::min<size_t>(keyLen, AI_MAXLEN - 1));
+    memcpy(pcNew->mKey.data, pKey, pcNew->mKey.length);
+    pcNew->mKey.data[pcNew->mKey.length] = '\0';
 
     if (UINT_MAX != iOutIndex) {
         mProperties[iOutIndex] = pcNew.release();


### PR DESCRIPTION
This patch addresses a classic memory safety issue by removing an unsafe `strcpy` call in `code/Material/MaterialSystem.cpp` (`aiMaterial::AddBinaryProperty`) and replacing it with a strictly bounded memory copy. 

Previously, the length of `pKey` was checked using `ai_assert(AI_MAXLEN > pcNew->mKey.length)`. In production environments built with optimizations (`NDEBUG`), this assertion expands to nothing. Consequently, the subsequent `strcpy(pcNew->mKey.data, pKey)` operation executes blindly. If the incoming key exceeds `AI_MAXLEN`, it writes past the allocated bounds of the `mKey.data` heap buffer.

The patch resolves this by:
1. Evaluating the length of the incoming key.
2. Statically bounding the length to `AI_MAXLEN - 1` using `std::min<size_t>()`.
3. Executing a bounded `memcpy` operation instead of an unbounded `strcpy`.
4. Manually appending the null-terminator at the exact copied length.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of material property handling by preventing issues with excessively long property identifiers, ensuring proper data integrity and always terminating property names.
  * Added a warning when a property name is too long and gets truncated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->