### PR TITLE
Fix mdl buffer overflow issue 6633

### DIFF
--- a/code/AssetLib/MDL/MDLLoader.cpp
+++ b/code/AssetLib/MDL/MDLLoader.cpp
@@ -1685,8 +1685,10 @@ void MDLImporter::ParseBoneTrafoKeys_3DGS_MDL7(
             // skip all frames vertices. We can't support them
             const MDL::BoneTransform_MDL7 *pcBoneTransforms = (const MDL::BoneTransform_MDL7 *)(((const char *)frame.pcFrame) + pcHeader->frame_stc_size +
                                                                                                 frame.pcFrame->vertices_count * pcHeader->framevertex_stc_size);
-            // Confirm that this frame is within the file.
-            VALIDATE_FILE_SIZE(pcBoneTransforms+sizeof(MDL::BoneTransform_MDL7));
+            // Confirm that the bone transformation matrices are within the file.
+            const size_t boneTransformSpan = sizeof(MDL::BoneTransform_MDL7) +
+                                             static_cast<size_t>(frame.pcFrame->transmatrix_count - 1u) * pcHeader->bonetrans_stc_size;
+            VALIDATE_FILE_SIZE(reinterpret_cast<const char *>(pcBoneTransforms) + boneTransformSpan);
 
             // read all transformation matrices
             for (unsigned int iTrafo = 0; iTrafo < frame.pcFrame->transmatrix_count; ++iTrafo) {

--- a/code/AssetLib/MDL/MDLLoader.cpp
+++ b/code/AssetLib/MDL/MDLLoader.cpp
@@ -1685,6 +1685,8 @@ void MDLImporter::ParseBoneTrafoKeys_3DGS_MDL7(
             // skip all frames vertices. We can't support them
             const MDL::BoneTransform_MDL7 *pcBoneTransforms = (const MDL::BoneTransform_MDL7 *)(((const char *)frame.pcFrame) + pcHeader->frame_stc_size +
                                                                                                 frame.pcFrame->vertices_count * pcHeader->framevertex_stc_size);
+            // Confirm that this frame is within the file.
+            VALIDATE_FILE_SIZE(pcBoneTransforms+sizeof(MDL::BoneTransform_MDL7));
 
             // read all transformation matrices
             for (unsigned int iTrafo = 0; iTrafo < frame.pcFrame->transmatrix_count; ++iTrafo) {


### PR DESCRIPTION
This PR addresses [issue 6633](https://github.com/assimp/assimp/issues/6633). The MDL asset loader did not validate the frame size before accessing data. This PR adds a check using VALIDATE_FILE_SIZE to ensure that the bone transform is within the file to prevent a buffer overflow.

Fixes #6633 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MDL7 model importing by validating bone transformation data before processing animation keys.
  * Prevented invalid or incomplete transformation data from being read.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->