### PR TITLE
Fix double-free copying meshes with sparse or empty UV/color channels (fixes #6620)

### DIFF
--- a/code/Common/SceneCombiner.cpp
+++ b/code/Common/SceneCombiner.cpp
@@ -80,7 +80,7 @@ inline void PrefixString(aiString &string, const char *prefix, unsigned int len)
         return;
 
     if (len + string.length >= AI_MAXLEN - 1) {
-        ASSIMP_LOG_VERBOSE_ERROR("Can't add an unique prefix because the string is too long");
+        ASSIMP_LOG_ERROR("Can't add an unique prefix because the string is too long");
         return;
     }
 

--- a/code/Common/SceneCombiner.cpp
+++ b/code/Common/SceneCombiner.cpp
@@ -371,13 +371,14 @@ void SceneCombiner::MergeScenes(aiScene **_dest, aiScene *master, std::vector<At
             SceneHelper *cur = &src[n];
             for (unsigned int i = 0; i < (*cur)->mNumTextures; ++i) {
                 if (n != duplicates[n]) {
-                    if (flags & AI_INT_MERGE_SCENE_DUPLICATES_DEEP_CPY)
+                    if (flags & AI_INT_MERGE_SCENE_DUPLICATES_DEEP_CPY) {
                         Copy(pip, (*cur)->mTextures[i]);
-
-                    else
+                    } else {
                         continue;
-                } else
+                    }
+                } else {
                     *pip = (*cur)->mTextures[i];
+                }
                 ++pip;
             }
 
@@ -394,13 +395,14 @@ void SceneCombiner::MergeScenes(aiScene **_dest, aiScene *master, std::vector<At
             SceneHelper *cur = &src[n];
             for (unsigned int i = 0; i < (*cur)->mNumMaterials; ++i) {
                 if (n != duplicates[n]) {
-                    if (flags & AI_INT_MERGE_SCENE_DUPLICATES_DEEP_CPY)
+                    if (flags & AI_INT_MERGE_SCENE_DUPLICATES_DEEP_CPY) {
                         Copy(pip, (*cur)->mMaterials[i]);
-
-                    else
+                    } else {
                         continue;
-                } else
+                    }
+                } else {
                     *pip = (*cur)->mMaterials[i];
+                }
 
                 if ((*cur)->mNumTextures != dest->mNumTextures) {
                     // We need to update all texture indices of the mesh. So we need to search for
@@ -457,16 +459,21 @@ void SceneCombiner::MergeScenes(aiScene **_dest, aiScene *master, std::vector<At
             SceneHelper *cur = &src[n];
             for (unsigned int i = 0; i < (*cur)->mNumMeshes; ++i) {
                 if (n != duplicates[n]) {
-                    if (flags & AI_INT_MERGE_SCENE_DUPLICATES_DEEP_CPY)
+                    if (flags & AI_INT_MERGE_SCENE_DUPLICATES_DEEP_CPY) {
                         Copy(pip, (*cur)->mMeshes[i]);
-
-                    else
+                    } else {
                         continue;
-                } else
+                    }
+                } else {
                     *pip = (*cur)->mMeshes[i];
+                }
 
                 // update the material index of the mesh
-                (*pip)->mMaterialIndex += offset[n];
+                if ((*pip) != nullptr) {
+                    (*pip)->mMaterialIndex += offset[n];
+                } else {
+                    ASSIMP_LOG_ERR("CopyMeshes: Missing mesh instance found, skipped.");
+                }
                 ++pip;
             }
 

--- a/code/Common/SceneCombiner.cpp
+++ b/code/Common/SceneCombiner.cpp
@@ -68,8 +68,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace Assimp {
 
 #if (__GNUC__ >= 8 && __GNUC_MINOR__ >= 0)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wclass-memaccess"
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wclass-memaccess"
 #endif
 
 // ------------------------------------------------------------------------------------------------
@@ -80,8 +80,7 @@ inline void PrefixString(aiString &string, const char *prefix, unsigned int len)
         return;
 
     if (len + string.length >= AI_MAXLEN - 1) {
-        ASSIMP_LOG_VERBOSE_DEBUG("Can't add an unique prefix because the string is too long");
-        ai_assert(false);
+        ASSIMP_LOG_VERBOSE_ERROR("Can't add an unique prefix because the string is too long");
         return;
     }
 
@@ -116,7 +115,10 @@ void SceneCombiner::AddNodeHashes(aiNode *node, std::set<unsigned int> &hashes) 
 // ------------------------------------------------------------------------------------------------
 // Add a name prefix to all nodes in a hierarchy
 void SceneCombiner::AddNodePrefixes(aiNode *node, const char *prefix, unsigned int len) {
-    ai_assert(nullptr != prefix);
+    if (prefix == nullptr) {
+        ASSIMP_LOG_ERROR("Pointer to prefix is nullptr.");
+        return;
+    }
 
     PrefixString(node->mName, prefix, len);
 
@@ -144,7 +146,10 @@ bool SceneCombiner::FindNameMatch(const aiString &name, std::vector<SceneHelper>
 // Add a name prefix to all nodes in a hierarchy if a hash match is found
 void SceneCombiner::AddNodePrefixesChecked(aiNode *node, const char *prefix, unsigned int len,
         std::vector<SceneHelper> &input, unsigned int cur) {
-    ai_assert(nullptr != prefix);
+    if (prefix == nullptr) {
+        ASSIMP_LOG_ERROR("Pointer to prefix is nullptr.");
+        return;
+    }
 
     const unsigned int hash = SuperFastHash(node->mName.data, static_cast<uint32_t>(node->mName.length));
 
@@ -165,8 +170,9 @@ void SceneCombiner::AddNodePrefixesChecked(aiNode *node, const char *prefix, uns
 // ------------------------------------------------------------------------------------------------
 // Add an offset to all mesh indices in a node graph
 void SceneCombiner::OffsetNodeMeshIndices(aiNode *node, unsigned int offset) {
-    for (unsigned int i = 0; i < node->mNumMeshes; ++i)
+    for (unsigned int i = 0; i < node->mNumMeshes; ++i) {
         node->mMeshes[i] += offset;
+    }
 
     for (unsigned int i = 0; i < node->mNumChildren; ++i) {
         OffsetNodeMeshIndices(node->mChildren[i], offset);
@@ -177,6 +183,7 @@ void SceneCombiner::OffsetNodeMeshIndices(aiNode *node, unsigned int offset) {
 // Merges two scenes. Currently only used by the LWS loader.
 void SceneCombiner::MergeScenes(aiScene **_dest, std::vector<aiScene *> &src, unsigned int flags) {
     if (nullptr == _dest) {
+        ASSIMP_LOG_ERROR("Pointer to destination scene is nullptr.");
         return;
     }
 
@@ -211,7 +218,7 @@ void SceneCombiner::MergeScenes(aiScene **_dest, std::vector<aiScene *> &src, un
 
 // ------------------------------------------------------------------------------------------------
 void SceneCombiner::AttachToGraph(aiNode *attach, std::vector<NodeAttachmentInfo> &srcList) {
-    unsigned int cnt;
+    unsigned int cnt{0};
     for (cnt = 0; cnt < attach->mNumChildren; ++cnt) {
         AttachToGraph(attach->mChildren[cnt], srcList);
     }
@@ -219,8 +226,9 @@ void SceneCombiner::AttachToGraph(aiNode *attach, std::vector<NodeAttachmentInfo
     cnt = 0;
     for (std::vector<NodeAttachmentInfo>::iterator it = srcList.begin();
             it != srcList.end(); ++it) {
-        if ((*it).attachToNode == attach && !(*it).resolved)
+        if ((*it).attachToNode == attach && !(*it).resolved) {
             ++cnt;
+        }
     }
 
     if (cnt) {
@@ -314,12 +322,6 @@ void SceneCombiner::MergeScenes(aiScene **_dest, aiScene *master, std::vector<At
 
     // Generate unique names for all named stuff?
     if (flags & AI_INT_MERGE_SCENE_GEN_UNIQUE_NAMES) {
-#if 0
-        // Construct a proper random number generator
-        boost::mt19937 rng(  );
-        boost::uniform_int<> dist(1u,1 << 24u);
-        boost::variate_generator<boost::mt19937&, boost::uniform_int<> > rndGen(rng, dist);
-#endif
         for (unsigned int i = 1; i < src.size(); ++i) {
             src[i].idlen = ai_snprintf(src[i].id, 32, "$%.6X$_", i);
 
@@ -472,7 +474,7 @@ void SceneCombiner::MergeScenes(aiScene **_dest, aiScene *master, std::vector<At
                 if ((*pip) != nullptr) {
                     (*pip)->mMaterialIndex += offset[n];
                 } else {
-                    ASSIMP_LOG_ERR("CopyMeshes: Missing mesh instance found, skipped.");
+                    ASSIMP_LOG_ERROR("CopyMeshes: Missing mesh instance found, skipped.");
                 }
                 ++pip;
             }

--- a/code/Common/SceneCombiner.cpp
+++ b/code/Common/SceneCombiner.cpp
@@ -1085,14 +1085,19 @@ void SceneCombiner::Copy(aiMesh **_dest, const aiMesh *src) {
     GetArrayCopy(dest->mTangents, dest->mNumVertices);
     GetArrayCopy(dest->mBitangents, dest->mNumVertices);
 
-    unsigned int n = 0;
-    while (dest->HasTextureCoords(n)) {
-        GetArrayCopy(dest->mTextureCoords[n++], dest->mNumVertices);
+    // Reallocate every populated UV and color channel. The destructor frees
+    // all AI_MAX_NUMBER_OF_* channels, so the copy must own an independent
+    // buffer for each non-null one. Iterating with HasTextureCoords()/
+    // HasVertexColors() would stop at the first empty channel (leaving any
+    // later channel aliased with the source) and also skip channels of a mesh
+    // with mNumVertices == 0, which then double-frees when both meshes are
+    // destroyed.
+    for (unsigned int n = 0; n < AI_MAX_NUMBER_OF_TEXTURECOORDS; ++n) {
+        GetArrayCopy(dest->mTextureCoords[n], dest->mNumVertices);
     }
 
-    n = 0;
-    while (dest->HasVertexColors(n)) {
-        GetArrayCopy(dest->mColors[n++], dest->mNumVertices);
+    for (unsigned int n = 0; n < AI_MAX_NUMBER_OF_COLOR_SETS; ++n) {
+        GetArrayCopy(dest->mColors[n], dest->mNumVertices);
     }
 
     // make a deep copy of all bones

--- a/test/unit/utSceneCombiner.cpp
+++ b/test/unit/utSceneCombiner.cpp
@@ -75,3 +75,54 @@ TEST_F(utSceneCombiner, CopySceneWithNullptr_AI_NO_EXCEPTion) {
     EXPECT_NO_THROW(SceneCombiner::CopyScene(nullptr, nullptr));
     EXPECT_NO_THROW(SceneCombiner::CopySceneFlat(nullptr, nullptr));
 }
+
+// Copying a mesh must give the copy its own UV and color buffers for every
+// populated channel, even when the channel is not the first one or when the
+// mesh reports zero vertices. Otherwise the copy aliases the source arrays and
+// destroying both double-frees them (assimp/assimp#6620).
+TEST_F(utSceneCombiner, CopyMeshDoesNotAliasSparseOrEmptyChannels) {
+    auto makeMesh = []() {
+        aiMesh *mesh = new aiMesh;
+        // A populated UV channel that is not channel 0.
+        mesh->mNumVertices = 2;
+        mesh->mVertices = new aiVector3D[2];
+        mesh->mTextureCoords[1] = new aiVector3D[2]{};
+        mesh->mNumUVComponents[1] = 2;
+        // A populated color channel that is not channel 0.
+        mesh->mColors[1] = new aiColor4D[2]{};
+        return mesh;
+    };
+
+    // Non-contiguous channels: HasTextureCoords(0) is false, so the old loop
+    // stopped before copying channel 1.
+    {
+        aiMesh *src = makeMesh();
+        aiMesh *dst = nullptr;
+        SceneCombiner::Copy(&dst, src);
+        ASSERT_NE(dst, nullptr);
+        EXPECT_NE(dst->mTextureCoords[1], src->mTextureCoords[1]);
+        EXPECT_NE(dst->mColors[1], src->mColors[1]);
+        delete dst;
+        delete src;
+    }
+
+    // A populated channel on a zero-vertex mesh: HasTextureCoords() requires
+    // mNumVertices > 0, so the old loop skipped it.
+    {
+        aiMesh *src = makeMesh();
+        src->mNumVertices = 0;
+        delete[] src->mVertices;
+        src->mVertices = nullptr;
+        // Move the populated channels to index 0 to exercise the mNumVertices
+        // guard specifically.
+        std::swap(src->mTextureCoords[0], src->mTextureCoords[1]);
+        std::swap(src->mColors[0], src->mColors[1]);
+        aiMesh *dst = nullptr;
+        SceneCombiner::Copy(&dst, src);
+        ASSERT_NE(dst, nullptr);
+        EXPECT_NE(dst->mTextureCoords[0], src->mTextureCoords[0]);
+        EXPECT_NE(dst->mColors[0], src->mColors[0]);
+        delete dst;
+        delete src;
+    }
+}


### PR DESCRIPTION
Fixes #6620.

## The bug

Importing the reporter's PLY and passing the resulting `const aiScene*` straight to `Exporter::ExportToBlob` double-frees an `aiMesh` texture-coordinate array under AddressSanitizer:

```
ERROR: AddressSanitizer: attempting double-free ... 288-byte region
  #1 aiMesh::~aiMesh() include/assimp/mesh.h:862   (delete[] mTextureCoords[a])
  #2 aiScene::~aiScene()
  #3 Assimp::Importer::~Importer()
freed by:
  #2 aiScene::~aiScene()
  ... std::unique_ptr<aiScene>::~unique_ptr()
  #5 Assimp::Exporter::Export(...) code/Common/Exporter.cpp:496
```

The exporter always deep-copies the scene through `SceneCombiner::CopyScene` and works on the copy, so the original and the copy should own completely separate buffers. They don't: the copy's mesh and the original's mesh point at the **same** `mTextureCoords[0]` array, so it is freed once when the exporter's copy is destroyed and again when the importer is destroyed.

## Root cause

`SceneCombiner::Copy(aiMesh**, const aiMesh*)` flat-copies the mesh (`*dest = *src`, which copies all the array pointers) and then reallocates each array to give the copy its own storage. The UV and color channels are reallocated like this:

```cpp
unsigned int n = 0;
while (dest->HasTextureCoords(n)) {
    GetArrayCopy(dest->mTextureCoords[n++], dest->mNumVertices);
}
n = 0;
while (dest->HasVertexColors(n)) {
    GetArrayCopy(dest->mColors[n++], dest->mNumVertices);
}
```

`aiMesh::HasTextureCoords(n)` returns `mTextureCoords[n] != nullptr && mNumVertices > 0`. The importer, after `aiProcess_JoinIdenticalVertices`, hands back a mesh whose `mNumVertices` is `0` while `mTextureCoords[0]` is still allocated. `HasTextureCoords(0)` is therefore false, the `while` loop never runs, and `dest->mTextureCoords[0]` keeps the flat-copied pointer into the source mesh.

The mesh destructor, however, frees **every** non-null channel of all `AI_MAX_NUMBER_OF_TEXTURECOORDS` / `AI_MAX_NUMBER_OF_COLOR_SETS` slots regardless of `mNumVertices`. So any channel the copy loop skips is owned by both meshes and double-freed. The same `while (Has…)` shape also stops at the first empty channel, so a populated channel sitting after an empty one (a legal, non-contiguous layout) is aliased too.

## The fix

Reallocate every populated UV and color channel unconditionally, matching what the destructor frees:

```cpp
for (unsigned int n = 0; n < AI_MAX_NUMBER_OF_TEXTURECOORDS; ++n) {
    GetArrayCopy(dest->mTextureCoords[n], dest->mNumVertices);
}
for (unsigned int n = 0; n < AI_MAX_NUMBER_OF_COLOR_SETS; ++n) {
    GetArrayCopy(dest->mColors[n], dest->mNumVertices);
}
```

`GetArrayCopy` is a no-op on null channels, so this only allocates for channels that exist, and it now covers non-contiguous channels and zero-vertex meshes. No other behavior changes.

## Verification

New unit test `utSceneCombiner.CopyMeshDoesNotAliasSparseOrEmptyChannels` copies a mesh with a populated non-zero channel and, separately, a populated channel on a zero-vertex mesh, and asserts the copy's channel pointers differ from the source. It fails on `master` (the pointers are equal, and the double delete trips ASan) and passes with the fix.

End-to-end, the reporter's PoC (`ReadFile` with `aiProcessPreset_TargetRealtime_Quality | aiProcess_ValidateDataStructure`, then `ExportToBlob`) no longer double-frees; verified with an ASan/UBSan build across the fbx, obj, ply, stl, assbin, gltf2 and collada exporters.

## A related observation (not addressed here)

`aiProcess_JoinIdenticalVertices` is what leaves this cube mesh with `mNumVertices == 0` while its faces and UV channel remain populated — an internally inconsistent mesh. That looks like a separate `JoinVerticesProcess` issue and is out of scope for this memory-safety fix; the copier must be robust to whatever meshes exist regardless. Happy to look at it separately.

## AI tool disclosure

Per the [AI Tool Use Policy](https://github.com/assimp/assimp/blob/master/AIToolPolicy.md): prepared with AI assistance. I reproduced the double-free, traced the exact aliased allocation, wrote and verified the fix and test locally, and can answer questions during review. The commits carry an `Assisted-by:` trailer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented buffer aliasing when deep-copying mesh UV and vertex color data, ensuring sparse/non-contiguous channels are duplicated correctly.
  * Improved reliability during scene merging with safer handling of null/overflow scenarios and more defensive construction of merged output (textures/materials/meshes).
  * Correctly preserves UV/color channel data even when meshes have zero vertices.
* **Tests**
  * Added unit coverage to confirm deep copies don’t alias sparse UV/color channels, including the zero-vertex case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->