### PR TITLE
STEP: reject malformed \\S\\ escapes instead of asserting

### DIFF
--- a/code/AssetLib/STEPParser/STEPFileEncoding.cpp
+++ b/code/AssetLib/STEPParser/STEPFileEncoding.cpp
@@ -289,9 +289,14 @@ bool STEP::StringToUTF8(std::string& s)
         if (s[i] == '\\') {
             // \S\X - cp1252 (X is the character remapped to [0,127])
             if (i+3 < s.size() && s[i+1] == 'S' && s[i+2] == '\\') {
-                // http://stackoverflow.com/questions/5586214/how-to-convert-char-from-iso-8859-1-to-utf-8-in-c-multiplatformly
-                ai_assert((uint8_t)s[i+3] < 0x80);
-                const uint8_t ch = s[i+3] + 0x80;
+                // STEP encodes \S\X using an ASCII byte remapped into the CP1252 upper half.
+                // Bytes outside the [0,127] range are malformed input and must be rejected
+                // without tripping debug asserts.
+                const uint8_t cp1252LowHalf = static_cast<uint8_t>(s[i+3]);
+                if (cp1252LowHalf >= 0x80) {
+                    return false;
+                }
+                const uint8_t ch = cp1252LowHalf + 0x80;
 
                 s[i] = 0xc0 | (ch & 0xc0) >> 6;
                 s[i+1] =  0x80 | (ch & 0x3f);

--- a/test/unit/utIFCImportExport.cpp
+++ b/test/unit/utIFCImportExport.cpp
@@ -78,3 +78,21 @@ TEST_F(utIFCImportExport, importComplextypeAsColor) {
     const aiScene *scene = importer.ReadFileFromMemory(asset.c_str(), asset.size(), 0);
     EXPECT_EQ(nullptr, scene);
 }
+
+TEST_F(utIFCImportExport, rejectsInvalidStepCp1252EscapeInSchema) {
+    std::string asset =
+            "ISO-10303-21;\n"
+            "HEADER;\n"
+            "FILE_SCHEMA( ( 'IFC2X3\\S\\";
+    asset.push_back(static_cast<char>(0x80));
+    asset +=
+            "' ) );\n"
+            "ENDSEC;\n"
+            "DATA;\n"
+            "ENDSEC;\n"
+            "END-ISO-10303-21;\n";
+
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFileFromMemory(asset.data(), asset.size(), 0, "ifc");
+    EXPECT_EQ(nullptr, scene);
+}


### PR DESCRIPTION
## Summary
- reject malformed high-bit bytes in STEP `\\S\\` CP1252 escapes instead of aborting on `ai_assert`
- add a minimal IFC regression test distilled from OSS-Fuzz issue #6767

## Root cause
`STEP::StringToUTF8()` treats `\\S\\X` as a remapped 7-bit CP1252 byte, but it enforced that precondition with `ai_assert((uint8_t)s[i+3] < 0x80)`. A malformed STEP/IFC string containing `\\S\\` followed by a high-bit byte therefore aborts debug/ASan builds in the parser instead of being rejected as invalid input.

## Fix
Validate the `\\S\\` payload byte explicitly and return `false` for malformed input. The existing caller already logs the string-decoding failure and continues to fail gracefully, so this keeps the change narrow.

## Tests
- added `utIFCImportExport.rejectsInvalidStepCp1252EscapeInSchema`
- reproduced the pre-fix crash locally: `ai_assert failure in .../STEPFileEncoding.cpp(293): (uint8_t)s[i+3] < 0x80`
- reran `./build-asan/bin/unit --gtest_filter=utIFCImportExport.*` successfully after the fix

## OSS-Fuzz
Fixes #6767.
Distilled from OSS-Fuzz testcase 6594797908328448.

This appears to be an old bug, not a short-lived regression: the `\\S\\` escape handling dates back to commit `03c01685d` (2013-01-24), so affected stable releases likely include the same behavior.

## AI disclosure
Prepared with AI assistance, then manually reviewed and verified locally before submission.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid CP1252 escape sequences in IFC files are now rejected safely instead of triggering an assertion.
  - Valid encoded characters continue to be imported correctly.

- **Tests**
  - Added regression coverage to verify that malformed IFC schema headers are rejected during memory-based loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->