### PR TITLE
bound cut frame indices in MD5 camera loader

### DIFF
--- a/code/AssetLib/MD5/MD5Loader.cpp
+++ b/code/AssetLib/MD5/MD5Loader.cpp
@@ -741,13 +741,21 @@ void MD5Importer::LoadMD5CameraFile() {
         aiNodeAnim *nd = anim->mChannels[0] = new aiNodeAnim();
         nd->mNodeName.Set("<MD5Camera>");
 
-        nd->mNumPositionKeys = nd->mNumRotationKeys = *(it + 1) - (*it);
+        const unsigned int firstFrame = *it;
+        const unsigned int lastFrame = *(it + 1);
+        // Cut indices come straight from the file and are used to index into
+        // frames; reject ranges that run past the end (or wrap) before use.
+        if (lastFrame < firstFrame || lastFrame > frames.size()) {
+            throw DeadlyImportError("MD5CAMERA: Cut references a frame out of range");
+        }
+
+        nd->mNumPositionKeys = nd->mNumRotationKeys = lastFrame - firstFrame;
         nd->mPositionKeys = new aiVectorKey[nd->mNumPositionKeys];
         nd->mRotationKeys = new aiQuatKey[nd->mNumRotationKeys];
         for (unsigned int i = 0; i < nd->mNumPositionKeys; ++i) {
-            nd->mPositionKeys[i].mValue = frames[*it + i].vPositionXYZ;
-            MD5::ConvertQuaternion(frames[*it + i].vRotationQuat, nd->mRotationKeys[i].mValue);
-            nd->mPositionKeys[i].mTime = *it + i;  
+            nd->mPositionKeys[i].mValue = frames[firstFrame + i].vPositionXYZ;
+            MD5::ConvertQuaternion(frames[firstFrame + i].vRotationQuat, nd->mRotationKeys[i].mValue);
+            nd->mPositionKeys[i].mTime = firstFrame + i;
             nd->mRotationKeys[i].mTime = nd->mPositionKeys[i].mTime;
         }
     }

--- a/code/AssetLib/MD5/MD5Loader.cpp
+++ b/code/AssetLib/MD5/MD5Loader.cpp
@@ -729,6 +729,16 @@ void MD5Importer::LoadMD5CameraFile() {
             cuts.push_back(static_cast<unsigned int>(frames.size() - 1));
     }
 
+    // Cut indices come straight from the file and are used to index into
+    // frames; reject any range that runs past the end (or wraps) before we
+    // allocate or read anything, so a mid-loop throw can't leave the scene
+    // holding half-initialized animations.
+    for (std::vector<unsigned int>::const_iterator it = cuts.begin(); it != cuts.end() - 1; ++it) {
+        if (*(it + 1) < *it || *(it + 1) > frames.size()) {
+            throw DeadlyImportError("MD5CAMERA: Cut references a frame out of range");
+        }
+    }
+
     mScene->mNumAnimations = static_cast<unsigned int>(cuts.size() - 1);
     aiAnimation **tmp = mScene->mAnimations = new aiAnimation *[mScene->mNumAnimations];
     for (std::vector<unsigned int>::const_iterator it = cuts.begin(); it != cuts.end() - 1; ++it) {
@@ -743,12 +753,6 @@ void MD5Importer::LoadMD5CameraFile() {
 
         const unsigned int firstFrame = *it;
         const unsigned int lastFrame = *(it + 1);
-        // Cut indices come straight from the file and are used to index into
-        // frames; reject ranges that run past the end (or wrap) before use.
-        if (lastFrame < firstFrame || lastFrame > frames.size()) {
-            throw DeadlyImportError("MD5CAMERA: Cut references a frame out of range");
-        }
-
         nd->mNumPositionKeys = nd->mNumRotationKeys = lastFrame - firstFrame;
         nd->mPositionKeys = new aiVectorKey[nd->mNumPositionKeys];
         nd->mRotationKeys = new aiQuatKey[nd->mNumRotationKeys];

--- a/code/AssetLib/MD5/MD5Loader.cpp
+++ b/code/AssetLib/MD5/MD5Loader.cpp
@@ -733,7 +733,7 @@ void MD5Importer::LoadMD5CameraFile() {
     // frames; reject any range that runs past the end (or wraps) before we
     // allocate or read anything, so a mid-loop throw can't leave the scene
     // holding half-initialized animations.
-    for (std::vector<unsigned int>::const_iterator it = cuts.begin(); it != cuts.end() - 1; ++it) {
+    for (auto it = cuts.begin(); it != cuts.end() - 1; ++it) {
         if (*(it + 1) < *it || *(it + 1) > frames.size()) {
             throw DeadlyImportError("MD5CAMERA: Cut references a frame out of range");
         }

--- a/test/models/MD5/invalid/InvalidCameraCut.md5camera
+++ b/test/models/MD5/invalid/InvalidCameraCut.md5camera
@@ -1,0 +1,14 @@
+MD5Version 10
+commandline ""
+
+numFrames 1
+frameRate 24
+numCuts 1
+
+cuts {
+8
+}
+
+camera {
+( 0 0 0 ) ( 0 0 0 ) 45
+}

--- a/test/unit/ImportExport/utMD5Importer.cpp
+++ b/test/unit/ImportExport/utMD5Importer.cpp
@@ -68,6 +68,15 @@ TEST(utMD5Importer, importInvalidBoneIndex) {
     ASSERT_EQ(nullptr, scene);
 }
 
+TEST(utMD5Importer, importInvalidCameraCut) {
+    // Regression test: a crafted .md5camera whose cut list references a frame
+    // index past the parsed frame array used to read out of bounds while
+    // building the camera animations. The importer must reject it gracefully.
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/MD5/invalid/InvalidCameraCut.md5camera", 0);
+    ASSERT_EQ(nullptr, scene);
+}
+
 TEST(utMD5Importer, importBoarMan) {
     Assimp::Importer importer;
     const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_NONBSD_DIR "/MD5/BoarMan.md5mesh", aiProcess_ValidateDataStructure);


### PR DESCRIPTION
LoadMD5CameraFile indexes the parsed frame array with cut values read straight from the .md5camera file, so a cut that points past the last frame walks past the vector and reads out of bounds while building the animation keys; validate each cut range against the frame count before the read. A crafted file is added under test/models/MD5/invalid with a regression test that now rejects it instead of over-reading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation of MD5 camera cut ranges to prevent out-of-bounds frame access during camera animation import.
  * Updated camera keyframe construction to use validated frame bounds and keep position/rotation key timestamps synchronized.
* **Tests**
  * Added an invalid MD5 camera-cut fixture and a unit test confirming the importer rejects the file cleanly (returns no scene).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->