### PR TITLE
Fix glTF ImportMeshes null dereference

### DIFF
--- a/code/AssetLib/glTF/glTFImporter.cpp
+++ b/code/AssetLib/glTF/glTFImporter.cpp
@@ -279,7 +279,11 @@ void glTFImporter::ImportMeshes(Asset &r) {
             if (attr.normal.size() > 0 && attr.normal[0]) attr.normal[0]->ExtractData(aim->mNormals);
 
             for (size_t tc = 0; tc < attr.texcoord.size() && tc < AI_MAX_NUMBER_OF_TEXTURECOORDS; ++tc) {
-                attr.texcoord[tc]->ExtractData(aim->mTextureCoords[tc]);
+                if (!attr.texcoord[tc] || !attr.texcoord[tc]->ExtractData(aim->mTextureCoords[tc])) {
+                    for (aiMesh *allocatedMesh : meshes) { delete allocatedMesh; }
+                    throw DeadlyImportError("Mesh \"", mesh.id, "\": failed to extract data for texcoord ", ai_to_string(tc));
+                }
+
                 aim->mNumUVComponents[tc] = attr.texcoord[tc]->GetNumComponents();
 
                 aiVector3D *values = aim->mTextureCoords[tc];

--- a/code/AssetLib/glTF/glTFImporter.cpp
+++ b/code/AssetLib/glTF/glTFImporter.cpp
@@ -56,6 +56,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/scene.h>
 #include <assimp/DefaultLogger.hpp>
 
+#include <memory>
+#include <vector>
+
 using namespace Assimp;
 using namespace glTF;
 
@@ -199,7 +202,10 @@ void glTFImporter::ImportMaterials(Asset &r) const {
 }
 
 void glTFImporter::ImportMeshes(Asset &r) {
-    std::vector<aiMesh *> meshes;
+    // Own the meshes through unique_ptr so that any exception thrown while
+    // importing frees the partially built meshes automatically (no manual
+    // delete needed). Ownership is transferred to the scene at the very end.
+    std::vector<std::unique_ptr<aiMesh>> meshes;
 
     unsigned int k = 0;
     meshOffsets.clear();
@@ -242,7 +248,7 @@ void glTFImporter::ImportMeshes(Asset &r) {
             auto &[mode, attributes, indices, material] = mesh.primitives[p];
 
             aiMesh *aim = new aiMesh();
-            meshes.push_back(aim);
+            meshes.emplace_back(aim);
 
             aim->mName = mesh.id;
             if (mesh.primitives.size() > 1) {
@@ -279,7 +285,13 @@ void glTFImporter::ImportMeshes(Asset &r) {
             if (attr.normal.size() > 0 && attr.normal[0]) attr.normal[0]->ExtractData(aim->mNormals);
 
             for (size_t tc = 0; tc < attr.texcoord.size() && tc < AI_MAX_NUMBER_OF_TEXTURECOORDS; ++tc) {
-                attr.texcoord[tc]->ExtractData(aim->mTextureCoords[tc]);
+                const bool extracted = attr.texcoord[tc] && attr.texcoord[tc]->ExtractData(aim->mTextureCoords[tc]);
+                if (!extracted) {
+                    // meshes owns the partially built aiMesh objects via unique_ptr,
+                    // so unwinding this exception frees them automatically.
+                    throw DeadlyImportError("Mesh \"", mesh.id, "\": failed to extract data for texcoord ", ai_to_string(tc));
+                }
+
                 aim->mNumUVComponents[tc] = attr.texcoord[tc]->GetNumComponents();
 
                 aiVector3D *values = aim->mTextureCoords[tc];
@@ -456,7 +468,15 @@ void glTFImporter::ImportMeshes(Asset &r) {
 
     meshOffsets.push_back(k);
 
-    CopyVector(meshes, mScene->mMeshes, mScene->mNumMeshes);
+    // Release ownership to the scene: CopyVector takes ownership of the raw
+    // pointers, so hand them over only now that import has fully succeeded.
+    std::vector<aiMesh *> rawMeshes;
+    rawMeshes.reserve(meshes.size());
+    for (std::unique_ptr<aiMesh> &m : meshes) {
+        rawMeshes.push_back(m.release());
+    }
+
+    CopyVector(rawMeshes, mScene->mMeshes, mScene->mNumMeshes);
 }
 
 void glTFImporter::ImportCameras(Asset &r) const {


### PR DESCRIPTION
This aims to fix [#6609](https://github.com/assimp/assimp/issues/6609).

Add a check in glTF ImportMeshes on texcoords accessors. If ExtractData fails, throw a DeadlyImportError to prevent null dereference later.

I reproduced the issue using the POCs provided in the original issue. The new result from sanitization (logging errors from the fuzzer):

```
root@c27cb1ce084c:/src/assimp# /out/assimp_fuzzer_gltf /src/CVE-2026-10198/ImportMeshes-segv.gltf
INFO: Running with entropic power schedule (0xFF, 100).
INFO: Seed: 1249325462
/out/assimp_fuzzer_gltf: Running 1 inputs 1 time(s) each.
Running: /src/CVE-2026-10198/ImportMeshes-segv.gltf
Import error: Mesh "Geometry-mesh002": failed to extract data for texcoord 0
Executed /src/CVE-2026-10198/ImportMeshes-segv.gltf in 3 ms
***
*** NOTE: fuzzing was not performed, you have only
***       executed the target code on a fixed set of inputs.
***
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during glTF model import by validating texture-coordinate extraction for each set.
  * Import failures now provide clearer details, including the affected mesh and texture-coordinate set, instead of potentially causing crashes.
  * Partially imported meshes are safely cleaned up when an error occurs, improving stability during failed imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->