### PR TITLE
Fix DXF polyline handling to respect vertex chain.

### DIFF
--- a/code/AssetLib/DXF/DXFLoader.cpp
+++ b/code/AssetLib/DXF/DXFLoader.cpp
@@ -900,10 +900,7 @@ void DXFImporter::ParsePolyLine(DXF::LineReader& reader, DXF::FileData& output) 
     }
     else if (!line.indices.size() && !line.counts.size()) {
         // a poly-line - so there are no indices yet.
-        // a polyline is a connected chain of segments, so segment i joins
-        // vertex i to vertex i+1. Emitting disjoint pairs (0,1), (2,3), ...
-        // instead drops every other segment and loses the final vertex when
-        // the vertex count is odd.
+        // a polyline is a connected chain of segments, so segment i joins vertex i to vertex i+1.
         size_t guess = line.positions.size() + (line.flags & DXF_POLYLINE_FLAG_CLOSED ? 1 : 0);
         line.indices.reserve(guess*2);
 

--- a/code/AssetLib/DXF/DXFLoader.cpp
+++ b/code/AssetLib/DXF/DXFLoader.cpp
@@ -900,13 +900,17 @@ void DXFImporter::ParsePolyLine(DXF::LineReader& reader, DXF::FileData& output) 
     }
     else if (!line.indices.size() && !line.counts.size()) {
         // a poly-line - so there are no indices yet.
+        // a polyline is a connected chain of segments, so segment i joins
+        // vertex i to vertex i+1. Emitting disjoint pairs (0,1), (2,3), ...
+        // instead drops every other segment and loses the final vertex when
+        // the vertex count is odd.
         size_t guess = line.positions.size() + (line.flags & DXF_POLYLINE_FLAG_CLOSED ? 1 : 0);
-        line.indices.reserve(guess);
+        line.indices.reserve(guess*2);
 
-        line.counts.reserve(guess/2);
-        for (unsigned int i = 0; i < line.positions.size()/2; ++i) {
-            line.indices.push_back(i*2);
-            line.indices.push_back(i*2+1);
+        line.counts.reserve(guess);
+        for (unsigned int i = 0; i + 1 < line.positions.size(); ++i) {
+            line.indices.push_back(i);
+            line.indices.push_back(i+1);
             line.counts.push_back(2);
         }
 


### PR DESCRIPTION
This PR fixes DXF polylines to emit lines while respecting chained vertexes. Previously it would emit disjoint pairs (0,1), (2,3), ..., which drops every second segment and loses the final vertex when the vertex count is odd.

This could be a contributor to #3286.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DXF polyline importing by correctly connecting consecutive vertices into continuous line segments.
  * Updated handling of closed polylines to preserve the connection between the final and first vertices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->