### PR TITLE
Add import properties support and update VectorKey structure in PyAssimp

### DIFF
--- a/port/PyAssimp/pyassimp/core.py
+++ b/port/PyAssimp/pyassimp/core.py
@@ -35,7 +35,7 @@ class AssimpLib(object):
     """
     Assimp-Singleton
     """
-    load, load_mem, export, export_blob, release, dll = helper.search_library()
+    load, load_mem, export, export_blob, release, dll, create_store, set_prop_int, set_prop_float, set_prop_string, import_props, release_store = helper.search_library()
 _assimp_lib = AssimpLib()
 
 def make_tuple(ai_obj, type = None):
@@ -288,7 +288,8 @@ def release(scene):
 @contextmanager
 def load(filename,
          file_type  = None,
-         processing = postprocess.aiProcess_Triangulate):
+         processing = postprocess.aiProcess_Triangulate,
+         properties = None):
     '''
     Load a model into a scene. On failure throws AssimpError.
 
@@ -327,8 +328,40 @@ def load(filename,
                                      processing,
                                      c_char_p(file_type.encode(sys.getfilesystemencoding())))
     else:
-        # a filename string has been passed
-        model = _assimp_lib.load(filename.encode(sys.getfilesystemencoding()), processing)
+        # a filename string has been passed -> ENTIÈREMENT REMPLACÉ PAR CE BLOC :
+
+        # Create a store to pass to the C importer
+        store = _assimp_lib.create_store()
+
+        # Autofill the store with the properties passed to the function
+        if properties:
+            for key, val in properties.items():
+                key_bytes = key.encode('utf-8') if isinstance(key, str) else key
+
+                if isinstance(val, bool):  # Les booléens héritent d'int en Python, on traite d'abord
+                    _assimp_lib.set_prop_int(store, key_bytes, 1 if val else 0)
+                elif isinstance(val, int):
+                    _assimp_lib.set_prop_int(store, key_bytes, val)
+                elif isinstance(val, float):
+                    _assimp_lib.set_prop_float(store, key_bytes, val)
+                elif isinstance(val, (str, bytes)):
+                    val_bytes = val.encode('utf-8') if isinstance(val, str) else val
+                    # Assimp exige une structure aiString (structs.String) passée par référence
+                    ai_str = structs.String()
+                    ai_str.data = val_bytes
+                    ai_str.length = len(val_bytes)
+                    _assimp_lib.set_prop_string(store, key_bytes, ctypes.byref(ai_str))
+
+        # File loading with the C importer that support properties
+        model = _assimp_lib.import_props(
+            filename.encode(sys.getfilesystemencoding()),
+            processing,
+            None,
+            store
+        )
+
+        # Free the store, as it is no longer needed.
+        _assimp_lib.release_store(store)
 
     if not model:
         raise AssimpError('Could not import file!')

--- a/port/PyAssimp/pyassimp/core.py
+++ b/port/PyAssimp/pyassimp/core.py
@@ -328,7 +328,7 @@ def load(filename,
                                      processing,
                                      c_char_p(file_type.encode(sys.getfilesystemencoding())))
     else:
-        # a filename string has been passed -> ENTIÈREMENT REMPLACÉ PAR CE BLOC :
+        # a filename string has been passed
 
         # Create a store to pass to the C importer
         store = _assimp_lib.create_store()

--- a/port/PyAssimp/pyassimp/helper.py
+++ b/port/PyAssimp/pyassimp/helper.py
@@ -196,16 +196,36 @@ def try_load_functions(library_path, dll):
         load_mem = dll.aiImportFileFromMemory
         export   = dll.aiExportScene
         export2blob = dll.aiExportSceneToBlob
+
+        create_store    = dll.aiCreatePropertyStore
+        set_prop_int    = dll.aiSetImportPropertyInteger
+        set_prop_float  = dll.aiSetImportPropertyFloat
+        set_prop_string = dll.aiSetImportPropertyString
+        import_props    = dll.aiImportFileExWithProperties # Advanced Import function that allows to set properties
+        release_store   = dll.aiReleasePropertyStore
     except AttributeError:
         #OK, this is a library, but it doesn't have the functions we need
         return None
 
     # library found!
-    from .structs import Scene, ExportDataBlob
+    from .structs import Scene, ExportDataBlob, String
     load.restype = ctypes.POINTER(Scene)
     load_mem.restype = ctypes.POINTER(Scene)
     export2blob.restype = ctypes.POINTER(ExportDataBlob)
-    return (library_path, load, load_mem, export, export2blob, release, dll)
+
+    create_store.restype = ctypes.c_void_p
+
+    set_prop_int.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_int]
+    set_prop_float.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_float]
+    set_prop_string.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.POINTER(String)]
+
+    import_props.restype = ctypes.POINTER(Scene)
+    import_props.argtypes = [ctypes.c_char_p, ctypes.c_uint, ctypes.c_void_p, ctypes.c_void_p]
+
+    release_store.argtypes = [ctypes.c_void_p]
+
+    return (library_path, load, load_mem, export, export2blob, release, dll,
+            create_store, set_prop_int, set_prop_float, set_prop_string, import_props, release_store)
 
 def search_library():
     '''

--- a/port/PyAssimp/pyassimp/structs.py
+++ b/port/PyAssimp/pyassimp/structs.py
@@ -852,6 +852,9 @@ class VectorKey(Structure):
 
             # The value of this key
             ("mValue", Vector3D),
+
+            # The interpolation setting of this key
+            ("mInterpolation", c_uint32)
         ]
 
 class QuatKey(Structure):


### PR DESCRIPTION
The VectorKey struct in PyAssimp was missing a "`mInterpolation`" field so I added it because I was getting nonsense values in my animation channels. So far so good, it seems it has fixed my issue.

Secondly, I don't want to deal with multiple nodes (such as `_$AssimpFbx$_Translation`, `_$AssimpFbx$_PreRotation`, `_$AssimpFbx$_Rotation`) for a same node / bone of a FBX file. So I wanted to set the `IMPORT_FBX_PRESERVE_PIVOTS` property to false in the PyAssimp importer. As a result, I tried to come up with a solution to set custom importer properties when the `pyassimp.load()` function is used. I asked Gemini to help me figure out how to do it. So let me know if there's anything wrong or bad with this solution for any reasons I'm not aware of. I think it could be useful for others to be able to set these properties.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File loading now accepts optional import properties, including Boolean, integer, decimal, and text values, to customize how assets are imported.
  * Animation keyframe data now includes interpolation information, supporting smoother and more accurate animation playback.
  * Asset import behavior remains unchanged when no additional properties are provided, preserving existing loading workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->