### PR TITLE
Fix CVE-2025-70070

### DIFF
--- a/code/AssetLib/FBX/FBXMeshGeometry.cpp
+++ b/code/AssetLib/FBX/FBXMeshGeometry.cpp
@@ -168,7 +168,10 @@ MeshGeometry::MeshGeometry(uint64_t id, const Element& element, const std::strin
     // if settings.readAllLayers is false:
     //  * read only the layer with index 0, but warn about any further layers
     for (ElementMap::const_iterator it = Layer.first; it != Layer.second; ++it) {
-        const TokenList& tokens = (*it).second->Tokens();
+        if (it->enmpty()) {
+            DOMError("expected Layer token", &element);
+		}
+		const TokenList& tokens = (*it).second->Tokens();
 
         if (tokens.empty()) {
             DOMError("expected Layer index token", &element);

--- a/code/AssetLib/FBX/FBXMeshGeometry.cpp
+++ b/code/AssetLib/FBX/FBXMeshGeometry.cpp
@@ -168,9 +168,6 @@ MeshGeometry::MeshGeometry(uint64_t id, const Element& element, const std::strin
     // if settings.readAllLayers is false:
     //  * read only the layer with index 0, but warn about any further layers
     for (ElementMap::const_iterator it = Layer.first; it != Layer.second; ++it) {
-        if (it->empty()) {
-            DOMError("expected Layer token", &element);
-		}
 		const TokenList& tokens = (*it).second->Tokens();
 
         if (tokens.empty()) {

--- a/code/AssetLib/FBX/FBXMeshGeometry.cpp
+++ b/code/AssetLib/FBX/FBXMeshGeometry.cpp
@@ -170,6 +170,10 @@ MeshGeometry::MeshGeometry(uint64_t id, const Element& element, const std::strin
     for (ElementMap::const_iterator it = Layer.first; it != Layer.second; ++it) {
         const TokenList& tokens = (*it).second->Tokens();
 
+        if (tokens.empty()) {
+            DOMError("expected Layer index token", &element);
+        }
+
         const char* err;
         const int index = ParseTokenAsInt(*tokens[0], err);
         if(err) {

--- a/code/AssetLib/FBX/FBXMeshGeometry.cpp
+++ b/code/AssetLib/FBX/FBXMeshGeometry.cpp
@@ -168,7 +168,7 @@ MeshGeometry::MeshGeometry(uint64_t id, const Element& element, const std::strin
     // if settings.readAllLayers is false:
     //  * read only the layer with index 0, but warn about any further layers
     for (ElementMap::const_iterator it = Layer.first; it != Layer.second; ++it) {
-        if (it->enmpty()) {
+        if (it->empty()) {
             DOMError("expected Layer token", &element);
 		}
 		const TokenList& tokens = (*it).second->Tokens();


### PR DESCRIPTION
Check `token` list is non-empty before dereferencing.

I was able to reproduce this CVE and confirmed the vulnerability is mitigated. I'm not going to post the reproducer here, but I can provide it upon request.

Original report referenced: https://gist.github.com/GunP4ng/a2118ba977b10074a4477322afa7b763

Closes #6443

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed geometry layer data by validating parsed layer tokens before use, preventing invalid reads and crashes.
  * Now records clearer parsing errors for missing layer information and skips invalid layers safely, resulting in more reliable file imports and better error feedback to users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/assimp/assimp/pull/6665?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->