### PR TITLE
Fix CVE-2025-70072

### DIFF
--- a/code/AssetLib/FBX/FBXConverter.cpp
+++ b/code/AssetLib/FBX/FBXConverter.cpp
@@ -1306,6 +1306,14 @@ FBXConverter::ConvertMeshMultiMaterial(const MeshGeometry &mesh, const Model &mo
     const MatIndexArray &mindices = mesh.GetMaterialIndices();
     ai_assert(mindices.size());
 
+    const std::vector<unsigned int> &faces = mesh.GetFaceIndexCounts();
+    if (mindices.size() != faces.size()) {
+        FBXImporter::LogError("material index count (", mindices.size(),
+            ") does not match face count (", faces.size(),
+            "), ignoring mesh");
+        return std::vector<unsigned int>();
+    }
+
     std::set<MatIndexArray::value_type> had;
     std::vector<unsigned int> indices;
 


### PR DESCRIPTION
Check size of `mindices` and `faces` before lockstep iteration in `FBXConverter::ConvertMeshMultiMaterial`. This prevents OOB reads, returning an empty vector when a mismatch is present.

I was able to reproduce this CVE, detecting the OOB read using ASAN. Following this change, ASAN did not detect an OOB read. I will not publicly share the reproducer here, but it is available upon request.

Based fix on details here: https://gist.github.com/GunP4ng/cdaf0cb89dc6f1d09a9e88fa1135894e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved FBX file conversion reliability. Enhanced validation for multi-material mesh processing now detects and reports inconsistencies between material data and mesh structure, preventing conversion errors and ensuring accurate import results for complex 3D models.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/assimp/assimp/pull/6667?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->