### PR TITLE
Reject MD5 element indices that wrap when the container is grown

### DIFF
--- a/code/AssetLib/MD5/MD5Parser.cpp
+++ b/code/AssetLib/MD5/MD5Parser.cpp
@@ -53,6 +53,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/mesh.h>
 #include <assimp/DefaultLogger.hpp>
 
+#include <limits>
+
 using namespace Assimp;
 using namespace Assimp::MD5;
 
@@ -91,6 +93,20 @@ AI_WONT_RETURN void MD5Parser::ReportError(const char *error, unsigned int line)
     char szBuffer[1024];
     ::ai_snprintf(szBuffer, 1024, "[MD5] Line %u: %s", line, error);
     throw DeadlyImportError(szBuffer);
+}
+
+// ------------------------------------------------------------------------------------------------
+// Grow a container so that a file-supplied index can be used to address it
+template <typename T>
+static void ResizeForIndex(std::vector<T> &container, unsigned int idx, unsigned int line) {
+    // The index is parsed without an overflow check, and idx + 1 wraps around to zero
+    // for the largest one, which would shrink the container instead of growing it.
+    if (idx == std::numeric_limits<unsigned int>::max()) {
+        MD5Parser::ReportError("Index out of range", line);
+    }
+    if (idx >= container.size()) {
+        container.resize(static_cast<size_t>(idx) + 1);
+    }
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -370,8 +386,7 @@ MD5MeshParser::MD5MeshParser(SectionArray &mSections) {
                     AI_MD5_SKIP_SPACES(&sz, elem.end, elem.iLineNumber);
                     const unsigned int idx = ::strtoul10(sz, &sz);
                     AI_MD5_SKIP_SPACES(&sz, elem.end, elem.iLineNumber);
-                    if (idx >= desc.mVertices.size())
-                        desc.mVertices.resize(idx + 1);
+                    ResizeForIndex(desc.mVertices, idx, elem.iLineNumber);
 
                     VertexDesc &vert = desc.mVertices[idx];
                     if ('(' != *sz++)
@@ -393,9 +408,7 @@ MD5MeshParser::MD5MeshParser(SectionArray &mSections) {
                 else if (TokenMatch(sz, "tri", 3)) {
                     AI_MD5_SKIP_SPACES(&sz, elem.end, elem.iLineNumber);
                     const unsigned int idx = strtoul10(sz, &sz);
-                    if (idx >= desc.mFaces.size()) {
-                        desc.mFaces.resize(idx + 1);
-					}
+                    ResizeForIndex(desc.mFaces, idx, elem.iLineNumber);
 
                     aiFace &face = desc.mFaces[idx];
                     if (face.mNumIndices != 3) {
@@ -413,8 +426,7 @@ MD5MeshParser::MD5MeshParser(SectionArray &mSections) {
                     AI_MD5_SKIP_SPACES(&sz, elem.end, elem.iLineNumber);
                     const unsigned int idx = strtoul10(sz, &sz);
                     AI_MD5_SKIP_SPACES(&sz, elem.end, elem.iLineNumber);
-                    if (idx >= desc.mWeights.size())
-                        desc.mWeights.resize(idx + 1);
+                    ResizeForIndex(desc.mWeights, idx, elem.iLineNumber);
 
                     WeightDesc &weight = desc.mWeights[idx];
                     weight.mBone = strtoul10(sz, &sz);

--- a/test/models/MD5/invalid/OverflowingTriangleIndex.md5mesh
+++ b/test/models/MD5/invalid/OverflowingTriangleIndex.md5mesh
@@ -1,0 +1,22 @@
+MD5Version 10
+commandline "crafted regression asset - triangle index overflow"
+
+numJoints 1
+numMeshes 1
+
+joints {
+"origin" -1 ( 0 0 0 ) ( 0 0 0 ) //
+}
+
+mesh {
+shader ""
+
+numverts 1
+vert 0 ( 0 0 ) 0 1
+
+numtris 1
+tri 4294967295 0 0 0
+
+numweights 1
+weight 0 0 1 ( 0 0 0 )
+}

--- a/test/models/MD5/invalid/OverflowingVertexIndex.md5mesh
+++ b/test/models/MD5/invalid/OverflowingVertexIndex.md5mesh
@@ -1,0 +1,22 @@
+MD5Version 10
+commandline "crafted regression asset - vertex index overflow"
+
+numJoints 1
+numMeshes 1
+
+joints {
+"origin" -1 ( 0 0 0 ) ( 0 0 0 ) //
+}
+
+mesh {
+shader ""
+
+numverts 1
+vert 4294967295 ( 0 0 ) 0 1
+
+numtris 1
+tri 0 0 0 0
+
+numweights 1
+weight 0 0 1 ( 0 0 0 )
+}

--- a/test/models/MD5/invalid/OverflowingWeightIndex.md5mesh
+++ b/test/models/MD5/invalid/OverflowingWeightIndex.md5mesh
@@ -1,0 +1,22 @@
+MD5Version 10
+commandline "crafted regression asset - weight index overflow"
+
+numJoints 1
+numMeshes 1
+
+joints {
+"origin" -1 ( 0 0 0 ) ( 0 0 0 ) //
+}
+
+mesh {
+shader ""
+
+numverts 1
+vert 0 ( 0 0 ) 0 1
+
+numtris 1
+tri 0 0 0 0
+
+numweights 1
+weight 4294967295 0 1 ( 0 0 0 )
+}

--- a/test/unit/ImportExport/utMD5Importer.cpp
+++ b/test/unit/ImportExport/utMD5Importer.cpp
@@ -68,6 +68,28 @@ TEST(utMD5Importer, importInvalidBoneIndex) {
     ASSERT_EQ(nullptr, scene);
 }
 
+TEST(utMD5Importer, importOverflowingVertexIndex) {
+    // Regression test: a vertex index of 0xffffffff makes idx + 1 wrap to zero, so the
+    // vertex array is resized to nothing and then indexed with the original value.
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/MD5/invalid/OverflowingVertexIndex.md5mesh", aiProcess_ValidateDataStructure);
+    ASSERT_EQ(nullptr, scene);
+}
+
+TEST(utMD5Importer, importOverflowingTriangleIndex) {
+    // Same wraparound through the triangle index.
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/MD5/invalid/OverflowingTriangleIndex.md5mesh", aiProcess_ValidateDataStructure);
+    ASSERT_EQ(nullptr, scene);
+}
+
+TEST(utMD5Importer, importOverflowingWeightIndex) {
+    // Same wraparound through the weight index.
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/MD5/invalid/OverflowingWeightIndex.md5mesh", aiProcess_ValidateDataStructure);
+    ASSERT_EQ(nullptr, scene);
+}
+
 TEST(utMD5Importer, importInvalidCameraCut) {
     // Regression test: a crafted .md5camera whose cut list references a frame
     // index past the parsed frame array used to read out of bounds while


### PR DESCRIPTION
## Motivation

Fixes #6710. The MD5 mesh parser grows its containers with the index the file supplies:

```cpp
const unsigned int idx = ::strtoul10(sz, &sz);
if (idx >= desc.mVertices.size())
    desc.mVertices.resize(idx + 1);

VertexDesc &vert = desc.mVertices[idx];
```

`strtoul10()` has no overflow check, so `4294967295` parses to `0xffffffff`. `idx + 1` then wraps to `0`, `resize(0)` empties the container instead of growing it, and the next line addresses it with the original index — an out-of-bounds read and write.

The same pattern exists three times, for `vert`, `tri` and `weight`:

```
code/AssetLib/MD5/MD5Parser.cpp:374   desc.mVertices.resize(idx + 1);
code/AssetLib/MD5/MD5Parser.cpp:397   desc.mFaces.resize(idx + 1);
code/AssetLib/MD5/MD5Parser.cpp:417   desc.mWeights.resize(idx + 1);
```

All three reproduce from a ~20 line `.md5mesh`. On a debug build with hardened libstdc++ each aborts in `std::vector::operator[]`:

```
... [with _Tp = Assimp::MD5::VertexDesc ...]: Assertion '__n < this->size()' failed.
... [with _Tp = aiFace ...]:                  Assertion '__n < this->size()' failed.
... [with _Tp = Assimp::MD5::WeightDesc ...]: Assertion '__n < this->size()' failed.
```

## Implementation

Move the three sites onto a small helper that rejects the index that cannot be grown past and does the arithmetic in `size_t`:

```cpp
template <typename T>
static void ResizeForIndex(std::vector<T> &container, unsigned int idx, unsigned int line) {
    if (idx == std::numeric_limits<unsigned int>::max()) {
        MD5Parser::ReportError("Index out of range", line);
    }
    if (idx >= container.size()) {
        container.resize(static_cast<size_t>(idx) + 1);
    }
}
```

Only the wrapping value is rejected; every other index keeps the existing tolerant behaviour of growing the container, so files that declare their counts late or list elements out of order still load. Large-but-representable indices continue to fail the way they do today, through a failed allocation that the importer reports as an import error.

The error goes through `MD5Parser::ReportError`, so it carries the line number like the other parser diagnostics: `[MD5] Line 7: Index out of range`.

## Impact

- Valid files are unaffected: `SimpleCube.md5mesh`, `BoarMan.md5mesh` and `Bob.md5mesh` still import.
- A crafted index now fails the import cleanly instead of accessing the container out of bounds.

## Verification

Three fixtures under `test/models/MD5/invalid/` and three tests in `utMD5Importer`, following the existing `InvalidBoneIndex.md5mesh` convention in that directory. Each test aborts on `master` with the assertion quoted above and passes with the fix.

```
./build-test/bin/unit --gtest_filter="utMD5Importer.*"  ->  [  PASSED  ] 9 tests
./build-test/bin/unit                                    ->  604 tests from 116 test suites, [  PASSED  ] 604 tests
```

The first commit adds only the fixtures and tests, the second the fix.

## AI tool disclosure

Per the [AI Tool Use Policy](https://github.com/assimp/assimp/blob/master/AIToolPolicy.md): prepared with AI assistance. I reviewed and verified the root cause, the fixtures and the fix myself, ran the suite locally, and can answer questions during review; the commits carry an `Assisted-by:` trailer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when importing MD5 meshes with invalid or overflowing vertex, triangle, and weight indices.
  * Invalid mesh files are now rejected safely instead of risking incorrect processing.

* **Tests**
  * Added regression coverage for overflowing indices across vertices, triangles, and weights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->