### PR TITLE
bound face texcoord count to vertex index count in ply LoadFace

### DIFF
--- a/code/AssetLib/Ply/PlyLoader.cpp
+++ b/code/AssetLib/Ply/PlyLoader.cpp
@@ -623,6 +623,9 @@ namespace Assimp {
                     // should be 6 coords
                     auto p = GetProperty(instElement->alProperties, iTextureCoord).avList.begin();
                     if ((iNum / 3) == 2) { // X Y coord
+                        if (iNum > mGeneratedMesh->mFaces[pos].mNumIndices * 2) {
+                            throw DeadlyImportError("Invalid .ply file: Too many texture coordinates for face");
+                        }
                         for (unsigned int a = 0; a < iNum; ++a, ++p) {
                             unsigned int vindex = mGeneratedMesh->mFaces[pos].mIndices[a / 2];
                             if (vindex < mGeneratedMesh->mNumVertices) {

--- a/test/unit/utPLYImportExport.cpp
+++ b/test/unit/utPLYImportExport.cpp
@@ -282,3 +282,24 @@ TEST_F(utPLYImportExport, parseInvalidDoubleCustomProperty) {
     const aiScene *scene = importer.ReadFileFromMemory(data, sizeof(data), 0);
     EXPECT_EQ(nullptr, scene);
 }
+
+TEST_F(utPLYImportExport, parseInvalidFaceTexcoordCount) {
+    const char data[] = "ply\n"
+                        "format ascii 1.0\n"
+                        "element vertex 3\n"
+                        "property float x\n"
+                        "property float y\n"
+                        "property float z\n"
+                        "element face 1\n"
+                        "property list uchar int vertex_index\n"
+                        "property list uchar float texcoord\n"
+                        "end_header\n"
+                        "0.0 0.0 0.0\n"
+                        "1.0 0.0 0.0\n"
+                        "0.0 1.0 0.0\n"
+                        "1 0 6 0.0 0.0 1.0 0.0 0.0 1.0\n";
+
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFileFromMemory(data, sizeof(data), 0);
+    EXPECT_EQ(nullptr, scene);
+}

--- a/test/unit/utPLYImportExport.cpp
+++ b/test/unit/utPLYImportExport.cpp
@@ -303,3 +303,27 @@ TEST_F(utPLYImportExport, parseInvalidFaceTexcoordCount) {
     const aiScene *scene = importer.ReadFileFromMemory(data, sizeof(data), 0);
     EXPECT_EQ(nullptr, scene);
 }
+
+TEST_F(utPLYImportExport, parseQuadFaceTexcoordCount) {
+    const char data[] = "ply\n"
+                        "format ascii 1.0\n"
+                        "element vertex 4\n"
+                        "property float x\n"
+                        "property float y\n"
+                        "property float z\n"
+                        "element face 1\n"
+                        "property list uchar int vertex_index\n"
+                        "property list uchar float texcoord\n"
+                        "end_header\n"
+                        "0.0 0.0 0.0\n"
+                        "1.0 0.0 0.0\n"
+                        "1.0 1.0 0.0\n"
+                        "0.0 1.0 0.0\n"
+                        "4 0 1 2 3 8 0.0 0.0 1.0 0.0 1.0 1.0 0.0 1.0\n";
+
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFileFromMemory(data, sizeof(data), 0);
+    ASSERT_NE(nullptr, scene);
+    ASSERT_EQ(1u, scene->mNumMeshes);
+    EXPECT_TRUE(scene->mMeshes[0]->HasTextureCoords(0));
+}


### PR DESCRIPTION
LoadFace reads the vertex_index list and the texcoord list of a face as two separate properties, but the texcoord loop indexes mIndices[a / 2] while a runs over the texcoord list length, and the file sets those two lengths independently. A face declaring one vertex index and six texcoord values makes the loop read past the end of the one-element mIndices array, which asan reports as a heap-buffer-overflow read at PlyLoader.cpp:627 against the allocation made a few lines above it; the stale value then picks which texture coordinate gets written. The check belongs here because this is the only point where both list lengths are known, so it rejects the face before the walk starts rather than after the read. Worth verifying that the bound allows quads, since (iNum / 3) == 2 also admits 7 and 8 coordinate values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of malformed PLY face texture-coordinate data by adding validation to prevent cases with excessive per-face texcoord values.
  * Invalid face texcoord definitions are now rejected safely, reducing the risk of crashes or incorrect imports.

* **Tests**
  * Added new unit tests covering both failure and success scenarios for face texcoord parsing, including invalid texcoord list metadata and a valid quad face with matching texcoord data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->