### PR TITLE
Correct material index handling in XFileImporter

### DIFF
--- a/code/AssetLib/X/XFileImporter.cpp
+++ b/code/AssetLib/X/XFileImporter.cpp
@@ -263,7 +263,7 @@ void XFileImporter::CreateMeshes(aiScene *pScene, aiNode *pNode, const std::vect
             // or referenced material, it should already have a valid index
             mesh->mMaterialIndex = 0;
             if (!sourceMesh->mFaceMaterials.empty()) {
-                if (sourceMesh->mMaterials) != nullptr) {
+                if (sourceMesh->mMaterials != nullptr) {
                     mesh->mMaterialIndex = static_cast<unsigned int>(sourceMesh->mMaterials[b].sceneIndex);
                 }
             }

--- a/code/AssetLib/X/XFileImporter.cpp
+++ b/code/AssetLib/X/XFileImporter.cpp
@@ -261,10 +261,11 @@ void XFileImporter::CreateMeshes(aiScene *pScene, aiNode *pNode, const std::vect
 
             // find the material in the scene's material list. Either own material
             // or referenced material, it should already have a valid index
+            mesh->mMaterialIndex = 0;
             if (!sourceMesh->mFaceMaterials.empty()) {
-                mesh->mMaterialIndex = static_cast<unsigned int>(sourceMesh->mMaterials[b].sceneIndex);
-            } else {
-                mesh->mMaterialIndex = 0;
+                if (sourceMesh->mMaterials) != nullptr) {
+                    mesh->mMaterialIndex = static_cast<unsigned int>(sourceMesh->mMaterials[b].sceneIndex);
+                }
             }
 
             // Create properly sized data arrays in the mesh. We store unique vertices per face,

--- a/code/AssetLib/X/XFileImporter.cpp
+++ b/code/AssetLib/X/XFileImporter.cpp
@@ -263,7 +263,7 @@ void XFileImporter::CreateMeshes(aiScene *pScene, aiNode *pNode, const std::vect
             // or referenced material, it should already have a valid index
             mesh->mMaterialIndex = 0;
             if (!sourceMesh->mFaceMaterials.empty()) {
-                if (sourceMesh->mMaterials != nullptr) {
+                if (sourceMesh->mMaterials.size() > b) {
                     mesh->mMaterialIndex = static_cast<unsigned int>(sourceMesh->mMaterials[b].sceneIndex);
                 }
             }


### PR DESCRIPTION
- Fix material index assignment logic for meshes.
- Closes https://github.com/assimp/assimp/issues/6683

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect material assignments when importing X files with per-face/material lists by adding validation for per-submesh material indices, preventing wrong materials from being applied and reducing import failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->