### PR TITLE
Fix BatchLoader ownership after polling shared scenes

### DIFF
--- a/code/Common/BaseImporter.cpp
+++ b/code/Common/BaseImporter.cpp
@@ -495,6 +495,7 @@ struct LoadRequest {
             flags(_flags),
             refCnt(1),
             scene(nullptr),
+            sceneClaimed(false),
             loaded(false),
             id(_id) {
         if (_map) {
@@ -510,6 +511,7 @@ struct LoadRequest {
     unsigned int flags;
     unsigned int refCnt;
     aiScene *scene;
+    bool sceneClaimed;
     bool loaded;
     BatchLoader::PropertyMap map;
     unsigned int id;
@@ -564,7 +566,9 @@ BatchLoader::BatchLoader(IOSystem *pIO, bool validate) {
 BatchLoader::~BatchLoader() {
     // delete all scenes what have not been polled by the user
     for (LoadReqIt it = m_data->requests.begin(); it != m_data->requests.end(); ++it) {
-        delete (*it).scene;
+        if (!(*it).sceneClaimed) {
+            delete (*it).scene;
+        }
     }
     delete m_data;
 }
@@ -611,6 +615,7 @@ aiScene *BatchLoader::GetImport(unsigned int which) {
     for (LoadReqIt it = m_data->requests.begin(); it != m_data->requests.end(); ++it) {
         if ((*it).id == which && (*it).loaded) {
             aiScene *sc = (*it).scene;
+            (*it).sceneClaimed = true;
             if (!(--(*it).refCnt)) {
                 m_data->requests.erase(it);
             }
@@ -643,6 +648,7 @@ void BatchLoader::LoadAll() {
         }
         m_data->pImporter->ReadFile((*it).file, pp);
         (*it).scene = m_data->pImporter->GetOrphanedScene();
+        (*it).sceneClaimed = false;
         (*it).loaded = true;
 
         ASSIMP_LOG_INFO("%%% END EXTERNAL FILE %%%");

--- a/code/Common/BaseImporter.cpp
+++ b/code/Common/BaseImporter.cpp
@@ -60,36 +60,35 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <sstream>
 
 namespace {
-// Checks whether the passed string is a gcs version.
-bool IsGcsVersion(const std::string &s) {
-    if (s.empty()) return false;
-    return std::all_of(s.cbegin(), s.cend(), [](const char c) {
-        // gcs only permits numeric characters.
-        return std::isdigit(static_cast<int>(c));
-    });
-}
-
-// Removes a possible version hash from a filename, as found for example in
-// gcs uris (e.g. `gs://bucket/model.glb#1234`), see also
-// https://github.com/GoogleCloudPlatform/gsutil/blob/c80f329bc3c4011236c78ce8910988773b2606cb/gslib/storage_url.py#L39.
-std::string StripVersionHash(const std::string &filename) {
-    const std::string::size_type pos = filename.find_last_of('#');
-    // Only strip if the hash is behind a possible file extension and the part
-    // behind the hash is a version string.
-    if (pos != std::string::npos && pos > filename.find_last_of('.') &&
-        IsGcsVersion(filename.substr(pos + 1))) {
-        return filename.substr(0, pos);
+    // Checks whether the passed string is a gcs version.
+    bool IsGcsVersion(const std::string &s) {
+        if (s.empty()) return false;
+        return std::all_of(s.cbegin(), s.cend(), [](const char c) {
+            // gcs only permits numeric characters.
+            return std::isdigit(static_cast<int>(c));
+        });
     }
-    return filename;
-}
+
+    // Removes a possible version hash from a filename, as found for example in
+    // gcs uris (e.g. `gs://bucket/model.glb#1234`), see also
+    // https://github.com/GoogleCloudPlatform/gsutil/blob/c80f329bc3c4011236c78ce8910988773b2606cb/gslib/storage_url.py#L39.
+    std::string StripVersionHash(const std::string &filename) {
+        const std::string::size_type pos = filename.find_last_of('#');
+        // Only strip if the hash is behind a possible file extension and the part
+        // behind the hash is a version string.
+        if (pos != std::string::npos && pos > filename.find_last_of('.') &&
+            IsGcsVersion(filename.substr(pos + 1))) {
+            return filename.substr(0, pos);
+        }
+        return filename;
+    }
 }  // namespace
 
 using namespace Assimp;
 
 // ------------------------------------------------------------------------------------------------
 // Constructor to be privately used by Importer
-BaseImporter::BaseImporter() AI_NO_EXCEPT
-        : m_progress() {
+BaseImporter::BaseImporter() AI_NO_EXCEPT : m_progress() {
     // empty
 }
 
@@ -109,13 +108,10 @@ void BaseImporter::UpdateImporterScale(Importer *pImp) {
 // ------------------------------------------------------------------------------------------------
 // Imports the given file and returns the imported data.
 aiScene *BaseImporter::ReadFile(Importer *pImp, const std::string &pFile, IOSystem *pIOHandler) {
-
     m_progress = pImp->GetProgressHandler();
-    if (nullptr == m_progress) {
+    if (m_progress == nullptr) {
         return nullptr;
     }
-
-    ai_assert(m_progress);
 
     // Gather configuration properties for this run
     SetupProperties(pImp);
@@ -133,7 +129,6 @@ aiScene *BaseImporter::ReadFile(Importer *pImp, const std::string &pFile, IOSyst
         // Calculate import scale hook - required because pImp not available anywhere else
         // passes scale into ScaleProcess
         UpdateImporterScale(pImp);
-
     } catch( const std::exception &err ) {
         // extract error description
         m_ErrorText = err.what();

--- a/code/Common/Importer.h
+++ b/code/Common/Importer.h
@@ -232,7 +232,8 @@ public:
      *
      *  @param which LRWC returned by AddLoadRequest().
      *  @return nullptr if there is no scene with this file name
-     *  in the queue of the scene hasn't been loaded yet. */
+     *  in the queue or the scene hasn't been loaded yet. The caller assumes
+     *  ownership of a non-null scene and must delete shared scenes only once. */
     aiScene* GetImport(
         unsigned int which
         );

--- a/include/assimp/BaseImporter.h
+++ b/include/assimp/BaseImporter.h
@@ -79,7 +79,8 @@ using UByteBuffer = std::vector<uint8_t>;
 using ByteBuffer = std::vector<int8_t>;
 
 // ---------------------------------------------------------------------------
-/** FOR IMPORTER PLUGINS ONLY: The BaseImporter defines a common interface
+/** 
+ *  @brief FOR IMPORTER PLUGINS ONLY: The BaseImporter defines a common interface
  *  for all importer worker classes.
  *
  * The interface defines two functions: CanRead() is used to check if the
@@ -87,6 +88,7 @@ using ByteBuffer = std::vector<int8_t>;
  * this function returns true, the importer then calls ReadFile() which
  * imports the given file. ReadFile is not overridable, it just calls
  * InternReadFile() and catches any ImportErrorException that might occur.
+ * The instance of the scene must be release manually!
  */
 class ASSIMP_API BaseImporter {
     friend class Importer;

--- a/test/unit/utBatchLoader.cpp
+++ b/test/unit/utBatchLoader.cpp
@@ -43,6 +43,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "UnitTestPCH.h"
 #include "Common/Importer.h"
 #include "TestIOSystem.h"
+#include <assimp/DefaultIOSystem.h>
+#include <assimp/MemoryIOWrapper.h>
+#include <assimp/scene.h>
 
 using namespace ::Assimp;
 
@@ -78,4 +81,28 @@ TEST_F( BatchLoaderTest, validateAccessTest ) {
 
     BatchLoader loader2( m_io, true );
     EXPECT_TRUE( loader2.getValidation() );
+}
+
+TEST_F(BatchLoaderTest, polledSceneOwnershipIsTransferred) {
+    static const char obj[] =
+            "o triangle\n"
+            "v 0 0 0\n"
+            "v 1 0 0\n"
+            "v 0 1 0\n"
+            "f 1 2 3\n";
+
+    DefaultIOSystem fileSystem;
+    MemoryIOSystem memoryIO(reinterpret_cast<const uint8_t *>(obj), sizeof(obj) - 1, &fileSystem);
+
+    BatchLoader loader(&memoryIO);
+    const std::string path = AI_MEMORYIO_MAGIC_FILENAME ".obj";
+    const unsigned int request = loader.AddLoadRequest(path);
+    EXPECT_EQ(request, loader.AddLoadRequest(path));
+
+    loader.LoadAll();
+    aiScene *scene = loader.GetImport(request);
+    ASSERT_NE(nullptr, scene);
+
+    // One duplicate request remains, but ownership transferred on the first poll.
+    delete scene;
 }


### PR DESCRIPTION
Fixes #6820.

## Root cause

`BatchLoader` coalesces duplicate file requests and keeps a reference count for the resulting `aiScene`. `GetImport()` can return that scene while another duplicate request remains unpolled. The caller then owns the scene, and the LWS merge path deletes it after transferring its contents, but the pending batch request still retains the same pointer. `BatchLoader` consequently deletes the already-freed scene from its destructor.

## Fix

Track whether each loaded scene has been claimed by a caller. The batch loader still deletes scenes that were never polled, while claimed scenes remain caller-owned even when duplicate request references are pending. The `GetImport()` documentation now states that ownership contract explicitly.

The regression queues the same in-memory OBJ twice, polls it once, deletes the caller-owned scene, and verifies that destroying the loader with the duplicate request still pending does not reclaim it.

## Verification

- Reproduced the public OSS-Fuzz testcase from #6820 on current `master` under AddressSanitizer before the change.
- Confirmed the same instrumented import/export harness exits cleanly after the change.
- `BatchLoaderTest.*` and `utLWSImportExport.*`: 17/17 pass under AddressSanitizer.
- Full unit suite: 632/632 pass under AddressSanitizer.

## AI tool disclosure

Prepared with AI assistance. I independently reviewed and tested the code, understand the ownership change, and take responsibility for the contribution. The commit includes an `Assisted-by: OpenAI Codex` trailer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed batch loading so scenes returned to callers are not deleted prematurely.
  - Preserved correct ownership when multiple requests reference the same loaded scene.
  - Clarified that callers are responsible for deleting returned scenes exactly once.

- **Documentation**
  - Updated API documentation to explain scene ownership and release requirements.

- **Tests**
  - Added regression coverage for scene ownership when duplicate requests remain outstanding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->