### PR TITLE
Fix out-of-bounds access on short uv source and mapping mode properties

### DIFF
--- a/code/PostProcessing/TextureTransform.cpp
+++ b/code/PostProcessing/TextureTransform.cpp
@@ -226,17 +226,30 @@ void TextureTransformStep::Execute( aiScene* pScene) {
                     }
 
                     if ( !::strcmp( prop2->mKey.data, "$tex.uvwsrc")) {
-                        info.uvIndex = *((int*)prop2->mData);
+                        if (prop2->mDataLength >= sizeof(unsigned int)) {
+                            info.uvIndex = *((int*)prop2->mData);
 
-                        // Store a direct pointer for later use
-                        update.directShortcut = (unsigned int*) prop2->mData;
+                            // Store a direct pointer for later use. Only safe while the
+                            // property is big enough to hold the index we write back.
+                            update.directShortcut = (unsigned int*) prop2->mData;
+                        } else {
+                            ASSIMP_LOG_WARN("Ignoring uv source property with insufficient data");
+                        }
                     }
 
                     else if ( !::strcmp( prop2->mKey.data, "$tex.mapmodeu")) {
-                        info.mapU = *((aiTextureMapMode*)prop2->mData);
+                        if (prop2->mDataLength >= sizeof(aiTextureMapMode)) {
+                            info.mapU = *((aiTextureMapMode*)prop2->mData);
+                        } else {
+                            ASSIMP_LOG_WARN("Ignoring u mapping mode property with insufficient data");
+                        }
                     }
                     else if ( !::strcmp( prop2->mKey.data, "$tex.mapmodev")) {
-                        info.mapV = *((aiTextureMapMode*)prop2->mData);
+                        if (prop2->mDataLength >= sizeof(aiTextureMapMode)) {
+                            info.mapV = *((aiTextureMapMode*)prop2->mData);
+                        } else {
+                            ASSIMP_LOG_WARN("Ignoring v mapping mode property with insufficient data");
+                        }
                     }
                     else if ( !::strcmp( prop2->mKey.data, "$tex.uvtrafo"))  {
                         if (prop2->mDataLength >= sizeof(aiUVTransform)) {

--- a/test/unit/utTextureTransform.cpp
+++ b/test/unit/utTextureTransform.cpp
@@ -67,6 +67,41 @@ aiScene *CreateSceneWithUVTransform(const void *trafoData, unsigned int trafoDat
     return scene;
 }
 
+// Builds a scene whose diffuse texture carries a one byte property under the given key.
+// The material also holds a real uv transform and is used by a mesh with uv coordinates,
+// so the step does not bail out early and reaches the code updating the uv index.
+aiScene *CreateSceneWithShortTextureProperty(const char *key) {
+    auto *mat = new aiMaterial;
+    aiString path("texture.png");
+    mat->AddProperty(&path, AI_MATKEY_TEXTURE_DIFFUSE(0));
+
+    const unsigned char oneByte = 0;
+    mat->AddBinaryProperty(&oneByte, sizeof(oneByte), key, aiTextureType_DIFFUSE, 0, aiPTI_Integer);
+
+    aiUVTransform trafo;
+    trafo.mTranslation = aiVector2D(0.5f, 0.25f);
+    trafo.mScaling = aiVector2D(2.f, 2.f);
+    mat->AddProperty(&trafo, 1, AI_MATKEY_UVTRANSFORM_DIFFUSE(0));
+
+    auto *mesh = new aiMesh;
+    mesh->mNumVertices = 3;
+    mesh->mVertices = new aiVector3D[3];
+    mesh->mTextureCoords[0] = new aiVector3D[3];
+    mesh->mNumUVComponents[0] = 2;
+    mesh->mMaterialIndex = 0;
+
+    auto *scene = new aiScene;
+    scene->mNumMaterials = 1;
+    scene->mMaterials = new aiMaterial *[1];
+    scene->mMaterials[0] = mat;
+    scene->mNumMeshes = 1;
+    scene->mMeshes = new aiMesh *[1];
+    scene->mMeshes[0] = mesh;
+    scene->mRootNode = new aiNode;
+
+    return scene;
+}
+
 } // namespace
 
 TEST(utTextureTransform, uvTransformPropertyIsConsumed) {
@@ -92,6 +127,36 @@ TEST(utTextureTransform, uvTransformPropertyShorterThanTheTransform) {
     TextureTransformStep step;
     step.SetupProperties(&importer);
     step.Execute(scene.get());
+
+    SUCCEED();
+}
+
+TEST(utTextureTransform, uvSourcePropertyShorterThanAnIndex) {
+    // A $tex.uvwsrc property smaller than the index it is supposed to hold must
+    // neither be read nor be kept as a write target for the new uv index.
+    std::unique_ptr<aiScene> scene(CreateSceneWithShortTextureProperty("$tex.uvwsrc"));
+
+    Importer importer;
+    TextureTransformStep step;
+    step.SetupProperties(&importer);
+    step.Execute(scene.get());
+
+    // The step replaces the short property with a proper one instead of writing into it.
+    int uvIndex = -1;
+    EXPECT_EQ(AI_SUCCESS, scene->mMaterials[0]->Get(AI_MATKEY_UVWSRC_DIFFUSE(0), uvIndex));
+    EXPECT_EQ(0, uvIndex);
+}
+
+TEST(utTextureTransform, mappingModePropertiesShorterThanTheMode) {
+    // Same for the two mapping mode properties, which are read as a full enum value.
+    for (const char *key : { "$tex.mapmodeu", "$tex.mapmodev" }) {
+        std::unique_ptr<aiScene> scene(CreateSceneWithShortTextureProperty(key));
+
+        Importer importer;
+        TextureTransformStep step;
+        step.SetupProperties(&importer);
+        step.Execute(scene.get());
+    }
 
     SUCCEED();
 }


### PR DESCRIPTION
#6748 added a length check to the `$tex.uvtrafo` branch of the property scan in
`TextureTransformStep::Execute`. The three sibling branches in the same loop read from
the same allocation and still have none:

```
$tex.uvwsrc    info.uvIndex = *((int*)prop2->mData);            // 4 bytes
$tex.mapmodeu  info.mapU = *((aiTextureMapMode*)prop2->mData);  // 4 bytes
$tex.mapmodev  info.mapV = *((aiTextureMapMode*)prop2->mData);  // 4 bytes
```

`mDataLength` comes from the file. `AssbinImporter::ReadBinaryMaterialProperty` does
`new char[prop->mDataLength]` with only an upper bound on the size, so a `.assbin` that
declares `$tex.uvwsrc` with `mDataLength = 1` produces a one byte allocation that the
step then reads four bytes out of.

The uvwsrc case does not stop at a read. The same pointer is stored:

```cpp
update.directShortcut = (unsigned int*) prop2->mData;
```

and `UpdateUVIndex` later does `*info.directShortcut = n;`, so the one byte property gets
written through as well. To reach the write the material has to be used by a mesh with uv
coordinates and a transform worth applying. The same file supplies that with a normal
`$tex.uvtrafo` property.

`aiProcess_TransformUVCoords` is one of the steps in `fuzz/assimp_postprocess_fuzzer.cc`,
so the OSS-Fuzz target reaches this.

The fix follows the uvtrafo branch: check `mDataLength` before each read, and do not keep
`directShortcut` when the property is too small, otherwise the write stays live even
though the read is fixed.

Tests for the three keys are in `test/unit/utTextureTransform.cpp`.

ASan on master, before the change:

```
==1319317==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x7b7d0ede0190 at pc 0x55c0b37f442a bp 0x7ffd1d6535d0 sp 0x7ffd1d6535c8
READ of size 4 at 0x7b7d0ede0190 thread T0
    #0 0x55c0b37f4429 in Assimp::TextureTransformStep::Execute(aiScene*) code/PostProcessing/TextureTransform.cpp:229:40
    #1 0x55c0b374326c in Assimp::BaseProcess::ExecuteOnScene(Assimp::Importer*) code/Common/BaseProcess.cpp:82:9
    #2 0x55c0b36b02c9 in Assimp::Importer::ApplyPostProcessing(unsigned int) code/Common/Importer.cpp:842:22
    #3 0x55c0b36a25c2 in LLVMFuzzerTestOneInput fuzz/assimp_postprocess_fuzzer.cc:115:14
    #4 0x55c0b36a2b45 in main replay_main.cpp:27:12
    #5 0x7f5d0fc27780 in __libc_start_call_main /usr/src/debug/glibc/glibc/csu/../sysdeps/nptl/libc_start_call_main.h:59:16
    #6 0x7f5d0fc278b8 in __libc_start_main /usr/src/debug/glibc/glibc/csu/../csu/libc-start.c:372:3
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of incomplete texture properties during scene processing.
  * Prevented invalid reads and writes when UV source or mapping data is undersized.
  * Safely ignores malformed properties while continuing to process valid texture data.

* **Tests**
  * Added coverage for incomplete UV source and mapping-mode properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->