### PR TITLE
Fix glTF2 ImportAnimations null deref on invalid target node

### DIFF
--- a/code/AssetLib/glTF2/glTF2Importer.cpp
+++ b/code/AssetLib/glTF2/glTF2Importer.cpp
@@ -1612,10 +1612,16 @@ void glTF2Importer::ImportAnimations(glTF2::Asset &r) {
             int j = 0;
             for (auto &iter : samplers) {
                 if ((nullptr != iter.second.rotation) || (nullptr != iter.second.scale) || (nullptr != iter.second.translation)) {
-                    ai_anim->mChannels[j] = CreateNodeAnim(r, r.nodes[iter.first], iter.second);
+                    Ref<Node> targetNode = r.nodes.Get(iter.first);
+                    if (!targetNode || nullptr == targetNode.operator->()) {
+                        ASSIMP_LOG_WARN("Animation ", anim.name, ": Invalid target node index ", iter.first, ". Skipping channel.");
+                        continue;
+                    }
+                    ai_anim->mChannels[j] = CreateNodeAnim(r, *targetNode, iter.second);
                     ++j;
                 }
             }
+            ai_anim->mNumChannels = j;
         }
 
         ai_anim->mNumMorphMeshChannels = numMorphMeshChannels;
@@ -1625,10 +1631,16 @@ void glTF2Importer::ImportAnimations(glTF2::Asset &r) {
             int j = 0;
             for (auto &iter : samplers) {
                 if (nullptr != iter.second.weight) {
-                    ai_anim->mMorphMeshChannels[j] = CreateMeshMorphAnim(r, r.nodes[iter.first], iter.second);
+                    Ref<Node> targetNode = r.nodes.Get(iter.first);
+                    if (!targetNode || nullptr == targetNode.operator->()) {
+                        ASSIMP_LOG_WARN("Animation ", anim.name, ": Invalid target node index ", iter.first, ". Skipping morph channel.");
+                        continue;
+                    }
+                    ai_anim->mMorphMeshChannels[j] = CreateMeshMorphAnim(r, *targetNode, iter.second);
                     ++j;
                 }
             }
+            ai_anim->mNumMorphMeshChannels = j;
         }
 
         // Use the latest key-frame for the duration of the animation

--- a/code/AssetLib/glTF2/glTF2Importer.cpp
+++ b/code/AssetLib/glTF2/glTF2Importer.cpp
@@ -1613,11 +1613,12 @@ void glTF2Importer::ImportAnimations(glTF2::Asset &r) {
             for (auto &iter : samplers) {
                 if ((nullptr != iter.second.rotation) || (nullptr != iter.second.scale) || (nullptr != iter.second.translation)) {
                     Ref<Node> targetNode = r.nodes.Get(iter.first);
-                    if (!targetNode || nullptr == targetNode.operator->()) {
+                    Node *nodePtr = targetNode ? targetNode.operator->() : nullptr;
+                    if (!nodePtr) {
                         ASSIMP_LOG_WARN("Animation ", anim.name, ": Invalid target node index ", iter.first, ". Skipping channel.");
                         continue;
                     }
-                    ai_anim->mChannels[j] = CreateNodeAnim(r, *targetNode, iter.second);
+                    ai_anim->mChannels[j] = CreateNodeAnim(r, *nodePtr, iter.second);
                     ++j;
                 }
             }
@@ -1632,11 +1633,12 @@ void glTF2Importer::ImportAnimations(glTF2::Asset &r) {
             for (auto &iter : samplers) {
                 if (nullptr != iter.second.weight) {
                     Ref<Node> targetNode = r.nodes.Get(iter.first);
-                    if (!targetNode || nullptr == targetNode.operator->()) {
+                    Node *nodePtr = targetNode ? targetNode.operator->() : nullptr;
+                    if (!nodePtr) {
                         ASSIMP_LOG_WARN("Animation ", anim.name, ": Invalid target node index ", iter.first, ". Skipping morph channel.");
                         continue;
                     }
-                    ai_anim->mMorphMeshChannels[j] = CreateMeshMorphAnim(r, *targetNode, iter.second);
+                    ai_anim->mMorphMeshChannels[j] = CreateMeshMorphAnim(r, *nodePtr, iter.second);
                     ++j;
                 }
             }


### PR DESCRIPTION
Resolves #6611.

`glTF2Importer::ImportAnimations` calls `r.nodes[iter.first]` without checking whether the target node index is valid. When a malformed glTF file references animations but provides no (or null) entries in the nodes array, `LazyDict::operator[]` dereferences a null `mObjs[i]` and crashes (SEGV in fuzzing).

Validate the `Ref<Node>` returned by `r.nodes.Get(i)` before dereferencing and skip the channel with a warning if the node is missing. The post-loop `mNumChannels`/`mNumMorphMeshChannels` are adjusted to the count of valid channels so downstream code doesn't iterate over uninitialised array slots.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved glTF2 animation import stability by validating animation targets before processing. Invalid or missing animation targets are now skipped with warnings logged, preventing failures and ensuring only valid animation channels are imported. This reduces errors when opening glTF2 files with incomplete or problematic animation data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/assimp/assimp/pull/6646?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->