### PR TITLE
fix oob vertex index check in unreal importer

### DIFF
--- a/code/AssetLib/Unreal/UnrealLoader.cpp
+++ b/code/AssetLib/Unreal/UnrealLoader.cpp
@@ -246,7 +246,7 @@ void UnrealImporter::InternReadFile(const std::string &pFile,
     for (auto &tri : triangles) {
         for (unsigned int i = 0; i < 3; ++i) {
             tri.mVertex[i] = d_reader.GetI2();
-            if (tri.mVertex[i] >= numTris) {
+            if (tri.mVertex[i] >= numVert) {
                 ASSIMP_LOG_WARN("UNREAL: vertex index out of range");
                 tri.mVertex[i] = 0;
             }


### PR DESCRIPTION
In UnrealLoader.cpp:249 the per-triangle vertex index is checked against numTris, but it indexes the vertices vector (sized numVert) at line 502, so a _d.3d file with numTris > numVert and an index in [numVert, numTris) reads out of bounds. Compare against numVert instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed vertex index bounds validation in Unreal 3D model imports, ensuring proper verification of vertex references for more reliable model loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->