### PR TITLE
3MF: free OPC package resources on every failure path

### DIFF
--- a/code/AssetLib/3MF/D3MFImporter.cpp
+++ b/code/AssetLib/3MF/D3MFImporter.cpp
@@ -110,13 +110,14 @@ void D3MFImporter::InternReadFile(const std::string &filename, aiScene *pScene, 
         XmlSerializer xmlSerializer(xmlParser, &opcPackage);
         xmlSerializer.ImportXml(pScene);
 
-        const std::vector<aiTexture*> &tex =  opcPackage.GetEmbeddedTextures();
-        if (!tex.empty()) {
-            pScene->mNumTextures = static_cast<unsigned int>(tex.size());
-            pScene->mTextures = new aiTexture *[pScene->mNumTextures];
-            for (unsigned int i = 0; i < pScene->mNumTextures; ++i) {
-                pScene->mTextures[i] = tex[i];
+        std::vector<std::unique_ptr<aiTexture>> embedded = opcPackage.TakeEmbeddedTextures();
+        if (!embedded.empty()) {
+            // embedded still owns the textures, so a throwing allocation here frees them.
+            pScene->mTextures = new aiTexture *[embedded.size()];
+            for (size_t i = 0; i < embedded.size(); ++i) {
+                pScene->mTextures[i] = embedded[i].release();
             }
+            pScene->mNumTextures = static_cast<unsigned int>(embedded.size());
         }
     }
 }

--- a/code/AssetLib/3MF/D3MFOpcPackage.cpp
+++ b/code/AssetLib/3MF/D3MFOpcPackage.cpp
@@ -56,6 +56,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cassert>
 #include <cstdlib>
 #include <map>
+#include <memory>
 #include <vector>
 
 namespace Assimp {
@@ -128,64 +129,109 @@ static bool IsEmbeddedTexture( const std::string &filename ) {
 
     return false;
 }
+
+namespace {
+
+/// @brief Closes a stream taken from the archive on every exit path, exceptions included.
+struct ScopedArchiveStream {
+    ScopedArchiveStream(ZipArchiveIOSystem &archive, IOStream *stream) :
+            mArchive(archive), mStream(stream) {
+        // empty
+    }
+
+    ~ScopedArchiveStream() {
+        mArchive.Close(mStream);
+    }
+
+    ScopedArchiveStream(const ScopedArchiveStream &) = delete;
+    ScopedArchiveStream &operator=(const ScopedArchiveStream &) = delete;
+
+    IOStream *get() const {
+        return mStream;
+    }
+
+private:
+    ZipArchiveIOSystem &mArchive;
+    IOStream *mStream;
+};
+
+} // namespace
+
 // ------------------------------------------------------------------------------------------------
 D3MFOpcPackage::D3MFOpcPackage(IOSystem *pIOHandler, const std::string &rFile) :
         mRootStream(nullptr),
         mRootPath(),
-        mZipArchive() {
+        mZipArchive(nullptr) {
     mZipArchive = new ZipArchiveIOSystem(pIOHandler, rFile);
-    if (!mZipArchive->isOpen()) {
-        throw DeadlyImportError("Failed to open file ", rFile, ".");
-    }
 
-    std::vector<std::string> fileList;
-    mZipArchive->getFileList(fileList);
-
-    for (auto &file : fileList) {
-        if (file == D3MF::XmlTag::ROOT_RELATIONSHIPS_ARCHIVE) {
-            if (!mZipArchive->Exists(file.c_str())) {
-                continue;
-            }
-
-            IOStream *fileStream = mZipArchive->Open(file.c_str());
-            if (nullptr == fileStream) {
-                ASSIMP_LOG_ERROR("Filestream is nullptr.");
-                continue;
-            }
-
-            std::string rootFile = NormalizePath(ReadPackageRootRelationship(fileStream));
-
-            ASSIMP_LOG_VERBOSE_DEBUG(rootFile);
-
-            mZipArchive->Close(fileStream);
-
-            mRootPath = rootFile;
-            mRootStream = mZipArchive->Open(rootFile.c_str());
-            ai_assert(mRootStream != nullptr);
-            if (nullptr == mRootStream) {
-                throw DeadlyImportError("Cannot open root-file in archive : " + rootFile);
-            }
-        } else if (file == D3MF::XmlTag::CONTENT_TYPES_ARCHIVE) {
-            ASSIMP_LOG_WARN("Ignored file of unsupported type CONTENT_TYPES_ARCHIVES", file);
-        } else if (IsEmbeddedTexture(file)) {
-            IOStream *fileStream = mZipArchive->Open(file.c_str());
-            LoadEmbeddedTextures(fileStream, file);
-            mZipArchive->Close(fileStream);
-        } else if (BaseImporter::GetExtension(file) == "model") {
-            // Production-extension model parts are opened on demand via OpenPart().
-            ASSIMP_LOG_VERBOSE_DEBUG("Referenced model part: ", file);
-        } else if (BaseImporter::GetExtension(file) == "rels") {
-            // Relationship parts of referenced model files; resolved via path attributes.
-            ASSIMP_LOG_VERBOSE_DEBUG("Relationship part: ", file);
-        } else {
-            ASSIMP_LOG_WARN("Ignored file of unknown type: ", file);
+    // A constructor that throws never runs its destructor. Every throwing path below must free
+    // what the package already owns: the archive, the root stream, and the textures read so far.
+    try {
+        if (!mZipArchive->isOpen()) {
+            throw DeadlyImportError("Failed to open file ", rFile, ".");
         }
+
+        std::vector<std::string> fileList;
+        mZipArchive->getFileList(fileList);
+
+        for (auto &file : fileList) {
+            if (file == D3MF::XmlTag::ROOT_RELATIONSHIPS_ARCHIVE) {
+                if (!mZipArchive->Exists(file.c_str())) {
+                    continue;
+                }
+
+                IOStream *stream = mZipArchive->Open(file.c_str());
+                if (nullptr == stream) {
+                    ASSIMP_LOG_ERROR("Filestream is nullptr.");
+                    continue;
+                }
+                ScopedArchiveStream fileStream(*mZipArchive, stream);
+
+                const std::string rootFile = NormalizePath(ReadPackageRootRelationship(fileStream.get()));
+
+                ASSIMP_LOG_VERBOSE_DEBUG(rootFile);
+
+                mRootPath = rootFile;
+                mRootStream = mZipArchive->Open(rootFile.c_str());
+                ai_assert(mRootStream != nullptr);
+                if (nullptr == mRootStream) {
+                    throw DeadlyImportError("Cannot open root-file in archive : " + rootFile);
+                }
+            } else if (file == D3MF::XmlTag::CONTENT_TYPES_ARCHIVE) {
+                ASSIMP_LOG_WARN("Ignored file of unsupported type CONTENT_TYPES_ARCHIVES", file);
+            } else if (IsEmbeddedTexture(file)) {
+                ScopedArchiveStream fileStream(*mZipArchive, mZipArchive->Open(file.c_str()));
+                LoadEmbeddedTextures(fileStream.get(), file);
+            } else if (BaseImporter::GetExtension(file) == "model") {
+                // Production-extension model parts are opened on demand via OpenPart().
+                ASSIMP_LOG_VERBOSE_DEBUG("Referenced model part: ", file);
+            } else if (BaseImporter::GetExtension(file) == "rels") {
+                // Relationship parts of referenced model files; resolved via path attributes.
+                ASSIMP_LOG_VERBOSE_DEBUG("Relationship part: ", file);
+            } else {
+                ASSIMP_LOG_WARN("Ignored file of unknown type: ", file);
+            }
+        }
+    } catch (...) {
+        FreeResources();
+        throw;
     }
 }
 
 D3MFOpcPackage::~D3MFOpcPackage() {
-    mZipArchive->Close(mRootStream);
+    FreeResources();
+}
+
+void D3MFOpcPackage::FreeResources() noexcept {
+    mEmbeddedTextures.clear();
+
+    if (mRootStream != nullptr) {
+        mZipArchive->Close(mRootStream);
+        mRootStream = nullptr;
+    }
+
     delete mZipArchive;
+    mZipArchive = nullptr;
 }
 
 IOStream *D3MFOpcPackage::RootStream() const {
@@ -219,8 +265,15 @@ void D3MFOpcPackage::CloseStream(IOStream *stream) {
     }
 }
 
-const std::vector<aiTexture *> &D3MFOpcPackage::GetEmbeddedTextures() const {
+const std::vector<std::unique_ptr<aiTexture>> &D3MFOpcPackage::GetEmbeddedTextures() const {
     return mEmbeddedTextures;
+}
+
+std::vector<std::unique_ptr<aiTexture>> D3MFOpcPackage::TakeEmbeddedTextures() {
+    std::vector<std::unique_ptr<aiTexture>> textures;
+    textures.swap(mEmbeddedTextures);
+
+    return textures;
 }
 
 static const char *const ModelRef = "3D/3dmodel.model";
@@ -262,9 +315,12 @@ void D3MFOpcPackage::LoadEmbeddedTextures(IOStream *fileStream, const std::strin
         return;
     }
 
-    unsigned char *data = new unsigned char[size];
-    fileStream->Read(data, 1, size);
-    aiTexture *texture = new aiTexture;
+    // ~aiTexture frees pcData with delete[] as aiTexel*, so allocate that type, as the other
+    // importers do, and round the byte count up. The texture owns the buffer from here and the
+    // unique_ptr owns the texture, so anything that throws before the emplace_back frees both.
+    auto texture = std::make_unique<aiTexture>();
+    texture->pcData = new aiTexel[(size + sizeof(aiTexel) - 1) / sizeof(aiTexel)];
+    fileStream->Read(texture->pcData, 1, size);
     std::string embName = "*" + filename;
     texture->mFilename.Set(embName.c_str());
     texture->mWidth = static_cast<unsigned int>(size);
@@ -273,8 +329,7 @@ void D3MFOpcPackage::LoadEmbeddedTextures(IOStream *fileStream, const std::strin
     texture->achFormatHint[1] = 'n';
     texture->achFormatHint[2] = 'g';
     texture->achFormatHint[3] = '\0';
-    texture->pcData = (aiTexel*) data;
-    mEmbeddedTextures.emplace_back(texture);
+    mEmbeddedTextures.emplace_back(std::move(texture));
 }
 
 } // Namespace D3MF

--- a/code/AssetLib/3MF/D3MFOpcPackage.h
+++ b/code/AssetLib/3MF/D3MFOpcPackage.h
@@ -64,6 +64,9 @@ class D3MFOpcPackage {
 public:
     D3MFOpcPackage( IOSystem* pIOHandler, const std::string& file );
     ~D3MFOpcPackage();
+    // The package owns the archive through a raw pointer, so copying one would free it twice.
+    D3MFOpcPackage(const D3MFOpcPackage &) = delete;
+    D3MFOpcPackage &operator=(const D3MFOpcPackage &) = delete;
     IOStream* RootStream() const;
     /// @brief Absolute path of the root model part inside the container (production extension).
     const std::string &RootPath() const;
@@ -74,17 +77,24 @@ public:
     /// @brief Strip leading slashes so an OPC absolute path matches the zip entry name.
     static std::string NormalizePath(const std::string &path);
     bool validate();
-    const std::vector<aiTexture*> &GetEmbeddedTextures() const;
+    const std::vector<std::unique_ptr<aiTexture>> &GetEmbeddedTextures() const;
+    /// @brief Hand the embedded textures to the caller, who owns them from then on.
+    ///        Until then the package frees them itself.
+    std::vector<std::unique_ptr<aiTexture>> TakeEmbeddedTextures();
 
 protected:
     std::string ReadPackageRootRelationship(IOStream* stream);
     void LoadEmbeddedTextures(IOStream *fileStream, const std::string &filename);
 
 private:
+    /// @brief Free everything the package still owns. The destructor calls this, and so does
+    ///        the constructor's failure path, which the destructor does not cover.
+    void FreeResources() noexcept;
+
     IOStream* mRootStream;
     std::string mRootPath;
     ZipArchiveIOSystem *mZipArchive;
-    std::vector<aiTexture *> mEmbeddedTextures;
+    std::vector<std::unique_ptr<aiTexture>> mEmbeddedTextures;
 };
 
 } // namespace D3MF


### PR DESCRIPTION
## Summary

`D3MFOpcPackage` owns its resources through raw pointers, and both the constructor and the handoff to the scene have failure paths that free nothing. A constructor that throws never runs its destructor, and the destructor never freed the embedded textures at all, so ordinary malformed input leaks.

The constructor (`code/AssetLib/3MF/D3MFOpcPackage.cpp`) throws on three paths:

1. `!mZipArchive->isOpen()`: the file is not a readable zip
2. inside `ReadPackageRootRelationship`: `_rels/.rels` carries no start-part relationship (`Cannot find <type>`)
3. the start-part relationship names a member the archive does not hold

All three leak the `ZipArchiveIOSystem` and every `aiTexture` that `LoadEmbeddedTextures` read before the throw. Path 2 also leaks the `IOStream` opened for `_rels/.rels`.

`D3MFImporter::InternReadFile` moves the textures into `aiScene::mTextures` only after `xmlParser.parse()` succeeds. When the root model part is not parseable XML, nothing frees them. Any valid package with a malformed model part hits this.

This is not a regression. The ownership predates the current file layout. Earlier oss-fuzz reports on this class (#4628, #5392) covered only the `CanRead` path, which #4629/#5393 fixed by no longer constructing the package during `CanRead`.

## Impact

- Any `.3mf` file that is not a readable zip hits path 1, so the leak is reachable from ordinary user input rather than crafted files. CWE-401.
- Paths 2 and 3 need only a valid zip with a wrong or missing root relationship.
- The parse-failure path leaks decoded textures, which dwarf the archive handle: 1115 bytes against 96 in the cases below.
- An asset pipeline importing many files leaks on every rejected one.

## Fix

The constructor body now sits in one `try { ... } catch (...) { FreeResources(); throw; }`. `FreeResources()` is a new private helper that frees the textures, closes the root stream and deletes the archive. The destructor calls it too, so construction failure and normal destruction free through one code path.

A file-local `ScopedArchiveStream` closes streams taken from the archive on every exit path, covering both sites that can throw while a stream is open. `mEmbeddedTextures` becomes a `std::vector<std::unique_ptr<aiTexture>>`, so nothing deletes a texture by hand. `LoadEmbeddedTextures` attaches the pixel buffer to its `aiTexture` as soon as it allocates it, which means a throw before the texture is stored frees both. A new `TakeEmbeddedTextures()` makes the handoff explicit: `InternReadFile` holds the moved-out vector while it fills `aiScene::mTextures`, so a failed allocation there frees the textures instead of stranding them.

Every error message, log line and success path is unchanged.

## Verification

Built with `-fsanitize=address` and read through `Assimp::Importer::ReadFile`. Each row is relinked against the build under test.

| case | before | after |
|---|---|---|
| not a zip (`printf 'not a zip at all\n' > plain.3mf`) | 96 B / 2 allocs | clean |
| valid `.rels`, start-part member absent | 684 B / 7 | clean |
| relationship `Type` is not the 3D-model start-part type | 987 B / 9 | clean |
| the two above, plus a `Tex.png` entry | 1887 B / 10, 2190 B / 12 | clean |
| valid package with a texture, unparseable root model part | 1115 B / 2 | clean |

The `Tex.png` variants matter because `getFileList()` iterates alphabetically and `_` sorts after `A-Z`, so an uppercase name reaches `LoadEmbeddedTextures` before `_rels/.rels` does.

Everything under `test/models/3MF/` still loads with the same mesh and texture counts, the same decoded texture bytes, and no leaks. `cube_gears_prod_req.3mf` carries 17 embedded textures, so the success handoff is covered. The library builds clean with `-DASSIMP_WARNINGS_AS_ERRORS=ON`, and `clang-format` reports no changes on any line this PR touches.

## Known limit, left as is

`XmlSerializer::LoadModelFile` opens a part via `OpenPart()` and calls `CloseStream()` only on the fall-through path, so a throw from `parser.parse()` or `ReadModel()` leaks that stream. `XmlSerializer.cpp` contains no explicit `throw`, so only `bad_alloc` reaches it. That is much narrower than the paths fixed here and belongs in its own change.

## AI usage

AI tools were used to help track down and fix this bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when importing 3MF files containing embedded textures.
  * Prevented resource leaks and ensured temporary archive and texture data are cleaned up when errors occur.
  * Preserved embedded textures safely when transferring them into imported scenes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->