### PR TITLE
Fix AC3D mesh count for empty surfaces

### DIFF
--- a/code/AssetLib/AC/ACLoader.cpp
+++ b/code/AssetLib/AC/ACLoader.cpp
@@ -58,6 +58,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/DefaultLogger.hpp>
 #include <assimp/IOSystem.hpp>
 #include <assimp/Importer.hpp>
+#include <algorithm>
 #include <memory>
 
 namespace Assimp {
@@ -490,10 +491,6 @@ aiNode *AC3DImporter::ConvertObjectSection(Object &object,
                     }
                 }
 
-                if (!needMat[idx].first) {
-                    ++node->mNumMeshes;
-                }
-
                 switch ((*it).GetType()) {
                 case Surface::ClosedLine: // closed line
                     needMat[idx].first += static_cast<unsigned int>((*it).entries.size());
@@ -526,6 +523,9 @@ aiNode *AC3DImporter::ConvertObjectSection(Object &object,
                     needMat[idx].second += static_cast<unsigned int>(it->entries.size()) * doubleSidedFactor;
                 };
             }
+            node->mNumMeshes = static_cast<unsigned int>(std::count_if(
+                    needMat.begin(), needMat.end(),
+                    [](const IntPair &entry) { return entry.first != 0; }));
             unsigned int *pip = node->mMeshes = new unsigned int[node->mNumMeshes];
             unsigned int mat = 0;
             const size_t oldm = meshes.size();

--- a/test/models/AC/emptyLineBeforePolygon.ac
+++ b/test/models/AC/emptyLineBeforePolygon.ac
@@ -1,0 +1,23 @@
+AC3Db
+MATERIAL "" rgb 1 1 1 amb 0.2 0.2 0.2 emis 0 0 0 spec 0.5 0.5 0.5 shi 10 trans 0
+OBJECT world
+kids 1
+OBJECT poly
+name "empty-line-before-polygon"
+numvert 4
+-1 0.5 0
+1 0.5 0
+1 -0.5 0
+-1 -0.5 0
+numsurf 2
+SURF 0x21
+mat 0
+refs 0
+SURF 0x20
+mat 0
+refs 4
+3 0 0
+2 1 0
+1 1 1
+0 0 1
+kids 0

--- a/test/unit/utACImportExport.cpp
+++ b/test/unit/utACImportExport.cpp
@@ -54,6 +54,15 @@ TEST(utACImportExport, importClosedLine) {
     ASSERT_NE(nullptr, scene);
 }
 
+TEST(utACImportExport, importEmptyLineBeforePolygon) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/AC/emptyLineBeforePolygon.ac", 0);
+    ASSERT_NE(nullptr, scene);
+    ASSERT_EQ(1u, scene->mRootNode->mNumChildren);
+    EXPECT_EQ(1u, scene->mRootNode->mChildren[0]->mNumMeshes);
+    EXPECT_NE(nullptr, importer.ApplyPostProcessing(aiProcess_OptimizeGraph));
+}
+
 TEST(utACImportExport, importNoSurfaces) {
     Assimp::Importer importer;
     const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/AC/nosurfaces.ac", aiProcess_ValidateDataStructure);


### PR DESCRIPTION
## Summary

- count AC3D node mesh slots after per-material face counts are known
- avoid allocating mesh-index slots for malformed surfaces that generate no faces
- add an AC3D regression model and exercise it through `aiProcess_OptimizeGraph`

## Root cause

`ConvertObjectSection` incremented `aiNode::mNumMeshes` before determining whether a surface actually generated any faces. An empty closed-line surface followed by a valid polygon using the same material therefore allocated two node mesh-index slots while only one mesh index was written. `OptimizeGraphProcess::FindInstancedMeshes` later read the uninitialized slot.

The faulty count is present in the v3.1 source and remains in v6.0.5/current master, so this is an old stable-release bug exposed by the newer post-processing fuzzer rather than a short-lived library regression.

## Validation

- reproduced the original MSan failure from OSS-Fuzz testcase `5426893772619776` at `OptimizeGraph.cpp:345`, with the uninitialized allocation originating in `ACLoader.cpp`
- reproduced the same read with a reduced AC3D model using only `aiProcess_OptimizeGraph`
- verified both reproducers no longer trigger the uninitialized node-mesh read after the fix
- passed all 14 `utACImportExport` tests, including the new regression test
- passed `git diff --check`

Fixes #6789


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue importing AC3D models containing blank lines before polygon definitions.
  * Improved mesh generation so materials without visible geometry no longer create unnecessary mesh entries.
  * AC3D scenes with multiple surfaces now retain their expected geometry and optimize correctly.

* **Tests**
  * Added regression coverage for importing and optimizing affected AC3D models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->