### PR TITLE
FBX: fix importing with AI_CONFIG_IMPORT_FBX_READ_ALL_MATERIALS

### DIFF
--- a/code/AssetLib/FBX/FBXConverter.cpp
+++ b/code/AssetLib/FBX/FBXConverter.cpp
@@ -156,6 +156,13 @@ FBXConverter::FBXConverter(aiScene *out, const Document &doc, bool removeEmptyBo
     if (doc.Settings().readAllMaterials) {
         // unfortunately this means we have to evaluate all objects
         for (const ObjectMap::value_type &v : doc.Objects()) {
+            // id 0 is the synthetic Model::RootNode placeholder added by
+            // Document::ReadObjects(). Its element is the Objects scope itself,
+            // which carries no id/name/class-tag tokens, so it must not be
+            // evaluated as an object.
+            if (v.first == 0) {
+                continue;
+            }
 
             const Object *ob = v.second->Get();
             if (!ob) {

--- a/code/AssetLib/FBX/FBXDocument.cpp
+++ b/code/AssetLib/FBX/FBXDocument.cpp
@@ -85,38 +85,38 @@ const Object* LazyObject::Get(bool dieOnError) {
     const Token& key = element.KeyToken();
     const TokenList& tokens = element.Tokens();
 
-    if(tokens.size() < 3) {
-        DOMError("expected at least 3 tokens: id, name and class tag",&element);
-    }
-
-    const char* err;
-    std::string name = ParseTokenAsString(*tokens[1],err);
-    if (err) {
-        DOMError(err,&element);
-    }
-
-    // small fix for binary reading: binary fbx files don't use
-    // prefixes such as Model:: in front of their names. The
-    // loading code expects this at many places, though!
-    // so convert the binary representation (a 0x0001) to the
-    // double colon notation.
-    if(tokens[1]->IsBinary()) {
-        for (size_t i = 0; i < name.length(); ++i) {
-            if (name[i] == 0x0 && name[i+1] == 0x1) {
-                name = name.substr(i+2) + "::" + name.substr(0,i);
-            }
-        }
-    }
-
-    const std::string classtag = ParseTokenAsString(*tokens[2],err);
-    if (err) {
-        DOMError(err,&element);
-    }
-
     // prevent recursive calls
     flags |= BEING_CONSTRUCTED;
 
     try {
+        if(tokens.size() < 3) {
+            DOMError("expected at least 3 tokens: id, name and class tag",&element);
+        }
+
+        const char* err;
+        std::string name = ParseTokenAsString(*tokens[1],err);
+        if (err) {
+            DOMError(err,&element);
+        }
+
+        // small fix for binary reading: binary fbx files don't use
+        // prefixes such as Model:: in front of their names. The
+        // loading code expects this at many places, though!
+        // so convert the binary representation (a 0x0001) to the
+        // double colon notation.
+        if(tokens[1]->IsBinary()) {
+            for (size_t i = 0; i < name.length(); ++i) {
+                if (name[i] == 0x0 && name[i+1] == 0x1) {
+                    name = name.substr(i+2) + "::" + name.substr(0,i);
+                }
+            }
+        }
+
+        const std::string classtag = ParseTokenAsString(*tokens[2],err);
+        if (err) {
+            DOMError(err,&element);
+        }
+
         // this needs to be relatively fast since it happens a lot,
         // so avoid constructing strings all the time.
         const char* obtype = key.begin();

--- a/tools/assimp_cmd/code/Main.cpp
+++ b/tools/assimp_cmd/code/Main.cpp
@@ -301,8 +301,11 @@ const aiScene* ImportModel(
 
 	// do the actual import, measure time
 	const clock_t first = clock();
-    ConsoleProgressHandler *ph = new ConsoleProgressHandler;
-    globalImporter->SetProgressHandler(ph);
+	ConsoleProgressHandler *ph = new ConsoleProgressHandler;
+	globalImporter->SetProgressHandler(ph);
+
+	globalImporter->SetPropertyBool(AI_CONFIG_IMPORT_FBX_READ_ALL_MATERIALS,
+		imp.readAllMaterials);
 
 	const aiScene* scene = globalImporter->ReadFile(path,imp.ppFlags);
 
@@ -414,6 +417,7 @@ int ProcessStandardArguments(
 	// -db     --debone
 	// -sbc    --split-by-bone-count
 	// -gs	   --global-scale
+	// -ram    --read-all-materials
 	//
 	// -c<file> --config-file=<file>
 
@@ -504,6 +508,9 @@ int ProcessStandardArguments(
 		}
 		else if (!strcmp(param, "-gs") || ! strcmp(param, "--global-scale")) {
 			fill.ppFlags |= aiProcess_GlobalScale;
+		}
+		else if (! strcmp( param, "-ram") || ! strcmp( param, "--read-all-materials")) {
+			fill.readAllMaterials = true;
 		}
 		else if (! strncmp( param, "-c",2) || ! strncmp( param, "--config=",9)) {
 			const unsigned int ofs = (params[i][1] == '-' ? 9 : 2);

--- a/tools/assimp_cmd/code/Main.h
+++ b/tools/assimp_cmd/code/Main.h
@@ -88,7 +88,8 @@ struct ImportData {
 		,	showLog (false)
 		,	verbose (false)
 		,	log	    (false)
-        ,   rot     (aiVector3D(0.f, 0.f, 0.f))
+		,	readAllMaterials (false)
+		,	rot	    (aiVector3D(0.f, 0.f, 0.f))
 	{}
 
 	/// Post-processing flags
@@ -105,6 +106,8 @@ struct ImportData {
 
 	// Need to log?
 	bool log;
+
+	bool readAllMaterials;
 
 	// Export With Rotation
 	aiVector3D rot;


### PR DESCRIPTION
- Skip id 0 (synthetic root node) during material import loop
- Guard LazyObject::Get against recursion by setting BEING_CONSTRUCTED flag before parsing tokens

Also add --read-all-materials CLI flag to assimp_cmd for easy testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a command-line option to read all materials when importing FBX files.

- **Bug Fixes**
  - Improved FBX material conversion by ignoring the synthetic root entry.
  - Strengthened FBX object loading so malformed metadata and parsing failures are handled more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->