### PR TITLE
Guard aiTexture.pcData against invalid dimensions in importers

### DIFF
--- a/code/AssetLib/Assbin/AssbinLoader.cpp
+++ b/code/AssetLib/Assbin/AssbinLoader.cpp
@@ -595,26 +595,18 @@ void AssbinImporter::ReadBinaryTexture(IOStream *stream, aiTexture *tex) {
     stream->Read(tex->achFormatHint, sizeof(char), HINTMAXTEXTURELEN - 1);
 
     if (!shortened) {
-        if (!tex->mHeight) {
-            if (tex->mWidth > AI_MAX_ALLOC(aiTexel)) {
+        if (!tex->mWidth) {
+            throw DeadlyImportError("Assbin: Texture width must be greater than 0");
+        } else if (!tex->mHeight) {
+            if (tex->mWidth > AI_MAX_ALLOC(aiTexel))
                 throw DeadlyImportError("Assbin: Texture width too large, would overflow");
-            }
             tex->pcData = new aiTexel[tex->mWidth];
             stream->Read(tex->pcData, 1, tex->mWidth);
         } else {
-            if (tex->mWidth != 0 &&
-                static_cast<size_t>(tex->mHeight) >
-                    AI_MAX_ALLOC(aiTexel) / static_cast<size_t>(tex->mWidth)) {
+            const size_t pixelCount = (size_t)tex->mWidth * tex->mHeight;
+            if (pixelCount > AI_MAX_ALLOC(aiTexel) || pixelCount > SIZE_MAX / sizeof(aiTexel))
                 throw DeadlyImportError("Assbin: Texture dimensions too large");
-            }
 
-            if (tex->mWidth != 0 &&
-                static_cast<size_t>(tex->mHeight) >
-                    SIZE_MAX / sizeof(aiTexel) / static_cast<size_t>(tex->mWidth)) {
-                throw DeadlyImportError("Assbin: Texture dimensions too large");
-            }
-
-            const size_t pixelCount = static_cast<size_t>(tex->mWidth) * tex->mHeight;
             tex->pcData = new aiTexel[pixelCount];
             stream->Read(tex->pcData, 1, pixelCount * sizeof(aiTexel));
         }

--- a/code/AssetLib/Blender/BlenderLoader.cpp
+++ b/code/AssetLib/Blender/BlenderLoader.cpp
@@ -356,6 +356,9 @@ void BlenderImporter::ResolveImage(aiMaterial *out, const Material *mat, const M
 
     // check if the file contents are bundled with the BLEND file
     if (img->packedfile) {
+        if (img->packedfile->size == 0)
+            ThrowException("Image has size 0.");
+
         name.data[0] = '*';
         name.length = 1 + ASSIMP_itoa10(name.data + 1, static_cast<unsigned int>(AI_MAXLEN - 1), static_cast<int32_t>(conv_data.textures->size()));
 
@@ -375,7 +378,7 @@ void BlenderImporter::ResolveImage(aiMaterial *out, const Material *mat, const M
         curTex->achFormatHint[2] = s + 3 > e ? '\0' : (char)::tolower((unsigned char)s[3]);
         curTex->achFormatHint[3] = '\0';
 
-        // tex->mHeight = 0;
+        curTex->mHeight = 0;
         curTex->mWidth = img->packedfile->size;
         uint8_t *ch = new uint8_t[curTex->mWidth];
 

--- a/code/AssetLib/MDL/HalfLife/HL1MDLLoader.cpp
+++ b/code/AssetLib/MDL/HalfLife/HL1MDLLoader.cpp
@@ -381,6 +381,8 @@ void HL1MDLLoader::load_sequence_groups_files() {
 void HL1MDLLoader::read_texture(const Texture_HL1 *ptexture,
         const uint8_t *data, const uint8_t *pal, aiTexture *pResult,
         aiColor3D &last_palette_color) {
+    if (!ptexture->width || !ptexture->height)
+        throw DeadlyImportError("Invalid HL1MD file. Texture dimensions must be greater than 0.");
     pResult->mFilename = ptexture->name;
     pResult->mWidth = static_cast<unsigned int>(ptexture->width);
     pResult->mHeight = static_cast<unsigned int>(ptexture->height);
@@ -394,11 +396,11 @@ void HL1MDLLoader::read_texture(const Texture_HL1 *ptexture,
     pResult->achFormatHint[7] = '8';
     pResult->achFormatHint[8] = '\0';
 
-    const size_t num_pixels = pResult->mWidth * pResult->mHeight;
-    aiTexel *out = pResult->pcData = new aiTexel[num_pixels];
+    const size_t numPixels = (size_t)pResult->mWidth * pResult->mHeight;
+    aiTexel *out = pResult->pcData = new aiTexel[numPixels];
 
     // Convert indexed 8 bit to 32 bit RGBA.
-    for (size_t i = 0; i < num_pixels; ++i, ++out) {
+    for (size_t i = 0; i < numPixels; ++i, ++out) {
         out->r = pal[data[i] * 3];
         out->g = pal[data[i] * 3 + 1];
         out->b = pal[data[i] * 3 + 2];

--- a/code/AssetLib/MDL/MDLMaterialLoader.cpp
+++ b/code/AssetLib/MDL/MDLMaterialLoader.cpp
@@ -156,7 +156,11 @@ aiColor4D MDLImporter::ReplaceTextureWithColor(const aiTexture *pcTexture) {
 // Read a texture from a MDL3 file
 void MDLImporter::CreateTextureARGB8_3DGS_MDL3(const unsigned char *szData) {
     const MDL::Header *pcHeader = (const MDL::Header *)mBuffer; //the endianness is already corrected in the InternReadFile_3DGS_MDL345 function
-    const size_t len = pcHeader->skinwidth * pcHeader->skinheight;
+
+    // Sanity check header before creating aiTexture
+    const size_t len = (size_t)pcHeader->skinwidth * pcHeader->skinheight;
+    if (!len)
+        throw DeadlyImportError("Invalid MDL file. Texture dimensions must be greater than 0.");
     VALIDATE_FILE_SIZE(szData + len);
 
     // allocate a new texture object
@@ -164,16 +168,17 @@ void MDLImporter::CreateTextureARGB8_3DGS_MDL3(const unsigned char *szData) {
     pcNew->mWidth = pcHeader->skinwidth;
     pcNew->mHeight = pcHeader->skinheight;
 
-    if(pcNew->mWidth != 0 && pcNew->mHeight > UINT_MAX/pcNew->mWidth) {
+
+    if(pcNew->mHeight > UINT_MAX/pcNew->mWidth) {
         throw DeadlyImportError("Invalid MDL file. A texture is too big.");
     }
-    pcNew->pcData = new aiTexel[pcNew->mWidth * pcNew->mHeight];
+    pcNew->pcData = new aiTexel[len];
 
     const unsigned char *szColorMap;
     this->SearchPalette(&szColorMap);
 
     // copy texture data
-    for (unsigned int i = 0; i < pcNew->mWidth * pcNew->mHeight; ++i) {
+    for (unsigned int i = 0; i < len; ++i) {
         const unsigned char val = szData[i];
         const unsigned char *sz = &szColorMap[val * 3];
 
@@ -203,12 +208,16 @@ void MDLImporter::CreateTexture_3DGS_MDL4(const unsigned char *szData,
         unsigned int *piSkip) {
     ai_assert(nullptr != piSkip);
 
-    const MDL::Header *pcHeader = (const MDL::Header *)mBuffer; //the endianness is already corrected in the InternReadFile_3DGS_MDL345 function
-
     if (iType == 1 || iType > 3) {
         ASSIMP_LOG_ERROR("Unsupported texture file format");
         return;
     }
+
+    const MDL::Header *pcHeader = (const MDL::Header *)mBuffer; //the endianness is already corrected in the InternReadFile_3DGS_MDL345 function
+
+    // Sanity check header before creating aiTexture
+    if (!pcHeader->skinwidth || !pcHeader->skinheight)
+        throw DeadlyImportError("Invalid MDL file. Texture dimensions must be greater than 0.");
 
     const bool bNoRead = *piSkip == UINT_MAX;
 
@@ -249,7 +258,7 @@ static const uint32_t MaxTextureSize = 4096;
 void MDLImporter::ParseTextureColorData(const unsigned char *szData,
         unsigned int iType,
         unsigned int *piSkip,
-        aiTexture *pcNew) {
+        aiTexture *pcNew) {    
     const bool do_read = bad_texel != pcNew->pcData;
 
     // allocate storage for the texture image
@@ -436,6 +445,8 @@ void MDLImporter::CreateTexture_3DGS_MDL5(const unsigned char *szData,
     if (6 == iType) {
         // this is a compressed texture in DDS format
         *piSkip = pcNew->mWidth;
+        if (!pcNew->mWidth)
+            throw DeadlyImportError("DDS texture width must be greater than 0.");
         VALIDATE_FILE_SIZE(szData + *piSkip);
 
         if (!bNoRead) {
@@ -450,6 +461,10 @@ void MDLImporter::CreateTexture_3DGS_MDL5(const unsigned char *szData,
             ::memcpy(pcNew->pcData, szData, pcNew->mWidth);
         }
     } else {
+        // sanity check dimensions
+        if (!pcNew->mWidth || !pcNew->mHeight)
+            throw DeadlyImportError("Texture dimensions must be greater than 0.");
+
         // parse the color data of the texture
         ParseTextureColorData(szData, iType, piSkip, pcNew);
     }

--- a/code/AssetLib/Q3BSP/Q3BSPFileImporter.cpp
+++ b/code/AssetLib/Q3BSP/Q3BSPFileImporter.cpp
@@ -571,6 +571,8 @@ bool Q3BSPFileImporter::importTextureFromArchive(const Q3BSP::Q3BSPModel *model,
         IOStream *pTextureStream = archive->Open(textureName.c_str());
         if (pTextureStream) {
             size_t texSize = pTextureStream->FileSize();
+            if (texSize == 0)
+                throw DeadlyImportError("Texture size must be greater than 0.");
             aiTexture *curTexture = new aiTexture;
             curTexture->mHeight = 0;
             curTexture->mWidth = static_cast<unsigned int>(texSize);

--- a/code/AssetLib/USD/USDLoaderImplTinyusdz.cpp
+++ b/code/AssetLib/USD/USDLoaderImplTinyusdz.cpp
@@ -677,16 +677,22 @@ static aiTexture *ownedEmbeddedTextureFor(const RenderScene &render_scene, const
     tex->mHeight = image.height;
 
     tex->mWidth = image.width;
-    if (tex->mHeight == 0) {
+    if (tex->mWidth == 0) {
+        throw DeadlyImportError("Texture width must be greater than 0");
+    } else if (tex->mHeight == 0) {
         pos = embTexName.find_last_of('.');
         strncpy(tex->achFormatHint, embTexName.substr(pos + 1).c_str(), 3);
         const size_t imageBytesCount{ render_scene.buffers[image.buffer_id].data.size() };
+        if (imageBytesCount == 0)
+            throw DeadlyImportError("Texture size must be greater than 0");
         tex->pcData = (aiTexel *)new char[imageBytesCount];
         memcpy(tex->pcData, &render_scene.buffers[image.buffer_id].data[0], imageBytesCount);
     } else {
         std::string formatHint{ "rgba8888" };
         strncpy(tex->achFormatHint, formatHint.c_str(), 8);
         const size_t imageTexelsCount{ tex->mWidth * tex->mHeight };
+        if (image.channels == 0)
+            throw DeadlyImportError("Texture channels must be greater than 0");
         tex->pcData = (aiTexel *)new char[imageTexelsCount * image.channels];
         const float *floatPtr = reinterpret_cast<const float *>(&render_scene.buffers[image.buffer_id].data[0]);
         ss.str("");

--- a/code/Common/SceneCombiner.cpp
+++ b/code/Common/SceneCombiner.cpp
@@ -1197,16 +1197,17 @@ void SceneCombiner::Copy(aiTexture **_dest, const aiTexture *src) {
     // and reallocate all arrays. We must do it manually here
     const char *old = (const char *)dest->pcData;
     if (old) {
-        unsigned int cpy;
-        if (!dest->mHeight)
-            cpy = dest->mWidth;
-        else
-            cpy = dest->mHeight * dest->mWidth * sizeof(aiTexel);
-
-        if (!cpy) {
+        if (dest->mWidth == 0) {
             dest->pcData = nullptr;
             return;
         }
+
+        // A compressed texture (mHeight == 0) stores mWidth raw bytes.
+        // An uncompressed texture stores mWidth * mHeight aiTexel elements.
+        size_t cpy = (size_t)dest->mWidth;
+        if (dest->mHeight != 0)
+            cpy *= (size_t)dest->mHeight * sizeof(aiTexel);
+
         // the cast is legal, the aiTexel c'tor does nothing important
         dest->pcData = (aiTexel *)new char[cpy];
         ::memcpy(dest->pcData, old, cpy);


### PR DESCRIPTION
Many allocation of `pcData` naively assume both dimensions are not 0 or at least `mWidth` is not 0, incorrectly multipliying and allocating a buffer of size 0 when size should instead be the non-zero dimension.

These changes add guards to various importers and `SceneCombiner::Copy`. I've validated using the reproducer included in #6079. I haven't been able to reproduce #4768. 

Fixes #6079 and #4768

# OLD DESCRIPTION

`aiTexture` allows either `mWidth` or `mHeight`. But currently, most importers only check if `mHeight == 0` and assumes `mWidth != 0`. Furthermore, allocation of `pcData` naively assume both dimensions are not 0, incorrectly multipliying and allocating a buffer of size 0 when size should instead be the non-zero dimension.

These changes fixes the issue in CVE-2025-15666 (#6079) by adding guards to `SceneCombiner::Copy` and `MLDImporter`. I've validated using the reproducer included in the original issue.

These changes also fix similar issues in other importers, throwing `DeadlyImportErrors` prior to allocating `pcData`.

Fixes #6079 and #4768

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of malformed or empty textures across multiple supported formats.
  - Texture data with invalid dimensions, missing embedded content, empty compressed data, or zero channels is now rejected safely.
  - Fixed texture allocation and size calculations to reduce the risk of incorrect memory handling.
  - Improved support for compressed textures with zero-height metadata where applicable.
  - Corrected handling of textures with no pixel data during scene processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->