### PR TITLE
3MF: free OPC package resources when the constructor throws

### DIFF
--- a/code/AssetLib/3MF/D3MFOpcPackage.cpp
+++ b/code/AssetLib/3MF/D3MFOpcPackage.cpp
@@ -56,6 +56,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cassert>
 #include <cstdlib>
 #include <map>
+#include <memory>
 #include <vector>
 
 namespace Assimp {
@@ -134,12 +135,34 @@ D3MFOpcPackage::D3MFOpcPackage(IOSystem *pIOHandler, const std::string &rFile) :
         mRootPath(),
         mZipArchive() {
     mZipArchive = new ZipArchiveIOSystem(pIOHandler, rFile);
+    // Own the archive for the duration of the constructor: several paths below throw,
+    // and a constructor that throws never runs its destructor, so a raw pointer here
+    // leaks the archive and every embedded texture read so far.
+    std::unique_ptr<ZipArchiveIOSystem> archive_owner(mZipArchive);
     if (!mZipArchive->isOpen()) {
         throw DeadlyImportError("Failed to open file ", rFile, ".");
     }
 
     std::vector<std::string> fileList;
     mZipArchive->getFileList(fileList);
+
+    // Same reasoning for the textures: they are handed to the scene only on success
+    // (D3MFImporter::InternReadFile), so any throw below must free them here.
+    struct TextureGuard {
+        std::vector<aiTexture *> *textures;
+        ~TextureGuard() {
+            if (textures != nullptr) {
+                for (aiTexture *texture : *textures) {
+                    std::unique_ptr<aiTexture> texture_owner(texture);
+                }
+                textures->clear();
+            }
+        }
+        TextureGuard(const TextureGuard &) = delete;
+        TextureGuard &operator=(const TextureGuard &) = delete;
+    };
+
+    TextureGuard texture_guard{ &mEmbeddedTextures };
 
     for (auto &file : fileList) {
         if (file == D3MF::XmlTag::ROOT_RELATIONSHIPS_ARCHIVE) {
@@ -153,7 +176,15 @@ D3MFOpcPackage::D3MFOpcPackage(IOSystem *pIOHandler, const std::string &rFile) :
                 continue;
             }
 
-            std::string rootFile = NormalizePath(ReadPackageRootRelationship(fileStream));
+            std::string rootFile;
+            try {
+                rootFile = NormalizePath(ReadPackageRootRelationship(fileStream));
+            } catch (...) {
+                // ReadPackageRootRelationship throws for a missing start-part relationship;
+                // the stream must not leak on that path.
+                mZipArchive->Close(fileStream);
+                throw;
+            }
 
             ASSIMP_LOG_VERBOSE_DEBUG(rootFile);
 
@@ -169,7 +200,12 @@ D3MFOpcPackage::D3MFOpcPackage(IOSystem *pIOHandler, const std::string &rFile) :
             ASSIMP_LOG_WARN("Ignored file of unsupported type CONTENT_TYPES_ARCHIVES", file);
         } else if (IsEmbeddedTexture(file)) {
             IOStream *fileStream = mZipArchive->Open(file.c_str());
-            LoadEmbeddedTextures(fileStream, file);
+            try {
+                LoadEmbeddedTextures(fileStream, file);
+            } catch (...) {
+                mZipArchive->Close(fileStream);
+                throw;
+            }
             mZipArchive->Close(fileStream);
         } else if (BaseImporter::GetExtension(file) == "model") {
             // Production-extension model parts are opened on demand via OpenPart().
@@ -181,6 +217,10 @@ D3MFOpcPackage::D3MFOpcPackage(IOSystem *pIOHandler, const std::string &rFile) :
             ASSIMP_LOG_WARN("Ignored file of unknown type: ", file);
         }
     }
+
+    // Constructor succeeded: hand ownership back to the members.
+    texture_guard.textures = nullptr;
+    archive_owner.release();
 }
 
 D3MFOpcPackage::~D3MFOpcPackage() {


### PR DESCRIPTION
## Summary

`D3MFOpcPackage::D3MFOpcPackage` allocates the resources it owns through raw pointers and then throws on three separate paths (`code/AssetLib/3MF/D3MFOpcPackage.cpp`). A constructor that throws never runs its destructor, so `~D3MFOpcPackage`, which does the `delete mZipArchive`, is never called, and the archive leaks along with every embedded texture read before the throw:

1. line 138, `!mZipArchive->isOpen()`: the file is not a readable zip
2. line 249, inside `ReadPackageRootRelationship`: `_rels/.rels` carries no start-part relationship (`Cannot find <type>`)
3. line 166: the start-part relationship names a member the archive does not hold

Two resources leak on all three paths: the `ZipArchiveIOSystem` allocated at line 136, and `mEmbeddedTextures` — a `std::vector<aiTexture*>` filled by `LoadEmbeddedTextures` whose ownership transfers to `aiScene::mTextures` only on success; the destructor never frees them. On path 2 there is a fourth leak: the `IOStream` opened for `_rels/.rels` at line 150, because `ReadPackageRootRelationship` throws before the `Close(fileStream)` at line 160 runs. The same stream-leak pattern exists at the embedded-texture branch (lines 170-173), where anything thrown between `Open()` and `Close()` also skips the close.

This is not a regression — the raw-pointer ownership predates the current file layout. Earlier oss-fuzz reports about this class (#4628, #5392) covered only the `CanRead` path, which #4629/#5393 fixed by no longer constructing the package during `CanRead`; the `InternReadFile` paths above still leak.

## Impact

- Any file with a `.3mf` extension that is not a readable zip hits path 1, so the leak is reachable from ordinary user input, not just crafted files. CWE-401.
- Paths 2 and 3 are reachable with valid zips that merely have a wrong or missing root relationship.
- Under a long-running process (e.g. an asset pipeline importing many files) each rejected file leaks the zip archive mapping plus any embedded textures.

## Reproduction

Build assimp with `-fsanitize=address` and read one of the following through `Assimp::Importer::ReadFile`:

- Case A (path 1): `printf 'not a zip at all\n' > plain.3mf`
  Before: `SUMMARY: AddressSanitizer: 96 byte(s) leaked in 2 allocation(s).` — both allocations trace to `D3MFOpcPackage.cpp:136`. No assert is involved, so release builds leak identically.
- Case B (path 3): a valid zip containing `[Content_Types].xml` and `_rels/.rels` whose start-part relationship targets `/3D/3dmodel.model` without that member being present.
- Path 2: same zip, but the relationship's `Type` is not the 3D-model start-part type.
- Embedded-texture variant: add a texture entry named e.g. `Tex.png` to cases B/path 2. The constructor walks `getFileList()`, which iterates alphabetically, so an uppercase-leading name reaches `LoadEmbeddedTextures` before `_rels/.rels` does; the `new aiTexture` at line 267 plus its data buffer then leak.

With this patch, all four cases report zero leaks under LeakSanitizer and the `DeadlyImportError` messages are byte-identical to master. The models under `test/models/3MF/` still load with no leaks.

## Fix

Hold the archive in a `std::unique_ptr<ZipArchiveIOSystem>` for the duration of the constructor and `release()` it into the member only once the constructor has succeeded; free the embedded textures with a small scope guard cleared on success; and close the opened stream before rethrowing at both sites that can throw while a stream is open (`ReadPackageRootRelationship` and `LoadEmbeddedTextures`):

```cpp
mZipArchive = new ZipArchiveIOSystem(pIOHandler, rFile);
std::unique_ptr<ZipArchiveIOSystem> archive_owner(mZipArchive);
```

No behavior change: every error message and the success path are unchanged. One known limit, left as is: inside `LoadEmbeddedTextures` itself, an exception between `new unsigned char[size]` / `new aiTexture` and the `emplace_back` would still leak that one half-built texture — the guard can only free what is already in `mEmbeddedTextures`. A wider cleanup (making `mZipArchive` a `std::unique_ptr` member and `mEmbeddedTextures` a vector of `std::unique_ptr<aiTexture>`) would remove the manual `delete` from the destructor too, but touches the header and the ownership transfer in `D3MFImporter::InternReadFile`, so I kept this diff minimal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when opening 3MF packages by ensuring archive and texture resources are cleaned up if loading fails.
  * Stream handling now closes resources correctly when errors occur, reducing the risk of leaks or incomplete cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->