### PR TITLE
Fix CVE-2025-70069

### DIFF
--- a/code/AssetLib/FBX/FBXConverter.cpp
+++ b/code/AssetLib/FBX/FBXConverter.cpp
@@ -1342,11 +1342,25 @@ unsigned int FBXConverter::ConvertMeshMultiMaterial(const MeshGeometry &mesh, co
             continue;
         }
         ++count_faces;
+
+        if (*itf > AI_MAX_FACE_INDICES) {
+            FBXImporter::LogError("ConvertMeshMultiMaterial: face index count ",
+                    *itf, " exceeds limit ", AI_MAX_FACE_INDICES,
+                    ". Rejecting malformed mesh.");
+            return static_cast<unsigned int>(mMeshes.size() - 1);
+        }
         count_vertices += *itf;
     }
 
     ai_assert(count_faces);
     ai_assert(count_vertices);
+
+    if (count_vertices > vertices.size()) {
+        FBXImporter::LogError("ConvertMeshMultiMaterial: face index counts sum to ",
+                count_vertices, " but mesh only has ", vertices.size(),
+                " vertices. Rejecting malformed mesh.");
+        return static_cast<unsigned int>(mMeshes.size() - 1);
+    }
 
     // mapping from output indices to DOM indexing, needed to resolve weights or blendshapes
     std::vector<unsigned int> reverseMapping;


