### PR TITLE
Fix std::terminate in COB chunk_guard destructor on malformed chunk size

### DIFF
--- a/code/AssetLib/COB/COBLoader.cpp
+++ b/code/AssetLib/COB/COBLoader.cpp
@@ -864,8 +864,13 @@ public:
             try {
                 reader.IncPtr(static_cast<int>(nfo.size) - reader.GetCurrentPos() + cur);
             } catch (const DeadlyImportError &) {
-                // out of limit so correct the value
-                reader.IncPtr(reader.GetReadLimit());
+                // The chunk size points past the end of the buffer; clamp to the
+                // read limit. This must not throw: a destructor is implicitly
+                // noexcept, and the previous code called IncPtr(GetReadLimit()),
+                // which interprets the absolute limit as a relative offset and
+                // seeks out of bounds again -- the escaping exception then
+                // terminated the process. SkipToReadLimit() clamps without throwing.
+                reader.SkipToReadLimit();
             }
         }
     }


### PR DESCRIPTION
## Motivation

In `code/AssetLib/COB/COBLoader.cpp`, `chunk_guard`'s destructor advances the stream to the end of a chunk and, if that seek is out of bounds, tries to recover:

```cpp
~chunk_guard() {
    if (nfo.size != static_cast<unsigned int>(-1)) {
        try {
            reader.IncPtr(static_cast<int>(nfo.size) - reader.GetCurrentPos() + cur);
        } catch (const DeadlyImportError &) {
            // out of limit so correct the value
            reader.IncPtr(reader.GetReadLimit());   // <-- throws again
        }
    }
}
```

`GetReadLimit()` returns the **absolute** read limit (`mLimit - mBuffer`), but `IncPtr()` takes a **relative** offset. So when a malformed `.cob` chunk declares a size past the end of the buffer, the catch handler seeks out of bounds a second time and throws another `DeadlyImportError`. Since a destructor is implicitly `noexcept`, that escaping exception calls `std::terminate()` and aborts the process — a malformed file becomes a denial of service.

```
terminate called after throwing an instance of 'DeadlyImportError'
  ... chunk_guard::~chunk_guard()   COBLoader.cpp
  ... COBImporter::ReadPolH_Binary(...) COBLoader.cpp:996
  ... COBImporter::ReadBinaryFile(...)  COBLoader.cpp:901
```

## Implementation

Replace `reader.IncPtr(reader.GetReadLimit())` with `reader.SkipToReadLimit()`, the purpose-built `StreamReader` method that clamps the cursor to the limit (`mCurrent = mLimit`) without throwing. The destructor can no longer emit an exception.

## Impact

- Well-formed COB files import identically — verified against the bundled `test/models*/COB` corpus.
- A malformed chunk size now safely stops at the read limit instead of terminating the process.

## How it was found / verified

AddressSanitizer + libFuzzer on the COB importer. After the fix the reproducer exits cleanly, the bundled COB models still import, and a follow-up coverage-guided run found no recurrence.

## AI tool disclosure

Per the [AI Tool Use Policy](https://github.com/assimp/assimp/blob/master/AIToolPolicy.md): prepared with AI assistance (fuzzing + initial draft); I reviewed and verified the root cause and fix myself and can answer questions during review. The commit carries an `Assisted-by:` trailer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file import reliability by preventing a stream-position correction from going out of bounds during chunk processing.
  * Fixed a crash path that could occur when recovering from an import error, keeping the reader safely within valid limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->