### PR TITLE
Fix OOM and heap buffer overflow in OFF parser

### DIFF
--- a/code/AssetLib/OFF/OFFLoader.cpp
+++ b/code/AssetLib/OFF/OFFLoader.cpp
@@ -49,12 +49,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "OFFLoader.h"
 #include <assimp/ParsingUtils.h>
 #include <assimp/fast_atof.h>
-#include <memory>
-#include <cstdint>
 #include <assimp/IOSystem.hpp>
 #include <assimp/scene.h>
 #include <assimp/DefaultLogger.hpp>
 #include <assimp/importerdesc.h>
+#include <cstdint>
+#include <memory>
 
 namespace Assimp {
 
@@ -167,9 +167,10 @@ void OFFImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
     strtoul10(car, &car); // skip edge count
     NextToken(&car, end);
 
-    // ===== SECURITY VALIDATION =====
-    constexpr uint64_t OFF_MAX_VERTICES = 10000000;   // 10 million vertices
-    constexpr uint64_t OFF_MAX_FACES = 10000000;      // 10 million faces
+    // Reject header counts large enough to drive the allocations below into
+    // out-of-memory territory (OSS-Fuzz 476180586).
+    constexpr uint64_t OFF_MAX_VERTICES = 10000000; // 10 million
+    constexpr uint64_t OFF_MAX_FACES = 10000000;    // 10 million
 
     if (!numVertices) {
         throw DeadlyImportError("OFF: There are no valid vertices");
@@ -178,29 +179,29 @@ void OFFImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
         throw DeadlyImportError("OFF: There are no valid faces");
     }
     if (numVertices > OFF_MAX_VERTICES) {
-        throw DeadlyImportError("OFF file has ", numVertices, " vertices, exceeds limit of ", OFF_MAX_VERTICES);
+        throw DeadlyImportError("OFF: File has ", numVertices, " vertices, exceeds limit of ", OFF_MAX_VERTICES);
     }
     if (numFaces > OFF_MAX_FACES) {
-        throw DeadlyImportError("OFF file has ", numFaces, " faces, exceeds limit of ", OFF_MAX_FACES);
+        throw DeadlyImportError("OFF: File has ", numFaces, " faces, exceeds limit of ", OFF_MAX_FACES);
     }
-    uint64_t requiredVertices = static_cast<uint64_t>(numVertices);
-    uint64_t requiredFaces = static_cast<uint64_t>(numFaces);
+    const uint64_t requiredVertices = static_cast<uint64_t>(numVertices);
+    const uint64_t requiredFaces = static_cast<uint64_t>(numFaces);
     if (requiredVertices > SIZE_MAX / sizeof(aiVector3D)) {
-        throw DeadlyImportError("Vertex count would cause size_t overflow");
+        throw DeadlyImportError("OFF: Vertex count would cause size_t overflow");
     }
     if (requiredFaces > SIZE_MAX / sizeof(aiFace)) {
-        throw DeadlyImportError("Face count would cause size_t overflow");
+        throw DeadlyImportError("OFF: Face count would cause size_t overflow");
     }
-    // Defense in depth: reject files that are too small to contain the vertex text data.
-    const uint64_t minimumVertexTextBytes = requiredVertices * 6; // "x y z\n" minimum
-    if (static_cast<uint64_t>(end - car) < minimumVertexTextBytes) {
-        throw DeadlyImportError("File size inconsistent with vertex count");
+    // Each vertex line holds at least `dimensions` single-character values,
+    // each followed by a separator or newline, so any shorter remainder cannot
+    // contain the declared vertex count.
+    if (const uint64_t minimumVertexTextBytes = requiredVertices * 2u * dimensions;
+            static_cast<uint64_t>(end - car) < minimumVertexTextBytes) {
+        throw DeadlyImportError("OFF: File size inconsistent with vertex count");
     }
-    ASSIMP_LOG_DEBUG("OFF security validation passed: ", numVertices, " vertices, ", numFaces, " faces");
 
     pScene->mNumMeshes = 1;
     pScene->mMeshes = new aiMesh *[pScene->mNumMeshes];
-
 
     aiMesh *mesh = new aiMesh();
     pScene->mMeshes[0] = mesh;

--- a/code/AssetLib/OFF/OFFLoader.cpp
+++ b/code/AssetLib/OFF/OFFLoader.cpp
@@ -169,8 +169,8 @@ void OFFImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
 
     // Reject header counts large enough to drive the allocations below into
     // out-of-memory territory (OSS-Fuzz 476180586).
-    constexpr uint64_t OFF_MAX_VERTICES = 10000000; // 10 million
-    constexpr uint64_t OFF_MAX_FACES = 10000000;    // 10 million
+    constexpr auto OFF_MAX_VERTICES = 10000000u; // 10 million
+    constexpr auto OFF_MAX_FACES = 10000000u;    // 10 million
 
     if (!numVertices) {
         throw DeadlyImportError("OFF: There are no valid vertices");

--- a/code/AssetLib/OFF/OFFLoader.cpp
+++ b/code/AssetLib/OFF/OFFLoader.cpp
@@ -50,6 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/ParsingUtils.h>
 #include <assimp/fast_atof.h>
 #include <memory>
+#include <cstdint>
 #include <assimp/IOSystem.hpp>
 #include <assimp/scene.h>
 #include <assimp/DefaultLogger.hpp>
@@ -166,15 +167,40 @@ void OFFImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
     strtoul10(car, &car); // skip edge count
     NextToken(&car, end);
 
+    // ===== SECURITY VALIDATION =====
+    constexpr uint64_t OFF_MAX_VERTICES = 10000000;   // 10 million vertices
+    constexpr uint64_t OFF_MAX_FACES = 10000000;      // 10 million faces
+
     if (!numVertices) {
         throw DeadlyImportError("OFF: There are no valid vertices");
     }
     if (!numFaces) {
         throw DeadlyImportError("OFF: There are no valid faces");
     }
+    if (numVertices > OFF_MAX_VERTICES) {
+        throw DeadlyImportError("OFF file has ", numVertices, " vertices, exceeds limit of ", OFF_MAX_VERTICES);
+    }
+    if (numFaces > OFF_MAX_FACES) {
+        throw DeadlyImportError("OFF file has ", numFaces, " faces, exceeds limit of ", OFF_MAX_FACES);
+    }
+    uint64_t requiredVertices = static_cast<uint64_t>(numVertices);
+    uint64_t requiredFaces = static_cast<uint64_t>(numFaces);
+    if (requiredVertices > SIZE_MAX / sizeof(aiVector3D)) {
+        throw DeadlyImportError("Vertex count would cause size_t overflow");
+    }
+    if (requiredFaces > SIZE_MAX / sizeof(aiFace)) {
+        throw DeadlyImportError("Face count would cause size_t overflow");
+    }
+    // Defense in depth: reject files that are too small to contain the vertex text data.
+    const uint64_t minimumVertexTextBytes = requiredVertices * 6; // "x y z\n" minimum
+    if (static_cast<uint64_t>(end - car) < minimumVertexTextBytes) {
+        throw DeadlyImportError("File size inconsistent with vertex count");
+    }
+    ASSIMP_LOG_DEBUG("OFF security validation passed: ", numVertices, " vertices, ", numFaces, " faces");
 
     pScene->mNumMeshes = 1;
     pScene->mMeshes = new aiMesh *[pScene->mNumMeshes];
+
 
     aiMesh *mesh = new aiMesh();
     pScene->mMeshes[0] = mesh;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -108,7 +108,7 @@ SET( COMMON
   unit/Common/utLogger.cpp
 )
 
-SET(Geometry 
+SET(Geometry
     unit/Geometry/utGeometryUtils.cpp
 )
 
@@ -158,6 +158,7 @@ SET( IMPORTERS
   unit/ImportExport/utOgreImportExport.cpp
   unit/ImportExport/utQ3BSPFileImportExport.cpp
   unit/ImportExport/utOFFImportExport.cpp
+  unit/utOFFSecurity.cpp
   unit/ImportExport/utNFFImportExport.cpp
   unit/ImportExport/utXGLImportExport.cpp
   unit/ImportExport/utMD2Importer.cpp
@@ -279,6 +280,8 @@ ENDIF()
 
 TARGET_USE_COMMON_OUTPUT_DIRECTORY(unit)
 
+enable_testing()
+
 add_definitions(-DASSIMP_TEST_MODELS_DIR="${CMAKE_CURRENT_LIST_DIR}/models")
 add_definitions(-DASSIMP_TEST_MODELS_NONBSD_DIR="${CMAKE_CURRENT_LIST_DIR}/models-nonbsd")
 
@@ -305,7 +308,8 @@ IF (ASSIMP_WARNINGS_AS_ERRORS)
 ENDIF()
 
 target_link_libraries( unit assimp ${platform_libs} )
+set_target_properties(unit PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${ASSIMP_RUNTIME_OUTPUT_DIRECTORY})
 
 add_subdirectory(headercheck)
 
-add_test( unittests unit )
+add_test( unittests "${CMAKE_CURRENT_BINARY_DIR}/../bin/Release/unit.exe")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -108,7 +108,7 @@ SET( COMMON
   unit/Common/utLogger.cpp
 )
 
-SET(Geometry
+SET(Geometry 
     unit/Geometry/utGeometryUtils.cpp
 )
 
@@ -280,8 +280,6 @@ ENDIF()
 
 TARGET_USE_COMMON_OUTPUT_DIRECTORY(unit)
 
-enable_testing()
-
 add_definitions(-DASSIMP_TEST_MODELS_DIR="${CMAKE_CURRENT_LIST_DIR}/models")
 add_definitions(-DASSIMP_TEST_MODELS_NONBSD_DIR="${CMAKE_CURRENT_LIST_DIR}/models-nonbsd")
 
@@ -308,8 +306,7 @@ IF (ASSIMP_WARNINGS_AS_ERRORS)
 ENDIF()
 
 target_link_libraries( unit assimp ${platform_libs} )
-set_target_properties(unit PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${ASSIMP_RUNTIME_OUTPUT_DIRECTORY})
 
 add_subdirectory(headercheck)
 
-add_test( unittests "${CMAKE_CURRENT_BINARY_DIR}/../bin/Release/unit.exe")
+add_test( unittests unit )

--- a/test/unit/utOFFSecurity.cpp
+++ b/test/unit/utOFFSecurity.cpp
@@ -1,0 +1,82 @@
+/*
+---------------------------------------------------------------------------
+Open Asset Import Library (assimp)
+---------------------------------------------------------------------------
+
+Copyright (c) 2006-2026, assimp team
+
+All rights reserved.
+
+Redistribution and use of this software in source and binary forms,
+with or without modification, are permitted provided that the following
+conditions are met:
+
+* Redistributions of source code must retain the above
+copyright notice, this list of conditions and the
+following disclaimer.
+
+* Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the
+following disclaimer in the documentation and/or other
+materials provided with the distribution.
+
+* Neither the name of the assimp team, nor the names of its
+contributors may be used to endorse or promote products
+derived from this software without specific prior
+written permission of the assimp team.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+---------------------------------------------------------------------------
+*/
+
+#include <gtest/gtest.h>
+#include <assimp/Importer.hpp>
+#include <assimp/postprocess.h>
+#include <cstring>
+
+// Test OOM vulnerability fix (OSS-Fuzz 476180586)
+TEST(OFFSecurityTest, NoOOMOnMaliciousCount) {
+    Assimp::Importer importer;
+    // Input that previously caused malloc(2.2GB) crash
+    const char* maliciousOFF = "OFF\n2000000000 1 0\n";
+    const aiScene* scene = importer.ReadFileFromMemory(
+        maliciousOFF, strlen(maliciousOFF),
+        aiProcess_ValidateDataStructure
+    );
+    // Should fail gracefully, not crash/OOM
+    EXPECT_EQ(scene, nullptr);
+    std::string error = importer.GetErrorString();
+    EXPECT_FALSE(error.empty());
+    EXPECT_TRUE(error.find("exceeds limit") != std::string::npos ||
+                error.find("overflow") != std::string::npos ||
+                error.find("no valid faces") != std::string::npos);
+}
+
+// Test valid OFF file still works (regression)
+TEST(OFFSecurityTest, ValidOFFLoadsSuccessfully) {
+    Assimp::Importer importer;
+    const char* validOFF =
+        "OFF\n"
+        "4 2 0\n"
+        "0.0 0.0 0.0\n"
+        "1.0 0.0 0.0\n"
+        "1.0 1.0 0.0\n"
+        "0.0 1.0 0.0\n"
+        "3 0 1 2\n"
+        "3 0 2 3\n";
+    const aiScene* scene = importer.ReadFileFromMemory(
+        validOFF, strlen(validOFF),
+        aiProcess_ValidateDataStructure
+    );
+    EXPECT_NE(scene, nullptr);
+}

--- a/test/unit/utOFFSecurity.cpp
+++ b/test/unit/utOFFSecurity.cpp
@@ -39,23 +39,22 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ---------------------------------------------------------------------------
 */
 
-#include <gtest/gtest.h>
+#include "UnitTestPCH.h"
+
 #include <assimp/Importer.hpp>
 #include <assimp/postprocess.h>
-#include <cstring>
 
 // Test OOM vulnerability fix (OSS-Fuzz 476180586)
-TEST(OFFSecurityTest, NoOOMOnMaliciousCount) {
+TEST(utOFFSecurity, noOOMOnMaliciousCount) {
     Assimp::Importer importer;
-    // Input that previously caused malloc(2.2GB) crash
-    const char* maliciousOFF = "OFF\n2000000000 1 0\n";
-    const aiScene* scene = importer.ReadFileFromMemory(
-        maliciousOFF, strlen(maliciousOFF),
-        aiProcess_ValidateDataStructure
-    );
+    // Header that previously made the importer allocate ~2.2GB up front
+    const char maliciousOFF[] = "OFF\n2000000000 1 0\n";
+    const aiScene *scene = importer.ReadFileFromMemory(
+            maliciousOFF, sizeof(maliciousOFF) - 1,
+            aiProcess_ValidateDataStructure);
     // Should fail gracefully, not crash/OOM
     EXPECT_EQ(scene, nullptr);
-    std::string error = importer.GetErrorString();
+    const std::string error = importer.GetErrorString();
     EXPECT_FALSE(error.empty());
     EXPECT_TRUE(error.find("exceeds limit") != std::string::npos ||
                 error.find("overflow") != std::string::npos ||
@@ -63,9 +62,9 @@ TEST(OFFSecurityTest, NoOOMOnMaliciousCount) {
 }
 
 // Test valid OFF file still works (regression)
-TEST(OFFSecurityTest, ValidOFFLoadsSuccessfully) {
+TEST(utOFFSecurity, validOFFLoadsSuccessfully) {
     Assimp::Importer importer;
-    const char* validOFF =
+    const char validOFF[] =
         "OFF\n"
         "4 2 0\n"
         "0.0 0.0 0.0\n"
@@ -74,9 +73,28 @@ TEST(OFFSecurityTest, ValidOFFLoadsSuccessfully) {
         "0.0 1.0 0.0\n"
         "3 0 1 2\n"
         "3 0 2 3\n";
-    const aiScene* scene = importer.ReadFileFromMemory(
-        validOFF, strlen(validOFF),
-        aiProcess_ValidateDataStructure
-    );
+    const aiScene *scene = importer.ReadFileFromMemory(
+            validOFF, sizeof(validOFF) - 1,
+            aiProcess_ValidateDataStructure);
+    EXPECT_NE(scene, nullptr);
+}
+
+// A compact 2D nOFF file must not be rejected by the file-size check,
+// which used to assume 3D vertex lines
+TEST(utOFFSecurity, valid2DnOFFLoadsSuccessfully) {
+    Assimp::Importer importer;
+    const char valid2D[] =
+        "nOFF\n"
+        "2\n"
+        "5 1 0\n"
+        "0 0\n"
+        "1 0\n"
+        "1 1\n"
+        "0 1\n"
+        "2 2\n"
+        "3 0 1 2\n";
+    const aiScene *scene = importer.ReadFileFromMemory(
+            valid2D, sizeof(valid2D) - 1,
+            aiProcess_ValidateDataStructure, "off");
     EXPECT_NE(scene, nullptr);
 }


### PR DESCRIPTION
Fixes an OOM in the OFF parser (OSS-Fuzz 476180586, OSV-2026-74).

**Problem:** The OFF importer allocated vertex and face arrays straight from the header counts, so a small malicious file could request a ~2.2GB allocation and take the process down.

**Fix:** Validate the header before allocating:
- reject zero or oversized vertex/face counts (hard cap of 10 million each)
- guard the allocation size arithmetic against size_t overflow
- reject files too short to contain the declared vertex count; the minimum is computed from the declared vertex dimensions, so compact 1D/2D nOFF files still load

**Testing:** New unit tests in `test/unit/utOFFSecurity.cpp` cover the malicious header, a valid 3D mesh and a compact 2D nOFF file. The full unit suite passes locally.

**Files changed:**
- `code/AssetLib/OFF/OFFLoader.cpp`
- `test/unit/utOFFSecurity.cpp` (new)
- `test/CMakeLists.txt` (registers the new test file)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OFF/nOFF importer robustness by validating declared vertex/face counts, preventing allocation size overflows, and ensuring the input buffer contains enough data before building the mesh.
* **Tests**
  * Added OFF security regression coverage to confirm safe failure on malicious counts (with non-empty, limit-related error messages) and successful loading for valid OFF and nOFF payloads.
* **Chores**
  * Updated unit test build configuration to include the new OFF security test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->