### PR TITLE
OSS-Fuzz: Add new fuzzer targets roundtrip process

### DIFF
--- a/fuzz/assimp_roundtrip_fuzzer.cc
+++ b/fuzz/assimp_roundtrip_fuzzer.cc
@@ -1,0 +1,86 @@
+/*
+---------------------------------------------------------------------------
+Open Asset Import Library (assimp)
+---------------------------------------------------------------------------
+
+Copyright (c) 2006-2026, assimp team
+
+All rights reserved.
+
+Redistribution and use of this software in source and binary forms,
+with or without modification, are permitted provided that the following
+conditions are met:
+
+* Redistributions of source code must retain the above
+  copyright notice, this list of conditions and the
+  following disclaimer.
+
+* Redistributions in binary form must reproduce the above
+  copyright notice, this list of conditions and the
+  following disclaimer in the documentation and/or other
+  materials provided with the distribution.
+
+* Neither the name of the assimp team, nor the names of its
+  contributors may be used to endorse or promote products
+  derived from this software without specific prior
+  written permission of the assimp team.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+---------------------------------------------------------------------------
+*/
+#include <assimp/cimport.h>
+#include <assimp/Importer.hpp>
+#include <assimp/Exporter.hpp>
+#include <assimp/scene.h>
+#include <assimp/postprocess.h>
+
+using namespace Assimp;
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t dataSize) {
+    // Limit input size to 1MB to prevent OOMs and timeouts
+    if (dataSize > 1024 * 1024) {
+        return 0;
+    }
+
+#ifdef _DEBUG
+    aiLogStream stream = aiGetPredefinedLogStream(aiDefaultLogStream_STDOUT, nullptr);
+    aiAttachLogStream(&stream);
+#endif
+
+    Importer importer;
+    unsigned int flags = aiProcessPreset_TargetRealtime_Quality | aiProcess_ValidateDataStructure;
+    const aiScene *sc = importer.ReadFileFromMemory(data, dataSize, flags, nullptr);
+
+    if (sc == nullptr) {
+#ifdef _DEBUG
+        aiDetachLogStream(&stream);
+#endif
+        return 0;
+    }
+
+    Exporter exporter;
+    const size_t formatCount = exporter.GetExportFormatCount();
+    for (size_t i = 0; i < formatCount; ++i) {
+        const aiExportFormatDesc *desc = exporter.GetExportFormatDescription(i);
+        if (desc == nullptr || desc->id == nullptr) {
+            continue;
+        }
+        exporter.ExportToBlob(sc, desc->id);
+    }
+
+#ifdef _DEBUG
+    aiDetachLogStream(&stream);
+#endif
+
+    return 0;
+}

--- a/fuzz/ossfuzz/build.sh
+++ b/fuzz/ossfuzz/build.sh
@@ -43,6 +43,13 @@ build_fuzzer "assimp_fuzzer" "../fuzz/assimp_fuzzer.cc"
 cp ../fuzz/assimp_fuzzer.dict $OUT/assimp_fuzzer.dict || true
 
 
+# 1b. Round-trip Fuzzer (import any format, then export to every supported
+#     format to exercise the otherwise-uncovered exporter back-ends).
+build_fuzzer "assimp_roundtrip_fuzzer" "../fuzz/assimp_roundtrip_fuzzer.cc"
+(cd ../test/models && zip -q -r $OUT/assimp_roundtrip_fuzzer_seed_corpus.zip .)
+cp ../fuzz/assimp_fuzzer.dict $OUT/assimp_roundtrip_fuzzer.dict || true
+
+
 # 2. OBJ Fuzzer
 build_fuzzer "assimp_fuzzer_obj" "../fuzz/assimp_fuzzer_obj.cc"
 if [ -d "../test/models/OBJ" ]; then


### PR DESCRIPTION
This PR creates a new OSS-Fuzz fuzzer targets roundtrip process for importer and exporter logic,

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added round-trip fuzzing for model import and export operations, testing compatibility across multiple export formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->