### PR TITLE
fix: prevent heap buffer overflow in CSM loader on non-positive frame range

### DIFF
--- a/code/AssetLib/CSM/CSMLoader.cpp
+++ b/code/AssetLib/CSM/CSMLoader.cpp
@@ -175,7 +175,7 @@ void CSMImporter::InternReadFile( const std::string& pFile,
 
                 // If we know how many frames we'll read, we can preallocate some storage
                 unsigned int alloc = 100;
-                if (last != 0x00ffffff) {
+                if (last != 0x00ffffff && last > first) {
                     // re-init if the file has last frame data
                     alloc = last-first;
                     alloc += alloc>>2u; // + 25%

--- a/test/models/CSM/malformed_zero_framerange.csm
+++ b/test/models/CSM/malformed_zero_framerange.csm
@@ -1,0 +1,6 @@
+$FirstFrame 0
+$LastFrame 0
+$Order
+A
+$Points
+0  1.0 2.0 3.0

--- a/test/unit/utCSMImportExport.cpp
+++ b/test/unit/utCSMImportExport.cpp
@@ -58,3 +58,9 @@ public:
 TEST_F(utCSMImportExport, importBlenFromFileTest) {
     EXPECT_TRUE(importerTest());
 }
+
+TEST_F(utCSMImportExport, importMalformedZeroFrameRange) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/CSM/malformed_zero_framerange.csm", 0);
+    EXPECT_NE(nullptr, scene);
+}


### PR DESCRIPTION
When a CSM file declares a `$LastFrame` that is less than or equal to its `$FirstFrame`, the position-key buffer was sized from `last - first` (zero or a huge unsigned value), so the first written key overflowed the allocation (ASAN report in the issue, CSMLoader.cpp:228). This falls back to the default allocation size when the declared frame range is not positive. Closes #6622

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CSM importer to safely handle frame-range edge cases (including zero-length ranges), preventing invalid allocations and avoiding crashes or malformed imports.

* **Tests**
  * Added a unit test and fixture covering a CSM with a zero-length frame range to ensure stable import behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/assimp/assimp/pull/6649)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->