### PR TITLE
Fix closed quad triangles so only a valid triangle is emitted

### DIFF
--- a/code/AssetLib/DXF/DXFLoader.cpp
+++ b/code/AssetLib/DXF/DXFLoader.cpp
@@ -993,6 +993,14 @@ void DXFImporter::ParsePolyLineVertex(DXF::LineReader& reader, DXF::PolyLine& li
     if (line.flags & DXF_POLYLINE_FLAG_POLYFACEMESH && !(flags & DXF_VERTEX_FLAG_PART_OF_POLYFACE)) {
         ASSIMP_LOG_WARN("DXF: expected vertex to be part of a polyface but the 0x128 flag isn't set");
     }
+    
+    // A triangular polyface is commonly written as a closed quad, repeating either
+    // the first corner (a,b,c,a) or the last one (a,b,c,c) in group code 74. Left
+    // as a 4-corner face it triangulates into the real triangle plus a zero-area
+    // sliver, so collapse it back to a single triangle here.
+    while (cnti > 3 && (indices[cnti-1] == indices[0] || indices[cnti-1] == indices[cnti-2])) {
+        --cnti;
+    }
 
     if (cnti) {
         line.counts.push_back(cnti);


### PR DESCRIPTION
This PR detects DXF triangles that have been written as closed quads and changes the behavior so that only 1 valid triangle is emitted instead of 1 valid and 1 degenerate sliver. Removing the degenerate triangle also reduces the output triangle count by 50%.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DXF polyface mesh importing for triangular faces incorrectly stored as closed quadrilaterals.
  * Prevented creation of extra zero-area triangle slivers in affected models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->