### PR TITLE
zero-initialize assbin bone, material and channel arrays before filling

### DIFF
--- a/code/AssetLib/Assbin/AssbinLoader.cpp
+++ b/code/AssetLib/Assbin/AssbinLoader.cpp
@@ -458,6 +458,7 @@ void AssbinImporter::ReadBinaryMesh(IOStream *stream, aiMesh *mesh) {
     // write bones
     if (mesh->mNumBones) {
         mesh->mBones = new C_STRUCT aiBone *[mesh->mNumBones];
+        memset(mesh->mBones, 0, mesh->mNumBones * sizeof(aiBone *));
         for (unsigned int a = 0; a < mesh->mNumBones; ++a) {
             mesh->mBones[a] = new aiBone();
             ReadBinaryBone(stream, mesh->mBones[a]);
@@ -498,6 +499,7 @@ void AssbinImporter::ReadBinaryMaterial(IOStream *stream, aiMaterial *mat) {
             delete[] mat->mProperties;
         }
         mat->mProperties = new aiMaterialProperty *[mat->mNumProperties];
+        memset(mat->mProperties, 0, mat->mNumProperties * sizeof(aiMaterialProperty *));
         for (unsigned int i = 0; i < mat->mNumProperties; ++i) {
             mat->mProperties[i] = new aiMaterialProperty();
             ReadBinaryMaterialProperty(stream, mat->mProperties[i]);
@@ -577,6 +579,7 @@ void AssbinImporter::ReadBinaryAnim(IOStream *stream, aiAnimation *anim) {
 
     if (anim->mNumChannels) {
         anim->mChannels = new aiNodeAnim *[anim->mNumChannels];
+        memset(anim->mChannels, 0, anim->mNumChannels * sizeof(aiNodeAnim *));
         for (unsigned int a = 0; a < anim->mNumChannels; ++a) {
             anim->mChannels[a] = new aiNodeAnim();
             ReadBinaryNodeAnim(stream, anim->mChannels[a]);

--- a/test/unit/utAssbinImportExport.cpp
+++ b/test/unit/utAssbinImportExport.cpp
@@ -52,6 +52,24 @@ using namespace Assimp;
 
 #ifndef ASSIMP_BUILD_NO_EXPORT
 
+namespace {
+
+uint32_t readUint32LE(const std::vector<uint8_t> &blob, size_t offset) {
+    return static_cast<uint32_t>(blob[offset + 0]) |
+            (static_cast<uint32_t>(blob[offset + 1]) << 8u) |
+            (static_cast<uint32_t>(blob[offset + 2]) << 16u) |
+            (static_cast<uint32_t>(blob[offset + 3]) << 24u);
+}
+
+void writeUint32LE(std::vector<uint8_t> &blob, size_t offset, uint32_t value) {
+    blob[offset + 0] = static_cast<uint8_t>(value & 0xffu);
+    blob[offset + 1] = static_cast<uint8_t>((value >> 8u) & 0xffu);
+    blob[offset + 2] = static_cast<uint8_t>((value >> 16u) & 0xffu);
+    blob[offset + 3] = static_cast<uint8_t>((value >> 24u) & 0xffu);
+}
+
+} // namespace
+
 class utAssbinImportExport : public AbstractImportExportBase {
 public:
     bool importerTest() override {
@@ -85,42 +103,28 @@ TEST_F(utAssbinImportExport, rejectOversizedNodeNameLengthInAssbin) {
     std::vector<uint8_t> corruptedBlob(blobBytes, blobBytes + blob->size);
     ASSERT_GT(corruptedBlob.size(), static_cast<size_t>(ASSBIN_HEADER_LENGTH));
 
-    auto readUint32LE = [&corruptedBlob](size_t offset) -> uint32_t {
-        return static_cast<uint32_t>(corruptedBlob[offset + 0]) |
-                (static_cast<uint32_t>(corruptedBlob[offset + 1]) << 8u) |
-                (static_cast<uint32_t>(corruptedBlob[offset + 2]) << 16u) |
-                (static_cast<uint32_t>(corruptedBlob[offset + 3]) << 24u);
-    };
-
-    auto writeUint32LE = [&corruptedBlob](size_t offset, uint32_t value) {
-        corruptedBlob[offset + 0] = static_cast<uint8_t>(value & 0xffu);
-        corruptedBlob[offset + 1] = static_cast<uint8_t>((value >> 8u) & 0xffu);
-        corruptedBlob[offset + 2] = static_cast<uint8_t>((value >> 16u) & 0xffu);
-        corruptedBlob[offset + 3] = static_cast<uint8_t>((value >> 24u) & 0xffu);
-    };
-
     ASSERT_GE(corruptedBlob.size(), static_cast<size_t>(ASSBIN_HEADER_LENGTH) + sizeof(uint32_t) * 2u);
-    ASSERT_EQ(static_cast<uint32_t>(ASSBIN_CHUNK_AISCENE), readUint32LE(ASSBIN_HEADER_LENGTH));
+    ASSERT_EQ(static_cast<uint32_t>(ASSBIN_CHUNK_AISCENE), readUint32LE(corruptedBlob, ASSBIN_HEADER_LENGTH));
 
-    const uint32_t sceneChunkSize = readUint32LE(ASSBIN_HEADER_LENGTH + sizeof(uint32_t));
+    const uint32_t sceneChunkSize = readUint32LE(corruptedBlob, ASSBIN_HEADER_LENGTH + sizeof(uint32_t));
     const size_t sceneChunkDataOffset = static_cast<size_t>(ASSBIN_HEADER_LENGTH) + sizeof(uint32_t) * 2u;
     const size_t sceneChunkEnd = sceneChunkDataOffset + static_cast<size_t>(sceneChunkSize);
     ASSERT_LE(sceneChunkEnd, corruptedBlob.size());
 
     size_t nodeChunkOffset = corruptedBlob.size();
     for (size_t offset = sceneChunkDataOffset; offset + sizeof(uint32_t) * 3u <= sceneChunkEnd; ++offset) {
-        if (readUint32LE(offset) != static_cast<uint32_t>(ASSBIN_CHUNK_AINODE)) {
+        if (readUint32LE(corruptedBlob, offset) != static_cast<uint32_t>(ASSBIN_CHUNK_AINODE)) {
             continue;
         }
 
-        const uint32_t chunkSize = readUint32LE(offset + sizeof(uint32_t));
+        const uint32_t chunkSize = readUint32LE(corruptedBlob, offset + sizeof(uint32_t));
         const size_t chunkEnd = offset + sizeof(uint32_t) * 2u + static_cast<size_t>(chunkSize);
         if (chunkEnd > sceneChunkEnd) {
             continue;
         }
 
         const size_t lengthOffset = offset + sizeof(uint32_t) * 2u;
-        const uint32_t originalLength = readUint32LE(lengthOffset);
+        const uint32_t originalLength = readUint32LE(corruptedBlob, lengthOffset);
         if (lengthOffset + sizeof(uint32_t) + static_cast<size_t>(originalLength) > chunkEnd) {
             continue;
         }
@@ -133,7 +137,7 @@ TEST_F(utAssbinImportExport, rejectOversizedNodeNameLengthInAssbin) {
 
     // Corrupt aiString length to exceed AI_MAXLEN to simulate malformed input.
     const size_t stringLengthOffset = nodeChunkOffset + sizeof(uint32_t) * 2u;
-    writeUint32LE(stringLengthOffset, static_cast<uint32_t>(AI_MAXLEN));
+    writeUint32LE(corruptedBlob, stringLengthOffset, static_cast<uint32_t>(AI_MAXLEN));
 
     Importer corruptedImporter;
     const aiScene *corruptedScene = corruptedImporter.ReadFileFromMemory(corruptedBlob.data(), corruptedBlob.size(), 0, "assbin");
@@ -157,28 +161,14 @@ TEST_F(utAssbinImportExport, rejectOversizedMaterialPropertyCountInAssbin) {
     const auto *blobBytes = static_cast<const uint8_t *>(blob->data);
     std::vector<uint8_t> corruptedBlob(blobBytes, blobBytes + blob->size);
 
-    auto readUint32LE = [&corruptedBlob](size_t offset) -> uint32_t {
-        return static_cast<uint32_t>(corruptedBlob[offset + 0]) |
-                (static_cast<uint32_t>(corruptedBlob[offset + 1]) << 8u) |
-                (static_cast<uint32_t>(corruptedBlob[offset + 2]) << 16u) |
-                (static_cast<uint32_t>(corruptedBlob[offset + 3]) << 24u);
-    };
-
-    auto writeUint32LE = [&corruptedBlob](size_t offset, uint32_t value) {
-        corruptedBlob[offset + 0] = static_cast<uint8_t>(value & 0xffu);
-        corruptedBlob[offset + 1] = static_cast<uint8_t>((value >> 8u) & 0xffu);
-        corruptedBlob[offset + 2] = static_cast<uint8_t>((value >> 16u) & 0xffu);
-        corruptedBlob[offset + 3] = static_cast<uint8_t>((value >> 24u) & 0xffu);
-    };
-
     // Locate a material chunk that is directly followed by its first property chunk.
     size_t materialChunkOffset = corruptedBlob.size();
     for (size_t offset = ASSBIN_HEADER_LENGTH; offset + sizeof(uint32_t) * 4u <= corruptedBlob.size(); ++offset) {
-        if (readUint32LE(offset) != static_cast<uint32_t>(ASSBIN_CHUNK_AIMATERIAL)) {
+        if (readUint32LE(corruptedBlob, offset) != static_cast<uint32_t>(ASSBIN_CHUNK_AIMATERIAL)) {
             continue;
         }
 
-        if (readUint32LE(offset + sizeof(uint32_t) * 3u) != static_cast<uint32_t>(ASSBIN_CHUNK_AIMATERIALPROPERTY)) {
+        if (readUint32LE(corruptedBlob, offset + sizeof(uint32_t) * 3u) != static_cast<uint32_t>(ASSBIN_CHUNK_AIMATERIALPROPERTY)) {
             continue;
         }
 
@@ -190,8 +180,8 @@ TEST_F(utAssbinImportExport, rejectOversizedMaterialPropertyCountInAssbin) {
 
     // Announce more properties than the file provides and break the first property
     // chunk, so the reader gives up before it has filled a single array slot.
-    writeUint32LE(materialChunkOffset + sizeof(uint32_t) * 2u, 64u);
-    writeUint32LE(materialChunkOffset + sizeof(uint32_t) * 3u, 0u);
+    writeUint32LE(corruptedBlob, materialChunkOffset + sizeof(uint32_t) * 2u, 64u);
+    writeUint32LE(corruptedBlob, materialChunkOffset + sizeof(uint32_t) * 3u, 0u);
 
     Importer corruptedImporter;
     const aiScene *corruptedScene = corruptedImporter.ReadFileFromMemory(corruptedBlob.data(), corruptedBlob.size(), 0, "assbin");

--- a/test/unit/utAssbinImportExport.cpp
+++ b/test/unit/utAssbinImportExport.cpp
@@ -143,4 +143,62 @@ TEST_F(utAssbinImportExport, rejectOversizedNodeNameLengthInAssbin) {
                     .find("String length too large"));
 }
 
+TEST_F(utAssbinImportExport, rejectOversizedMaterialPropertyCountInAssbin) {
+    Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/OBJ/spider.obj", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+
+    Exporter exporter;
+    const aiExportDataBlob *blob = exporter.ExportToBlob(scene, "assbin");
+    ASSERT_NE(nullptr, blob);
+    ASSERT_NE(nullptr, blob->data);
+    ASSERT_GT(blob->size, 0u);
+
+    const auto *blobBytes = static_cast<const uint8_t *>(blob->data);
+    std::vector<uint8_t> corruptedBlob(blobBytes, blobBytes + blob->size);
+
+    auto readUint32LE = [&corruptedBlob](size_t offset) -> uint32_t {
+        return static_cast<uint32_t>(corruptedBlob[offset + 0]) |
+                (static_cast<uint32_t>(corruptedBlob[offset + 1]) << 8u) |
+                (static_cast<uint32_t>(corruptedBlob[offset + 2]) << 16u) |
+                (static_cast<uint32_t>(corruptedBlob[offset + 3]) << 24u);
+    };
+
+    auto writeUint32LE = [&corruptedBlob](size_t offset, uint32_t value) {
+        corruptedBlob[offset + 0] = static_cast<uint8_t>(value & 0xffu);
+        corruptedBlob[offset + 1] = static_cast<uint8_t>((value >> 8u) & 0xffu);
+        corruptedBlob[offset + 2] = static_cast<uint8_t>((value >> 16u) & 0xffu);
+        corruptedBlob[offset + 3] = static_cast<uint8_t>((value >> 24u) & 0xffu);
+    };
+
+    // Locate a material chunk that is directly followed by its first property chunk.
+    size_t materialChunkOffset = corruptedBlob.size();
+    for (size_t offset = ASSBIN_HEADER_LENGTH; offset + sizeof(uint32_t) * 4u <= corruptedBlob.size(); ++offset) {
+        if (readUint32LE(offset) != static_cast<uint32_t>(ASSBIN_CHUNK_AIMATERIAL)) {
+            continue;
+        }
+
+        if (readUint32LE(offset + sizeof(uint32_t) * 3u) != static_cast<uint32_t>(ASSBIN_CHUNK_AIMATERIALPROPERTY)) {
+            continue;
+        }
+
+        materialChunkOffset = offset;
+        break;
+    }
+
+    ASSERT_NE(corruptedBlob.size(), materialChunkOffset);
+
+    // Announce more properties than the file provides and break the first property
+    // chunk, so the reader gives up before it has filled a single array slot.
+    writeUint32LE(materialChunkOffset + sizeof(uint32_t) * 2u, 64u);
+    writeUint32LE(materialChunkOffset + sizeof(uint32_t) * 3u, 0u);
+
+    Importer corruptedImporter;
+    const aiScene *corruptedScene = corruptedImporter.ReadFileFromMemory(corruptedBlob.data(), corruptedBlob.size(), 0, "assbin");
+    EXPECT_EQ(nullptr, corruptedScene);
+    EXPECT_NE(std::string::npos,
+            std::string(corruptedImporter.GetErrorString())
+                    .find("Magic chunk identifiers are wrong"));
+}
+
 #endif // #ifndef ASSIMP_BUILD_NO_EXPORT

--- a/test/unit/utAssbinImportExport.cpp
+++ b/test/unit/utAssbinImportExport.cpp
@@ -54,18 +54,38 @@ using namespace Assimp;
 
 namespace {
 
-uint32_t readUint32LE(const std::vector<uint8_t> &blob, size_t offset) {
+uint32_t ReadUint32LE(const std::vector<uint8_t> &blob, size_t offset) {
     return static_cast<uint32_t>(blob[offset + 0]) |
             (static_cast<uint32_t>(blob[offset + 1]) << 8u) |
             (static_cast<uint32_t>(blob[offset + 2]) << 16u) |
             (static_cast<uint32_t>(blob[offset + 3]) << 24u);
 }
 
-void writeUint32LE(std::vector<uint8_t> &blob, size_t offset, uint32_t value) {
+void WriteUint32LE(std::vector<uint8_t> &blob, size_t offset, uint32_t value) {
     blob[offset + 0] = static_cast<uint8_t>(value & 0xffu);
     blob[offset + 1] = static_cast<uint8_t>((value >> 8u) & 0xffu);
     blob[offset + 2] = static_cast<uint8_t>((value >> 16u) & 0xffu);
     blob[offset + 3] = static_cast<uint8_t>((value >> 24u) & 0xffu);
+}
+
+// Export the shared spider.obj fixture to an assbin blob and hand back a mutable
+// copy the corruption tests can poke at. Returns an empty vector on failure so
+// callers can assert on it.
+std::vector<uint8_t> ExportSpiderToAssbinBytes() {
+    Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/OBJ/spider.obj", aiProcess_ValidateDataStructure);
+    if (scene == nullptr) {
+        return {};
+    }
+
+    Exporter exporter;
+    const aiExportDataBlob *blob = exporter.ExportToBlob(scene, "assbin");
+    if (blob == nullptr || blob->data == nullptr || blob->size == 0) {
+        return {};
+    }
+
+    const auto *blobBytes = static_cast<const uint8_t *>(blob->data);
+    return std::vector<uint8_t>(blobBytes, blobBytes + blob->size);
 }
 
 } // namespace
@@ -89,42 +109,31 @@ TEST_F(utAssbinImportExport, import3ExportAssbinDFromFileTest) {
 }
 
 TEST_F(utAssbinImportExport, rejectOversizedNodeNameLengthInAssbin) {
-    Importer importer;
-    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/OBJ/spider.obj", aiProcess_ValidateDataStructure);
-    ASSERT_NE(nullptr, scene);
-
-    Exporter exporter;
-    const aiExportDataBlob *blob = exporter.ExportToBlob(scene, "assbin");
-    ASSERT_NE(nullptr, blob);
-    ASSERT_NE(nullptr, blob->data);
-    ASSERT_GT(blob->size, 0u);
-
-    const auto *blobBytes = static_cast<const uint8_t *>(blob->data);
-    std::vector<uint8_t> corruptedBlob(blobBytes, blobBytes + blob->size);
+    std::vector<uint8_t> corruptedBlob = ExportSpiderToAssbinBytes();
     ASSERT_GT(corruptedBlob.size(), static_cast<size_t>(ASSBIN_HEADER_LENGTH));
 
     ASSERT_GE(corruptedBlob.size(), static_cast<size_t>(ASSBIN_HEADER_LENGTH) + sizeof(uint32_t) * 2u);
-    ASSERT_EQ(static_cast<uint32_t>(ASSBIN_CHUNK_AISCENE), readUint32LE(corruptedBlob, ASSBIN_HEADER_LENGTH));
+    ASSERT_EQ(static_cast<uint32_t>(ASSBIN_CHUNK_AISCENE), ReadUint32LE(corruptedBlob, ASSBIN_HEADER_LENGTH));
 
-    const uint32_t sceneChunkSize = readUint32LE(corruptedBlob, ASSBIN_HEADER_LENGTH + sizeof(uint32_t));
+    const uint32_t sceneChunkSize = ReadUint32LE(corruptedBlob, ASSBIN_HEADER_LENGTH + sizeof(uint32_t));
     const size_t sceneChunkDataOffset = static_cast<size_t>(ASSBIN_HEADER_LENGTH) + sizeof(uint32_t) * 2u;
     const size_t sceneChunkEnd = sceneChunkDataOffset + static_cast<size_t>(sceneChunkSize);
     ASSERT_LE(sceneChunkEnd, corruptedBlob.size());
 
     size_t nodeChunkOffset = corruptedBlob.size();
     for (size_t offset = sceneChunkDataOffset; offset + sizeof(uint32_t) * 3u <= sceneChunkEnd; ++offset) {
-        if (readUint32LE(corruptedBlob, offset) != static_cast<uint32_t>(ASSBIN_CHUNK_AINODE)) {
+        if (ReadUint32LE(corruptedBlob, offset) != static_cast<uint32_t>(ASSBIN_CHUNK_AINODE)) {
             continue;
         }
 
-        const uint32_t chunkSize = readUint32LE(corruptedBlob, offset + sizeof(uint32_t));
+        const uint32_t chunkSize = ReadUint32LE(corruptedBlob, offset + sizeof(uint32_t));
         const size_t chunkEnd = offset + sizeof(uint32_t) * 2u + static_cast<size_t>(chunkSize);
         if (chunkEnd > sceneChunkEnd) {
             continue;
         }
 
         const size_t lengthOffset = offset + sizeof(uint32_t) * 2u;
-        const uint32_t originalLength = readUint32LE(corruptedBlob, lengthOffset);
+        const uint32_t originalLength = ReadUint32LE(corruptedBlob, lengthOffset);
         if (lengthOffset + sizeof(uint32_t) + static_cast<size_t>(originalLength) > chunkEnd) {
             continue;
         }
@@ -137,7 +146,7 @@ TEST_F(utAssbinImportExport, rejectOversizedNodeNameLengthInAssbin) {
 
     // Corrupt aiString length to exceed AI_MAXLEN to simulate malformed input.
     const size_t stringLengthOffset = nodeChunkOffset + sizeof(uint32_t) * 2u;
-    writeUint32LE(corruptedBlob, stringLengthOffset, static_cast<uint32_t>(AI_MAXLEN));
+    WriteUint32LE(corruptedBlob, stringLengthOffset, static_cast<uint32_t>(AI_MAXLEN));
 
     Importer corruptedImporter;
     const aiScene *corruptedScene = corruptedImporter.ReadFileFromMemory(corruptedBlob.data(), corruptedBlob.size(), 0, "assbin");
@@ -148,27 +157,17 @@ TEST_F(utAssbinImportExport, rejectOversizedNodeNameLengthInAssbin) {
 }
 
 TEST_F(utAssbinImportExport, rejectOversizedMaterialPropertyCountInAssbin) {
-    Importer importer;
-    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/OBJ/spider.obj", aiProcess_ValidateDataStructure);
-    ASSERT_NE(nullptr, scene);
-
-    Exporter exporter;
-    const aiExportDataBlob *blob = exporter.ExportToBlob(scene, "assbin");
-    ASSERT_NE(nullptr, blob);
-    ASSERT_NE(nullptr, blob->data);
-    ASSERT_GT(blob->size, 0u);
-
-    const auto *blobBytes = static_cast<const uint8_t *>(blob->data);
-    std::vector<uint8_t> corruptedBlob(blobBytes, blobBytes + blob->size);
+    std::vector<uint8_t> corruptedBlob = ExportSpiderToAssbinBytes();
+    ASSERT_GT(corruptedBlob.size(), static_cast<size_t>(ASSBIN_HEADER_LENGTH));
 
     // Locate a material chunk that is directly followed by its first property chunk.
     size_t materialChunkOffset = corruptedBlob.size();
     for (size_t offset = ASSBIN_HEADER_LENGTH; offset + sizeof(uint32_t) * 4u <= corruptedBlob.size(); ++offset) {
-        if (readUint32LE(corruptedBlob, offset) != static_cast<uint32_t>(ASSBIN_CHUNK_AIMATERIAL)) {
+        if (ReadUint32LE(corruptedBlob, offset) != static_cast<uint32_t>(ASSBIN_CHUNK_AIMATERIAL)) {
             continue;
         }
 
-        if (readUint32LE(corruptedBlob, offset + sizeof(uint32_t) * 3u) != static_cast<uint32_t>(ASSBIN_CHUNK_AIMATERIALPROPERTY)) {
+        if (ReadUint32LE(corruptedBlob, offset + sizeof(uint32_t) * 3u) != static_cast<uint32_t>(ASSBIN_CHUNK_AIMATERIALPROPERTY)) {
             continue;
         }
 
@@ -180,8 +179,8 @@ TEST_F(utAssbinImportExport, rejectOversizedMaterialPropertyCountInAssbin) {
 
     // Announce more properties than the file provides and break the first property
     // chunk, so the reader gives up before it has filled a single array slot.
-    writeUint32LE(corruptedBlob, materialChunkOffset + sizeof(uint32_t) * 2u, 64u);
-    writeUint32LE(corruptedBlob, materialChunkOffset + sizeof(uint32_t) * 3u, 0u);
+    WriteUint32LE(corruptedBlob, materialChunkOffset + sizeof(uint32_t) * 2u, 64u);
+    WriteUint32LE(corruptedBlob, materialChunkOffset + sizeof(uint32_t) * 3u, 0u);
 
     Importer corruptedImporter;
     const aiScene *corruptedScene = corruptedImporter.ReadFileFromMemory(corruptedBlob.data(), corruptedBlob.size(), 0, "assbin");


### PR DESCRIPTION
ReadBinaryMesh, ReadBinaryMaterial and ReadBinaryAnim read an element count out of the .assbin file, store it into mNumBones/mNumProperties/mNumChannels, and only then allocate the pointer array and fill it entry by entry. The per-entry readers throw on a bad chunk magic or on EOF, so a file that announces 64 entries and supplies none leaves the array uninitialized while the count already claims 64; unwinding destroys the half-built scene and ~aiMesh, aiMaterial::Clear and ~aiAnimation each walk the count and delete every slot, so operator delete runs on uninitialized heap bytes. Under ASAN a crafted file crashes in each of the three destructors with 0xbebebebebebebebe in the register holding the freed pointer.

ReadBinaryScene already memsets all six of its own pointer arrays for this reason and ReadBinaryNode bumps mNumChildren only after each child is read, so this just applies the existing idiom to the three nested arrays that were missed. Worth checking the fourth case, node->mChildren at line 262, which I left alone because its count is incremented per successful read and is never ahead of the array contents.

The regression test corrupts an exported blob in memory the same way the neighbouring rejectOversizedNodeNameLengthInAssbin test does; it segfaults in ~aiMaterial without the patch. Full unit suite is 602/602 both under ASAN and in a -Werror release build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when loading binary assets by initializing allocated data before use.
  * Strengthened handling of malformed binary files, including invalid size and count values.

* **Tests**
  * Added and refactored unit coverage for corrupted binary data to confirm imports fail safely with clear error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->