### PR TITLE
Assbin: Validate mesh and texture allocation sizes

### DIFF
--- a/code/AssetLib/Assbin/AssbinLoader.cpp
+++ b/code/AssetLib/Assbin/AssbinLoader.cpp
@@ -460,6 +460,10 @@ void AssbinImporter::ReadBinaryMaterialProperty(IOStream *stream, aiMaterialProp
     prop->mDataLength = Read<unsigned int>(stream);
     prop->mType = (aiPropertyTypeInfo)Read<unsigned int>(stream);
 
+    if (prop->mDataLength > AI_MAX_ALLOC(char)) {
+        throw DeadlyImportError("Assbin: Material property data too large");
+    }
+
     prop->mData = new char[prop->mDataLength];
     stream->Read(prop->mData, 1, prop->mDataLength);
 }
@@ -566,14 +570,21 @@ void AssbinImporter::ReadBinaryTexture(IOStream *stream, aiTexture *tex) {
             tex->pcData = new aiTexel[tex->mWidth];
             stream->Read(tex->pcData, 1, tex->mWidth);
         } else {
-            if (tex->mWidth > AI_MAX_ALLOC(aiTexel) || tex->mHeight > AI_MAX_ALLOC(aiTexel) ||
-                    (size_t)tex->mWidth > SIZE_MAX / sizeof(aiTexel) || (size_t)tex->mHeight > SIZE_MAX / sizeof(aiTexel) ||
-                    (size_t)tex->mWidth * (size_t)tex->mHeight > AI_MAX_ALLOC(aiTexel) ||
-                    (size_t)tex->mWidth * (size_t)tex->mHeight > SIZE_MAX / sizeof(aiTexel)) {
-                throw DeadlyImportError("Assbin: Texture dimensions too large, would overflow");
+            if (tex->mWidth != 0 &&
+                static_cast<size_t>(tex->mHeight) >
+                    AI_MAX_ALLOC(aiTexel) / static_cast<size_t>(tex->mWidth)) {
+                throw DeadlyImportError("Assbin: Texture dimensions too large");
             }
-            tex->pcData = new aiTexel[tex->mWidth * tex->mHeight];
-            stream->Read(tex->pcData, 1, tex->mWidth * tex->mHeight * 4);
+
+            if (tex->mWidth != 0 &&
+                static_cast<size_t>(tex->mHeight) >
+                    SIZE_MAX / sizeof(aiTexel) / static_cast<size_t>(tex->mWidth)) {
+                throw DeadlyImportError("Assbin: Texture dimensions too large");
+            }
+
+            const size_t pixelCount = static_cast<size_t>(tex->mWidth) * tex->mHeight;
+            tex->pcData = new aiTexel[pixelCount];
+            stream->Read(tex->pcData, 1, pixelCount * sizeof(aiTexel));
         }
     }
 }

