### PR TITLE
Fix memory leaks in IRR and re-enable their tests

### DIFF
--- a/code/AssetLib/Irr/IRRLoader.cpp
+++ b/code/AssetLib/Irr/IRRLoader.cpp
@@ -658,7 +658,7 @@ void IRRImporter::GenerateGraph(Node *root, aiNode *rootOut, aiScene *scene,
             // often the case so we can simply extract it to a shared oacity
             // value.
             auto &src = root->materials[mesh->mMaterialIndex];
-            aiMaterial *mat = (aiMaterial *)src.first;
+            aiMaterial *mat = src.first;
 
             if (mesh->HasVertexColors(0) && src.second & AI_IRRMESH_MAT_trans_vertex_alpha) {
                 bool bdo = true;

--- a/code/AssetLib/Irr/IRRLoader.cpp
+++ b/code/AssetLib/Irr/IRRLoader.cpp
@@ -1326,7 +1326,9 @@ void IRRImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
     if (!materials.empty()) {
         tempScene->mNumMaterials = (unsigned int)materials.size();
         tempScene->mMaterials = new aiMaterial *[tempScene->mNumMaterials];
-        ::memcpy(tempScene->mMaterials, &materials[0], sizeof(void *) * tempScene->mNumMaterials);
+        for (unsigned int i = 0; i < tempScene->mNumMaterials; i++) {
+            tempScene->mMaterials[i] = materials[i];
+        }
     }
 
     //  Now merge all sub scenes and attach them to the correct

--- a/code/AssetLib/Irr/IRRLoader.cpp
+++ b/code/AssetLib/Irr/IRRLoader.cpp
@@ -162,10 +162,10 @@ aiMesh *IRRImporter::BuildSingleQuadMesh(const SkyboxVertex &v1,
 }
 
 // ------------------------------------------------------------------------------------------------
-void IRRImporter::BuildSkybox(std::vector<aiMesh *> &meshes, std::vector<aiMaterial *> materials) {
+void IRRImporter::BuildSkybox(std::vector<aiMesh *> &meshes, std::vector<std::unique_ptr<aiMaterial> > &materials) {
     // Update the material of the skybox - replace the name and disable shading for skyboxes.
     for (unsigned int i = 0; i < 6; ++i) {
-        aiMaterial *out = (aiMaterial *)(*(materials.end() - (6 - i)));
+        aiMaterial *out = (*(materials.end() - (6 - i))).get();
 
         aiString s;
         s.length = ::ai_snprintf(s.data, AI_MAXLEN, "SkyboxSide_%u", i);
@@ -231,8 +231,8 @@ void IRRImporter::BuildSkybox(std::vector<aiMesh *> &meshes, std::vector<aiMater
 }
 
 // ------------------------------------------------------------------------------------------------
-void IRRImporter::CopyMaterial(std::vector<aiMaterial *> &materials,
-        std::vector<std::pair<aiMaterial *, unsigned int>> &inmaterials,
+void IRRImporter::CopyMaterial(std::vector<std::unique_ptr<aiMaterial> > &materials,
+        std::vector<std::pair<std::unique_ptr<aiMaterial>, unsigned int>> &inmaterials,
         unsigned int &defMatIdx,
         aiMesh *mesh) {
     if (inmaterials.empty()) {
@@ -256,7 +256,7 @@ void IRRImporter::CopyMaterial(std::vector<aiMaterial *> &materials,
     }
 
     mesh->mMaterialIndex = (unsigned int)materials.size();
-    materials.push_back(inmaterials[0].first);
+    materials.emplace_back(std::move(inmaterials[0].first));
 }
 
 // ------------------------------------------------------------------------------------------------
@@ -605,7 +605,7 @@ void IRRImporter::GenerateGraph(Node *root, aiNode *rootOut, aiScene *scene,
         std::vector<aiMesh *> &meshes,
         std::vector<aiNodeAnim *> &anims,
         std::vector<AttachmentInfo> &attach,
-        std::vector<aiMaterial *> &materials,
+        std::vector<std::unique_ptr<aiMaterial> > &materials,
         unsigned int &defMatIdx) {
     unsigned int oldMeshSize = (unsigned int)meshes.size();
     // unsigned int meshTrafoAssign = 0;
@@ -643,7 +643,8 @@ void IRRImporter::GenerateGraph(Node *root, aiNode *rootOut, aiScene *scene,
             delete localScene->mMaterials[i];
 
             auto &src = root->materials[i];
-            localScene->mMaterials[i] = src.first;
+            // store a pointer in localScene but don't release yet, the next loop needs them too
+            localScene->mMaterials[i] = src.first.get();
         }
 
         // NOTE: Each mesh should have exactly one material assigned,
@@ -658,7 +659,7 @@ void IRRImporter::GenerateGraph(Node *root, aiNode *rootOut, aiScene *scene,
             // often the case so we can simply extract it to a shared oacity
             // value.
             auto &src = root->materials[mesh->mMaterialIndex];
-            aiMaterial *mat = src.first;
+            aiMaterial *mat = src.first.get();
 
             if (mesh->HasVertexColors(0) && src.second & AI_IRRMESH_MAT_trans_vertex_alpha) {
                 bool bdo = true;
@@ -693,6 +694,12 @@ void IRRImporter::GenerateGraph(Node *root, aiNode *rootOut, aiScene *scene,
                 }
             }
         }
+
+        // now release the pointers in root->materials
+        for (unsigned int i = 0; i < localScene->mNumMaterials; ++i) {
+            // just release, they were already stored in localScene two loops ago
+            root->materials[i].first.release();
+        }
     } break;
 
     case Node::LIGHT:
@@ -726,7 +733,7 @@ void IRRImporter::GenerateGraph(Node *root, aiNode *rootOut, aiScene *scene,
 
         // Now adjust this output material - if there is a first texture
         // set, setup spherical UV mapping around the Y axis.
-        SetupMapping((aiMaterial *)materials.back(), aiTextureMapping_SPHERE);
+        SetupMapping(materials.back().get(), aiTextureMapping_SPHERE);
     } break;
 
     case Node::CUBE: {
@@ -742,7 +749,7 @@ void IRRImporter::GenerateGraph(Node *root, aiNode *rootOut, aiScene *scene,
 
         // Now adjust this output material - if there is a first texture
         // set, setup cubic UV mapping
-        SetupMapping((aiMaterial *)materials.back(), aiTextureMapping_BOX);
+        SetupMapping(materials.back().get(), aiTextureMapping_BOX);
     } break;
 
     case Node::SKYBOX: {
@@ -755,7 +762,7 @@ void IRRImporter::GenerateGraph(Node *root, aiNode *rootOut, aiScene *scene,
         // copy those materials and generate 6 meshes for our new sky-box
         materials.reserve(materials.size() + 6);
         for (unsigned int i = 0; i < 6; ++i)
-            materials.insert(materials.end(), root->materials[i].first);
+            materials.emplace(materials.end(), std::move(root->materials[i].first));
 
         BuildSkybox(meshes, materials);
 
@@ -1281,7 +1288,7 @@ void IRRImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
 
     // temporary data
     std::vector<aiNodeAnim *> anims;
-    std::vector<aiMaterial *> materials;
+    std::vector<std::unique_ptr<aiMaterial> > materials;
     std::vector<AttachmentInfo> attach;
     std::vector<aiMesh *> meshes;
 
@@ -1327,7 +1334,7 @@ void IRRImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
         tempScene->mNumMaterials = (unsigned int)materials.size();
         tempScene->mMaterials = new aiMaterial *[tempScene->mNumMaterials];
         for (unsigned int i = 0; i < tempScene->mNumMaterials; i++) {
-            tempScene->mMaterials[i] = materials[i];
+            tempScene->mMaterials[i] = materials[i].release();
         }
     }
 

--- a/code/AssetLib/Irr/IRRLoader.cpp
+++ b/code/AssetLib/Irr/IRRLoader.cpp
@@ -828,10 +828,10 @@ void IRRImporter::GenerateGraph(Node *root, aiNode *rootOut, aiScene *scene,
         for (unsigned int i = 0; i < rootOut->mNumChildren; ++i) {
 
             aiNode *node = new aiNode();
-            rootOut->mChildren[i] = node;
             node->mParent = rootOut;
             GenerateGraph(root->children[i], node, scene, batch, meshes,
                     anims, attach, materials, defMatIdx);
+            rootOut->mChildren[i] = node;
         }
     }
 }

--- a/code/AssetLib/Irr/IRRLoader.cpp
+++ b/code/AssetLib/Irr/IRRLoader.cpp
@@ -827,11 +827,11 @@ void IRRImporter::GenerateGraph(Node *root, aiNode *rootOut, aiScene *scene,
         rootOut->mChildren = new aiNode *[rootOut->mNumChildren];
         for (unsigned int i = 0; i < rootOut->mNumChildren; ++i) {
 
-            aiNode *node = new aiNode();
+            auto node = std::make_unique<aiNode>();
             node->mParent = rootOut;
-            GenerateGraph(root->children[i], node, scene, batch, meshes,
+            GenerateGraph(root->children[i].get(), node.get(), scene, batch, meshes,
                     anims, attach, materials, defMatIdx);
-            rootOut->mChildren[i] = node;
+            rootOut->mChildren[i] = node.release();
         }
     }
 }
@@ -1085,7 +1085,7 @@ void IRRImporter::ParseAnimators(pugi::xml_node &animatorNode, IRRImporter::Node
     }
 }
 
-IRRImporter::Node *IRRImporter::ParseNode(pugi::xml_node &node, BatchLoader &batch) {
+std::unique_ptr<IRRImporter::Node> IRRImporter::ParseNode(pugi::xml_node &node, BatchLoader &batch) {
     // Parse <node> tags.
     // <node> tags have various types
     // <node> tags can contain <attribute>, <material>
@@ -1111,42 +1111,42 @@ IRRImporter::Node *IRRImporter::ParseNode(pugi::xml_node &node, BatchLoader &bat
      *  Said materials and animators are all collected at the bottom
      */
     // ***********************************************************************
-    Node *nd;
+    std::unique_ptr<Node> nd;
     pugi::xml_attribute nodeTypeAttrib = node.attribute("type");
     if (!ASSIMP_stricmp(nodeTypeAttrib.value(), "mesh") || !ASSIMP_stricmp(nodeTypeAttrib.value(), "octTree")) {
         // OctTree's and meshes are treated equally
-        nd = new Node(Node::MESH);
+        nd = std::make_unique<Node>(Node::MESH);
     } else if (!ASSIMP_stricmp(nodeTypeAttrib.value(), "cube")) {
-        nd = new Node(Node::CUBE);
+        nd = std::make_unique<Node>(Node::CUBE);
         guessedMeshCnt += 1; // Cube is only one mesh
     } else if (!ASSIMP_stricmp(nodeTypeAttrib.value(), "skybox")) {
-        nd = new Node(Node::SKYBOX);
+        nd = std::make_unique<Node>(Node::SKYBOX);
         guessedMeshCnt += 6; // Skybox is a box, with 6 meshes?
     } else if (!ASSIMP_stricmp(nodeTypeAttrib.value(), "camera")) {
-        nd = new Node(Node::CAMERA);
+        nd = std::make_unique<Node>(Node::CAMERA);
         // Setup a temporary name for the camera
         aiCamera *cam = new aiCamera();
         cam->mName.Set(nd->name);
         cameras.push_back(cam);
     } else if (!ASSIMP_stricmp(nodeTypeAttrib.value(), "light")) {
-        nd = new Node(Node::LIGHT);
+        nd = std::make_unique<Node>(Node::LIGHT);
         // Setup a temporary name for the light
         aiLight *cam = new aiLight();
         cam->mName.Set(nd->name);
         lights.push_back(cam);
     } else if (!ASSIMP_stricmp(nodeTypeAttrib.value(), "sphere")) {
-        nd = new Node(Node::SPHERE);
+        nd = std::make_unique<Node>(Node::SPHERE);
         guessedMeshCnt += 1;
     } else if (!ASSIMP_stricmp(nodeTypeAttrib.value(), "animatedMesh")) {
-        nd = new Node(Node::ANIMMESH);
+        nd = std::make_unique<Node>(Node::ANIMMESH);
     } else if (!ASSIMP_stricmp(nodeTypeAttrib.value(), "empty")) {
-        nd = new Node(Node::DUMMY);
+        nd = std::make_unique<Node>(Node::DUMMY);
     } else if (!ASSIMP_stricmp(nodeTypeAttrib.value(), "terrain")) {
-        nd = new Node(Node::TERRAIN);
+        nd = std::make_unique<Node>(Node::TERRAIN);
     } else if (!ASSIMP_stricmp(nodeTypeAttrib.value(), "billBoard")) {
         // We don't support billboards, so ignore them
         ASSIMP_LOG_ERROR("IRR: Billboards are not supported by Assimp");
-        nd = new Node(Node::DUMMY);
+        nd = std::make_unique<Node>(Node::DUMMY);
     } else {
         ASSIMP_LOG_WARN("IRR: Found unknown node: ", nodeTypeAttrib.value());
 
@@ -1154,21 +1154,21 @@ IRRImporter::Node *IRRImporter::ParseNode(pugi::xml_node &node, BatchLoader &bat
          *  We parse the transformation and all animators
          *  and skip the rest.
          */
-        nd = new Node(Node::DUMMY);
+        nd = std::make_unique<Node>(Node::DUMMY);
     }
 
     // TODO: consolidate all into one loop
     for (pugi::xml_node subNode : node.children()) {
         // Collect node attributes first
         if (!ASSIMP_stricmp(subNode.name(), "attributes")) {
-            ParseNodeAttributes(subNode, nd, batch); // Parse attributes into this node
+            ParseNodeAttributes(subNode, nd.get(), batch); // Parse attributes into this node
         } else if (!ASSIMP_stricmp(subNode.name(), "animators")) {
             // Then parse any animators
             // All animators should contain an <attributes> tag
 
             //  This is an animation path - add a new animator
             //  to the list.
-            ParseAnimators(subNode, nd); // Function modifies nd's animator vector
+            ParseAnimators(subNode, nd.get()); // Function modifies nd's animator vector
             guessedAnimCnt += 1;
         }
 
@@ -1191,8 +1191,8 @@ IRRImporter::Node *IRRImporter::ParseNode(pugi::xml_node &node, BatchLoader &bat
     // Attach the newly created node to the scene-graph
     for (pugi::xml_node child : node.children()) {
         if (!ASSIMP_stricmp(child.name(), "node")) { // Is a child node
-            Node *childNd = ParseNode(child, batch); // Repeat this function for all children
-            nd->children.push_back(childNd);
+            std::unique_ptr<Node> childNd = ParseNode(child, batch); // Repeat this function for all children
+            nd->children.emplace_back(std::move(childNd));
         };
     }
 
@@ -1217,7 +1217,7 @@ void IRRImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
     pugi::xml_node documentRoot = st.getRootNode();
 
     // The root node of the scene
-    Node *root = new Node(Node::DUMMY);
+    auto root = std::make_unique<Node>(Node::DUMMY);
     root->parent = nullptr;
     root->name = "<IRRSceneRoot>";
 
@@ -1236,16 +1236,15 @@ void IRRImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
     // Find the scene root from document root.
     const pugi::xml_node &sceneRoot = documentRoot.child("irr_scene");
     if (!sceneRoot) {
-        delete root;
         throw new DeadlyImportError("IRR: <irr_scene> not found in file");
     }
     for (pugi::xml_node &child : sceneRoot.children()) {
         // XML elements are either nodes, animators, attributes, or materials
         if (!ASSIMP_stricmp(child.name(), "node")) {
             // Recursive collect subtree children
-            Node *nd = ParseNode(child, batch);
+            std::unique_ptr<Node> nd = ParseNode(child, batch);
             // Attach to root
-            root->children.push_back(nd);
+            root->children.emplace_back(std::move(nd));
         }
     }
 
@@ -1294,7 +1293,7 @@ void IRRImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
     // Now process our scene-graph recursively: generate final
     // meshes and generate animation channels for all nodes.
     unsigned int defMatIdx = UINT_MAX;
-    GenerateGraph(root, tempScene->mRootNode, tempScene,
+    GenerateGraph(root.get(), tempScene->mRootNode, tempScene,
             batch, meshes, anims, attach, materials, defMatIdx);
 
     if (!anims.empty()) {
@@ -1346,7 +1345,6 @@ void IRRImporter::InternReadFile(const std::string &pFile, aiScene *pScene, IOSy
 
     // Finished ... everything destructs automatically and all
     // temporary scenes have already been deleted by MergeScenes()
-    delete root;
 }
 
 #endif // !! ASSIMP_BUILD_NO_IRR_IMPORTER

--- a/code/AssetLib/Irr/IRRLoader.cpp
+++ b/code/AssetLib/Irr/IRRLoader.cpp
@@ -642,7 +642,7 @@ void IRRImporter::GenerateGraph(Node *root, aiNode *rootOut, aiScene *scene,
             // Delete the old material, we don't need it anymore
             delete localScene->mMaterials[i];
 
-            std::pair<aiMaterial *, unsigned int> &src = root->materials[i];
+            auto &src = root->materials[i];
             localScene->mMaterials[i] = src.first;
         }
 
@@ -657,7 +657,7 @@ void IRRImporter::GenerateGraph(Node *root, aiNode *rootOut, aiScene *scene,
             // and check whether they have a common alpha value. This is quite
             // often the case so we can simply extract it to a shared oacity
             // value.
-            std::pair<aiMaterial *, unsigned int> &src = root->materials[mesh->mMaterialIndex];
+            auto &src = root->materials[mesh->mMaterialIndex];
             aiMaterial *mat = (aiMaterial *)src.first;
 
             if (mesh->HasVertexColors(0) && src.second & AI_IRRMESH_MAT_trans_vertex_alpha) {
@@ -1179,7 +1179,7 @@ IRRImporter::Node *IRRImporter::ParseNode(pugi::xml_node &node, BatchLoader &bat
                 // Each material should contain an <attributes> node
                 // with everything specified
                 nd->materials.emplace_back();
-                std::pair<aiMaterial *, unsigned int> &p = nd->materials.back();
+                auto &p = nd->materials.back();
                 p.first = ParseMaterial(subNode, p.second);
                 guessedMatCnt += 1;
             }

--- a/code/AssetLib/Irr/IRRLoader.cpp
+++ b/code/AssetLib/Irr/IRRLoader.cpp
@@ -827,7 +827,8 @@ void IRRImporter::GenerateGraph(Node *root, aiNode *rootOut, aiScene *scene,
         rootOut->mChildren = new aiNode *[rootOut->mNumChildren];
         for (unsigned int i = 0; i < rootOut->mNumChildren; ++i) {
 
-            aiNode *node = rootOut->mChildren[i] = new aiNode();
+            aiNode *node = new aiNode();
+            rootOut->mChildren[i] = node;
             node->mParent = rootOut;
             GenerateGraph(root->children[i], node, scene, batch, meshes,
                     anims, attach, materials, defMatIdx);

--- a/code/AssetLib/Irr/IRRLoader.h
+++ b/code/AssetLib/Irr/IRRLoader.h
@@ -52,6 +52,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/SceneCombiner.h>
 #include <assimp/StringUtils.h>
 #include <assimp/anim.h>
+#include <assimp/material.h>
 
 namespace Assimp {
 
@@ -179,7 +180,7 @@ private:
 
         // Meshes: List of materials to be assigned
         // along with their corresponding material flags
-        std::vector<std::pair<aiMaterial *, unsigned int>> materials;
+        std::vector<std::pair<std::unique_ptr<aiMaterial>, unsigned int>> materials;
 
         // Spheres: radius of the sphere to be generates
         ai_real sphereRadius;
@@ -232,7 +233,7 @@ private:
             std::vector<aiMesh *> &meshes,
             std::vector<aiNodeAnim *> &anims,
             std::vector<AttachmentInfo> &attach,
-            std::vector<aiMaterial *> &materials,
+            std::vector<std::unique_ptr<aiMaterial> > &materials,
             unsigned int &defaultMatIdx);
 
     // -------------------------------------------------------------------
@@ -249,7 +250,7 @@ private:
     /// @param materials The last 6 materials are assigned to the newly
     ///                  created meshes. The names of the materials are adjusted.
     void BuildSkybox(std::vector<aiMesh *> &meshes,
-            std::vector<aiMaterial *> materials);
+                     std::vector<std::unique_ptr<aiMaterial> > &materials);
 
     // -------------------------------------------------------------------
     /** Copy a material for a mesh to the output material list
@@ -259,8 +260,8 @@ private:
      *  @param defMatIdx Default material index - UINT_MAX if not present
      *  @param mesh Mesh to work on
      */
-    void CopyMaterial(std::vector<aiMaterial *> &materials,
-            std::vector<std::pair<aiMaterial *, unsigned int>> &inmaterials,
+    void CopyMaterial(std::vector<std::unique_ptr<aiMaterial> > &materials,
+            std::vector<std::pair<std::unique_ptr<aiMaterial>, unsigned int>> &inmaterials,
             unsigned int &defMatIdx,
             aiMesh *mesh);
 

--- a/code/AssetLib/Irr/IRRLoader.h
+++ b/code/AssetLib/Irr/IRRLoader.h
@@ -164,7 +164,7 @@ private:
         std::string name;
 
         // List of all child nodes
-        std::vector<Node *> children;
+        std::vector<std::unique_ptr<Node> > children;
 
         // Parent node
         Node *parent;
@@ -211,7 +211,7 @@ private:
     // Parse <node> tag from XML file and extract child node
     // @param node XML node
     // @param guessedMeshesContained number of extra guessed meshes
-    IRRImporter::Node *ParseNode(pugi::xml_node &node, BatchLoader& batch);
+    std::unique_ptr<IRRImporter::Node> ParseNode(pugi::xml_node &node, BatchLoader& batch);
 
     // -------------------------------------------------------------------
     // Parse <attributes> tags within <node> tags and apply to scene node

--- a/code/AssetLib/Irr/IRRMeshLoader.cpp
+++ b/code/AssetLib/Irr/IRRMeshLoader.cpp
@@ -214,7 +214,7 @@ void IRRMeshImporter::InternReadFile(const std::string &pFile,
                     // map (normal_..., parallax_...)
                     // *********************************************************
                     int idx = 1;
-                    aiMaterial *mat = (aiMaterial *)curMat;
+                    aiMaterial *mat = curMat;
 
                     if (curMatFlags & AI_IRRMESH_MAT_lightmap) {
                         mat->AddProperty(&idx, 1, AI_MATKEY_UVWSRC_LIGHTMAP(0));
@@ -377,7 +377,7 @@ void IRRMeshImporter::InternReadFile(const std::string &pFile,
         if (curMatFlags & AI_IRRMESH_MAT_trans_vertex_alpha && !useColors) {
             // Take the opacity value of the current material
             // from the common vertex color alpha
-            aiMaterial *mat = (aiMaterial *)curMat;
+            aiMaterial *mat = curMat;
             mat->AddProperty(&curColors[0].a, 1, AI_MATKEY_OPACITY);
         }
 

--- a/code/AssetLib/Irr/IRRMeshLoader.cpp
+++ b/code/AssetLib/Irr/IRRMeshLoader.cpp
@@ -87,12 +87,6 @@ const aiImporterDesc *IRRMeshImporter::GetInfo() const {
     return &desc;
 }
 
-static void releaseMaterial(aiMaterial **mat) {
-    if (*mat != nullptr) {
-        delete *mat;
-        *mat = nullptr;
-    }
-}
 
 static void releaseMesh(aiMesh **mesh) {
     if (*mesh != nullptr) {
@@ -120,14 +114,14 @@ void IRRMeshImporter::InternReadFile(const std::string &pFile,
     XmlNode root = parser.getRootNode();
 
     // final data
-    std::vector<aiMaterial *> materials;
+    std::vector<std::unique_ptr<aiMaterial> > materials;
     std::vector<aiMesh *> meshes;
     materials.reserve(5);
     meshes.reserve(5);
 
     // temporary data - current mesh buffer
     // TODO move all these to inside loop
-    aiMaterial *curMat = nullptr;
+    std::unique_ptr<aiMaterial> curMat;
     aiMesh *curMesh = nullptr;
     unsigned int curMatFlags = 0;
 
@@ -191,7 +185,7 @@ void IRRMeshImporter::InternReadFile(const std::string &pFile,
             if (vertexCount == 0) {
                 // This is possible ... remove the mesh from the list and skip further reading
                 ASSIMP_LOG_WARN("IRRMESH: Found mesh with zero vertices");
-                releaseMaterial(&curMat);
+                curMat.reset();
                 continue; // Bail out early
             };
 
@@ -214,7 +208,7 @@ void IRRMeshImporter::InternReadFile(const std::string &pFile,
                     // map (normal_..., parallax_...)
                     // *********************************************************
                     int idx = 1;
-                    aiMaterial *mat = curMat;
+                    aiMaterial *mat = curMat.get();
 
                     if (curMatFlags & AI_IRRMESH_MAT_lightmap) {
                         mat->AddProperty(&idx, 1, AI_MATKEY_UVWSRC_LIGHTMAP(0));
@@ -234,7 +228,7 @@ void IRRMeshImporter::InternReadFile(const std::string &pFile,
                 // Unsupported format, discard whole buffer/mesh
                 // Assuming we have a correct material, then release it
                 // We don't have a correct mesh for sure here
-                releaseMaterial(&curMat);
+                curMat.reset();
                 ASSIMP_LOG_ERROR("IRRMESH: Unknown vertex format");
                 continue; // Skip rest of buffer
             };
@@ -266,8 +260,7 @@ void IRRMeshImporter::InternReadFile(const std::string &pFile,
                 // mesh - away
                 releaseMesh(&curMesh);
 
-                // material - away
-                releaseMaterial(&curMat);
+                curMat.reset();
                 continue; // Go to next buffer
             }
 
@@ -377,17 +370,16 @@ void IRRMeshImporter::InternReadFile(const std::string &pFile,
         if (curMatFlags & AI_IRRMESH_MAT_trans_vertex_alpha && !useColors) {
             // Take the opacity value of the current material
             // from the common vertex color alpha
-            aiMaterial *mat = curMat;
-            mat->AddProperty(&curColors[0].a, 1, AI_MATKEY_OPACITY);
+            curMat.get()->AddProperty(&curColors[0].a, 1, AI_MATKEY_OPACITY);
         }
 
         // end of previous buffer. A material and a mesh should be there
         if (!curMat || !curMesh) {
             ASSIMP_LOG_ERROR("IRRMESH: A buffer must contain a mesh and a material");
-            releaseMaterial(&curMat);
+            curMat.reset();
             releaseMesh(&curMesh);
         } else {
-            materials.push_back(curMat);
+            materials.emplace_back(std::move(curMat));
             meshes.push_back(curMesh);
         }
     }
@@ -410,7 +402,7 @@ void IRRMeshImporter::InternReadFile(const std::string &pFile,
     pScene->mNumMaterials = (unsigned int)materials.size();
     pScene->mMaterials = new aiMaterial *[pScene->mNumMaterials];
     for (unsigned int i = 0; i < materials.size(); i++) {
-        pScene->mMaterials[i] = materials[i];
+        pScene->mMaterials[i] = materials[i].release();
     }
 
     pScene->mRootNode = new aiNode();

--- a/code/AssetLib/Irr/IRRMeshLoader.cpp
+++ b/code/AssetLib/Irr/IRRMeshLoader.cpp
@@ -409,7 +409,9 @@ void IRRMeshImporter::InternReadFile(const std::string &pFile,
 
     pScene->mNumMaterials = (unsigned int)materials.size();
     pScene->mMaterials = new aiMaterial *[pScene->mNumMaterials];
-    ::memcpy(pScene->mMaterials, &materials[0], sizeof(void *) * pScene->mNumMaterials);
+    for (unsigned int i = 0; i < materials.size(); i++) {
+        pScene->mMaterials[i] = materials[i];
+    }
 
     pScene->mRootNode = new aiNode();
     pScene->mRootNode->mName.Set("<IRRMesh>");

--- a/code/AssetLib/Irr/IRRShared.cpp
+++ b/code/AssetLib/Irr/IRRShared.cpp
@@ -172,8 +172,8 @@ int ConvertMappingMode(const std::string &mode) {
 
 // ------------------------------------------------------------------------------------------------
 // Parse a material from the XML file
-aiMaterial *IrrlichtBase::ParseMaterial(pugi::xml_node& materialNode, unsigned int &matFlags) {
-    aiMaterial *mat = new aiMaterial();
+std::unique_ptr<aiMaterial> IrrlichtBase::ParseMaterial(pugi::xml_node& materialNode, unsigned int &matFlags) {
+    auto mat = std::make_unique<aiMaterial>();
     aiColor4D clr;
     aiString s;
 

--- a/code/AssetLib/Irr/IRRShared.h
+++ b/code/AssetLib/Irr/IRRShared.h
@@ -87,7 +87,7 @@ protected:
      *  @return The created material
      *  @param matFlags Receives AI_IRRMESH_MAT_XX flags
      */
-    aiMaterial *ParseMaterial(pugi::xml_node &materialNode, unsigned int &matFlags);
+    std::unique_ptr<aiMaterial> ParseMaterial(pugi::xml_node &materialNode, unsigned int &matFlags);
 
     // -------------------------------------------------------------------
     /** Read a property of the specified type from the current XML element.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -170,6 +170,7 @@ SET( IMPORTERS
   unit/ImportExport/utMD5Importer.cpp
   unit/ImportExport/utIQMImporter.cpp
   unit/ImportExport/utMDLImporter.cpp
+  unit/ImportExport/IRR/utIrrImportExport.cpp
   unit/ImportExport/MDL/MDLHL1TestFiles.h
   unit/ImportExport/MDL/utMDLImporter_HL1_ImportSettings.cpp
   unit/ImportExport/MDL/utMDLImporter_HL1_Materials.cpp

--- a/test/unit/ImportExport/IRR/utIrrImportExport.cpp
+++ b/test/unit/ImportExport/IRR/utIrrImportExport.cpp
@@ -50,21 +50,243 @@ class utIrrImportExport : public AbstractImportExportBase {
 public:
     virtual bool importerTest() {
         Assimp::Importer importer;
+
+#if 0  // FIXME: this leaks memory
+
         const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/IRR/box.irr", aiProcess_ValidateDataStructure);
         // Only one box thus only one mesh
         return nullptr != scene && scene->mNumMeshes == 1;
+
+#else
+
+        return true;
+
+#endif  // 0
     }
 };
+
 
 TEST_F(utIrrImportExport, importSimpleIrrTest) {
     EXPECT_TRUE(importerTest());
 }
 
+
+#if 0  // FIXME: these leak memory
+
+TEST_F(utIrrImportExport, importAnimMesh) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/IRR/animMesh.irr", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+}
+
+
+TEST_F(utIrrImportExport, importAnimMeshUTF16) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/IRR/animMesh_UTF16LE.irr", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+}
+
+
+TEST_F(utIrrImportExport, importBox) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/IRR/box.irr", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+}
+
+
+TEST_F(utIrrImportExport, importBoxUTF16) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/IRR/box_UTF16LE.irr", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+}
+
+#endif  // 0
+
+
+TEST_F(utIrrImportExport, importCellar) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/IRRMesh/cellar.irrmesh", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+}
+
+
+TEST_F(utIrrImportExport, importCellarUTF16) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/IRRMesh/cellar_UTF16LE.irrmesh", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+}
+
+
+#if 0  // FIXME: these leak memory
+
+TEST_F(utIrrImportExport, importDawfInCellar) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/IRR/dawfInCellar_ChildOfCellar.irr", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+}
+
+
+TEST_F(utIrrImportExport, importDawfInCellarUTF16) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/IRR/dawfInCellar_ChildOfCellar_UTF16LE.irr", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+}
+
+
 TEST_F(utIrrImportExport, importSGIrrTest) {
     Assimp::Importer importer;
     const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/IRR/dawfInCellar_SameHierarchy.irr", aiProcess_ValidateDataStructure);
-    EXPECT_NE(nullptr, scene);
-    EXPECT_EQ(scene->mNumMeshes, 2);
-    EXPECT_EQ(scene->mNumMaterials, 2);
-    EXPECT_GT(scene->mMeshes[0]->mNumVertices, 0);
+    ASSERT_NE(nullptr, scene);
+    EXPECT_EQ(scene->mNumMeshes, 4u);
+    EXPECT_EQ(scene->mNumMaterials, 5u);
+    ASSERT_GT(scene->mNumMeshes, 0u);
+    EXPECT_GT(scene->mMeshes[0]->mNumVertices, 0u);
 }
+
+
+TEST_F(utIrrImportExport, importSGIrrTestUTF16) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/IRR/dawfInCellar_SameHierarchy_UTF16LE.irr", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+    EXPECT_EQ(scene->mNumMeshes, 4u);
+    EXPECT_EQ(scene->mNumMaterials, 5u);
+    ASSERT_GT(scene->mNumMeshes, 0u);
+    EXPECT_GT(scene->mMeshes[0]->mNumVertices, 0u);
+}
+
+
+TEST_F(utIrrImportExport, importANewDwarf) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/IRR/EpisodeI_ANewDwarf.irr", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+}
+
+
+TEST_F(utIrrImportExport, importANewDwarfUTF16) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/IRR/EpisodeI_ANewDwarf_UTF16LE.irr", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+}
+
+
+TEST_F(utIrrImportExport, importDwarfStrikesBack) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/IRR/EpisodeII_TheDwarfesStrikeBack.irr", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+}
+
+
+TEST_F(utIrrImportExport, importDwarfStrikesBackUTF16) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/IRR/EpisodeII_TheDwarfesStrikeBack_UTF16LE.irr", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+}
+
+
+TEST_F(utIrrImportExport, importInstancing) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/IRR/instancing.irr", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+}
+
+
+TEST_F(utIrrImportExport, importMultipleAnimators) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/IRR/multipleAnimators.irr", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+}
+
+
+TEST_F(utIrrImportExport, importMultipleAnimatorsUTF16) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/IRR/multipleAnimators_UTF16LE.irr", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+}
+
+
+TEST_F(utIrrImportExport, importScenegraphAnim) {
+    Assimp::Importer importer;
+    // FIXME: this fails but probably shouldn't
+    // Validation failed: Empty node animation channel
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/IRR/scenegraphAnim.irr", aiProcess_ValidateDataStructure);
+    ASSERT_EQ(nullptr, scene);
+
+    Assimp::Importer importer2;
+    const aiScene *scene2 = importer2.ReadFile(ASSIMP_TEST_MODELS_DIR "/IRR/scenegraphAnim.irr", 0);
+    ASSERT_NE(nullptr, scene2);
+}
+
+
+TEST_F(utIrrImportExport, importScenegraphAnimUTF16) {
+    Assimp::Importer importer;
+    // FIXME: this fails but probably shouldn't
+    // Validation failed: Empty node animation channel
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/IRR/scenegraphAnim_UTF16LE.irr", aiProcess_ValidateDataStructure);
+    ASSERT_EQ(nullptr, scene);
+
+    Assimp::Importer importer2;
+    const aiScene *scene2 = importer2.ReadFile(ASSIMP_TEST_MODELS_DIR "/IRR/scenegraphAnim_UTF16LE.irr", 0);
+    ASSERT_NE(nullptr, scene2);
+}
+
+
+TEST_F(utIrrImportExport, importScenegraphAnimMod) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/IRR/scenegraphAnimMod.irr", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+}
+
+
+TEST_F(utIrrImportExport, importScenegraphAnimModUTF16) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/IRR/scenegraphAnimMod_UTF16LE.irr", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+}
+
+
+TEST_F(utIrrImportExport, importSphere) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/IRR/sphere.irr", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+}
+
+
+TEST_F(utIrrImportExport, importSphereUTF16) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/IRR/sphere_UTF16LE.irr", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+}
+
+#endif  // 0
+
+
+TEST_F(utIrrImportExport, importSpider) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/IRRMesh/spider.irrmesh", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+}
+
+
+TEST_F(utIrrImportExport, importSpiderUTF166) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/IRRMesh/spider_UTF16LE.irrmesh", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+}
+
+
+#if 0  // FIXME: these leak memory
+
+TEST_F(utIrrImportExport, importSkybox) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_NONBSD_DIR "/IRR/skybox.xml", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+}
+
+
+TEST_F(utIrrImportExport, importSkyboxUTF16) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_NONBSD_DIR "/IRR/skybox_UTF16LE.xml", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+}
+
+#endif  // 0

--- a/test/unit/ImportExport/IRR/utIrrImportExport.cpp
+++ b/test/unit/ImportExport/IRR/utIrrImportExport.cpp
@@ -50,18 +50,9 @@ class utIrrImportExport : public AbstractImportExportBase {
 public:
     virtual bool importerTest() {
         Assimp::Importer importer;
-
-#if 0  // FIXME: this leaks memory
-
         const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/IRR/box.irr", aiProcess_ValidateDataStructure);
         // Only one box thus only one mesh
         return nullptr != scene && scene->mNumMeshes == 1;
-
-#else
-
-        return true;
-
-#endif  // 0
     }
 };
 
@@ -70,8 +61,6 @@ TEST_F(utIrrImportExport, importSimpleIrrTest) {
     EXPECT_TRUE(importerTest());
 }
 
-
-#if 0  // FIXME: these leak memory
 
 TEST_F(utIrrImportExport, importAnimMesh) {
     Assimp::Importer importer;
@@ -100,8 +89,6 @@ TEST_F(utIrrImportExport, importBoxUTF16) {
     ASSERT_NE(nullptr, scene);
 }
 
-#endif  // 0
-
 
 TEST_F(utIrrImportExport, importCellar) {
     Assimp::Importer importer;
@@ -116,8 +103,6 @@ TEST_F(utIrrImportExport, importCellarUTF16) {
     ASSERT_NE(nullptr, scene);
 }
 
-
-#if 0  // FIXME: these leak memory
 
 TEST_F(utIrrImportExport, importDawfInCellar) {
     Assimp::Importer importer;
@@ -257,8 +242,6 @@ TEST_F(utIrrImportExport, importSphereUTF16) {
     ASSERT_NE(nullptr, scene);
 }
 
-#endif  // 0
-
 
 TEST_F(utIrrImportExport, importSpider) {
     Assimp::Importer importer;
@@ -274,8 +257,6 @@ TEST_F(utIrrImportExport, importSpiderUTF166) {
 }
 
 
-#if 0  // FIXME: these leak memory
-
 TEST_F(utIrrImportExport, importSkybox) {
     Assimp::Importer importer;
     const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_NONBSD_DIR "/IRR/skybox.xml", aiProcess_ValidateDataStructure);
@@ -288,5 +269,3 @@ TEST_F(utIrrImportExport, importSkyboxUTF16) {
     const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_NONBSD_DIR "/IRR/skybox_UTF16LE.xml", aiProcess_ValidateDataStructure);
     ASSERT_NE(nullptr, scene);
 }
-
-#endif  // 0


### PR DESCRIPTION
Probably fixes #6768.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when importing IRR and IRRMesh assets through safer resource and material handling.
  * Import failures and scene validation scenarios now behave more consistently.

* **Tests**
  * Expanded coverage for ASCII and UTF-16 assets, animations, scene graphs, instancing, skyboxes, and multiple sample scenes.
  * Added checks for mesh and material counts and strengthened null-scene validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->