### PR TITLE
Add support for gltf2 KHR_mesh_quantization

### DIFF
--- a/code/AssetLib/glTF2/glTF2Asset.h
+++ b/code/AssetLib/glTF2/glTF2Asset.h
@@ -556,6 +556,7 @@ struct Accessor : public Object {
     std::vector<double> min; //!< Minimum value of each component in this attribute.
     std::unique_ptr<Sparse> sparse;
     std::unique_ptr<Buffer> decodedBuffer; // Packed decoded data, returned instead of original bufferView if present
+    bool normalized = false;
 
     unsigned int GetNumComponents();
     unsigned int GetBytesPerComponent();
@@ -567,6 +568,8 @@ struct Accessor : public Object {
 
     template <class T>
     size_t ExtractData(T *&outData, const std::vector<unsigned int> *remappingIndices = nullptr);
+    template <class TTarget_type, class TScalar>
+    size_t ExtractConvertedData(TTarget_type *&outData, const std::vector<unsigned int> *remappingIndices = nullptr);
 
     void WriteData(size_t count, const void *src_buffer, size_t src_stride);
     void WriteSparseValues(size_t count, const void *src_data, size_t src_dataStride);
@@ -1138,6 +1141,7 @@ public:
         bool FB_ngon_encoding{false};
         bool KHR_texture_basisu{false};
         bool EXT_texture_webp{false};
+        bool KHR_mesh_quantization{false};
 
         Extensions() = default;
         ~Extensions() = default;
@@ -1148,6 +1152,7 @@ public:
         bool KHR_draco_mesh_compression{false};
         bool KHR_texture_basisu{false};
         bool EXT_texture_webp{false};
+        bool KHR_mesh_quantization{false};
 
         RequiredExtensions() = default;
     } extensionsRequired;

--- a/code/AssetLib/glTF2/glTF2Asset.inl
+++ b/code/AssetLib/glTF2/glTF2Asset.inl
@@ -1081,14 +1081,28 @@ inline size_t Accessor::ExtractConvertedData(TTarget_type *&outData, const std::
 
     uint8_t *data = GetPointer();
     if (!data) {
-        // No backing buffer (missing bufferView, unresolved sparse-only accessor,
-        // malformed file, etc). Fail loudly instead of memcpy-ing from garbage.
-        outData = nullptr;
-        return 0;
+        throw DeadlyImportError("GLTF2: data is null when extracting data from ", getContextForErrorMessages(id, name));
     }
 
     unsigned int numComponents = GetNumComponents();
     size_t stride = GetStride();
+
+    // Ensure the accessor components fit within the target type
+    const size_t targetComponents = sizeof(TTarget_type) / sizeof(TScalar);
+    if (numComponents > targetComponents) {
+        throw DeadlyImportError("GLTF: numComponents ", numComponents, " > targetComponents ", targetComponents, " in ", getContextForErrorMessages(id, name));
+    }
+
+    // Validate buffer bounds
+    const size_t elemSize = GetElementSize();
+    const size_t maxSize = GetMaxByteSize();
+    if (elemSize > maxSize) {
+        throw DeadlyImportError("GLTF: elemSize ", elemSize, " > maxSize ", maxSize, " in ", getContextForErrorMessages(id, name));
+    }
+    const size_t maxCount = (maxSize - elemSize) / stride + 1;
+    if (count > maxCount) {
+        throw DeadlyImportError("GLTF: count ", count, " > maxCount ", maxCount, " in ", getContextForErrorMessages(id, name));
+    }
 
     // Allocate and zero-initialize
     outData = new TTarget_type[usedCount]();
@@ -1099,6 +1113,9 @@ inline size_t Accessor::ExtractConvertedData(TTarget_type *&outData, const std::
 
         for (size_t i = 0; i < usedCount; ++i) {
             const size_t srcIdx = remappingIndices ? (*remappingIndices)[i] : i;
+            if (srcIdx >= count) {
+                throw DeadlyImportError("GLTF: index ", srcIdx, " >= count ", count, " in ", getContextForErrorMessages(id, name));
+            }
             const uint8_t *vptr = data + srcIdx * stride;
             TScalar *out = reinterpret_cast<TScalar *>(&outData[i]);
             for (unsigned int c = 0; c < numComponents; ++c) {

--- a/code/AssetLib/glTF2/glTF2Asset.inl
+++ b/code/AssetLib/glTF2/glTF2Asset.inl
@@ -885,6 +885,7 @@ inline void Accessor::Read(Value &obj, Asset &r) {
 
     const char *typestr;
     type = ReadMember(obj, "type", typestr) ? AttribType::FromString(typestr) : AttribType::SCALAR;
+    normalized = MemberOrDefault(obj, "normalized", false);
 
     if (bufferView) {
         // Check length
@@ -1067,6 +1068,109 @@ size_t Accessor::ExtractData(T *&outData, const std::vector<unsigned int> *remap
             }
         }
     }
+    return usedCount;
+}
+
+template <class TTarget_type, class TScalar>
+inline size_t Accessor::ExtractConvertedData(TTarget_type *&outData, const std::vector<unsigned int> *remappingIndices) {
+    size_t usedCount = remappingIndices ? remappingIndices->size() : count;
+    if (usedCount == 0) {
+        outData = nullptr;
+        return 0;
+    }
+
+    uint8_t *data = GetPointer();
+    if (!data) {
+        // No backing buffer (missing bufferView, unresolved sparse-only accessor,
+        // malformed file, etc). Fail loudly instead of memcpy-ing from garbage.
+        outData = nullptr;
+        return 0;
+    }
+
+    unsigned int numComponents = GetNumComponents();
+    size_t stride = GetStride();
+
+    // Allocate and zero-initialize
+    outData = new TTarget_type[usedCount]();
+
+    // Unified extraction loop. The compiler stamps out optimized versions via the lambda.
+    auto executeExtraction = [&](auto dummyType, auto normalizeFunc) {
+        using SrcType = decltype(dummyType);
+
+        for (size_t i = 0; i < usedCount; ++i) {
+            const size_t srcIdx = remappingIndices ? (*remappingIndices)[i] : i;
+            const uint8_t *vptr = data + srcIdx * stride;
+            TScalar *out = reinterpret_cast<TScalar *>(&outData[i]);
+            for (unsigned int c = 0; c < numComponents; ++c) {
+                SrcType val;
+                std::memcpy(&val, vptr + c * sizeof(SrcType), sizeof(SrcType));
+                out[c] = normalizeFunc(val);
+            }
+        }
+    };
+
+    // Default pass-through function for unnormalized types
+    auto no_norm = [](auto v) { return static_cast<TScalar>(v); };
+
+    // Note: glTF 2.0 spec requires clamping signed normalized integers to -1.0
+    // to prevent underflow from the most-negative representable values.
+    switch (componentType) {
+    case ComponentType_BYTE:
+        if (normalized) {
+            executeExtraction(int8_t{}, [](int8_t v) {
+                return std::max(static_cast<TScalar>(v) / static_cast<TScalar>(127.0), static_cast<TScalar>(-1.0));
+            });
+        } else {
+            executeExtraction(int8_t{}, no_norm);
+        }
+        break;
+
+    case ComponentType_UNSIGNED_BYTE:
+        if (normalized) {
+            executeExtraction(uint8_t{}, [](uint8_t v) {
+                return static_cast<TScalar>(v) / static_cast<TScalar>(255.0);
+            });
+        } else {
+            executeExtraction(uint8_t{}, no_norm);
+        }
+        break;
+
+    case ComponentType_SHORT:
+        if (normalized) {
+            executeExtraction(int16_t{}, [](int16_t v) {
+                return std::max(static_cast<TScalar>(v) / static_cast<TScalar>(32767.0), static_cast<TScalar>(-1.0));
+            });
+        } else {
+            executeExtraction(int16_t{}, no_norm);
+        }
+        break;
+
+    case ComponentType_UNSIGNED_SHORT:
+        if (normalized) {
+            executeExtraction(uint16_t{}, [](uint16_t v) {
+                return static_cast<TScalar>(v) / static_cast<TScalar>(65535.0);
+            });
+        } else {
+            executeExtraction(uint16_t{}, no_norm);
+        }
+        break;
+
+    case ComponentType_FLOAT:
+        // FAST PATH: For standard, tightly packed float arrays with exact type matches.
+        if (!remappingIndices && stride == GetElementSize() && sizeof(TTarget_type) == GetElementSize() && !normalized) {
+            std::memcpy(outData, data, usedCount * GetElementSize());
+        } else {
+            executeExtraction(float{}, no_norm);
+        }
+        break;
+
+    default:
+        // Warn on unsupported component types instead of silently copying garbage.
+        DefaultLogger::get()->warn("glTF2: Accessor::ExtractConvertedData - unsupported componentType (",
+                static_cast<int>(componentType), "), returning zeroed data.");
+        break;
+    }
+
     return usedCount;
 }
 
@@ -2204,6 +2308,7 @@ inline void Asset::ReadExtensionsRequired(Document &doc) {
     CHECK_REQUIRED_EXT(KHR_draco_mesh_compression);
     CHECK_REQUIRED_EXT(KHR_texture_basisu);
     CHECK_REQUIRED_EXT(EXT_texture_webp);
+    CHECK_REQUIRED_EXT(KHR_mesh_quantization);
 
 #undef CHECK_REQUIRED_EXT
 }
@@ -2235,6 +2340,7 @@ inline void Asset::ReadExtensionsUsed(Document &doc) {
     CHECK_EXT(KHR_draco_mesh_compression);
     CHECK_EXT(KHR_texture_basisu);
     CHECK_EXT(EXT_texture_webp);
+    CHECK_EXT(KHR_mesh_quantization);
 
 #undef CHECK_EXT
 }

--- a/code/AssetLib/glTF2/glTF2Importer.cpp
+++ b/code/AssetLib/glTF2/glTF2Importer.cpp
@@ -457,21 +457,6 @@ static inline bool CheckValidFacesIndices(aiFace *faces, unsigned nFaces, unsign
 }
 #endif // ASSIMP_BUILD_DEBUG
 
-template <typename T>
-aiColor4D *GetVertexColorsForType(Ref<Accessor> input, std::vector<unsigned int> *vertexRemappingTable) {
-    constexpr float max = std::numeric_limits<T>::max();
-    aiColor4t<T> *colors;
-    size_t count = input->ExtractData(colors, vertexRemappingTable);
-    auto output = new aiColor4D[count];
-    for (size_t i = 0; i < count; i++) {
-        output[i] = aiColor4D(
-                colors[i].r / max, colors[i].g / max,
-                colors[i].b / max, colors[i].a / max);
-    }
-    delete[] colors;
-    return output;
-}
-
 void glTF2Importer::ImportMeshes(glTF2::Asset &r) {
     ASSIMP_LOG_DEBUG("Importing ", r.meshes.Size(), " meshes");
     std::vector<std::unique_ptr<aiMesh>> meshes;
@@ -573,14 +558,14 @@ void glTF2Importer::ImportMeshes(glTF2::Asset &r) {
             }
 
             if (!attr.position.empty() && attr.position[0]) {
-                aim->mNumVertices = static_cast<unsigned int>(attr.position[0]->ExtractData(aim->mVertices, vertexRemappingTable));
+                aim->mNumVertices = static_cast<unsigned int>(attr.position[0]->ExtractConvertedData<aiVector3D, ai_real>(aim->mVertices, vertexRemappingTable));
             }
 
             if (!attr.normal.empty() && attr.normal[0]) {
                     if (attr.normal[0]->count != numAllVertices) {
                     DefaultLogger::get()->warn("Normal count in mesh \"", mesh.name, "\" does not match the vertex count, normals ignored.");
                 } else {
-                    attr.normal[0]->ExtractData(aim->mNormals, vertexRemappingTable);
+                    attr.normal[0]->ExtractConvertedData<aiVector3D, ai_real>(aim->mNormals, vertexRemappingTable);
 
                     // only extract tangents if normals are present
                     if (!attr.tangent.empty() && attr.tangent[0]) {
@@ -590,7 +575,7 @@ void glTF2Importer::ImportMeshes(glTF2::Asset &r) {
                             // generate bitangents from normals and tangents according to spec
                             Tangent *tangents = nullptr;
 
-                            attr.tangent[0]->ExtractData(tangents, vertexRemappingTable);
+                            attr.tangent[0]->ExtractConvertedData<Tangent, ai_real>(tangents, vertexRemappingTable);
 
                             aim->mTangents = new aiVector3D[aim->mNumVertices];
                             aim->mBitangents = new aiVector3D[aim->mNumVertices];
@@ -613,14 +598,11 @@ void glTF2Importer::ImportMeshes(glTF2::Asset &r) {
                     continue;
                 }
 
-                auto componentType = attr.color[c]->componentType;
-                if (componentType == glTF2::ComponentType_FLOAT) {
-                    attr.color[c]->ExtractData(aim->mColors[c], vertexRemappingTable);
-                } else {
-                    if (componentType == glTF2::ComponentType_UNSIGNED_BYTE) {
-                        aim->mColors[c] = GetVertexColorsForType<unsigned char>(attr.color[c], vertexRemappingTable);
-                    } else if (componentType == glTF2::ComponentType_UNSIGNED_SHORT) {
-                        aim->mColors[c] = GetVertexColorsForType<unsigned short>(attr.color[c], vertexRemappingTable);
+                attr.color[c]->ExtractConvertedData<aiColor4D, ai_real>(aim->mColors[c], vertexRemappingTable);
+
+                if (attr.color[c]->GetNumComponents() == 3) {
+                    for (unsigned int i = 0; i < aim->mNumVertices; ++i) {
+                        aim->mColors[c][i].a = 1.0f;
                     }
                 }
             }
@@ -636,7 +618,7 @@ void glTF2Importer::ImportMeshes(glTF2::Asset &r) {
                     continue;
                 }
 
-                attr.texcoord[tc]->ExtractData(aim->mTextureCoords[tc], vertexRemappingTable);
+                attr.texcoord[tc]->ExtractConvertedData<aiVector3D, ai_real>(aim->mTextureCoords[tc], vertexRemappingTable);
                 aim->mNumUVComponents[tc] = attr.texcoord[tc]->GetNumComponents();
 
                 aiVector3D *values = aim->mTextureCoords[tc];
@@ -665,7 +647,7 @@ void glTF2Importer::ImportMeshes(glTF2::Asset &r) {
                             ASSIMP_LOG_WARN("Positions of target ", i, " in mesh \"", mesh.name, "\" does not match the vertex count");
                         } else {
                             aiVector3D *positionDiff = nullptr;
-                            target.position[0]->ExtractData(positionDiff, vertexRemappingTable);
+                            target.position[0]->ExtractConvertedData<aiVector3D, ai_real>(positionDiff, vertexRemappingTable);
                             for (unsigned int vertexId = 0; vertexId < aim->mNumVertices; vertexId++) {
                                 aiAnimMesh.mVertices[vertexId] += positionDiff[vertexId];
                             }
@@ -677,7 +659,7 @@ void glTF2Importer::ImportMeshes(glTF2::Asset &r) {
                             ASSIMP_LOG_WARN("Normals of target ", i, " in mesh \"", mesh.name, "\" does not match the vertex count");
                         } else {
                             aiVector3D *normalDiff = nullptr;
-                            target.normal[0]->ExtractData(normalDiff, vertexRemappingTable);
+                            target.normal[0]->ExtractConvertedData<aiVector3D, ai_real>(normalDiff, vertexRemappingTable);
                             for (unsigned int vertexId = 0; vertexId < aim->mNumVertices; vertexId++) {
                                 aiAnimMesh.mNormals[vertexId] += normalDiff[vertexId];
                             }
@@ -692,10 +674,10 @@ void glTF2Importer::ImportMeshes(glTF2::Asset &r) {
                             ASSIMP_LOG_WARN("Tangents of target ", i, " in mesh \"", mesh.name, "\" does not match the vertex count");
                         } else {
                             Tangent *tangent = nullptr;
-                            attr.tangent[0]->ExtractData(tangent, vertexRemappingTable);
+                            attr.tangent[0]->ExtractConvertedData<Tangent, ai_real>(tangent, vertexRemappingTable);
 
                             aiVector3D *tangentDiff = nullptr;
-                            target.tangent[0]->ExtractData(tangentDiff, vertexRemappingTable);
+                            target.tangent[0]->ExtractConvertedData<aiVector3D, ai_real>(tangentDiff, vertexRemappingTable);
 
                             for (unsigned int vertexId = 0; vertexId < aim->mNumVertices; ++vertexId) {
                                 tangent[vertexId].xyz += tangentDiff[vertexId];
@@ -1048,7 +1030,7 @@ static void BuildVertexWeightMapping(Mesh::Primitive &primitive, std::vector<std
     };
     Weights **weights = new Weights*[attr.weight.size()];
     for (size_t w = 0; w < attr.weight.size(); ++w) {
-        num_vertices = attr.weight[w]->ExtractData(weights[w], vertexRemappingTablePtr);
+        num_vertices = attr.weight[w]->ExtractConvertedData<Weights, float>(weights[w], vertexRemappingTablePtr);
     }
 
     struct Indices8 {

--- a/test/models/glTF2/Triangle-Mesh-Quantized/triangle_mesh_quantized.gltf
+++ b/test/models/glTF2/Triangle-Mesh-Quantized/triangle_mesh_quantized.gltf
@@ -1,0 +1,22 @@
+{
+  "asset": { "version": "2.0" },
+  "extensionsUsed": [ "KHR_mesh_quantization" ],
+  "extensionsRequired": [ "KHR_mesh_quantization" ],
+  "scenes": [ { "nodes": [ 0 ] } ],
+  "nodes": [ { "mesh": 0 } ],
+  "meshes": [ {
+      "primitives": [ { "attributes": { "POSITION": 0, "NORMAL": 1 } } ]
+  } ],
+  "buffers": [ {
+      "byteLength": 30,
+      "uri": "data:application/octet-stream;base64,AAAAAAAAZAAAAAAAAABkAAAAAAB/AAB/AAB/AAAA"
+  } ],
+  "bufferViews": [
+    { "buffer": 0, "byteOffset": 0, "byteLength": 18, "target": 34962 },
+    { "buffer": 0, "byteOffset": 18, "byteLength": 12, "byteStride": 4, "target": 34962 }
+  ],
+  "accessors": [
+    { "bufferView": 0, "byteOffset": 0, "componentType": 5122, "count": 3, "type": "VEC3", "normalized": false, "min": [ 0, 0, 0 ], "max": [ 100, 100, 0 ] },
+    { "bufferView": 1, "byteOffset": 0, "componentType": 5120, "count": 3, "type": "VEC3", "normalized": true }
+  ]
+}

--- a/test/unit/utglTF2ImportExport.cpp
+++ b/test/unit/utglTF2ImportExport.cpp
@@ -499,6 +499,42 @@ TEST_F(utglTF2ImportExport, importglTF2FromMemory) {
     EXPECT_EQ( nullptr, Scene );*/
 }
 
+TEST_F(utglTF2ImportExport, test_KHR_mesh_quantization) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/glTF2/Triangle-Mesh-Quantized/triangle_mesh_quantized.gltf", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+    ASSERT_EQ(1u, scene->mNumMeshes);
+
+    aiMesh *mesh = scene->mMeshes[0];
+    ASSERT_EQ(3u, mesh->mNumVertices);
+
+    // Positions were SHORT (5122) unnormalized: 0, 100, 100
+    EXPECT_FLOAT_EQ(0.0f, mesh->mVertices[0].x);
+    EXPECT_FLOAT_EQ(0.0f, mesh->mVertices[0].y);
+    EXPECT_FLOAT_EQ(0.0f, mesh->mVertices[0].z);
+
+    EXPECT_FLOAT_EQ(100.0f, mesh->mVertices[1].x);
+    EXPECT_FLOAT_EQ(0.0f, mesh->mVertices[1].y);
+    EXPECT_FLOAT_EQ(0.0f, mesh->mVertices[1].z);
+
+    EXPECT_FLOAT_EQ(0.0f, mesh->mVertices[2].x);
+    EXPECT_FLOAT_EQ(100.0f, mesh->mVertices[2].y);
+    EXPECT_FLOAT_EQ(0.0f, mesh->mVertices[2].z);
+
+    // Normals were BYTE (5120) normalized: max(0/127, -1), max(127/127, -1) = 0, 1
+    EXPECT_FLOAT_EQ(0.0f, mesh->mNormals[0].x);
+    EXPECT_FLOAT_EQ(0.0f, mesh->mNormals[0].y);
+    EXPECT_FLOAT_EQ(1.0f, mesh->mNormals[0].z);
+
+    EXPECT_FLOAT_EQ(0.0f, mesh->mNormals[1].x);
+    EXPECT_FLOAT_EQ(1.0f, mesh->mNormals[1].y);
+    EXPECT_FLOAT_EQ(0.0f, mesh->mNormals[1].z);
+
+    EXPECT_FLOAT_EQ(1.0f, mesh->mNormals[2].x);
+    EXPECT_FLOAT_EQ(0.0f, mesh->mNormals[2].y);
+    EXPECT_FLOAT_EQ(0.0f, mesh->mNormals[2].z);
+}
+
 TEST_F(utglTF2ImportExport, bug_import_simple_skin) {
     Assimp::Importer importer;
     const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/glTF2/simple_skin/simple_skin.gltf",


### PR DESCRIPTION
## The problem

Currently, assimp accepts `KHR_mesh_quantization` files but ignores the extension, **even if it is required by the file**. The `ExtractData` function just does a `memcpy` into float arrays. So, if the original data is `BYTE`, `SHORT`, `UNSIGNED_BYTE`, or `UNSIGNED_SHORT`, we get completely broken positions, normals, and colors. There is no error or warning, just garbage geometry.

## Changes

**New `ExtractConvertedData` method on `Accessor`**

Instead of fixing every call site, I added one generic function. It handles the conversion and normalization in one place. It reads the `componentType` and the `normalized` flag from the accessor and converts the data:

* Normalized integers: divided by their max value (like value / 127.0). Signed types are clamped to [-1.0, 1.0].
* Unnormalized integers: simply cast to float.
* Standard FLOAT data: fast path. It uses `memcpy` directly when types match. This is the what the normal `ExtractData` function does, so there should be zero overhead.

Now, all mesh attributes in `glTF2Importer.cpp` use `ExtractConvertedData`.

**Extension registration**

I added `KHR_mesh_quantization` in `extensionsUsed` and `extensionsRequired`. Also, we now parse the `normalized` flag from the accessor definitions.

**Vertex color cleanup**

I removed the old `GetVertexColorsForType` function. It only handled a few types, and it didn't set alpha to `1.0` for `VEC3`. The new generic path handles all of this correctly now.

**Dequantization transform**

Quantized models usually have a transform matrix on the mesh node to go back to world space. We don't need to do anything for this. The existing node transform import handles it already.

## Tests

I added a simple `triangle_mesh_quantized.gltf` test model. It uses `SHORT` positions (unnormalized) and `BYTE` normals (normalized). I added assertions on the decoded values. The model passes the Khronos glTF Validator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for glTF mesh quantization through `KHR_mesh_quantization`.
  * Improved conversion of normalized and quantized vertex data, including positions, normals, tangents, colors, texture coordinates, morph targets, and skin weights.
  * Three-component vertex colors now receive an opaque alpha channel.

* **Bug Fixes**
  * Improved handling of missing, empty, and remapped accessor data.
  * Added regression coverage for decoding quantized mesh attributes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->