### PR TITLE
Fix glTF2 ImportEmbeddedTextures NULL deref when mimeType lacks '/'

### DIFF
--- a/code/AssetLib/glTF2/glTF2Importer.cpp
+++ b/code/AssetLib/glTF2/glTF2Importer.cpp
@@ -1720,8 +1720,9 @@ void glTF2Importer::ImportEmbeddedTextures(glTF2::Asset &r) {
         tex->pcData = reinterpret_cast<aiTexel *>(data);
 
         if (!img.mimeType.empty()) {
-            const char *ext = strchr(img.mimeType.c_str(), '/') + 1;
-            if (ext) {
+            const char *slash = strchr(img.mimeType.c_str(), '/');
+            if (slash != nullptr) {
+                const char *ext = slash + 1;
                 if (strncmp(ext, "jpeg", 4) == 0) {
                     ext = "jpg";
                 } else if (strcmp(ext, "ktx2") == 0) { // basisu: ktx remains


### PR DESCRIPTION
Fixes #6608.

`ImportEmbeddedTextures` did `strchr(mimeType, '/') + 1` and then null-checked the offset pointer, so a mimeType without a `/` produced the bogus address 0x1 and the subsequent `strncmp` dereferenced it (caught by oss-fuzz/ASan, full stack trace in the issue). Check the `strchr` result before applying the offset and scope `ext` inside the guarded branch.

```cpp
const char *slash = strchr(img.mimeType.c_str(), '/');
if (slash != nullptr) {
    const char *ext = slash + 1;
    ...
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness when importing embedded textures in 3D models by handling unexpected or malformed MIME type values more safely, reducing import errors and potential crashes.
  * This change increases reliability when loading models with nonstandard or missing texture metadata, leading to smoother asset imports and fewer manual fixes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/assimp/assimp/pull/6645?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->