### PR TITLE
Fix out-of-bounds access on degenerate glTF2 primitives

### DIFF
--- a/code/AssetLib/glTF2/glTF2Importer.cpp
+++ b/code/AssetLib/glTF2/glTF2Importer.cpp
@@ -747,6 +747,10 @@ void glTF2Importer::ImportMeshes(glTF2::Asset &r) {
 
                 case PrimitiveMode_LINE_LOOP:
                 case PrimitiveMode_LINE_STRIP: {
+                    if (count < 2) {
+                        ASSIMP_LOG_WARN("The number of indices was not compatible with the LINE_LOOP/LINE_STRIP mode. The primitive was dropped.");
+                        break;
+                    }
                     nFaces = count - ((prim.mode == PrimitiveMode_LINE_STRIP) ? 1 : 0);
                     facePtr = faces = new aiFace[nFaces];
                     SetFaceAndAdvance2(facePtr, aim->mNumVertices, indexBuffer[0], indexBuffer[1]);
@@ -754,7 +758,9 @@ void glTF2Importer::ImportMeshes(glTF2::Asset &r) {
                         SetFaceAndAdvance2(facePtr, aim->mNumVertices, indexBuffer[i - 1], indexBuffer[i]);
                     }
                     if (prim.mode == PrimitiveMode_LINE_LOOP) { // close the loop
-                        SetFaceAndAdvance2(facePtr, aim->mNumVertices, indexBuffer[static_cast<int>(count) - 1], faces[0].mIndices[0]);
+                        // Use the first index directly: the first face is dropped when its
+                        // indices are out of range, which would leave faces[0].mIndices null.
+                        SetFaceAndAdvance2(facePtr, aim->mNumVertices, indexBuffer[count - 1], indexBuffer[0]);
                     }
                     break;
                 }
@@ -775,6 +781,10 @@ void glTF2Importer::ImportMeshes(glTF2::Asset &r) {
                     break;
                 }
                 case PrimitiveMode_TRIANGLE_STRIP: {
+                    if (count < 3) {
+                        ASSIMP_LOG_WARN("The number of indices was not compatible with the TRIANGLE_STRIP mode. The primitive was dropped.");
+                        break;
+                    }
                     nFaces = count - 2;
                     facePtr = faces = new aiFace[nFaces];
                     for (unsigned int i = 0; i < nFaces; ++i) {
@@ -790,6 +800,10 @@ void glTF2Importer::ImportMeshes(glTF2::Asset &r) {
                     break;
                 }
                 case PrimitiveMode_TRIANGLE_FAN:
+                    if (count < 3) {
+                        ASSIMP_LOG_WARN("The number of indices was not compatible with the TRIANGLE_FAN mode. The primitive was dropped.");
+                        break;
+                    }
                     nFaces = count - 2;
                     facePtr = faces = new aiFace[nFaces];
                     SetFaceAndAdvance3(facePtr, aim->mNumVertices, indexBuffer[0], indexBuffer[1], indexBuffer[2]);
@@ -828,6 +842,10 @@ void glTF2Importer::ImportMeshes(glTF2::Asset &r) {
 
                 case PrimitiveMode_LINE_LOOP:
                 case PrimitiveMode_LINE_STRIP: {
+                    if (count < 2) {
+                        ASSIMP_LOG_WARN("The number of vertices was not compatible with the LINE_LOOP/LINE_STRIP mode. The primitive was dropped.");
+                        break;
+                    }
                     nFaces = count - ((prim.mode == PrimitiveMode_LINE_STRIP) ? 1 : 0);
                     facePtr = faces = new aiFace[nFaces];
                     SetFaceAndAdvance2(facePtr, aim->mNumVertices, 0, 1);
@@ -853,6 +871,10 @@ void glTF2Importer::ImportMeshes(glTF2::Asset &r) {
                     break;
                 }
                 case PrimitiveMode_TRIANGLE_STRIP: {
+                    if (count < 3) {
+                        ASSIMP_LOG_WARN("The number of vertices was not compatible with the TRIANGLE_STRIP mode. The primitive was dropped.");
+                        break;
+                    }
                     nFaces = count - 2;
                     facePtr = faces = new aiFace[nFaces];
                     for (unsigned int i = 0; i < nFaces; ++i) {
@@ -868,6 +890,10 @@ void glTF2Importer::ImportMeshes(glTF2::Asset &r) {
                     break;
                 }
                 case PrimitiveMode_TRIANGLE_FAN:
+                    if (count < 3) {
+                        ASSIMP_LOG_WARN("The number of vertices was not compatible with the TRIANGLE_FAN mode. The primitive was dropped.");
+                        break;
+                    }
                     nFaces = count - 2;
                     facePtr = faces = new aiFace[nFaces];
                     SetFaceAndAdvance3(facePtr, aim->mNumVertices, 0, 1, 2);

--- a/test/models/glTF2/DegeneratePrimitives/LineLoopFirstIndexOutOfRange.gltf
+++ b/test/models/glTF2/DegeneratePrimitives/LineLoopFirstIndexOutOfRange.gltf
@@ -1,0 +1,85 @@
+{
+    "asset": {
+        "version": "2.0",
+        "generator": "handwritten regression fixture"
+    },
+    "scene": 0,
+    "scenes": [
+        {
+            "nodes": [
+                0
+            ]
+        }
+    ],
+    "nodes": [
+        {
+            "mesh": 0
+        }
+    ],
+    "meshes": [
+        {
+            "name": "LineLoopBadFirstIndex",
+            "primitives": [
+                {
+                    "attributes": {
+                        "POSITION": 0
+                    },
+                    "indices": 1,
+                    "mode": 2
+                }
+            ]
+        }
+    ],
+    "accessors": [
+        {
+            "bufferView": 0,
+            "byteOffset": 0,
+            "componentType": 5126,
+            "count": 3,
+            "type": "VEC3",
+            "min": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "max": [
+                1.0,
+                1.0,
+                0.0
+            ]
+        },
+        {
+            "bufferView": 1,
+            "byteOffset": 0,
+            "componentType": 5123,
+            "count": 2,
+            "type": "SCALAR",
+            "min": [
+                1
+            ],
+            "max": [
+                99
+            ]
+        }
+    ],
+    "bufferViews": [
+        {
+            "buffer": 0,
+            "byteOffset": 0,
+            "byteLength": 36,
+            "target": 34962
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 36,
+            "byteLength": 4,
+            "target": 34963
+        }
+    ],
+    "buffers": [
+        {
+            "byteLength": 40,
+            "uri": "data:application/octet-stream;base64,AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAYwABAA=="
+        }
+    ]
+}

--- a/test/models/glTF2/DegeneratePrimitives/LineLoopOneIndex.gltf
+++ b/test/models/glTF2/DegeneratePrimitives/LineLoopOneIndex.gltf
@@ -1,0 +1,85 @@
+{
+    "asset": {
+        "version": "2.0",
+        "generator": "handwritten regression fixture"
+    },
+    "scene": 0,
+    "scenes": [
+        {
+            "nodes": [
+                0
+            ]
+        }
+    ],
+    "nodes": [
+        {
+            "mesh": 0
+        }
+    ],
+    "meshes": [
+        {
+            "name": "LineLoop",
+            "primitives": [
+                {
+                    "attributes": {
+                        "POSITION": 0
+                    },
+                    "indices": 1,
+                    "mode": 2
+                }
+            ]
+        }
+    ],
+    "accessors": [
+        {
+            "bufferView": 0,
+            "byteOffset": 0,
+            "componentType": 5126,
+            "count": 3,
+            "type": "VEC3",
+            "min": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "max": [
+                1.0,
+                1.0,
+                0.0
+            ]
+        },
+        {
+            "bufferView": 1,
+            "byteOffset": 0,
+            "componentType": 5123,
+            "count": 1,
+            "type": "SCALAR",
+            "min": [
+                0
+            ],
+            "max": [
+                0
+            ]
+        }
+    ],
+    "bufferViews": [
+        {
+            "buffer": 0,
+            "byteOffset": 0,
+            "byteLength": 36,
+            "target": 34962
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 36,
+            "byteLength": 2,
+            "target": 34963
+        }
+    ],
+    "buffers": [
+        {
+            "byteLength": 40,
+            "uri": "data:application/octet-stream;base64,AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAA=="
+        }
+    ]
+}

--- a/test/models/glTF2/DegeneratePrimitives/LineStripOneIndex.gltf
+++ b/test/models/glTF2/DegeneratePrimitives/LineStripOneIndex.gltf
@@ -1,0 +1,85 @@
+{
+    "asset": {
+        "version": "2.0",
+        "generator": "handwritten regression fixture"
+    },
+    "scene": 0,
+    "scenes": [
+        {
+            "nodes": [
+                0
+            ]
+        }
+    ],
+    "nodes": [
+        {
+            "mesh": 0
+        }
+    ],
+    "meshes": [
+        {
+            "name": "LineStrip",
+            "primitives": [
+                {
+                    "attributes": {
+                        "POSITION": 0
+                    },
+                    "indices": 1,
+                    "mode": 3
+                }
+            ]
+        }
+    ],
+    "accessors": [
+        {
+            "bufferView": 0,
+            "byteOffset": 0,
+            "componentType": 5126,
+            "count": 3,
+            "type": "VEC3",
+            "min": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "max": [
+                1.0,
+                1.0,
+                0.0
+            ]
+        },
+        {
+            "bufferView": 1,
+            "byteOffset": 0,
+            "componentType": 5123,
+            "count": 1,
+            "type": "SCALAR",
+            "min": [
+                0
+            ],
+            "max": [
+                0
+            ]
+        }
+    ],
+    "bufferViews": [
+        {
+            "buffer": 0,
+            "byteOffset": 0,
+            "byteLength": 36,
+            "target": 34962
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 36,
+            "byteLength": 2,
+            "target": 34963
+        }
+    ],
+    "buffers": [
+        {
+            "byteLength": 40,
+            "uri": "data:application/octet-stream;base64,AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAA=="
+        }
+    ]
+}

--- a/test/models/glTF2/DegeneratePrimitives/TriangleFanTwoIndices.gltf
+++ b/test/models/glTF2/DegeneratePrimitives/TriangleFanTwoIndices.gltf
@@ -1,0 +1,85 @@
+{
+    "asset": {
+        "version": "2.0",
+        "generator": "handwritten regression fixture"
+    },
+    "scene": 0,
+    "scenes": [
+        {
+            "nodes": [
+                0
+            ]
+        }
+    ],
+    "nodes": [
+        {
+            "mesh": 0
+        }
+    ],
+    "meshes": [
+        {
+            "name": "TriangleFan",
+            "primitives": [
+                {
+                    "attributes": {
+                        "POSITION": 0
+                    },
+                    "indices": 1,
+                    "mode": 6
+                }
+            ]
+        }
+    ],
+    "accessors": [
+        {
+            "bufferView": 0,
+            "byteOffset": 0,
+            "componentType": 5126,
+            "count": 3,
+            "type": "VEC3",
+            "min": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "max": [
+                1.0,
+                1.0,
+                0.0
+            ]
+        },
+        {
+            "bufferView": 1,
+            "byteOffset": 0,
+            "componentType": 5123,
+            "count": 2,
+            "type": "SCALAR",
+            "min": [
+                0
+            ],
+            "max": [
+                1
+            ]
+        }
+    ],
+    "bufferViews": [
+        {
+            "buffer": 0,
+            "byteOffset": 0,
+            "byteLength": 36,
+            "target": 34962
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 36,
+            "byteLength": 4,
+            "target": 34963
+        }
+    ],
+    "buffers": [
+        {
+            "byteLength": 40,
+            "uri": "data:application/octet-stream;base64,AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAABAA=="
+        }
+    ]
+}

--- a/test/models/glTF2/DegeneratePrimitives/TriangleStripOneIndex.gltf
+++ b/test/models/glTF2/DegeneratePrimitives/TriangleStripOneIndex.gltf
@@ -1,0 +1,85 @@
+{
+    "asset": {
+        "version": "2.0",
+        "generator": "handwritten regression fixture"
+    },
+    "scene": 0,
+    "scenes": [
+        {
+            "nodes": [
+                0
+            ]
+        }
+    ],
+    "nodes": [
+        {
+            "mesh": 0
+        }
+    ],
+    "meshes": [
+        {
+            "name": "TriangleStrip",
+            "primitives": [
+                {
+                    "attributes": {
+                        "POSITION": 0
+                    },
+                    "indices": 1,
+                    "mode": 5
+                }
+            ]
+        }
+    ],
+    "accessors": [
+        {
+            "bufferView": 0,
+            "byteOffset": 0,
+            "componentType": 5126,
+            "count": 3,
+            "type": "VEC3",
+            "min": [
+                0.0,
+                0.0,
+                0.0
+            ],
+            "max": [
+                1.0,
+                1.0,
+                0.0
+            ]
+        },
+        {
+            "bufferView": 1,
+            "byteOffset": 0,
+            "componentType": 5123,
+            "count": 1,
+            "type": "SCALAR",
+            "min": [
+                0
+            ],
+            "max": [
+                0
+            ]
+        }
+    ],
+    "bufferViews": [
+        {
+            "buffer": 0,
+            "byteOffset": 0,
+            "byteLength": 36,
+            "target": 34962
+        },
+        {
+            "buffer": 0,
+            "byteOffset": 36,
+            "byteLength": 2,
+            "target": 34963
+        }
+    ],
+    "buffers": [
+        {
+            "byteLength": 40,
+            "uri": "data:application/octet-stream;base64,AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAA=="
+        }
+    ]
+}

--- a/test/unit/utglTF2ImportExport.cpp
+++ b/test/unit/utglTF2ImportExport.cpp
@@ -866,6 +866,56 @@ TEST_F(utglTF2ImportExport, allIndicesOutOfRange) {
     ASSERT_NE(error.find("Mesh \"Mesh\" has no faces"), std::string::npos);
 }
 
+TEST_F(utglTF2ImportExport, lineLoopWithSingleIndex) {
+    // A LINE_LOOP primitive needs at least two indices. A single index must not
+    // make the importer read past the end of the index buffer.
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/glTF2/DegeneratePrimitives/LineLoopOneIndex.gltf", aiProcess_ValidateDataStructure);
+    ASSERT_EQ(scene, nullptr);
+    const std::string error = importer.GetErrorString();
+    ASSERT_NE(error.find("no faces"), std::string::npos);
+}
+
+TEST_F(utglTF2ImportExport, lineStripWithSingleIndex) {
+    // A LINE_STRIP primitive needs at least two indices. A single index must not
+    // make the importer read past the end of the index buffer.
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/glTF2/DegeneratePrimitives/LineStripOneIndex.gltf", aiProcess_ValidateDataStructure);
+    ASSERT_EQ(scene, nullptr);
+    const std::string error = importer.GetErrorString();
+    ASSERT_NE(error.find("no faces"), std::string::npos);
+}
+
+TEST_F(utglTF2ImportExport, triangleFanWithTwoIndices) {
+    // A TRIANGLE_FAN primitive needs at least three indices. Two indices must not
+    // make the importer read past the end of the index buffer.
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/glTF2/DegeneratePrimitives/TriangleFanTwoIndices.gltf", aiProcess_ValidateDataStructure);
+    ASSERT_EQ(scene, nullptr);
+    const std::string error = importer.GetErrorString();
+    ASSERT_NE(error.find("no faces"), std::string::npos);
+}
+
+TEST_F(utglTF2ImportExport, triangleStripWithSingleIndex) {
+    // A TRIANGLE_STRIP primitive needs at least three indices. A single index must not
+    // make the face count underflow.
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/glTF2/DegeneratePrimitives/TriangleStripOneIndex.gltf", aiProcess_ValidateDataStructure);
+    ASSERT_EQ(scene, nullptr);
+    const std::string error = importer.GetErrorString();
+    ASSERT_NE(error.find("no faces"), std::string::npos);
+}
+
+TEST_F(utglTF2ImportExport, lineLoopWithOutOfRangeFirstIndex) {
+    // The closing segment of a LINE_LOOP must not dereference the first face when that
+    // face was dropped because its indices were out of range.
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/glTF2/DegeneratePrimitives/LineLoopFirstIndexOutOfRange.gltf", aiProcess_ValidateDataStructure);
+    ASSERT_EQ(scene, nullptr);
+    const std::string error = importer.GetErrorString();
+    ASSERT_NE(error.find("no faces"), std::string::npos);
+}
+
 /////////////////////////////////
 // Draco decoding
 


### PR DESCRIPTION
## Motivation

Fixes #6634. `glTF2Importer::ImportMeshes()` derives the face count from the index count (or, for non-indexed primitives, the vertex count) without checking that the count is large enough for the requested primitive mode. Investigating the reported LINE_LOOP case turned up four defects in the same `switch`, in both the indexed and the non-indexed branch:

| Mode | Issue |
|---|---|
| `LINE_LOOP` / `LINE_STRIP` | `indexBuffer[0]` and `indexBuffer[1]` are read unconditionally → a primitive with a single index reads past the end of the buffer (the reported bug) |
| `TRIANGLE_FAN` | `indexBuffer[2]` is read the same way → out-of-bounds read with fewer than three indices |
| `TRIANGLE_STRIP` / `TRIANGLE_FAN` | `count - 2` is computed in unsigned arithmetic → a count below two underflows and requests `new aiFace[SIZE_MAX]` |
| `LINE_LOOP` (closing segment) | reads `faces[0].mIndices[0]`, which is null whenever the first face was dropped because its indices were out of range |

The last one needs no degenerate count at all: a two-index LINE_LOOP whose first index is out of range is enough, because `SetFaceAndAdvance2()` skips such faces and leaves `mIndices` null.

Each case reproduces from a small glTF file. On a debug build with hardened libstdc++ the first three abort in `std::vector::operator[]`, the fourth reports `std::bad_alloc`, and the null-dereference case segfaults:

```
# LINE_LOOP with one index
/usr/include/c++/15/bits/stl_vector.h:1263: ... Assertion '__n < this->size()' failed.

# TRIANGLE_STRIP with one index
Error, T0: std::bad_alloc

# LINE_LOOP whose first index is out of range
Segmentation fault (core dumped)
```

## Implementation

Check the count before deriving `nFaces`: LINE_LOOP/LINE_STRIP need at least two indices, TRIANGLE_STRIP/TRIANGLE_FAN at least three. A primitive that does not meet its minimum is dropped with a warning, which is how an unsupported `prim.mode` is already handled — that path also leaves the mesh without faces rather than throwing. The closing segment of a LINE_LOOP now takes the first index from `indexBuffer` instead of from the first face; the value is identical whenever that face exists, and it is safe when the face was dropped.

Both the indexed and the non-indexed branch get the same guards, since the non-indexed branch underflows `count - 1` / `count - 2` in exactly the same way.

## Impact

- Well-formed files are unaffected: no valid primitive has fewer indices than its mode requires.
- Degenerate primitives now produce a warning and no faces instead of reading out of bounds or requesting a huge allocation. With `aiProcess_ValidateDataStructure` the import then fails cleanly with `Mesh <name> contains no faces`, matching the existing behaviour for meshes whose faces were all dropped.

## Verification

New fixtures under `test/models/glTF2/DegeneratePrimitives/` (small hand-written glTF files with embedded base64 buffers) and five tests in `utglTF2ImportExport`. Each test fails on `master` — with the aborts and the segfault quoted above — and passes with the fix.

```
./build-test/bin/unit --gtest_filter="utglTF2ImportExport.*"   ->  [  PASSED  ] 53 tests
./build-test/bin/unit                                          ->  606 tests from 116 test suites, [  PASSED  ] 606 tests
```

The first commit adds only the fixtures and the failing tests, the second contains the fix, so the failures can be reproduced by building at the first commit.

## AI tool disclosure

Per the [AI Tool Use Policy](https://github.com/assimp/assimp/blob/master/AIToolPolicy.md): prepared with AI assistance. I reviewed and verified every root cause, fixture and fix myself, ran the test suite locally, and can answer questions during review; the commits carry an `Assisted-by:` trailer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved glTF mesh importing for degenerate line and triangle primitives.
  * Invalid primitives with insufficient or out-of-range indices are now rejected safely with clear errors.
  * Improved handling of line-loop closure during import.

* **Tests**
  * Added coverage for malformed line-loop, line-strip, triangle-fan, and triangle-strip data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->