### PR TITLE
Fix leak in AMF importer

### DIFF
--- a/code/AssetLib/AMF/AMFImporter_Postprocess.cpp
+++ b/code/AssetLib/AMF/AMFImporter_Postprocess.cpp
@@ -812,7 +812,7 @@ nl_clean_loop:
             for (; next_it != nodeArray.end(); ++next_it) {
                 if ((*next_it)->FindNode((*nl_it)->mName) != nullptr) {
                     // if current top node(nl_it) found in another top node then erase it from node_list and restart search loop.
-                    // FIXME: this leaks memory on test models test8.amf and test9.amf
+                    delete *nl_it;
                     nodeArray.erase(nl_it);
 
                     goto nl_clean_loop;

--- a/test/unit/utAMFImportExport.cpp
+++ b/test/unit/utAMFImportExport.cpp
@@ -114,10 +114,6 @@ TEST_F(utAMFImportExport, importTest7) {
 }
 
 
-#if 0
-// FIXME: these tests are disabled because they leak memory in AMFImporter_Postprocess.cpp
-
-
 TEST_F(utAMFImportExport, importTest8) {
     Assimp::Importer importer;
     const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/AMF/test8.amf", aiProcess_ValidateDataStructure);
@@ -130,9 +126,6 @@ TEST_F(utAMFImportExport, importTest9) {
     const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/AMF/test9.amf", aiProcess_ValidateDataStructure);
     ASSERT_NE(nullptr, scene);
 }
-
-
-#endif  // 0
 
 
 TEST_F(utAMFImportExport, importAMFWithMatFromFileTest) {


### PR DESCRIPTION
The `nodeArray` vector holds the pointer allocated previously in the function.
When removing the node, memory must be released.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a memory leak during AMF scene hierarchy cleanup.

* **Tests**
  * Enabled additional AMF import tests to improve coverage and verify import behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->