### PR TITLE
Initialize malformed IRR property values

### DIFF
--- a/code/AssetLib/Irr/IRRShared.h
+++ b/code/AssetLib/Irr/IRRShared.h
@@ -69,7 +69,7 @@ protected:
     template <class T>
     struct Property {
         std::string name;
-        T value;
+        T value{};
     };
 
     typedef Property<uint32_t> HexProperty;

--- a/test/unit/utIssues.cpp
+++ b/test/unit/utIssues.cpp
@@ -47,6 +47,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "TestModelFactory.h"
 
+#if !(defined(ASSIMP_BUILD_NO_IRR_IMPORTER) && defined(ASSIMP_BUILD_NO_IRRMESH_IMPORTER))
+#include "AssetLib/Irr/IRRShared.h"
+#endif
+
 using namespace Assimp;
 
 class utIssues : public ::testing::Test {};
@@ -81,3 +85,23 @@ TEST_F( utIssues, OpacityBugWhenExporting_727 ) {
 }
 
 #endif // ASSIMP_BUILD_NO_EXPORT
+
+#if !(defined(ASSIMP_BUILD_NO_IRR_IMPORTER) && defined(ASSIMP_BUILD_NO_IRRMESH_IMPORTER))
+
+namespace {
+
+class IrrPropertyReader : public IrrlichtBase {
+public:
+    using FloatProperty = IrrlichtBase::FloatProperty;
+};
+
+} // namespace
+
+TEST_F(utIssues, IrrMissingFloatValue_6790) {
+    IrrPropertyReader::FloatProperty property;
+
+    EXPECT_TRUE(property.name.empty());
+    EXPECT_FLOAT_EQ(0.0f, property.value);
+}
+
+#endif // IRR or IRRMESH importer


### PR DESCRIPTION
Fixes #6790.

## Root cause

IRR property objects left scalar `value` members uninitialized when an XML
property had a recognized `name` but no recognized `value` attribute. The
public OSS-Fuzz testcase contains such a malformed `Radius` attribute. Its
indeterminate float was copied into the generated sphere state and later read
on the import-to-export path.

## Fix

- Value-initialize property values so malformed or incomplete XML cannot
  propagate indeterminate scalar data.
- Add a focused regression test for the scalar-property initialization
  invariant, without adding an exporter dependency to the IRR unit coverage.

## Verification

- A focused MemorySanitizer probe using the exact public OSS-Fuzz testcase
  reported all four `Radius` bytes uninitialized before the fix and completed
  cleanly afterward with `Radius=0.0`.
- `utIssues.IrrMissingFloatValue_6790` passes in a warnings-as-errors
  AddressSanitizer build with the IRR importer enabled.
- `git diff --check` passes.

The uninitialized `Property<T>::value` member is present in v3.1 and v6.0.5,
so this is an old bug affecting stable releases rather than a short-lived
regression.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved default property initialization for more predictable values.
  * Fixed handling of missing floating-point values during IRR importing.
  * Ensured unnamed float properties default to an empty name and zero value.

* **Tests**
  * Added regression coverage for missing float values in imported data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->