### PR TITLE
Fix loop condition to prevent out-of-bounds access

### DIFF
--- a/code/AssetLib/STEPParser/STEPFileReader.cpp
+++ b/code/AssetLib/STEPParser/STEPFileReader.cpp
@@ -434,7 +434,7 @@ std::shared_ptr<const EXPRESS::LIST> EXPRESS::LIST::Parse(const char*& inout, co
 
     // estimate the number of items upfront - lists can grow large
     size_t count = 1;
-    for(const char* c=cur; *c && *c != ')'; ++c) {
+    for(const char* c=cur; *c && *c != ')' && c != end; ++c) {
         count += (*c == ',' ? 1 : 0);
     }
 

--- a/code/AssetLib/STEPParser/STEPFileReader.cpp
+++ b/code/AssetLib/STEPParser/STEPFileReader.cpp
@@ -434,7 +434,7 @@ std::shared_ptr<const EXPRESS::LIST> EXPRESS::LIST::Parse(const char*& inout, co
 
     // estimate the number of items upfront - lists can grow large
     size_t count = 1;
-    for(const char* c=cur; *c && *c != ')' && c != end; ++c) {
+    for(const char* c=cur; *c && c != end && *c != ')'; ++c) {
         count += (*c == ',' ? 1 : 0);
     }
 


### PR DESCRIPTION
- closes https://github.com/assimp/assimp/issues/6815

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved STEP file parsing by preventing list-item scans from reading beyond the provided input buffer.
  * Enhanced parser reliability when processing lists with a defined endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->