### PR TITLE
Add animation metadata import for gltf2

### DIFF
--- a/code/AssetLib/glTF2/glTF2Importer.cpp
+++ b/code/AssetLib/glTF2/glTF2Importer.cpp
@@ -1687,6 +1687,11 @@ void glTF2Importer::ImportAnimations(glTF2::Asset &r) {
 
         ai_anim->mDuration = maxDuration;
         ai_anim->mTicksPerSecond = 1000.0;
+
+        if (anim.extras.HasExtras()) {
+            ai_anim->mMetaData = new aiMetadata;
+            ParseExtras(ai_anim->mMetaData, anim.extras);
+        }
     }
 }
 

--- a/include/assimp/anim.h
+++ b/include/assimp/anim.h
@@ -54,6 +54,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <assimp/quaternion.h>
 #include <assimp/types.h>
+#include <assimp/metadata.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/assimp/anim.h
+++ b/include/assimp/anim.h
@@ -457,6 +457,10 @@ struct aiAnimation {
      *  The array is mNumMorphMeshChannels in size. */
     C_STRUCT aiMeshMorphAnim **mMorphMeshChannels;
 
+    /** Metadata of the animation, if any. May be nullptr.
+     *  Populated from animation.extras in glTF2 files. */
+    C_STRUCT aiMetadata *mMetaData;
+
 #ifdef __cplusplus
     aiAnimation() AI_NO_EXCEPT
             : mDuration(-1.),

--- a/include/assimp/anim.h
+++ b/include/assimp/anim.h
@@ -470,7 +470,8 @@ struct aiAnimation {
               mNumMeshChannels(0),
               mMeshChannels(nullptr),
               mNumMorphMeshChannels(0),
-              mMorphMeshChannels(nullptr) {
+              mMorphMeshChannels(nullptr),
+              mMetaData(nullptr) {
         // empty
     }
 
@@ -497,6 +498,7 @@ struct aiAnimation {
 
             delete[] mMorphMeshChannels;
         }
+        delete mMetaData;
     }
 #endif // __cplusplus
 };


### PR DESCRIPTION
This adds support for importing animation metadata for GLTF2 exported under the `extras` node.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Animation metadata from glTF2 files is now imported and stored with animation entries, preserving additional animation properties.

* **API Changes**
  * Public animation data structures now support attached metadata so imported animation extras are exposed and managed by the library.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/assimp/assimp/pull/6675?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->