### PR TITLE
bound texcoord index against face index count in ply loader

### DIFF
--- a/code/AssetLib/Ply/PlyLoader.cpp
+++ b/code/AssetLib/Ply/PlyLoader.cpp
@@ -624,7 +624,11 @@ namespace Assimp {
                     auto p = GetProperty(instElement->alProperties, iTextureCoord).avList.begin();
                     if ((iNum / 3) == 2) { // X Y coord
                         for (unsigned int a = 0; a < iNum; ++a, ++p) {
-                            unsigned int vindex = mGeneratedMesh->mFaces[pos].mIndices[a / 2];
+                            const unsigned int idx = a / 2;
+                            if (idx >= mGeneratedMesh->mFaces[pos].mNumIndices) {
+                                break;
+                            }
+                            unsigned int vindex = mGeneratedMesh->mFaces[pos].mIndices[idx];
                             if (vindex < mGeneratedMesh->mNumVertices) {
                                 if (mGeneratedMesh->mTextureCoords[0] == nullptr) {
                                     mGeneratedMesh->mNumUVComponents[0] = 2;

--- a/test/models/PLY/malformed_face_texcoord_oob.ply
+++ b/test/models/PLY/malformed_face_texcoord_oob.ply
@@ -1,0 +1,14 @@
+ply
+format ascii 1.0
+element vertex 3
+property float x
+property float y
+property float z
+element face 1
+property list uchar uint vertex_indices
+property list uchar float texcoord
+end_header
+0 0 0
+1 0 0
+0 1 0
+1 0 6 0.0 0.0 0.0 0.0 0.0 0.0

--- a/test/unit/utPLYImportExport.cpp
+++ b/test/unit/utPLYImportExport.cpp
@@ -115,6 +115,14 @@ TEST_F(utPLYImportExport, importPLYwithUV) {
     EXPECT_EQ(true, scene->mMeshes[0]->HasTextureCoords(0));
 }
 
+// A face whose texcoord list is longer than twice its vertex-index list must not
+// read past the face index array.
+TEST_F(utPLYImportExport, faceTexCoordOutOfBounds) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/PLY/malformed_face_texcoord_oob.ply", 0);
+    EXPECT_NE(nullptr, scene);
+}
+
 TEST_F(utPLYImportExport, importBinaryPLY) {
     Assimp::Importer importer;
     const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/PLY/cube_binary.ply", aiProcess_ValidateDataStructure);


### PR DESCRIPTION
Repro: import a `.ply` whose face `texcoord` list is longer than twice its `vertex_indices` list (1 index, 6 texcoords reproduces it). ASAN reports a `heap-buffer-overflow` READ at `PlyLoader.cpp:627`.
Cause: the UV loop in `LoadFace` reads `mFaces[pos].mIndices[a / 2]` with `a` bounded by the texcoord list length, which is independent of `mNumIndices`, so `a / 2` walks off the end of the face index array.
Fix: stop the loop once `a / 2` reaches `mNumIndices`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential out-of-bounds indexing vulnerability when importing PLY files with malformed face texture coordinates.

* **Tests**
  * Added test coverage for handling PLY files with out-of-bounds texture coordinate data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->