### PR TITLE
Fix CVE-2025-70071

### DIFF
--- a/code/AssetLib/FBX/FBXParser.cpp
+++ b/code/AssetLib/FBX/FBXParser.cpp
@@ -573,7 +573,7 @@ void ReadBinaryDataArray(char type, uint32_t count, const char*& data, const cha
         ParseError("binary data array length mismatch", &el);
     }
 
-    const uint32_t full_length = static_cast<uint32_t>(full_length64);
+    const auto full_length = static_cast<uint32_t>(full_length64);
     buff.resize(full_length);
 
     if(encmode == 0) {

--- a/code/AssetLib/FBX/FBXParser.cpp
+++ b/code/AssetLib/FBX/FBXParser.cpp
@@ -534,7 +534,7 @@ void ReadBinaryDataArrayHead(const char*& data, const char* end, char& type, uin
 // ------------------------------------------------------------------------------------------------
 // read binary data array, assume cursor points to the 'compression mode' field (i.e. behind the header)
 void ReadBinaryDataArray(char type, uint32_t count, const char*& data, const char* end,
-        std::vector<char>& buff, const Element& /*el*/) {
+        std::vector<char>& buff, const Element& el) {
     BE_NCONST uint32_t encmode = SafeParse<uint32_t>(data, end);
     AI_SWAP4(encmode);
     data += 4;
@@ -564,7 +564,16 @@ void ReadBinaryDataArray(char type, uint32_t count, const char*& data, const cha
             ai_assert(false);
     };
 
-    const uint32_t full_length = stride * count;
+    // Validate that count does not cause excessive allocation
+    const uint64_t full_length64 = static_cast<uint64_t>(stride) * count;
+    if (full_length64 > SIZE_MAX || full_length64 > AI_MAX_ALLOC(char)) {
+        ParseError("binary data array too large", &el);
+    }
+    if (encmode == 0 && full_length64 != static_cast<uint64_t>(comp_len)) {
+        ParseError("binary data array length mismatch", &el);
+    }
+
+    const uint32_t full_length = static_cast<uint32_t>(full_length64);
     buff.resize(full_length);
 
     if(encmode == 0) {


### PR DESCRIPTION
Check for FBX binary array size before allocation. Prevents parsing buffers and output vectors from exceeding per instance allocation limit (`AI_MAX_ALLOC`) and overflows.

I was able to reproduce this CVE, getting a `std::bad_alloc` on a system with 256 MB of memory when processing a 1480 B file that allocates 2 GB. Without the 256 MB limit, processing time is reduced from 10+ seconds to 1 ms, meaning these changes avoid the allocation and processing of that data. I will not be sharing the reproducer publicly here, but it is available upon request.

Based fix on details here: https://gist.github.com/GunP4ng/6d80919905037929ce9266ccd207b9ea

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FBX import robustness by adding stricter data validation and allocation safeguards to prevent crashes or failed imports when encountering malformed or oversized files.
  * Enhanced error reporting during FBX import so failures produce clearer, more actionable messages for troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/assimp/assimp/pull/6666?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->