### PR TITLE
Use raw string for regex with invalid escape sequence

### DIFF
--- a/port/PyAssimp/pyassimp/helper.py
+++ b/port/PyAssimp/pyassimp/helper.py
@@ -45,7 +45,7 @@ if os.name=='posix':
     anaconda_keywords = ("conda", "continuum")
     if have_distutils and any(k in sys.version.lower() for k in anaconda_keywords):
       cur_path = get_python_lib()
-      pattern = re.compile('.*\/lib\/')
+      pattern = re.compile(r'.*\/lib\/')
       conda_lib = pattern.match(cur_path).group()
       logger.info("Adding Anaconda lib path:"+ conda_lib)
       additional_dirs.append(conda_lib)


### PR DESCRIPTION
Python 3.12 introduced a SyntaxWarning for invalid escape sequences (e.g. \/) which will in the future become a SyntaxError.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved regex pattern handling in library path detection for better reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->