### PR TITLE
Fix null context logging in glTF object lookup

### DIFF
--- a/code/AssetLib/glTFCommon/glTFCommon.h
+++ b/code/AssetLib/glTFCommon/glTFCommon.h
@@ -467,7 +467,13 @@ inline Value *FindObjectInContext(Value &val, const char * memberId, const char 
         return nullptr;
     }
     if (!it->value.IsObject()) {
-        ASSIMP_LOG_ERROR("Member \"", memberId, "\" was not of type \"", context, "\" when reading ", extraContext);
+        std::string fullContext = context;
+        if (extraContext && extraContext[0] != '\0') {
+            fullContext += " (";
+            fullContext += extraContext;
+            fullContext += ")";
+        }
+        ASSIMP_LOG_ERROR("Member \"", memberId, "\" was not of type \"object\" when reading ", fullContext);
         return nullptr;
    }
     return &it->value;

--- a/test/models/glTF2/wrongTypes/topLevelExtensionsNotObject.gltf
+++ b/test/models/glTF2/wrongTypes/topLevelExtensionsNotObject.gltf
@@ -1,0 +1,1 @@
+{"asset":{"version":"2.0"},"extensions":0,"scene":0,"scenes":[{"nodes":[0]}],"nodes":[{}]}

--- a/test/unit/utglTF2ImportExport.cpp
+++ b/test/unit/utglTF2ImportExport.cpp
@@ -964,7 +964,8 @@ TEST_F(utglTF2ImportExport, wrongObject) {
 #define TUPLE(x, y, z, w) tup_T(x, y, z, w)
 #endif
     TUPLE("/glTF2/wrongTypes/badObject.gltf", "object", "pbrMetallicRoughness", "materials[0]"),
-    TUPLE("/glTF2/wrongTypes/badExtension.gltf", "object", "KHR_texture_transform", "materials[0]")
+    TUPLE("/glTF2/wrongTypes/badExtension.gltf", "object", "KHR_texture_transform", "materials[0]"),
+    TUPLE("/glTF2/wrongTypes/topLevelExtensionsNotObject.gltf", "object", "extensions", "the document")
 #undef TUPLE
     };
     for (const auto &tuple : wrongTypes) {
@@ -1055,4 +1056,3 @@ TEST_F(utglTF2ImportExport, testSetIdentityMatrixEpsilon) {
     m = aiMatrix4x4(1.00009f, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1);
     EXPECT_TRUE(m.IsIdentity(epsilon));
 }
-


### PR DESCRIPTION
## Summary

- guard the optional glTF object error context before formatting it
- report the expected `object` type with the same context format as sibling lookups
- add a regression fixture for a non-object top-level `extensions` member

## Testing

- reproduced the original 64-byte GLB crash under AddressSanitizer before the fix
- `build-asan/bin/unit --gtest_filter=utglTF2ImportExport.wrongObject`
- `build-asan/bin/unit --gtest_filter=utglTF2ImportExport.*` (48 tests)
- verified the original GLB no longer triggers an AddressSanitizer error

Fixes #6811

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting when invalid glTF object types are encountered.
  * Error messages now correctly identify the expected type and include the full context.

* **Tests**
  * Added coverage for invalid top-level extensions data to ensure imports handle malformed assets safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->