### PR TITLE
Fix KHR_texture_basisu metadata in glTF2 export

### DIFF
--- a/code/AssetLib/glTF2/glTF2AssetWriter.inl
+++ b/code/AssetLib/glTF2/glTF2AssetWriter.inl
@@ -54,6 +54,12 @@ namespace glTF2 {
 
     namespace {
 
+        inline bool IsBasisUniversalMimeType(const std::string &mime_type)
+        {
+            return mime_type == "image/ktx" || mime_type == "image/ktx2" ||
+                    mime_type == "image/basis";
+        }
+
         template<typename T, size_t N>
         inline Value& MakeValue(Value& val, T(&r)[N], MemoryPoolAllocator<>& al) {
             val.SetArray();
@@ -268,6 +274,9 @@ namespace glTF2 {
             }
 
             obj.AddMember("uri", Value(uri, w.mAl).Move(), w.mAl);
+            if (!img.mimeType.empty()) {
+                obj.AddMember("mimeType", Value(img.mimeType, w.mAl).Move(), w.mAl);
+            }
         }
     }
 
@@ -817,7 +826,18 @@ namespace glTF2 {
     inline void Write(Value& obj, Texture& tex, AssetWriter& w)
     {
         if (tex.source) {
-            obj.AddMember("source", tex.source->index, w.mAl);
+            if (IsBasisUniversalMimeType(tex.source->mimeType)) {
+                Value basisu;
+                basisu.SetObject();
+                basisu.AddMember("source", tex.source->index, w.mAl);
+
+                Value extensions;
+                extensions.SetObject();
+                extensions.AddMember("KHR_texture_basisu", basisu, w.mAl);
+                obj.AddMember("extensions", extensions, w.mAl);
+            } else {
+                obj.AddMember("source", tex.source->index, w.mAl);
+            }
         }
         if (tex.sampler) {
             obj.AddMember("sampler", tex.sampler->index, w.mAl);

--- a/code/AssetLib/glTF2/glTF2AssetWriter.inl
+++ b/code/AssetLib/glTF2/glTF2AssetWriter.inl
@@ -56,8 +56,7 @@ namespace glTF2 {
 
         inline bool IsBasisUniversalMimeType(const std::string &mime_type)
         {
-            return mime_type == "image/ktx" || mime_type == "image/ktx2" ||
-                    mime_type == "image/basis";
+            return mime_type == "image/ktx2";
         }
 
         template<typename T, size_t N>

--- a/code/AssetLib/glTF2/glTF2Exporter.cpp
+++ b/code/AssetLib/glTF2/glTF2Exporter.cpp
@@ -82,14 +82,6 @@ std::string BasisUniversalMimeType(const std::string &path) {
         lower_path.compare(lower_path.size() - 5, 5, ".ktx2") == 0) {
         return "image/ktx2";
     }
-    if (lower_path.size() >= 4 &&
-        lower_path.compare(lower_path.size() - 4, 4, ".ktx") == 0) {
-        return "image/ktx";
-    }
-    if (lower_path.size() >= 6 &&
-        lower_path.compare(lower_path.size() - 6, 6, ".basis") == 0) {
-        return "image/basis";
-    }
     return {};
 }
 

--- a/code/AssetLib/glTF2/glTF2Exporter.cpp
+++ b/code/AssetLib/glTF2/glTF2Exporter.cpp
@@ -77,8 +77,8 @@ using namespace glTF2;
 namespace {
 
 std::string BasisUniversalMimeType(const std::string &path) {
-    const std::string lower_path = ai_tolower(path);
-    if (lower_path.size() >= 5 &&
+    if (const std::string lower_path = ai_tolower(path);
+        lower_path.size() >= 5 &&
         lower_path.compare(lower_path.size() - 5, 5, ".ktx2") == 0) {
         return "image/ktx2";
     }

--- a/code/AssetLib/glTF2/glTF2Exporter.cpp
+++ b/code/AssetLib/glTF2/glTF2Exporter.cpp
@@ -56,6 +56,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/Exporter.hpp>
 #include <assimp/IOSystem.hpp>
 #include <assimp/config.h>
+#include <assimp/StringUtils.h>
 
 // Header files, standard library.
 #include <cinttypes>
@@ -72,6 +73,27 @@ using namespace rapidjson;
 
 using namespace Assimp;
 using namespace glTF2;
+
+namespace {
+
+std::string BasisUniversalMimeType(const std::string &path) {
+    const std::string lower_path = ai_tolower(path);
+    if (lower_path.size() >= 5 &&
+        lower_path.compare(lower_path.size() - 5, 5, ".ktx2") == 0) {
+        return "image/ktx2";
+    }
+    if (lower_path.size() >= 4 &&
+        lower_path.compare(lower_path.size() - 4, 4, ".ktx") == 0) {
+        return "image/ktx";
+    }
+    if (lower_path.size() >= 6 &&
+        lower_path.compare(lower_path.size() - 6, 6, ".basis") == 0) {
+        return "image/basis";
+    }
+    return {};
+}
+
+}  // namespace
 
 namespace Assimp {
 
@@ -616,8 +638,8 @@ void glTF2Exporter::GetMatTex(const aiMaterial &mat, Ref<Texture> &texture, unsi
                     texture->source->SetData(reinterpret_cast<uint8_t *>(curTex->pcData), curTex->mWidth, *mAsset);
                 } else {
                     texture->source->uri = path;
-                    if (texture->source->uri.find(".ktx") != std::string::npos ||
-                            texture->source->uri.find(".basis") != std::string::npos) {
+                    texture->source->mimeType = BasisUniversalMimeType(path);
+                    if (!texture->source->mimeType.empty()) {
                         useBasisUniversal = true;
                     }
                 }

--- a/test/unit/utglTF2ImportExport.cpp
+++ b/test/unit/utglTF2ImportExport.cpp
@@ -41,6 +41,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "AbstractImportExportBase.h"
 #include "UnitTestPCH.h"
 #include "Tools/TestTools.h"
+#ifndef ASSIMP_BUILD_NO_EXPORT
+#include "AssetLib/glTF2/glTF2AssetWriter.h"
+#endif
 #include <assimp/commonMetaData.h>
 #include <assimp/postprocess.h>
 #include <assimp/config.h>
@@ -53,6 +56,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <rapidjson/schema.h>
 
 #include <array>
+#include <fstream>
+#include <sstream>
 
 #include <assimp/material.h>
 #include <assimp/GltfMaterial.h>
@@ -200,6 +205,83 @@ TEST_F(utglTF2ImportExport, importglTF2_KHR_materials_clearcoat) {
 }
 
 #ifndef ASSIMP_BUILD_NO_EXPORT
+
+TEST_F(utglTF2ImportExport, exportExternalBasisUniversalTexture) {
+    glTF2::Asset asset;
+    asset.extensionsUsed.KHR_texture_basisu = true;
+
+    auto image = asset.images.Create("image");
+    image->uri = "textures/albedo.KTX2";
+    image->mimeType = "image/ktx2";
+
+    auto texture = asset.textures.Create("texture");
+    texture->source = image;
+
+    glTF2::AssetWriter writer(asset);
+    ASSERT_TRUE(writer.mDoc.HasMember("images"));
+    ASSERT_EQ(writer.mDoc["images"].Size(), 1u);
+    const auto &image_json = writer.mDoc["images"][0];
+    ASSERT_TRUE(image_json.HasMember("uri"));
+    EXPECT_STREQ(image_json["uri"].GetString(), "textures/albedo.KTX2");
+    ASSERT_TRUE(image_json.HasMember("mimeType"));
+    EXPECT_STREQ(image_json["mimeType"].GetString(), "image/ktx2");
+
+    ASSERT_TRUE(writer.mDoc.HasMember("textures"));
+    ASSERT_EQ(writer.mDoc["textures"].Size(), 1u);
+    const auto &texture_json = writer.mDoc["textures"][0];
+    EXPECT_FALSE(texture_json.HasMember("source"));
+    ASSERT_TRUE(texture_json.HasMember("extensions"));
+    ASSERT_TRUE(texture_json["extensions"].HasMember("KHR_texture_basisu"));
+    const auto &basisu = texture_json["extensions"]["KHR_texture_basisu"];
+    ASSERT_TRUE(basisu.HasMember("source"));
+    EXPECT_EQ(basisu["source"].GetUint(), 0u);
+}
+
+TEST_F(utglTF2ImportExport, exportExternalBasisUniversalTexturePath) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(
+            ASSIMP_TEST_MODELS_DIR "/glTF2/BoxTextured-glTF/BoxTextured.gltf",
+            aiProcess_ValidateDataStructure);
+    ASSERT_NE(scene, nullptr);
+    ASSERT_GT(scene->mNumMaterials, 0u);
+
+    scene->mMaterials[0]->Clear();
+    aiString texture_path("textures/albedo.KTX2");
+    scene->mMaterials[0]->AddProperty(
+            &texture_path, AI_MATKEY_TEXTURE(aiTextureType_DIFFUSE, 0));
+
+    const std::string output =
+            std::string(ASSIMP_TEST_MODELS_DIR) +
+            "/glTF2/external_basis_texture_path_test.gltf";
+    Assimp::Exporter exporter;
+    ASSERT_EQ(aiReturn_SUCCESS,
+              exporter.Export(scene, "gltf2", output.c_str()))
+            << exporter.GetErrorString();
+
+    std::ifstream input(output);
+    ASSERT_TRUE(input.good());
+    std::stringstream contents;
+    contents << input.rdbuf();
+    rapidjson::Document document;
+    document.Parse(contents.str().c_str());
+    ASSERT_FALSE(document.HasParseError());
+
+    ASSERT_TRUE(document.HasMember("images"));
+    ASSERT_EQ(document["images"].Size(), 1u);
+    EXPECT_STREQ(document["images"][0]["mimeType"].GetString(),
+                 "image/ktx2");
+    ASSERT_TRUE(document.HasMember("textures"));
+    ASSERT_EQ(document["textures"].Size(), 1u);
+    EXPECT_FALSE(document["textures"][0].HasMember("source"));
+    EXPECT_EQ(document["textures"][0]["extensions"]["KHR_texture_basisu"]
+                      ["source"]
+                              .GetUint(),
+              0u);
+
+    ::remove(output.c_str());
+    const std::string binary = output.substr(0, output.size() - 5) + ".bin";
+    ::remove(binary.c_str());
+}
 
 TEST_F(utglTF2ImportExport, importglTF2AndExport_KHR_materials_clearcoat) {
     {


### PR DESCRIPTION
## Summary

Fix glTF2 export of external Basis Universal textures by preserving their MIME
type and placing their image source in the `KHR_texture_basisu` extension.

## Changes

- Infer `image/ktx2` for external `.ktx2` texture paths. Other extensions keep
  their normal URI-based texture source.
- Emit a non-empty MIME type for URI-backed images.
- Move the texture source into `extensions.KHR_texture_basisu.source` for
  Basis Universal images while leaving regular textures unchanged.
- Add exporter and writer regression tests for an external uppercase `.KTX2`
  path.

## Test plan

- [x] Built the `unit` target with glTF2 import/export enabled and system zlib.
- [x] `utglTF2ImportExport.exportExternalBasisUniversalTexture*` passes.
- [x] All 51 `utglTF2ImportExport.*` tests pass.
- [x] Independent exporter check confirms `image/ktx2` and extension source
      placement for an external `.KTX2` URI.

Fixes #6662
Fixes #6663


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved glTF export support for external KTX2 textures.
  * KTX2 images now include the correct MIME type when serialized.
  * KTX2 textures now use the `KHR_texture_basisu` extension correctly.
  * Other texture formats continue to use standard source serialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->