### PR TITLE
Fix C++ 23 compatibility issue

### DIFF
--- a/code/AssetLib/IFC/IFCLoader.cpp
+++ b/code/AssetLib/IFC/IFCLoader.cpp
@@ -352,7 +352,7 @@ void ConvertUnit(const ::Assimp::STEP::EXPRESS::DataType &dt, ConversionData &co
 
 // ------------------------------------------------------------------------------------------------
 void SetUnits(ConversionData &conv) {
-    if (conv.proj.UnitsInContext == nullptr) {
+    if (!conv.proj.UnitsInContext) {
         IFCImporter::LogError("Skipping conversion data, nullptr.");
         return;
     }


### PR DESCRIPTION
The old comparison is ambiguous in C++ 23 and later.
```
code/AssetLib/IFC/IFCLoader.cpp:355:34: error: ambiguous overload for ‘operator==’ (operand types are ‘const Assimp::STEP::Lazy<Assimp::IFC::Schema_2x3::IfcUnitAssignment>’ and ‘std::nullptr_t’)
  355 |     if (conv.proj.UnitsInContext == nullptr) {
code/AssetLib/IFC/IFCLoader.cpp:355:34: note: there are 2 candidates
In file included from code/AssetLib/IFC/../STEPParser/STEPFileReader.h:45,
                 from code/AssetLib/IFC/IFCLoader.cpp:60:
code/AssetLib/Step/STEPFile.h:582:13: note: candidate 1: ‘bool Assimp::STEP::operator==(const std::shared_ptr<LazyObject>&, T) [with T = Lazy<Assimp::IFC::Schema_2x3::IfcUnitAssignment>]’ (reversed)
  582 | inline bool operator == (const std::shared_ptr<LazyObject> &lo, T whatever) {
code/AssetLib/IFC/IFCLoader.cpp:355:34: note: candidate 2: ‘operator==(const Assimp::IFC::Schema_2x3::IfcUnitAssignment*, const Assimp::IFC::Schema_2x3::IfcUnitAssignment*)’ (built-in)
```

This does not increase the required standard version, only allows compiling with it for future compatibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing unit conversion context during IFC loading while preserving existing error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->