### PR TITLE
B3D: validate chunk size against buffer and parent chunk

### DIFF
--- a/code/AssetLib/B3D/B3DImporter.cpp
+++ b/code/AssetLib/B3D/B3DImporter.cpp
@@ -234,7 +234,18 @@ string B3DImporter::ReadChunk() {
     ASSIMP_LOG_DEBUG("ReadChunk: ", tag);
 #endif
     unsigned sz = (unsigned)ReadInt();
-    _stack.push_back(_pos + sz);
+    // Validate the chunk extent before trusting it: a chunk must lie within
+    // the file and within its enclosing chunk. Without this check a crafted
+    // size lets ChunkSize() -- and the element counts derived from it in
+    // ReadVRTS()/ReadTRIS() -- run far past the buffer.
+    if (sz > _buf.size() - _pos) {
+        Fail("Bad chunk size");
+    }
+    const size_t end = _pos + sz;
+    if (!_stack.empty() && end > _stack.back()) {
+        Fail("Bad chunk size");
+    }
+    _stack.push_back(end);
     return tag;
 }
 
@@ -246,7 +257,9 @@ void B3DImporter::ExitChunk() {
 
 // ------------------------------------------------------------------------------------------------
 size_t B3DImporter::ChunkSize() {
-    return _stack.back() - _pos;
+    // _stack.back() is the validated end offset of the current chunk; guard
+    // against unsigned underflow should _pos ever be advanced past it.
+    return _stack.back() > _pos ? _stack.back() - _pos : 0;
 }
 // ------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
### Problem
`B3DImporter::ReadChunk()` pushed `_pos + sz` onto the chunk stack with `sz` taken directly from the file and never validated. `ChunkSize()` returns `_stack.back() - _pos`, so a crafted `.b3d` can make it either report a value far larger than the remaining buffer (oversized chunk) or **underflow** to a near-`SIZE_MAX` value when a nested chunk's end exceeds its parent's (after `ExitChunk()` advances `_pos` past the outer chunk end).

The element counts derived from `ChunkSize()` then drive unbounded allocations:
- `ReadVRTS()`: `n_verts = ChunkSize() / sz; _vertices.resize(v0 + n_verts);`
- `ReadTRIS()`: `n_tris = ChunkSize() / 12; new aiFace[n_tris];`

so a small malformed file triggers a wild allocation / OOM. (The per-field reads are already bounds-checked, so this is an allocation/DoS issue rather than an out-of-bounds read.)

### Fix
Harden the two chunk-model chokepoints rather than each consumer:
- `ReadChunk()` now validates that each chunk lies within the file **and** within its enclosing chunk before pushing its end offset.
- `ChunkSize()` is made underflow-safe.

This caps every `ChunkSize()`-derived count at the remaining file size, fixing `ReadVRTS` / `ReadTRIS` / `ReadTEXS` / `ReadBRUS` at the root. No behavioral change for well-formed files — a conformant chunk never exceeds its parent or the file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced validation of B3D file imports to better detect and reject malformed or corrupted files, improving stability and robustness when loading 3D model files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->