### PR TITLE
fix off-by-one face index check in lwo importers

### DIFF
--- a/code/AssetLib/LWO/LWOBLoader.cpp
+++ b/code/AssetLib/LWO/LWOBLoader.cpp
@@ -171,7 +171,7 @@ void LWOImporter::CopyFaceIndicesLWOB(FaceList::iterator &it,
                 uint16_t index;
                 ::memcpy(&index, cursor++, 2);
                 mi = index;
-                if (mi > mCurLayer->mTempPoints.size()) {
+                if (mi >= mCurLayer->mTempPoints.size()) {
                     ASSIMP_LOG_WARN("LWOB: face index is out of range");
                     mi = (unsigned int)mCurLayer->mTempPoints.size()-1;
                 }

--- a/code/AssetLib/LWO/LWOLoader.cpp
+++ b/code/AssetLib/LWO/LWOLoader.cpp
@@ -835,7 +835,7 @@ void LWOImporter::CopyFaceIndicesLWO2(FaceList::iterator &it,
             face.mIndices = new unsigned int[face.mNumIndices];
             for (unsigned int i = 0; i < face.mNumIndices; i++) {
                 face.mIndices[i] = ReadVSizedIntLWO2((uint8_t *&)cursor) + mCurLayer->mPointIDXOfs;
-                if (face.mIndices[i] > mCurLayer->mTempPoints.size()) {
+                if (face.mIndices[i] >= mCurLayer->mTempPoints.size()) {
                     ASSIMP_LOG_WARN("LWO2: Failure evaluating face record, index is out of range");
                     face.mIndices[i] = (unsigned int)mCurLayer->mTempPoints.size() - 1;
                 }


### PR DESCRIPTION
ASAN on a crafted lwo2 file (1 point, one polygon indexing vertex 1):

    READ of size 12 at ... heap-buffer-overflow
      #1 Assimp::LWOImporter::InternReadFile LWOLoader.cpp:341
      0x... is located 0 bytes after 12-byte region

the clamp uses `index > mTempPoints.size()`, so an index equal to the point count slips through and `mTempPoints[index]` reads one past the end. same bug in the legacy LWOB path. changed both to `>=`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bounds checking for face vertex indices in LWO 3D model files, fixing off-by-one errors that could cause geometry loading issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->