### PR TITLE
Harden OpenGEX importer against malformed input (null derefs + heap overflow)

### DIFF
--- a/code/AssetLib/OpenGEX/OpenGEXImporter.cpp
+++ b/code/AssetLib/OpenGEX/OpenGEXImporter.cpp
@@ -51,6 +51,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/importerdesc.h>
 #include <assimp/scene.h>
 #include <openddlparser/OpenDDLParser.h>
+#include <limits>
 
 static constexpr aiImporterDesc desc = {
     "Open Game Engine Exchange",
@@ -928,18 +929,28 @@ void OpenGEXImporter::handleIndexArrayNode(ODDLParser::DDLNode *node, aiScene * 
             if (nullptr == next) {
                 throw DeadlyImportError("OpenGEX: index array entry has fewer than three indices");
             }
-            int idx = -1;
-            if (next->m_type == Value::ValueType::ddl_unsigned_int16) {
+            size_t idx = 0;
+            if (next->m_type == Value::ValueType::ddl_unsigned_int8) {
+                idx = next->getUnsignedInt8();
+            } else if (next->m_type == Value::ValueType::ddl_unsigned_int16) {
                 idx = next->getUnsignedInt16();
             } else if (next->m_type == Value::ValueType::ddl_unsigned_int32) {
                 idx = next->getUnsignedInt32();
+            } else if (next->m_type == Value::ValueType::ddl_unsigned_int64) {
+                const auto idx64 = next->getUnsignedInt64();
+                if (idx64 > static_cast<decltype(idx64)>(std::numeric_limits<size_t>::max())) {
+                    throw DeadlyImportError("OpenGEX: vertex index is too large");
+                }
+                idx = static_cast<size_t>(idx64);
+            } else {
+                throw DeadlyImportError("OpenGEX: index array uses an unsupported index type");
             }
 
             // idx comes straight from the file. Validate it (and the output
             // cursor) at runtime -- the previous ai_assert()s are compiled out
             // of release builds, so an out-of-range index read past the end of
             // the vertex arrays (heap-buffer-overflow).
-            if (idx < 0 || static_cast<size_t>(idx) >= m_currentVertices.m_vertices.size()) {
+            if (idx >= m_currentVertices.m_vertices.size()) {
                 throw DeadlyImportError("OpenGEX: vertex index is out of range");
             }
             if (index >= m_currentMesh->mNumVertices) {

--- a/code/AssetLib/OpenGEX/OpenGEXImporter.cpp
+++ b/code/AssetLib/OpenGEX/OpenGEXImporter.cpp
@@ -434,7 +434,7 @@ void OpenGEXImporter::handleMetricNode(DDLNode *node, aiScene * /*pScene*/) {
 
     Property *prop(node->getProperties());
     while (nullptr != prop) {
-        if (nullptr != prop->m_key) {
+        if (nullptr != prop->m_key && nullptr != prop->m_value) {
             if (Value::ValueType::ddl_string == prop->m_value->m_type) {
                 std::string valName((char *)prop->m_value->m_data);
                 int type(Grammar::isValidMetricType(valName.c_str()));
@@ -753,16 +753,22 @@ static MeshAttribute getAttributeByName(const char *attribName) {
 //------------------------------------------------------------------------------------------------
 static void fillVector3(aiVector3D *vec3, Value *vals) {
     ai_assert(nullptr != vec3);
-    ai_assert(nullptr != vals);
 
     float x(0.0f), y(0.0f), z(0.0f);
+    // A vector-array entry may carry fewer values than expected; missing
+    // components default to 0 instead of dereferencing a null Value. The
+    // previous code read y and z unconditionally and crashed on short input.
     Value *next(vals);
-    x = next->getFloat();
-    next = next->m_next;
-    y = next->getFloat();
-    next = next->m_next;
     if (nullptr != next) {
-        z = next->getFloat();
+        x = next->getFloat();
+        next = next->m_next;
+        if (nullptr != next) {
+            y = next->getFloat();
+            next = next->m_next;
+            if (nullptr != next) {
+                z = next->getFloat();
+            }
+        }
     }
 
     vec3->Set(x, y, z);
@@ -815,7 +821,7 @@ static size_t countDataArrayListItems(DataArrayList *vaList) {
 
 //------------------------------------------------------------------------------------------------
 static void copyVectorArray(size_t numItems, DataArrayList *vaList, aiVector3D *vectorArray) {
-    for (size_t i = 0; i < numItems; i++) {
+    for (size_t i = 0; i < numItems && nullptr != vaList; i++) {
         Value *next(vaList->m_dataList);
         fillVector3(&vectorArray[i], next);
         vaList = vaList->m_next;
@@ -911,28 +917,45 @@ void OpenGEXImporter::handleIndexArrayNode(ODDLParser::DDLNode *node, aiScene * 
         aiFace &current(m_currentMesh->mFaces[i]);
         current.mNumIndices = 3;
         current.mIndices = new unsigned int[current.mNumIndices];
+        // The index array must supply one data entry per face.
+        if (nullptr == vaList) {
+            throw DeadlyImportError("OpenGEX: index array has fewer entries than the mesh has faces");
+        }
         Value *next(vaList->m_dataList);
         for (size_t indices = 0; indices < current.mNumIndices; indices++) {
+            // Each face needs three indices; a short entry must not walk off
+            // the value list.
+            if (nullptr == next) {
+                throw DeadlyImportError("OpenGEX: index array entry has fewer than three indices");
+            }
             int idx = -1;
             if (next->m_type == Value::ValueType::ddl_unsigned_int16) {
                 idx = next->getUnsignedInt16();
             } else if (next->m_type == Value::ValueType::ddl_unsigned_int32) {
                 idx = next->getUnsignedInt32();
             }
-            
-            ai_assert(static_cast<size_t>(idx) <= m_currentVertices.m_vertices.size());
-            ai_assert(index < m_currentMesh->mNumVertices);
+
+            // idx comes straight from the file. Validate it (and the output
+            // cursor) at runtime -- the previous ai_assert()s are compiled out
+            // of release builds, so an out-of-range index read past the end of
+            // the vertex arrays (heap-buffer-overflow).
+            if (idx < 0 || static_cast<size_t>(idx) >= m_currentVertices.m_vertices.size()) {
+                throw DeadlyImportError("OpenGEX: vertex index is out of range");
+            }
+            if (index >= m_currentMesh->mNumVertices) {
+                throw DeadlyImportError("OpenGEX: index array references more vertices than declared");
+            }
             aiVector3D &pos = (m_currentVertices.m_vertices[idx]);
             m_currentMesh->mVertices[index].Set(pos.x, pos.y, pos.z);
             if (hasColors && static_cast<size_t>(idx) < m_currentVertices.m_numColors) {
                 aiColor4D &col = m_currentVertices.m_colors[idx];
                 m_currentMesh->mColors[0][index] = col;
             }
-            if (hasNormalCoords) {
+            if (hasNormalCoords && static_cast<size_t>(idx) < m_currentVertices.m_normals.size()) {
                 aiVector3D &normal = (m_currentVertices.m_normals[idx]);
                 m_currentMesh->mNormals[index].Set(normal.x, normal.y, normal.z);
             }
-            if (hasTexCoords) {
+            if (hasTexCoords && static_cast<size_t>(idx) < m_currentVertices.m_numUVComps[0]) {
                 aiVector3D &tex = (m_currentVertices.m_textureCoords[0][idx]);
                 m_currentMesh->mTextureCoords[0][index].Set(tex.x, tex.y, tex.z);
             }
@@ -951,12 +974,16 @@ static void getColorRGB3(aiColor3D *pColor, DataArrayList *colList) {
         return;
     }
 
-    ai_assert(3 == colList->m_numItems);
+    // The data list may be shorter than three entries on malformed input;
+    // stop instead of dereferencing a null Value.
     Value *val(colList->m_dataList);
+    if (nullptr == val) return;
     pColor->r = val->getFloat();
     val = val->getNext();
+    if (nullptr == val) return;
     pColor->g = val->getFloat();
     val = val->getNext();
+    if (nullptr == val) return;
     pColor->b = val->getFloat();
 }
 
@@ -966,14 +993,19 @@ static void getColorRGB4(aiColor4D *pColor, DataArrayList *colList) {
         return;
     }
 
-    ai_assert(4 == colList->m_numItems);
+    // The data list may be shorter than four entries on malformed input;
+    // stop instead of dereferencing a null Value.
     Value *val(colList->m_dataList);
+    if (nullptr == val) return;
     pColor->r = val->getFloat();
     val = val->getNext();
+    if (nullptr == val) return;
     pColor->g = val->getFloat();
     val = val->getNext();
+    if (nullptr == val) return;
     pColor->b = val->getFloat();
     val = val->getNext();
+    if (nullptr == val) return;
     pColor->a = val->getFloat();
 }
 
@@ -1106,6 +1138,12 @@ void OpenGEXImporter::handleParamNode(ODDLParser::DDLNode *node, aiScene * /*pSc
     if (nullptr != prop->m_value) {
         Value *val(node->getValue());
         if (nullptr == val) {
+            return;
+        }
+        // A Param node carrying camera attributes can appear without a
+        // preceding CameraObject node, leaving m_currentCamera null. Skip it
+        // rather than dereferencing a null aiCamera.
+        if (nullptr == m_currentCamera) {
             return;
         }
         const float floatVal(val->getFloat());


### PR DESCRIPTION
## Motivation

Fuzzing the OpenGEX importer (`code/AssetLib/OpenGEX/OpenGEXImporter.cpp`) with AddressSanitizer surfaced a cluster of related issues: several handlers trust data straight from the file, validating it only with `ai_assert()`, which is compiled out of release builds. A crafted `.ogex` file reaches all of them.

| Function | Issue |
|---|---|
| `fillVector3` | reads 2nd/3rd components without checking `Value::m_next` for null (the sibling `fillColor4` does) → null deref on a short vector entry |
| `copyVectorArray` | walks past the end of the data-array list when the item count exceeds the list length |
| `handleIndexArrayNode` | file-supplied vertex indices only `ai_assert`-checked → out-of-range/negative index reads past the vertex/normal/texcoord arrays (**heap-buffer-overflow**); also unchecked null list nodes and an output-cursor overrun |
| `handleParamNode` | writes camera attributes through `m_currentCamera` without a null check → null `aiCamera` deref when a `Param` node has no preceding `CameraObject` |
| `handleMetricNode` | dereferences `Property::m_value` without a null check |
| `getColorRGB3` / `getColorRGB4` | walk the value list calling `getFloat()` without null checks → crash when the list is shorter than the declared item count |

Representative ASan reports:

```
heap-buffer-overflow READ ... handleIndexArrayNode  OpenGEXImporter.cpp:932
SEGV (null aiCamera)      ... handleParamNode        OpenGEXImporter.cpp:1119
member call on null Value ... getColorRGB4           OpenGEXImporter.cpp:998
```

## Implementation

Replace the compiled-out `ai_assert()`s and missing checks with real runtime validation: bounds-check file-supplied indices and the output cursor (raising `DeadlyImportError` on bad data), null-check every walked `Value`/`DataArrayList` node, and default missing vector/color components to 0 rather than dereferencing null. The fixes are confined to `OpenGEXImporter.cpp`.

## Impact

- Well-formed OpenGEX files import unchanged — verified against the bundled `test/models*/OpenGEX` corpus.
- Malformed files now fail cleanly (or skip the bad sub-element) instead of corrupting/over-reading the heap or dereferencing null.

## Scope note

This PR hardens the importer's own code. Fuzzing also reaches separate issues inside the bundled `contrib/openddlparser` DDL parser (e.g. `lookForNextToken`); those live in a vendored third-party component and are out of scope here — happy to follow up on them separately.

## How it was found / verified

AddressSanitizer + libFuzzer on the OpenGEX importer. Each reproducer is clean after the fix, the bundled corpus still imports, and ~10 minutes of additional coverage-guided fuzzing found no further crash *in the importer* (only the separate openddlparser issues noted above).

## AI tool disclosure

Per the [AI Tool Use Policy](https://github.com/assimp/assimp/blob/master/AIToolPolicy.md): prepared with AI assistance (fuzzing + initial drafts). I reviewed and verified each root cause and fix myself and can answer questions during review; the commit carries an `Assisted-by:` trailer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness when importing malformed OpenGEX data, preventing crashes and out-of-bounds access.
  * Vector and color parsing now tolerates missing components and incomplete data more safely.
  * Index and metric parsing now validate required values before processing, including stricter checks for unsupported or out-of-range values.
  * Camera-related parameters are now skipped safely when no active camera is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->