### PR DESCRIPTION
This is a fix to [CVE-2025-70069](https://gist.github.com/GunP4ng/9080ae7f0470c889a59cc3bfca445223). This change adds check in `FBXConverter::ConvertMeshMultiMaterial` to enforce limits on vertices and faces. If caught, it will return early and the empty mesh will be caught by the caller.

I've was able to reproduce the original CVE and tested it against these changes. I won't share the reproducing payload here but can on request.

Results from before fix:
```
[*] Testing CVE-2025-70069: Uncontrolled memory allocation in FBX multi-material mesh

[Test 1] Import with 576MB virtual memory limit:
  VULNERABLE: std::bad_alloc triggered by excessive allocation in converter
50 %ERROR: Failed to load file: std::bad_alloc

[Test 2] Import without post-processing (isolates converter behavior):
  VULNERABLE: Converter allocated ~46MB * N arrays from a 7.7MB file without rejection
  Import time: 1.52520s

[Test 3] Standard import (confirms graceful rejection):
  FIXED: File rejected gracefully without excessive allocation
50 %ERROR: Failed to load file: Validation failed: Face 0 has too many faces: 4000000, but the limit is 32767

[*] Summary:
  - Input file: 7.7 MB (4M polygon vertex indices pointing to 4 vertices)
  - Face vertex count: 4,000,000 (untrusted, from file)
  - AI_MAX_FACE_INDICES limit: 32,767
  - Root cause: No bounds check on face index counts before allocation
  - Location: FBXConverter::ConvertMeshMultiMaterial in code/AssetLib/FBX/FBXConverter.cpp
  - Fix: Validate each face index count against AI_MAX_FACE_INDICES before summing
```

Results from after fix:
```
[*] Testing CVE-2025-70069: Uncontrolled memory allocation in FBX multi-material mesh

[Test 1] Import with 576MB virtual memory limit:
  FIXED: Malformed mesh rejected early (no excessive allocation)
50 %ERROR: Failed to load file: Validation failed: The mesh Mesh contains no vertices

[Test 2] Import without post-processing (isolates converter behavior):
  FIXED: Converter rejected malformed mesh before allocation
  Output: 

[Test 3] Standard import (confirms graceful rejection):
  FIXED: File rejected gracefully without excessive allocation
50 %ERROR: Failed to load file: Validation failed: The mesh Mesh contains no vertices

[*] Summary:
  - Input file: 7.7 MB (4M polygon vertex indices pointing to 4 vertices)
  - Face vertex count: 4,000,000 (untrusted, from file)
  - AI_MAX_FACE_INDICES limit: 32,767
  - Root cause: No bounds check on face index counts before allocation
  - Location: FBXConverter::ConvertMeshMultiMaterial in code/AssetLib/FBX/FBXConverter.cpp
  - Fix: Validate each face index count against AI_MAX_FACE_INDICES before summing
```

Testing script:
```
#!/bin/bash
# CVE-2025-70069 Reproducer Test
#
# Demonstrates uncontrolled memory allocation in FBXConverter::ConvertMeshMultiMaterial.
# A crafted FBX file with an oversized face (4M vertices) in a multi-material mesh
# causes excessive memory allocation in the converter, leading to denial of service.
#
# The vulnerability is that count_vertices is summed from untrusted face index counts
# without bounds checking before being used to allocate output arrays.
#
# With the fix applied, the converter validates each face index count against
# AI_MAX_FACE_INDICES (32767) and rejects malformed meshes early, before allocation.

set -e

SCRIPT_DIR="$(pwd)"
POC_FILE="$SCRIPT_DIR/poc_cve_2025_70069.fbx"
ASSIMP_BIN="${ASSIMP_BIN:-$SCRIPT_DIR/bin/assimp}"
ASSIMP_LIB="${ASSIMP_LIB:-$SCRIPT_DIR/bin}"

# Generate the PoC if it doesn't exist
if [ ! -f "$POC_FILE" ]; then
    echo "[*] Generating PoC file..."
    python3 "$SCRIPT_DIR/generate_poc.py"
fi

echo "[*] PoC file: $POC_FILE ($(du -h "$POC_FILE" | cut -f1))"
echo "[*] Testing CVE-2025-70069: Uncontrolled memory allocation in FBX multi-material mesh"
echo ""

# Test 1: Import with enough memory to parse the file but not enough for
# the unvalidated allocation. 576MB allows parsing the PolygonVertexIndex
# array but is insufficient for the converter's multiple ~46MB array
# allocations in ConvertMeshMultiMaterial.
#
# VULNERABLE binary: std::bad_alloc at 576MB (converter allocates ~46MB * N arrays)
# FIXED binary: graceful rejection at 576MB (converter rejects oversized face early)
echo "[Test 1] Import with 576MB virtual memory limit:"
set +e
OUTPUT=$(bash -c "ulimit -v 589824 && LD_LIBRARY_PATH=$ASSIMP_LIB $ASSIMP_BIN info $POC_FILE" 2>&1)
EXIT_CODE=$?
set -e

if echo "$OUTPUT" | grep -q "std::bad_alloc"; then
    echo "  VULNERABLE: std::bad_alloc triggered by excessive allocation in converter"
    echo "  Output: $(echo "$OUTPUT" | grep -E 'ERROR|bad_alloc')"
elif echo "$OUTPUT" | grep -q "contains no vertices"; then
    echo "  FIXED: Malformed mesh rejected early (no excessive allocation)"
    echo "  Output: $(echo "$OUTPUT" | grep 'ERROR')"
else
    echo "  Output: $OUTPUT"
    echo "  Exit code: $EXIT_CODE"
fi
echo ""

# Test 2: Import without post-processing to isolate converter behavior.
#
# VULNERABLE binary: imports successfully, allocating ~46MB * N arrays silently
# FIXED binary: rejects the mesh, resulting in an empty scene or import failure
echo "[Test 2] Import without post-processing (isolates converter behavior):"
set +e
OUTPUT=$(LD_LIBRARY_PATH=$ASSIMP_LIB $ASSIMP_BIN dump "$POC_FILE" /dev/null --no-pp 2>&1)
EXIT_CODE=$?
set -e

if [ $EXIT_CODE -eq 0 ] && echo "$OUTPUT" | grep -q "import took"; then
    IMPORT_TIME=$(echo "$OUTPUT" | grep 'import took' | grep -oP '[0-9]+\.[0-9]+')
    echo "  VULNERABLE: Converter allocated ~46MB * N arrays from a 7.7MB file without rejection"
    echo "  Import time: ${IMPORT_TIME}s"
else
    echo "  FIXED: Converter rejected malformed mesh before allocation"
    echo "  Output: $(echo "$OUTPUT" | grep -E 'ERROR|error' | head -1)"
fi
echo ""

# Test 3: Confirm the fix rejects the file gracefully (no crash, no bad_alloc)
echo "[Test 3] Standard import (confirms graceful rejection):"
set +e
OUTPUT=$(LD_LIBRARY_PATH=$ASSIMP_LIB $ASSIMP_BIN info "$POC_FILE" 2>&1)
EXIT_CODE=$?
set -e

if echo "$OUTPUT" | grep -q "std::bad_alloc"; then
    echo "  VULNERABLE: Uncontrolled allocation caused bad_alloc"
elif echo "$OUTPUT" | grep -qE "contains no vertices|too many faces"; then
    echo "  FIXED: File rejected gracefully without excessive allocation"
    echo "  Output: $(echo "$OUTPUT" | grep 'ERROR')"
else
    echo "  Output: $OUTPUT"
fi
echo ""

echo "[*] Summary:"
echo "  - Input file: 7.7 MB (4M polygon vertex indices pointing to 4 vertices)"
echo "  - Face vertex count: 4,000,000 (untrusted, from file)"
echo "  - AI_MAX_FACE_INDICES limit: 32,767"
echo "  - Root cause: No bounds check on face index counts before allocation"
echo "  - Location: FBXConverter::ConvertMeshMultiMaterial in code/AssetLib/FBX/FBXConverter.cpp"
echo "  - Fix: Validate each face index count against AI_MAX_FACE_INDICES before summing"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness when importing FBX meshes with malformed face/index data: the importer now detects invalid submeshes, rejects unsafe geometry early, prevents crashes during import, and emits clearer error messages to help diagnose problematic files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/assimp/assimp/pull/6664?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->