### PR TITLE
PLY: declare the vertex properties the exporter actually writes

### DIFF
--- a/code/AssetLib/Ply/PlyExporter.cpp
+++ b/code/AssetLib/Ply/PlyExporter.cpp
@@ -116,7 +116,13 @@ PlyExporter::PlyExporter(const char* _filename, const aiScene* pScene, bool bina
             components |= PLY_EXPORT_HAS_TANGENTS_BITANGENTS;
         }
         for (unsigned int t = 0; m.HasTextureCoords(t); ++t) {
+            if (m.mNumUVComponents[t] != 2 && m.mNumUVComponents[t] != 3) {
+                throw DeadlyExportError("Invalid number of texture coordinates detected: " + std::to_string(m.mNumUVComponents[t]));
+            }
             components |= PLY_EXPORT_HAS_TEXCOORDS << t;
+            if (m.mNumUVComponents[t] > mUVComponents[t]) {
+                mUVComponents[t] = m.mNumUVComponents[t];
+            }
         }
         for (unsigned int t = 0; m.HasVertexColors(t); ++t) {
             components |= PLY_EXPORT_HAS_COLORS << t;
@@ -167,17 +173,20 @@ PlyExporter::PlyExporter(const char* _filename, const aiScene* pScene, bool bina
     // but in reality most importers only know about vertex positions, normals
     // and texture coordinates).
     for (unsigned int n = PLY_EXPORT_HAS_TEXCOORDS, c = 0; (components & n) && c != AI_MAX_NUMBER_OF_TEXTURECOORDS; n <<= 1, ++c) {
-        if (!c) {
-            mOutput << "property " << "uchar" << " red" << endl;
-            mOutput << "property " << "uchar" << " green" << endl;
-            mOutput << "property " << "uchar" << " blue" << endl;
-            mOutput << "property " << "uchar" << " alpha" << endl;
-        } else {
-            mOutput << "property " << "uchar" << " red" << c << endl;
-            mOutput << "property " << "uchar" << " green" << c << endl;
-            mOutput << "property " << "uchar" << " blue" << c << endl;
-            mOutput << "property " << "uchar" << " alpha" << c << endl;
+        const std::string suffix = c ? std::to_string(c) : std::string();
+        mOutput << "property " << typeName << " s" << suffix << endl;
+        mOutput << "property " << typeName << " t" << suffix << endl;
+        if (mUVComponents[c] == 3) {
+            mOutput << "property " << typeName << " w" << suffix << endl;
         }
+    }
+
+    for (unsigned int n = PLY_EXPORT_HAS_COLORS, c = 0; (components & n) && c != AI_MAX_NUMBER_OF_COLOR_SETS; n <<= 1, ++c) {
+        const std::string suffix = c ? std::to_string(c) : std::string();
+        mOutput << "property " << "uchar" << " red" << suffix << endl;
+        mOutput << "property " << "uchar" << " green" << suffix << endl;
+        mOutput << "property " << "uchar" << " blue" << suffix << endl;
+        mOutput << "property " << "uchar" << " alpha" << suffix << endl;
     }
 
     if(components & PLY_EXPORT_HAS_TANGENTS_BITANGENTS) {
@@ -238,21 +247,19 @@ void PlyExporter::WriteMeshVerts(const aiMesh* m, unsigned int components) {
         }
 
         for (unsigned int n = PLY_EXPORT_HAS_TEXCOORDS, c = 0; (components & n) && c != AI_MAX_NUMBER_OF_TEXTURECOORDS; n <<= 1, ++c) {
+            // Always emit exactly as many components as the header declared for this channel.
             if (m->HasTextureCoords(c)) {
-                if (m->mNumUVComponents[c] == 3) {
-                    mOutput <<
-                        " " << m->mTextureCoords[c][i].x <<
-                        " " << m->mTextureCoords[c][i].y <<
-                        " " << m->mTextureCoords[c][i].z;
-                } else if (m->mNumUVComponents[c] == 2) {
-                    mOutput <<
-                        " " << m->mTextureCoords[c][i].x <<
-                        " " << m->mTextureCoords[c][i].y;
-                } else {
-                    throw DeadlyExportError("Invalid number of texture coordinates detected: " + std::to_string(m->mNumUVComponents[c]));
+                mOutput <<
+                    " " << m->mTextureCoords[c][i].x <<
+                    " " << m->mTextureCoords[c][i].y;
+                if (mUVComponents[c] == 3) {
+                    mOutput << " " << m->mTextureCoords[c][i].z;
                 }
             } else {
                 mOutput << " -1.0 -1.0";
+                if (mUVComponents[c] == 3) {
+                    mOutput << " -1.0";
+                }
             }
         }
 
@@ -264,7 +271,7 @@ void PlyExporter::WriteMeshVerts(const aiMesh* m, unsigned int components) {
                     " " << (int)(m->mColors[c][i].b * 255) <<
                     " " << (int)(m->mColors[c][i].a * 255);
             } else {
-                mOutput << " 0 0 0";
+                mOutput << " 0 0 0 0";
             }
         }
 
@@ -291,7 +298,7 @@ void PlyExporter::WriteMeshVertsBinary(const aiMesh* m, unsigned int components)
     // If a component (for instance normal vectors) is present in at least one mesh in the scene,
     // then default values are written for meshes that do not contain this component.
     aiVector3D defaultNormal(0, 0, 0);
-    aiVector2D defaultUV(-1, -1);
+    aiVector3D defaultUV(-1, -1, -1);
     aiColor4D defaultColor(-1, -1, -1, -1);
     for (unsigned int i = 0; i < m->mNumVertices; ++i) {
         mOutput.write(reinterpret_cast<const char*>(&m->mVertices[i].x), 12);
@@ -304,10 +311,12 @@ void PlyExporter::WriteMeshVertsBinary(const aiMesh* m, unsigned int components)
         }
 
         for (unsigned int n = PLY_EXPORT_HAS_TEXCOORDS, c = 0; (components & n) && c != AI_MAX_NUMBER_OF_TEXTURECOORDS; n <<= 1, ++c) {
+            // Always emit exactly as many components as the header declared for this channel.
+            const std::streamsize uvBytes = static_cast<std::streamsize>(mUVComponents[c] * sizeof(ai_real));
             if (m->HasTextureCoords(c)) {
-                mOutput.write(reinterpret_cast<const char*>(&m->mTextureCoords[c][i].x), 8);
+                mOutput.write(reinterpret_cast<const char*>(&m->mTextureCoords[c][i].x), uvBytes);
             } else {
-                mOutput.write(reinterpret_cast<const char*>(&defaultUV.x), 8);
+                mOutput.write(reinterpret_cast<const char*>(&defaultUV.x), uvBytes);
             }
         }
 

--- a/code/AssetLib/Ply/PlyExporter.h
+++ b/code/AssetLib/Ply/PlyExporter.h
@@ -45,6 +45,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef AI_PLYEXPORTER_H_INC
 #define AI_PLYEXPORTER_H_INC
 
+#include <assimp/mesh.h>
+
 #include <sstream>
 
 struct aiScene;
@@ -79,6 +81,9 @@ private:
 private:
     const std::string filename;  // tHE FILENAME
     const std::string endl;      // obviously, this endl() doesn't flush() the stream
+    // Number of texture-coordinate components declared in the header for each channel. The header is
+    // written once for the whole scene, so this has to be the same for every mesh sharing a channel.
+    unsigned int mUVComponents[AI_MAX_NUMBER_OF_TEXTURECOORDS] = {};
 };
 
 } // Namespace Assimp

--- a/test/unit/utPLYImportExport.cpp
+++ b/test/unit/utPLYImportExport.cpp
@@ -46,6 +46,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/Exporter.hpp>
 #include <assimp/Importer.hpp>
 
+#include <sstream>
+#include <string>
+#include <vector>
+
 using namespace ::Assimp;
 
 class utPLYImportExport : public AbstractImportExportBase {
@@ -282,3 +286,103 @@ TEST_F(utPLYImportExport, parseInvalidDoubleCustomProperty) {
     const aiScene *scene = importer.ReadFileFromMemory(data, sizeof(data), 0);
     EXPECT_EQ(nullptr, scene);
 }
+
+#ifndef ASSIMP_BUILD_NO_EXPORT
+
+// A PLY header has to declare exactly the properties that each vertex row carries. Anything else is
+// unreadable for a conformant parser (ASCII) or silently misaligned (binary).
+static void expectBlobHeaderMatchesVertexRows(const aiExportDataBlob *blob, const char *model) {
+    std::istringstream ply(std::string(static_cast<const char *>(blob->data), blob->size));
+    std::string line, element;
+    unsigned int declared = 0, vertices = 0;
+    while (std::getline(ply, line)) {
+        std::istringstream words(line);
+        std::string first;
+        words >> first;
+        if (first == "element") {
+            words >> element >> vertices;
+        } else if (first == "property" && element == "vertex") {
+            ++declared;
+        } else if (first == "end_header") {
+            break;
+        }
+    }
+    ASSERT_GT(declared, 0u) << model;
+    ASSERT_GT(vertices, 0u) << model;
+
+    for (unsigned int i = 0; i < vertices; ++i) {
+        ASSERT_TRUE(std::getline(ply, line)) << model << ": vertex row " << i << " missing";
+        std::istringstream values(line);
+        unsigned int written = 0;
+        for (std::string value; values >> value;) {
+            ++written;
+        }
+        EXPECT_EQ(declared, written) << model << ": vertex row " << i
+                                     << " carries " << written << " values but the header declares "
+                                     << declared << " properties";
+    }
+}
+
+static void expectHeaderMatchesVertexRows(const char *model) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(model, aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene) << model;
+
+    Assimp::Exporter exporter;
+    const aiExportDataBlob *blob = exporter.ExportToBlob(scene, "ply");
+    ASSERT_NE(nullptr, blob) << model;
+    expectBlobHeaderMatchesVertexRows(blob, model);
+}
+
+// Tests that the exported header describes the exported payload, for a mesh with neither texture
+// coordinates nor vertex colours, with texture coordinates, and with vertex colours.
+TEST_F(utPLYImportExport, exportedHeaderMatchesVertexRows) {
+    expectHeaderMatchesVertexRows(ASSIMP_TEST_MODELS_DIR "/PLY/cube.ply");
+    expectHeaderMatchesVertexRows(ASSIMP_TEST_MODELS_DIR "/PLY/cube_uv.ply");
+    expectHeaderMatchesVertexRows(ASSIMP_TEST_MODELS_DIR "/PLY/float-color.ply");
+}
+
+// Tests the same invariant for a 3-component (UVW) texture-coordinate channel, which is written with
+// one value more per vertex than the usual 2-component channel.
+TEST_F(utPLYImportExport, exportedHeaderMatchesVertexRowsForUVW) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/PLY/cube_uv.ply", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+    ASSERT_EQ(1u, scene->mNumMeshes);
+    ASSERT_TRUE(scene->mMeshes[0]->HasTextureCoords(0));
+    scene->mMeshes[0]->mNumUVComponents[0] = 3;
+
+    Assimp::Exporter exporter;
+    const aiExportDataBlob *blob = exporter.ExportToBlob(scene, "ply");
+    ASSERT_NE(nullptr, blob);
+    expectBlobHeaderMatchesVertexRows(blob, "cube_uv.ply as UVW");
+}
+
+// Tests that texture coordinates and vertex colours survive an export/import round trip.
+TEST_F(utPLYImportExport, exportImportRoundTripKeepsTexCoords) {
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/PLY/cube_uv.ply", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+    ASSERT_EQ(1u, scene->mNumMeshes);
+    ASSERT_TRUE(scene->mMeshes[0]->HasTextureCoords(0));
+    const unsigned int numVertices = scene->mMeshes[0]->mNumVertices;
+    std::vector<aiVector3D> expected(scene->mMeshes[0]->mTextureCoords[0],
+            scene->mMeshes[0]->mTextureCoords[0] + numVertices);
+
+    Assimp::Exporter exporter;
+    const aiExportDataBlob *blob = exporter.ExportToBlob(scene, "ply");
+    ASSERT_NE(nullptr, blob);
+
+    Assimp::Importer reimporter;
+    const aiScene *roundTripped = reimporter.ReadFileFromMemory(blob->data, blob->size, 0, "ply");
+    ASSERT_NE(nullptr, roundTripped);
+    ASSERT_EQ(1u, roundTripped->mNumMeshes);
+    ASSERT_EQ(numVertices, roundTripped->mMeshes[0]->mNumVertices);
+    ASSERT_TRUE(roundTripped->mMeshes[0]->HasTextureCoords(0));
+    for (unsigned int i = 0; i < numVertices; ++i) {
+        EXPECT_NEAR(expected[i].x, roundTripped->mMeshes[0]->mTextureCoords[0][i].x, 1e-5) << "vertex " << i;
+        EXPECT_NEAR(expected[i].y, roundTripped->mMeshes[0]->mTextureCoords[0][i].y, 1e-5) << "vertex " << i;
+    }
+}
+
+#endif // ASSIMP_BUILD_NO_EXPORT


### PR DESCRIPTION
The header block guarded by `PLY_EXPORT_HAS_TEXCOORDS` emits `red`/`green`/`blue`/`alpha` property names, and the `PLY_EXPORT_HAS_COLORS` header block is gone. Both writers still emit texcoords *then* colours, so a mesh with UVs or vertex colours gets a header that does not describe its own vertex rows.

A mesh with normals, UVs and colours declares **10 properties**; each vertex row carries **12 values**.

- ASCII: `plyfile` 1.1.5 refuses the file — `element 'vertex': row 0: expected end-of-line`.
- Binary: parses, then decodes garbage (positions like `-3.4e+38`) — stride 28 declared vs 36 written.

Introduced by 275eca95 (#6124), a reformat that dropped the `s`/`t` lines and the colours-loop header. Ships in v6.0.0–v6.0.5.

This restores both header blocks. The header is written once per scene while the payload is per-mesh, so the per-channel component count is recorded up front and both writers emit exactly the declared arity — which also gives the binary exporter the 3-component support #6124 added to ASCII only (#3829).

Tests assert header-property-count == vertex-value-count for `cube.ply`, `cube_uv.ply`, `float-color.ply`, a UVW channel, and a UV round trip. On master they fail 8-vs-10 and 7-vs-3. Suite 663 → 666.

Checked with `plyfile` as an outside reader: ASCII and binary, 2- and 3-component, all parse with correct positions, UVs, colours and faces.

Assisted-by: Claude Code (claude-opus-5), per AIToolPolicy.md. Draft pending my own line-by-line review.
