### PR TITLE
Fix OFF face count validation

### DIFF
--- a/code/AssetLib/OFF/OFFLoader.cpp
+++ b/code/AssetLib/OFF/OFFLoader.cpp
@@ -195,7 +195,8 @@ void OFFImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
     // Each vertex line holds at least `dimensions` single-character values,
     // each followed by a separator or newline, so any shorter remainder cannot
     // contain the declared vertex count.
-    if (const uint64_t minimumVertexTextBytes = requiredVertices * 2u * dimensions; static_cast<uint64_t>(end - car) < minimumVertexTextBytes) {
+    const uint64_t minimumVertexTextBytes = requiredVertices * 2u * dimensions;  
+    if (static_cast<uint64_t>(end - car) < minimumVertexTextBytes) {
         throw DeadlyImportError("OFF: File size inconsistent with vertex count");
     }
     // Each face line needs at least a face vertex count and one vertex index,

--- a/code/AssetLib/OFF/OFFLoader.cpp
+++ b/code/AssetLib/OFF/OFFLoader.cpp
@@ -195,8 +195,7 @@ void OFFImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
     // Each vertex line holds at least `dimensions` single-character values,
     // each followed by a separator or newline, so any shorter remainder cannot
     // contain the declared vertex count.
-    const uint64_t minimumVertexTextBytes = requiredVertices * 2u * dimensions;
-    if (static_cast<uint64_t>(end - car) < minimumVertexTextBytes) {
+    if (const uint64_t minimumVertexTextBytes = requiredVertices * 2u * dimensions; static_cast<uint64_t>(end - car) < minimumVertexTextBytes) {
         throw DeadlyImportError("OFF: File size inconsistent with vertex count");
     }
     // Each face line needs at least a face vertex count and one vertex index,

--- a/code/AssetLib/OFF/OFFLoader.cpp
+++ b/code/AssetLib/OFF/OFFLoader.cpp
@@ -195,9 +195,16 @@ void OFFImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
     // Each vertex line holds at least `dimensions` single-character values,
     // each followed by a separator or newline, so any shorter remainder cannot
     // contain the declared vertex count.
-    if (const uint64_t minimumVertexTextBytes = requiredVertices * 2u * dimensions;
-            static_cast<uint64_t>(end - car) < minimumVertexTextBytes) {
+    const uint64_t minimumVertexTextBytes = requiredVertices * 2u * dimensions;
+    if (static_cast<uint64_t>(end - car) < minimumVertexTextBytes) {
         throw DeadlyImportError("OFF: File size inconsistent with vertex count");
+    }
+    // Each face line needs at least a face vertex count and one vertex index,
+    // separated by whitespace. Reject impossible declarations before allocating
+    // the face array.
+    if (const uint64_t minimumFaceTextBytes = requiredFaces * 3u;
+            static_cast<uint64_t>(end - car) < minimumVertexTextBytes + minimumFaceTextBytes) {
+        throw DeadlyImportError("OFF: File size inconsistent with face count");
     }
 
     pScene->mNumMeshes = 1;

--- a/test/unit/utOFFSecurity.cpp
+++ b/test/unit/utOFFSecurity.cpp
@@ -61,6 +61,21 @@ TEST(utOFFSecurity, noOOMOnMaliciousCount) {
                 error.find("no valid faces") != std::string::npos);
 }
 
+TEST(utOFFSecurity, rejectsImpossibleFaceCountBeforeAllocation) {
+    Assimp::Importer importer;
+    const char maliciousOFF[] =
+        "OFF\n"
+        "1 1000000 0\n"
+        "0 0 0\n";
+    const aiScene *scene = importer.ReadFileFromMemory(
+            maliciousOFF, sizeof(maliciousOFF) - 1,
+            aiProcess_ValidateDataStructure, "off");
+
+    EXPECT_EQ(scene, nullptr);
+    const std::string error = importer.GetErrorString();
+    EXPECT_TRUE(error.find("face count") != std::string::npos) << error;
+}
+
 // Test valid OFF file still works (regression)
 TEST(utOFFSecurity, validOFFLoadsSuccessfully) {
     Assimp::Importer importer;


### PR DESCRIPTION
Fixes #6750.
Summary:
- add a pre-allocation consistency check for declared OFF face counts
- reject tiny files that declare impossible face counts before allocating the face array
- add a regression test for the malformed face-count case

Duplicate checks before opening:
- no open/closed PR found for "OFF face-count" or "OFF numFaces"
- no open PR found for "OFF face count" or "OFF validation"
- issue #6750 is open, unassigned, and has no comments

Local validation:
- git diff --check
- cmake -S . -B /private/tmp/assimp-off-build -G Ninja -DASSIMP_BUILD_TESTS=ON -DASSIMP_BUILD_ALL_IMPORTERS_BY_DEFAULT=OFF -DASSIMP_BUILD_OFF_IMPORTER=ON -DASSIMP_BUILD_ALL_EXPORTERS_BY_DEFAULT=OFF -DASSIMP_WARNINGS_AS_ERRORS=OFF -DCMAKE_CXX_FLAGS=-isystem\ /Library/Developer/CommandLineTools/SDKs/MacOSX26.5.sdk/usr/include/c++/v1
- cmake --build /private/tmp/assimp-off-build --target unit
- /private/tmp/assimp-off-build/bin/unit --gtest_filter='utOFFSecurity.*:utOFFImportExport.*'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OFF file validation by rejecting files with impossible vertex or face counts before processing.
  * Prevented invalid mesh data from being allocated or loaded as a scene.
  * Added clearer error reporting for malformed face-count data.
  * Strengthened protection against malformed or potentially resource-intensive OFF files.

* **Tests**
  * Added regression coverage for OFF files with invalid face counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->