### PR TITLE
GenBoundingBoxes: fix AABB for meshes with coordinates beyond +/-999999

### DIFF
--- a/code/PostProcessing/GenBoundingBoxesProcess.cpp
+++ b/code/PostProcessing/GenBoundingBoxesProcess.cpp
@@ -46,6 +46,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/postprocess.h>
 #include <assimp/scene.h>
 
+#include <limits>
+
 namespace Assimp {
 
 bool GenBoundingBoxesProcess::IsActive(unsigned int pFlags) const {
@@ -90,11 +92,12 @@ void GenBoundingBoxesProcess::Execute(aiScene* pScene) {
 
     for (unsigned int i = 0; i < pScene->mNumMeshes; ++i) {
         aiMesh* mesh = pScene->mMeshes[i];
-        if (nullptr == mesh) {
+        if (nullptr == mesh || 0 == mesh->mNumVertices) {
             continue;
         }
 
-        aiVector3D min(999999, 999999, 999999), max(-999999, -999999, -999999);
+        constexpr ai_real maxVal = std::numeric_limits<ai_real>::max();
+        aiVector3D min(maxVal, maxVal, maxVal), max(-maxVal, -maxVal, -maxVal);
         checkMesh(mesh, min, max);
         mesh->mAABB.mMin = min;
         mesh->mAABB.mMax = max;

--- a/code/PostProcessing/GenBoundingBoxesProcess.cpp
+++ b/code/PostProcessing/GenBoundingBoxesProcess.cpp
@@ -96,8 +96,8 @@ void GenBoundingBoxesProcess::Execute(aiScene* pScene) {
             continue;
         }
 
-        constexpr ai_real maxVal = std::numeric_limits<ai_real>::max();
-        aiVector3D min(maxVal, maxVal, maxVal), max(-maxVal, -maxVal, -maxVal);
+        constexpr ai_real kMaxVal = std::numeric_limits<ai_real>::max();
+        aiVector3D min(kMaxVal, kMaxVal, kMaxVal), max(-kMaxVal, -kMaxVal, -kMaxVal);
         checkMesh(mesh, min, max);
         mesh->mAABB.mMin = min;
         mesh->mAABB.mMax = max;

--- a/test/unit/utGenBoundingBoxesProcess.cpp
+++ b/test/unit/utGenBoundingBoxesProcess.cpp
@@ -91,3 +91,24 @@ TEST_F(utGenBoundingBoxesProcess, executeTest) {
     EXPECT_EQ(99, mesh->mAABB.mMax.y);
     EXPECT_EQ(99, mesh->mAABB.mMax.z);
 }
+
+TEST_F(utGenBoundingBoxesProcess, executeFarFromOriginTest) {
+    // Coordinates beyond the former +/-999999 sentinel values, e.g. from projected
+    // geographic coordinate systems, must still yield a tight bounding box.
+    const ai_real offset = (ai_real)2600000;
+    for (unsigned int i = 0; i < mMesh->mNumVertices; ++i) {
+        mMesh->mVertices[i] = aiVector3D(offset + (ai_real)i, offset + (ai_real)i, offset + (ai_real)i);
+    }
+
+    mProcess->Execute(mScene);
+
+    aiMesh *mesh = mScene->mMeshes[0];
+    EXPECT_NE(nullptr, mesh);
+    EXPECT_EQ(offset, mesh->mAABB.mMin.x);
+    EXPECT_EQ(offset, mesh->mAABB.mMin.y);
+    EXPECT_EQ(offset, mesh->mAABB.mMin.z);
+
+    EXPECT_EQ(offset + 99, mesh->mAABB.mMax.x);
+    EXPECT_EQ(offset + 99, mesh->mAABB.mMax.y);
+    EXPECT_EQ(offset + 99, mesh->mAABB.mMax.z);
+}

--- a/test/unit/utGenBoundingBoxesProcess.cpp
+++ b/test/unit/utGenBoundingBoxesProcess.cpp
@@ -92,7 +92,7 @@ TEST_F(utGenBoundingBoxesProcess, executeTest) {
     EXPECT_EQ(99, mesh->mAABB.mMax.z);
 }
 
-TEST_F(utGenBoundingBoxesProcess, executeFarFromOriginTest) {
+TEST_F(utGenBoundingBoxesProcess, ExecuteFarFromOriginTest) {
     // Coordinates beyond the former +/-999999 sentinel values, e.g. from projected
     // geographic coordinate systems, must still yield a tight bounding box.
     const ai_real kOffset = (ai_real)2600000;
@@ -113,7 +113,7 @@ TEST_F(utGenBoundingBoxesProcess, executeFarFromOriginTest) {
     EXPECT_EQ(kOffset + 99, mesh->mAABB.mMax.z);
 }
 
-TEST_F(utGenBoundingBoxesProcess, executeEmptyMeshTest) {
+TEST_F(utGenBoundingBoxesProcess, ExecuteEmptyMeshTest) {
     delete[] mMesh->mVertices;
     mMesh->mVertices = nullptr;
     mMesh->mNumVertices = 0;

--- a/test/unit/utGenBoundingBoxesProcess.cpp
+++ b/test/unit/utGenBoundingBoxesProcess.cpp
@@ -95,20 +95,38 @@ TEST_F(utGenBoundingBoxesProcess, executeTest) {
 TEST_F(utGenBoundingBoxesProcess, executeFarFromOriginTest) {
     // Coordinates beyond the former +/-999999 sentinel values, e.g. from projected
     // geographic coordinate systems, must still yield a tight bounding box.
-    const ai_real offset = (ai_real)2600000;
+    const ai_real kOffset = (ai_real)2600000;
     for (unsigned int i = 0; i < mMesh->mNumVertices; ++i) {
-        mMesh->mVertices[i] = aiVector3D(offset + (ai_real)i, offset + (ai_real)i, offset + (ai_real)i);
+        mMesh->mVertices[i] = aiVector3D(kOffset + (ai_real)i, -(kOffset + (ai_real)i), kOffset + (ai_real)i);
     }
 
     mProcess->Execute(mScene);
 
     aiMesh *mesh = mScene->mMeshes[0];
     EXPECT_NE(nullptr, mesh);
-    EXPECT_EQ(offset, mesh->mAABB.mMin.x);
-    EXPECT_EQ(offset, mesh->mAABB.mMin.y);
-    EXPECT_EQ(offset, mesh->mAABB.mMin.z);
+    EXPECT_EQ(kOffset, mesh->mAABB.mMin.x);
+    EXPECT_EQ(-(kOffset + 99), mesh->mAABB.mMin.y);
+    EXPECT_EQ(kOffset, mesh->mAABB.mMin.z);
 
-    EXPECT_EQ(offset + 99, mesh->mAABB.mMax.x);
-    EXPECT_EQ(offset + 99, mesh->mAABB.mMax.y);
-    EXPECT_EQ(offset + 99, mesh->mAABB.mMax.z);
+    EXPECT_EQ(kOffset + 99, mesh->mAABB.mMax.x);
+    EXPECT_EQ(-kOffset, mesh->mAABB.mMax.y);
+    EXPECT_EQ(kOffset + 99, mesh->mAABB.mMax.z);
+}
+
+TEST_F(utGenBoundingBoxesProcess, executeEmptyMeshTest) {
+    delete[] mMesh->mVertices;
+    mMesh->mVertices = nullptr;
+    mMesh->mNumVertices = 0;
+
+    mProcess->Execute(mScene);
+
+    aiMesh *mesh = mScene->mMeshes[0];
+    EXPECT_NE(nullptr, mesh);
+    EXPECT_EQ(0, mesh->mAABB.mMin.x);
+    EXPECT_EQ(0, mesh->mAABB.mMin.y);
+    EXPECT_EQ(0, mesh->mAABB.mMin.z);
+
+    EXPECT_EQ(0, mesh->mAABB.mMax.x);
+    EXPECT_EQ(0, mesh->mAABB.mMax.y);
+    EXPECT_EQ(0, mesh->mAABB.mMax.z);
 }


### PR DESCRIPTION
### Problem

`aiProcess_GenBoundingBoxes` initializes its min/max accumulators with hardcoded `+/-999999` sentinel values:

```cpp
aiVector3D min(999999, 999999, 999999), max(-999999, -999999, -999999);
```

Any mesh containing a coordinate beyond that range gets a wildly wrong AABB, because the corresponding accumulator never moves past the sentinel. This is easy to hit in practice:

- CAD/DXF files in projected geographic coordinate systems (e.g. Swiss LV95, eastings ~2'600'000)
- millimeter-unit files for anything larger than ~1 km

Example: a small polyline at `x ≈ 2'600'000` ends up with `mAABB.mMin.x = 999999` and `mAABB.mMax.x ≈ 2'600'000`, i.e. a bounding box ~1'600'000 units across for a tiny object.

### Fix

- Initialize the accumulators with `std::numeric_limits<ai_real>::max()` / its negation.
- Skip meshes without vertices so their AABB stays at the default zero value instead of being filled with the initialization values.

### Testing

Added `utGenBoundingBoxesProcess.executeFarFromOriginTest`, which places vertices at offsets around 2.6e6 and verifies a tight AABB. It fails against the previous sentinel-based initialization and passes with this change. Existing `executeTest` still passes.

Per the AI tool policy: this change was prepared with assistance from Claude and has been reviewed by me.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bounding-box generation for meshes with vertices located far from the origin.
  * Meshes without vertices are now handled safely without producing invalid bounds.

* **Tests**
  * Added regression coverage to verify accurate minimum and maximum coordinates for distant vertices.
  * Added coverage for empty meshes, confirming their bounds default to zero.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->