### PR TITLE
MDL: reject non-positive skin dimensions and use size_t multiply in CreateTextureARGB8_3DGS_MDL3

### DIFF
--- a/code/AssetLib/MDL/MDLMaterialLoader.cpp
+++ b/code/AssetLib/MDL/MDLMaterialLoader.cpp
@@ -156,16 +156,19 @@ aiColor4D MDLImporter::ReplaceTextureWithColor(const aiTexture *pcTexture) {
 // Read a texture from a MDL3 file
 void MDLImporter::CreateTextureARGB8_3DGS_MDL3(const unsigned char *szData) {
     const MDL::Header *pcHeader = (const MDL::Header *)mBuffer; //the endianness is already corrected in the InternReadFile_3DGS_MDL345 function
-    const size_t len = pcHeader->skinwidth * pcHeader->skinheight;
+    if (pcHeader->skinwidth <= 0 || pcHeader->skinheight <= 0) {
+        throw DeadlyImportError("Invalid MDL3 file. Skin dimensions must be positive.");
+    }
+    const size_t len = (size_t)pcHeader->skinwidth * (size_t)pcHeader->skinheight;
     VALIDATE_FILE_SIZE(szData + len);
 
     // allocate a new texture object
     aiTexture *pcNew = new aiTexture();
-    pcNew->mWidth = pcHeader->skinwidth;
-    pcNew->mHeight = pcHeader->skinheight;
+    pcNew->mWidth = (unsigned int)pcHeader->skinwidth;
+    pcNew->mHeight = (unsigned int)pcHeader->skinheight;
 
-    if(pcNew->mWidth != 0 && pcNew->mHeight > UINT_MAX/pcNew->mWidth) {
-        throw DeadlyImportError("Invalid MDL file. A texture is too big.");
+    if (len > AI_MAX_ALLOC(aiTexel)) {
+        throw DeadlyImportError("Invalid MDL3 file. Texture allocation would exceed resource limit.");
     }
     pcNew->pcData = new aiTexel[pcNew->mWidth * pcNew->mHeight];
 

--- a/test/unit/ImportExport/utMDLImporter.cpp
+++ b/test/unit/ImportExport/utMDLImporter.cpp
@@ -78,3 +78,45 @@ private:
 TEST_F(utMDLImporter, importMDLFromFileTest) {
     EXPECT_TRUE(importerTest());
 }
+
+#ifndef ASSIMP_BUILD_NO_MDL_IMPORTER
+// Regression test for OSS-Fuzz issue #6793:
+// CreateTextureARGB8_3DGS_MDL3() computed skinwidth * skinheight as signed int32,
+// triggering UBSan integer-overflow when the product exceeds INT32_MAX.
+// After the fix the importer rejects the file before reaching the multiply.
+TEST_F(utMDLImporter, Quake1MDL3SkinDimensionOverflow) {
+    // Minimal Quake 1 MDL (ident="IDPO", version=6) with a group-skin whose
+    // skinwidth * skinheight = 50000 * 43000 = 2,150,000,000 > INT32_MAX.
+    // The importer must reject the file (return nullptr) rather than causing a
+    // signed-integer overflow UBSan crash.
+    static const unsigned char kMalformedMDL3[] = {
+        // Header: ident="IDPO"
+        0x49, 0x44, 0x50, 0x4F,
+        // version=6
+        0x06, 0x00, 0x00, 0x00,
+        // scale[3]=1.0,1.0,1.0
+        0x00, 0x00, 0x80, 0x3F, 0x00, 0x00, 0x80, 0x3F, 0x00, 0x00, 0x80, 0x3F,
+        // translate[3]=0.0,0.0,0.0
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        // boundingradius=1.0
+        0x00, 0x00, 0x80, 0x3F,
+        // vEyePos[3]=0.0,0.0,0.0
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        // num_skins=1, skinwidth=50000 (0xC350), skinheight=43000 (0xA7F8)
+        0x01, 0x00, 0x00, 0x00, 0x50, 0xC3, 0x00, 0x00, 0xF8, 0xA7, 0x00, 0x00,
+        // num_verts=3, num_tris=1, num_frames=1, synctype=0, flags=0
+        0x03, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        // Skin data: group=1 (group skin), nb=1 (one image)
+        0x01, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00,
+        // 1 float of group skin timing, then pixel stub (all zeros)
+        0xCD, 0xCC, 0xCC, 0x3D, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00
+    };
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFileFromMemory(
+        kMalformedMDL3, sizeof(kMalformedMDL3), 0, "mdl");
+    EXPECT_EQ(nullptr, scene);
+}
+#endif // ASSIMP_BUILD_NO_MDL_IMPORTER


### PR DESCRIPTION
## Summary

Fixes **OSS-Fuzz issue #6793** — signed-integer overflow (UBSan) in
`CreateTextureARGB8_3DGS_MDL3()` triggered by a Quake 1 MDL with
`skinwidth * skinheight > INT32_MAX`.

### Root cause

```cpp
const size_t len = pcHeader->skinwidth * pcHeader->skinheight;
```

Both `skinwidth` and `skinheight` are `int32_t`.  Multiplying two
`int32_t` values that together exceed `INT32_MAX` (e.g. 50 000 × 43 000
= 2 150 000 000 > 2 147 483 647) is undefined behaviour.  UBSan reports it
as signed-integer overflow; in practice the result wraps to a small positive
value, bypassing the `VALIDATE_FILE_SIZE` check that follows.

### Fix

1. Reject non-positive skin dimensions before computing `len` —
   `VALIDATE_FILE_SIZE` and the allocation guards already assume positive
   values.
2. Cast operands to `size_t` before multiplying so the arithmetic is done
   in 64-bit unsigned space and cannot overflow on any supported platform.
3. Add an `AI_MAX_ALLOC(aiTexel)` guard before the allocation to cap the
   maximum texture size at 256 MB.

### Test

`Quake1MDL3SkinDimensionOverflow` in `utMDLImporter.cpp` feeds a crafted
IDPO buffer (108 bytes) with `skinwidth = 50000`, `skinheight = 43000`
and asserts the importer returns `nullptr` rather than crashing.
All 17 MDL unit tests pass locally.

Fixes #6793

Assisted-by: Claude Code:claude-sonnet-4-6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation when importing Quake 1 MDL3 textures.
  - Rejects files with invalid or excessively large skin dimensions before allocation.
  - Prevents integer overflow and related crashes when processing malformed model files.

- **Tests**
  - Added regression coverage confirming oversized MDL3 skin data is rejected safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->