--- a/code/AssetLib/Assbin/AssbinLoader.cpp
+++ b/code/AssetLib/Assbin/AssbinLoader.cpp
@@ -236,6 +236,16 @@ void AssbinImporter::ReadBinaryNode(IOStream *stream, aiNode **onode, aiNode *pa
     unsigned numMeshes = Read<unsigned int>(stream);
     unsigned int nb_metadata = Read<unsigned int>(stream);
 
+    if (numMeshes > AI_MAX_ALLOC(unsigned int)) {
+        throw DeadlyImportError("Assbin: Too many meshes in node, would overflow");
+    }
+    if (numChildren > AI_MAX_ALLOC(aiNode *)) {
+        throw DeadlyImportError("Assbin: Too many children in node, would overflow");
+    }
+    if (nb_metadata > AI_MAX_ALLOC(aiMetadataEntry)) {
+        throw DeadlyImportError("Assbin: Too many metadata properties, would overflow");
+    }
+
     if (parent) {
         node->mParent = parent;
     }
@@ -308,6 +318,10 @@ void AssbinImporter::ReadBinaryBone(IOStream *stream, aiBone *b) {
     b->mNumWeights = Read<unsigned int>(stream);
     b->mOffsetMatrix = Read<aiMatrix4x4>(stream);
 
+    if (b->mNumWeights > AI_MAX_ALLOC(aiVertexWeight) || (size_t)b->mNumWeights > SIZE_MAX / sizeof(aiVertexWeight)) {
+        throw DeadlyImportError("Assbin: Too many weights, would overflow");
+    }
+
     // for the moment we write dumb min/max values for the bones, too.
     // maybe I'll add a better, hash-like solution later
     if (shortened) {
@@ -342,6 +356,9 @@ void AssbinImporter::ReadBinaryMesh(IOStream *stream, aiMesh *mesh) {
     }
     if (mesh->mNumFaces > AI_MAX_ALLOC(aiFace) || (size_t)mesh->mNumFaces > SIZE_MAX / sizeof(aiFace)) {
         throw DeadlyImportError("Assbin: Too many faces, would overflow");
+    }
+    if (mesh->mNumBones > AI_MAX_ALLOC(aiBone *) || (size_t)mesh->mNumBones > SIZE_MAX / sizeof(aiBone *)) {
+        throw DeadlyImportError("Assbin: Too many bones, would overflow");
     }
 
     // first of all, write bits for all existent vertex components
@@ -501,6 +518,16 @@ void AssbinImporter::ReadBinaryNodeAnim(IOStream *stream, aiNodeAnim *nd) {
     nd->mPreState = (aiAnimBehaviour)Read<unsigned int>(stream);
     nd->mPostState = (aiAnimBehaviour)Read<unsigned int>(stream);
 
+    if (nd->mNumPositionKeys > AI_MAX_ALLOC(aiVectorKey) || (size_t)nd->mNumPositionKeys > SIZE_MAX / sizeof(aiVectorKey)) {
+        throw DeadlyImportError("Assbin: Too many position keys, would overflow");
+    }
+    if (nd->mNumRotationKeys > AI_MAX_ALLOC(aiQuatKey) || (size_t)nd->mNumRotationKeys > SIZE_MAX / sizeof(aiQuatKey)) {
+        throw DeadlyImportError("Assbin: Too many rotation keys, would overflow");
+    }
+    if (nd->mNumScalingKeys > AI_MAX_ALLOC(aiVectorKey) || (size_t)nd->mNumScalingKeys > SIZE_MAX / sizeof(aiVectorKey)) {
+        throw DeadlyImportError("Assbin: Too many scaling keys, would overflow");
+    }
+
     if (nd->mNumPositionKeys) {
         if (shortened) {
             ReadBounds(stream, nd->mPositionKeys, nd->mNumPositionKeys);
@@ -543,6 +570,10 @@ void AssbinImporter::ReadBinaryAnim(IOStream *stream, aiAnimation *anim) {
     anim->mDuration = Read<double>(stream);
     anim->mTicksPerSecond = Read<double>(stream);
     anim->mNumChannels = Read<unsigned int>(stream);
+
+    if (anim->mNumChannels > AI_MAX_ALLOC(aiNodeAnim *) || (size_t)anim->mNumChannels > SIZE_MAX / sizeof(aiNodeAnim *)) {
+        throw DeadlyImportError("Assbin: Too many animation channels, would overflow");
+    }
 
     if (anim->mNumChannels) {
         anim->mChannels = new aiNodeAnim *[anim->mNumChannels];

--- a/code/AssetLib/Assbin/AssbinLoader.cpp
+++ b/code/AssetLib/Assbin/AssbinLoader.cpp
@@ -336,6 +336,13 @@ void AssbinImporter::ReadBinaryMesh(IOStream *stream, aiMesh *mesh) {
     mesh->mNumBones = Read<unsigned int>(stream);
     mesh->mMaterialIndex = Read<unsigned int>(stream);
 
+    if (mesh->mNumVertices > AI_MAX_ALLOC(aiVector3D) || (size_t)mesh->mNumVertices > SIZE_MAX / sizeof(aiVector3D)) {
+        throw DeadlyImportError("Assbin: Too many vertices, would overflow");
+    }
+    if (mesh->mNumFaces > AI_MAX_ALLOC(aiFace) || (size_t)mesh->mNumFaces > SIZE_MAX / sizeof(aiFace)) {
+        throw DeadlyImportError("Assbin: Too many faces, would overflow");
+    }
+
     // first of all, write bits for all existent vertex components
     unsigned int c = Read<unsigned int>(stream);
 
@@ -414,6 +421,9 @@ void AssbinImporter::ReadBinaryMesh(IOStream *stream, aiMesh *mesh) {
 
             static_assert(AI_MAX_FACE_INDICES <= 0xffff, "AI_MAX_FACE_INDICES <= 0xffff");
             f.mNumIndices = Read<uint16_t>(stream);
+            if (f.mNumIndices > AI_MAX_FACE_INDICES) {
+                throw DeadlyImportError("Assbin: Too many face indices, would overflow");
+            }
             f.mIndices = new unsigned int[f.mNumIndices];
 
             for (unsigned int a = 0; a < f.mNumIndices; ++a) {
@@ -449,6 +459,7 @@ void AssbinImporter::ReadBinaryMaterialProperty(IOStream *stream, aiMaterialProp
 
     prop->mDataLength = Read<unsigned int>(stream);
     prop->mType = (aiPropertyTypeInfo)Read<unsigned int>(stream);
+
     prop->mData = new char[prop->mDataLength];
     stream->Read(prop->mData, 1, prop->mDataLength);
 }
@@ -549,9 +560,18 @@ void AssbinImporter::ReadBinaryTexture(IOStream *stream, aiTexture *tex) {
 
     if (!shortened) {
         if (!tex->mHeight) {
+            if (tex->mWidth > AI_MAX_ALLOC(aiTexel)) {
+                throw DeadlyImportError("Assbin: Texture width too large, would overflow");
+            }
             tex->pcData = new aiTexel[tex->mWidth];
             stream->Read(tex->pcData, 1, tex->mWidth);
         } else {
+            if (tex->mWidth > AI_MAX_ALLOC(aiTexel) || tex->mHeight > AI_MAX_ALLOC(aiTexel) ||
+                    (size_t)tex->mWidth > SIZE_MAX / sizeof(aiTexel) || (size_t)tex->mHeight > SIZE_MAX / sizeof(aiTexel) ||
+                    (size_t)tex->mWidth * (size_t)tex->mHeight > AI_MAX_ALLOC(aiTexel) ||
+                    (size_t)tex->mWidth * (size_t)tex->mHeight > SIZE_MAX / sizeof(aiTexel)) {
+                throw DeadlyImportError("Assbin: Texture dimensions too large, would overflow");
+            }
             tex->pcData = new aiTexel[tex->mWidth * tex->mHeight];
             stream->Read(tex->pcData, 1, tex->mWidth * tex->mHeight * 4);
         }

--- a/code/AssetLib/Assbin/AssbinLoader.cpp
+++ b/code/AssetLib/Assbin/AssbinLoader.cpp
@@ -336,7 +336,8 @@ void AssbinImporter::ReadBinaryMesh(IOStream *stream, aiMesh *mesh) {
     mesh->mNumBones = Read<unsigned int>(stream);
     mesh->mMaterialIndex = Read<unsigned int>(stream);
 
-    if (mesh->mNumVertices > AI_MAX_ALLOC(aiVector3D) || (size_t)mesh->mNumVertices > SIZE_MAX / sizeof(aiVector3D)) {
+    if (mesh->mNumVertices > AI_MAX_ALLOC(aiVector3D) || (size_t)mesh->mNumVertices > SIZE_MAX / sizeof(aiVector3D) ||
+        mesh->mNumVertices > AI_MAX_ALLOC(aiColor4D) || (size_t)mesh->mNumVertices > SIZE_MAX / sizeof(aiColor4D)) {
         throw DeadlyImportError("Assbin: Too many vertices, would overflow");
     }
     if (mesh->mNumFaces > AI_MAX_ALLOC(aiFace) || (size_t)mesh->mNumFaces > SIZE_MAX / sizeof(aiFace)) {


### PR DESCRIPTION
While reviewing Assbin deserialization paths, I noticed several allocations derived directly from attacker-controlled mesh and texture counts without validating allocation size limits first.

Malformed .assbin files can provide extremely large values for mesh vertex counts, face counts, or texture dimensions, potentially leading to allocation overflows or excessive memory allocation attempts during parsing.

This patch adds validation for the affected allocation paths in ReadBinaryMesh and ReadBinaryTexture using existing Assimp allocation limit conventions and face index limits.

The changes are localized and do not affect valid inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asset importer stability with additional overflow and allocation-size checks during binary deserialization.
  * Validated mesh vertex, face and bone counts to prevent unsafe allocations and crashes from malformed/oversized meshes.
  * Added bounds checks for material data lengths and texture dimensions/pixel counts to avoid memory overflows when reading binary assets.
  * Extended validation to animation and node data to guard against allocation and multiplication overflow risks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/assimp/assimp/pull/6641)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->