### PR TITLE
FVFData support for multiple UV Sets

### DIFF
--- a/code/AssetLib/X/XFileParser.cpp
+++ b/code/AssetLib/X/XFileParser.cpp
@@ -573,16 +573,8 @@ void XFileParser::ParseDataObjectMeshFVFData(Mesh *pMesh) {
     // Number of total values in FVF Data. 2 x Vertices x UV sets
     unsigned int numCoords = ReadInt();
     
-    // Number of additional UV Channels in FVFData
-    unsigned int channels = 0;
-    if ((flags & 0x100) != 0) // D3DFVF_TEX1
-        channels++;
-
-    if ((flags & 0x200) != 0) // D3DFVF_TEX2
-        channels++;
-
-    if ((flags & 0x400) != 0) // D3DFVF_TEX3
-        channels++;
+    // Number of additional UV Channels in FVFData (D3DFVF_TEX1 | D3DFVF_TEX2 | D3DFVF_TEX3)
+    unsigned int channels = (flags & 0xF00) >> 8;
 
     if (pMesh->mNumTextures + channels > AI_MAX_NUMBER_OF_TEXTURECOORDS)
         ThrowException("Too many sets of texture coordinates");
@@ -590,25 +582,27 @@ void XFileParser::ParseDataObjectMeshFVFData(Mesh *pMesh) {
     unsigned int baseUvSetCount = pMesh->mNumTextures;
     pMesh->mNumTextures += channels;
 
-    for (unsigned int uvSet = 0; uvSet < channels; uvSet++) {
+    if (channels > 0) {
 
-        std::vector<aiVector2D> &coords = pMesh->mTexCoords[baseUvSetCount + uvSet];
+        unsigned int coordCount = numCoords / (2 * channels);
+        for (unsigned int uvSet = 0; uvSet < channels; uvSet++) {
 
-        // UVs are saved as ints, so two for each vertex
-        coords.resize(numCoords / ( 2 * channels));
-    }
-    for (unsigned int a = 0; a < numCoords / (2 * channels); a++)
-    {
-        for (unsigned int uvSet = 0; uvSet < channels; uvSet++) 
-        {
             std::vector<aiVector2D> &coords = pMesh->mTexCoords[baseUvSetCount + uvSet];
+            // UVs are saved as ints, so two for each vertex
+            coords.resize(coordCount);
+        }
 
-            // They're saved as ints but they're actually floats.
-            unsigned int val = ReadInt();
-            float x = reinterpret_cast<float &>(val);
-            val = ReadInt();
-            float y = reinterpret_cast<float &>(val);
-            coords[a] = aiVector2D(x, y);
+        for (unsigned int a = 0; a < coordCount; a++) {
+            for (unsigned int uvSet = 0; uvSet < channels; uvSet++) {
+                std::vector<aiVector2D> &coords = pMesh->mTexCoords[baseUvSetCount + uvSet];
+
+                // They're saved as ints but they're actually floats.
+                unsigned int val = ReadInt();
+                auto x = static_cast<float>(val);
+                val = ReadInt();
+                auto y = static_cast<float>(val);
+                coords[a] = aiVector2D(x, y);
+            }
         }
     }
 

--- a/code/AssetLib/X/XFileParser.cpp
+++ b/code/AssetLib/X/XFileParser.cpp
@@ -564,6 +564,7 @@ void XFileParser::ParseDataObjectMeshTextureCoords(Mesh *pMesh) {
     CheckForClosingBrace();
 }
 
+// ------------------------------------------------------------------------------------------------
 void XFileParser::ParseDataObjectMeshFVFData(Mesh *pMesh) {
     readHeadOfDataObject();
 
@@ -583,18 +584,16 @@ void XFileParser::ParseDataObjectMeshFVFData(Mesh *pMesh) {
     pMesh->mNumTextures += channels;
 
     if (channels > 0) {
-
-        unsigned int coordCount = numCoords / (2 * channels);
+        const unsigned int coordCount = numCoords / (2 * channels);
         for (unsigned int uvSet = 0; uvSet < channels; uvSet++) {
-
-            std::vector<aiVector2D> &coords = pMesh->mTexCoords[baseUvSetCount + uvSet];
+            auto &coords = pMesh->mTexCoords[baseUvSetCount + uvSet];
             // UVs are saved as ints, so two for each vertex
             coords.resize(coordCount);
         }
 
         for (unsigned int a = 0; a < coordCount; a++) {
             for (unsigned int uvSet = 0; uvSet < channels; uvSet++) {
-                std::vector<aiVector2D> &coords = pMesh->mTexCoords[baseUvSetCount + uvSet];
+                auto &coords = pMesh->mTexCoords[baseUvSetCount + uvSet];
 
                 // They're saved as ints but they're actually floats.
                 unsigned int val = ReadInt();

--- a/code/AssetLib/X/XFileParser.cpp
+++ b/code/AssetLib/X/XFileParser.cpp
@@ -437,6 +437,8 @@ void XFileParser::ParseDataObjectMesh(Mesh *pMesh) {
             ParseDataObjectSkinMeshHeader(pMesh);
         else if (objectName == "SkinWeights")
             ParseDataObjectSkinWeights(pMesh);
+        else if (objectName == "FVFData")
+            ParseDataObjectMeshFVFData(pMesh);
         else {
             ASSIMP_LOG_WARN("Unknown data object in mesh in x file");
             ParseUnknownDataObject();
@@ -558,6 +560,57 @@ void XFileParser::ParseDataObjectMeshTextureCoords(Mesh *pMesh) {
     coords.resize(numCoords);
     for (unsigned int a = 0; a < numCoords; a++)
         coords[a] = ReadVector2();
+
+    CheckForClosingBrace();
+}
+
+void XFileParser::ParseDataObjectMeshFVFData(Mesh *pMesh) {
+    readHeadOfDataObject();
+
+    // Flags from d3d9types.h . For multi-UV sets, this usually is D3DFVF_XYZ (unused) and D3DFVF_TEX1, D3DFVF_TEX2, etc.
+    unsigned int flags = ReadInt();
+    
+    // Number of total values in FVF Data. 2 x Vertices x UV sets
+    unsigned int numCoords = ReadInt();
+    
+    // Number of additional UV Channels in FVFData
+    unsigned int channels = 0;
+    if ((flags & 0x100) != 0) // D3DFVF_TEX1
+        channels++;
+
+    if ((flags & 0x200) != 0) // D3DFVF_TEX2
+        channels++;
+
+    if ((flags & 0x400) != 0) // D3DFVF_TEX3
+        channels++;
+
+    if (pMesh->mNumTextures + channels > AI_MAX_NUMBER_OF_TEXTURECOORDS)
+        ThrowException("Too many sets of texture coordinates");
+
+    unsigned int baseUvSetCount = pMesh->mNumTextures;
+    pMesh->mNumTextures += channels;
+
+    for (unsigned int uvSet = 0; uvSet < channels; uvSet++) {
+
+        std::vector<aiVector2D> &coords = pMesh->mTexCoords[baseUvSetCount + uvSet];
+
+        // UVs are saved as ints, so two for each vertex
+        coords.resize(numCoords / ( 2 * channels));
+    }
+    for (unsigned int a = 0; a < numCoords / (2 * channels); a++)
+    {
+        for (unsigned int uvSet = 0; uvSet < channels; uvSet++) 
+        {
+            std::vector<aiVector2D> &coords = pMesh->mTexCoords[baseUvSetCount + uvSet];
+
+            // They're saved as ints but they're actually floats.
+            unsigned int val = ReadInt();
+            float x = reinterpret_cast<float &>(val);
+            val = ReadInt();
+            float y = reinterpret_cast<float &>(val);
+            coords[a] = aiVector2D(x, y);
+        }
+    }
 
     CheckForClosingBrace();
 }

--- a/code/AssetLib/X/XFileParser.h
+++ b/code/AssetLib/X/XFileParser.h
@@ -84,6 +84,7 @@ protected:
     void ParseDataObjectSkinMeshHeader( XFile::Mesh* pMesh);
     void ParseDataObjectMeshNormals( XFile::Mesh* pMesh);
     void ParseDataObjectMeshTextureCoords( XFile::Mesh* pMesh);
+    void ParseDataObjectMeshFVFData(XFile::Mesh *pMesh);
     void ParseDataObjectMeshVertexColors( XFile::Mesh* pMesh);
     void ParseDataObjectMeshMaterialList( XFile::Mesh* pMesh);
     void ParseDataObjectMaterial( XFile::Material* pMaterial);


### PR DESCRIPTION
Added FVFData support for up to 3 additional UV Sets.

Attached is a sample .X model file with 3 UV Sets (one via standard means, the other 2 via FVFData)

[CarModel.zip](https://github.com/user-attachments/files/28758874/CarModel.zip)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * X model parsing now detects and processes FVF data blocks inside mesh geometry.
  * Additional UV channels from those blocks are imported and populate extra texture-coordinate sets so multi-UV assets display correctly.
  * Added bounds checks to prevent exceeding supported texture-coordinate limits, avoiding corrupted or dropped UV data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->