### PR TITLE
More collada tests

### DIFF
--- a/code/AssetLib/Collada/ColladaHelper.h
+++ b/code/AssetLib/Collada/ColladaHelper.h
@@ -50,6 +50,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <cstdint>
 #include <map>
+#include <memory>
 #include <set>
 #include <vector>
 
@@ -591,7 +592,7 @@ struct Animation {
     std::vector<AnimationChannel> mChannels;
 
     /// the sub-animations, if any
-    std::vector<Animation *> mSubAnims;
+    std::vector<std::unique_ptr<Animation>> mSubAnims;
 
     Animation() {}
 
@@ -603,9 +604,6 @@ struct Animation {
 
     /// Destructor
     ~Animation() {
-        for (auto it = mSubAnims.begin(); it != mSubAnims.end(); ++it) {
-            delete *it;
-        }
     }
 
     /// Collect all channels in the animation hierarchy into a single channel list.
@@ -613,7 +611,7 @@ struct Animation {
         channels.insert(channels.end(), mChannels.begin(), mChannels.end());
 
         for (auto it = mSubAnims.begin(); it != mSubAnims.end(); ++it) {
-            Animation *pAnim = (*it);
+            Animation *pAnim = it->get();
             pAnim->CollectChannelsRecursively(channels);
         }
     }
@@ -628,7 +626,7 @@ struct Animation {
         bool childrenAnimationsHaveDifferentChannels = true;
 
         for (auto it = pParent->mSubAnims.begin(); it != pParent->mSubAnims.end();) {
-            Animation *anim = *it;
+            Animation *anim = it->get();
             // Assign the first animation name to the parent if empty.
             // This prevents the animation name from being lost when animations are combined
             if (mName.empty()) {
@@ -649,7 +647,7 @@ struct Animation {
         // We only want to combine animations if they have different channels
         if (childrenAnimationsHaveDifferentChannels) {
             for (auto it = pParent->mSubAnims.begin(); it != pParent->mSubAnims.end();) {
-                Animation *anim = *it;
+                Animation *anim = it->release();
 
                 pParent->mChannels.push_back(anim->mChannels[0]);
 

--- a/code/AssetLib/Collada/ColladaHelper.h
+++ b/code/AssetLib/Collada/ColladaHelper.h
@@ -593,6 +593,14 @@ struct Animation {
     /// the sub-animations, if any
     std::vector<Animation *> mSubAnims;
 
+    Animation() {}
+
+    Animation(const Animation &)            = delete;
+    Animation &operator=(const Animation &) = delete;
+
+    Animation(Animation &&) noexcept            = default;
+    Animation &operator=(Animation &&) noexcept = default;
+
     /// Destructor
     ~Animation() {
         for (auto it = mSubAnims.begin(); it != mSubAnims.end(); ++it) {

--- a/code/AssetLib/Collada/ColladaHelper.h
+++ b/code/AssetLib/Collada/ColladaHelper.h
@@ -595,7 +595,7 @@ struct Animation {
 
     /// Destructor
     ~Animation() {
-        for (std::vector<Animation *>::iterator it = mSubAnims.begin(); it != mSubAnims.end(); ++it) {
+        for (auto it = mSubAnims.begin(); it != mSubAnims.end(); ++it) {
             delete *it;
         }
     }
@@ -604,7 +604,7 @@ struct Animation {
     void CollectChannelsRecursively(std::vector<AnimationChannel> &channels) {
         channels.insert(channels.end(), mChannels.begin(), mChannels.end());
 
-        for (std::vector<Animation *>::iterator it = mSubAnims.begin(); it != mSubAnims.end(); ++it) {
+        for (auto it = mSubAnims.begin(); it != mSubAnims.end(); ++it) {
             Animation *pAnim = (*it);
             pAnim->CollectChannelsRecursively(channels);
         }
@@ -619,7 +619,7 @@ struct Animation {
         std::set<std::string> childrenTargets;
         bool childrenAnimationsHaveDifferentChannels = true;
 
-        for (std::vector<Animation *>::iterator it = pParent->mSubAnims.begin(); it != pParent->mSubAnims.end();) {
+        for (auto it = pParent->mSubAnims.begin(); it != pParent->mSubAnims.end();) {
             Animation *anim = *it;
             // Assign the first animation name to the parent if empty.
             // This prevents the animation name from being lost when animations are combined
@@ -640,7 +640,7 @@ struct Animation {
 
         // We only want to combine animations if they have different channels
         if (childrenAnimationsHaveDifferentChannels) {
-            for (std::vector<Animation *>::iterator it = pParent->mSubAnims.begin(); it != pParent->mSubAnims.end();) {
+            for (auto it = pParent->mSubAnims.begin(); it != pParent->mSubAnims.end();) {
                 Animation *anim = *it;
 
                 pParent->mChannels.push_back(anim->mChannels[0]);

--- a/code/AssetLib/Collada/ColladaLoader.cpp
+++ b/code/AssetLib/Collada/ColladaLoader.cpp
@@ -1032,8 +1032,8 @@ void ColladaLoader::StoreAnimations(aiScene *pScene, const ColladaParser &pParse
     std::string animName = pPrefix.empty() ? pSrcAnim->mName : pPrefix + "_" + pSrcAnim->mName;
 
     // create nested animations, if given
-    for (auto mSubAnim : pSrcAnim->mSubAnims) {
-        StoreAnimations(pScene, pParser, mSubAnim, animName);
+    for (auto &mSubAnim : pSrcAnim->mSubAnims) {
+        StoreAnimations(pScene, pParser, mSubAnim.get(), animName);
     }
 
     // create animation channels, if any

--- a/code/AssetLib/Collada/ColladaParser.cpp
+++ b/code/AssetLib/Collada/ColladaParser.cpp
@@ -470,7 +470,6 @@ ColladaParser::ColladaParser(IOSystem *pIOHandler, const std::string &pFile) :
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
 ColladaParser::~ColladaParser() {
-    // FIXME: some animations in mAnimationLibrary leak
     for (auto &it : mNodeLibrary) {
         delete it.second;
     }
@@ -727,11 +726,10 @@ void ColladaParser::PostProcessRootAnimations() {
     for (auto &it : mAnimationClipLibrary) {
         std::string clipName = it.first;
 
-        // FIXME: this leaks
         auto *clip = new Animation();
         clip->mName = clipName;
 
-        temp.mSubAnims.push_back(clip);
+        temp.mSubAnims.push_back(std::unique_ptr<Animation>(clip));
 
         for (const std::string &animationID : it.second) {
             auto animation = mAnimationLibrary.find(animationID);
@@ -793,7 +791,7 @@ void ColladaParser::ReadAnimation(XmlNode &node, Collada::Animation *pParent) {
             if (!anim) {
                 anim = new Animation;
                 anim->mName = animName;
-                pParent->mSubAnims.push_back(anim);
+                pParent->mSubAnims.push_back(std::unique_ptr<Animation>(anim));
             }
 
             // recurse into the sub-element
@@ -826,7 +824,7 @@ void ColladaParser::ReadAnimation(XmlNode &node, Collada::Animation *pParent) {
         if (nullptr == anim) {
             anim = new Animation;
             anim->mName = animName;
-            pParent->mSubAnims.push_back(anim);
+            pParent->mSubAnims.push_back(std::unique_ptr<Animation>(anim));
         }
 
         for (const auto &channel : channels) {

--- a/code/AssetLib/Collada/ColladaParser.cpp
+++ b/code/AssetLib/Collada/ColladaParser.cpp
@@ -470,6 +470,7 @@ ColladaParser::ColladaParser(IOSystem *pIOHandler, const std::string &pFile) :
 // ------------------------------------------------------------------------------------------------
 // Destructor, private as well
 ColladaParser::~ColladaParser() {
+    // FIXME: some animations in mAnimationLibrary leak
     for (auto &it : mNodeLibrary) {
         delete it.second;
     }
@@ -726,6 +727,7 @@ void ColladaParser::PostProcessRootAnimations() {
     for (auto &it : mAnimationClipLibrary) {
         std::string clipName = it.first;
 
+        // FIXME: this leaks
         auto *clip = new Animation();
         clip->mName = clipName;
 

--- a/code/AssetLib/Collada/ColladaParser.cpp
+++ b/code/AssetLib/Collada/ColladaParser.cpp
@@ -743,10 +743,7 @@ void ColladaParser::PostProcessRootAnimations() {
         }
     }
 
-    mAnims = temp;
-
-    // Ensure no double deletes.
-    temp.mSubAnims.clear();
+    mAnims = std::move(temp);
 }
 
 // ------------------------------------------------------------------------------------------------

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -151,6 +151,8 @@ SET( IMPORTERS
   unit/utBlendImportMaterials.cpp
   unit/utBlenderWork.cpp
   unit/utBVHImportExport.cpp
+  unit/utColladaExport.cpp
+  unit/utColladaImportExport.cpp
   unit/utCSMImportExport.cpp
   unit/utB3DImportExport.cpp
   unit/utNDOImportExport.cpp
@@ -183,18 +185,6 @@ SET( IMPORTERS
 if(ASSIMP_BUILD_USD_IMPORTER)
   list( APPEND IMPORTERS
     unit/utUSDImport.cpp
-  )
-endif()
-
-if(ASSIMP_BUILD_COLLADA_EXPORTER)
-  list( APPEND IMPORTERS
-    unit/utColladaExport.cpp
-  )
-endif()
-
-if(ASSIMP_BUILD_COLLADA_IMPORTER)
-  list( APPEND IMPORTERS
-    unit/utColladaImportExport.cpp
   )
 endif()
 

--- a/test/unit/utColladaImportExport.cpp
+++ b/test/unit/utColladaImportExport.cpp
@@ -369,19 +369,12 @@ TEST_F(utColladaImportExport, importKwxport) {
 }
 
 
-#if 0
-// FIXME: disabled because it leaks memory
-
-
 TEST_F(utColladaImportExport, importAnimationLibrary) {
     Importer importer;
 
     const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/Collada/library_animation_clips.dae", aiProcess_ValidateDataStructure);
     ASSERT_NE(scene, nullptr);
 }
-
-
-#endif  // 0
 
 
 TEST_F(utColladaImportExport, importLights) {

--- a/test/unit/utColladaImportExport.cpp
+++ b/test/unit/utColladaImportExport.cpp
@@ -240,6 +240,190 @@ TEST_F(utColladaImportExport, importDaeFromFileTest) {
     EXPECT_TRUE(importerTest());
 }
 
+
+TEST_F(utColladaImportExport, importDaeAnims) {
+    Importer importer;
+
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/Collada/anims_with_full_rotations_between_keys.DAE", aiProcess_ValidateDataStructure);
+    ASSERT_NE(scene, nullptr);
+}
+
+
+TEST_F(utColladaImportExport, importCameras) {
+    Importer importer;
+
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/Collada/cameras.dae", aiProcess_ValidateDataStructure);
+    ASSERT_NE(scene, nullptr);
+}
+
+
+TEST_F(utColladaImportExport, importCinema4D) {
+    Importer importer;
+
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/Collada/Cinema4D.dae", aiProcess_ValidateDataStructure);
+    ASSERT_NE(scene, nullptr);
+}
+
+
+TEST_F(utColladaImportExport, importCollada) {
+    Importer importer;
+
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/Collada/COLLADA.dae", aiProcess_ValidateDataStructure);
+    ASSERT_NE(scene, nullptr);
+}
+
+
+TEST_F(utColladaImportExport, importTriangulate) {
+    Importer importer;
+
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/Collada/COLLADA_triangulate.dae", aiProcess_ValidateDataStructure);
+    ASSERT_NE(scene, nullptr);
+}
+
+
+TEST_F(utColladaImportExport, importConcavePolygon) {
+    Importer importer;
+
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/Collada/ConcavePolygon.dae", aiProcess_ValidateDataStructure);
+    ASSERT_NE(scene, nullptr);
+}
+
+
+TEST_F(utColladaImportExport, importCubeEmptyTags) {
+    Importer importer;
+
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/Collada/cube_emptyTags.dae", aiProcess_ValidateDataStructure);
+    ASSERT_NE(scene, nullptr);
+}
+
+
+TEST_F(utColladaImportExport, importCubeTriangulate) {
+    Importer importer;
+
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/Collada/cube_triangulate.dae", aiProcess_ValidateDataStructure);
+    ASSERT_NE(scene, nullptr);
+}
+
+
+TEST_F(utColladaImportExport, importCubeTristrips) {
+    Importer importer;
+
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/Collada/cube_tristrips.dae", aiProcess_ValidateDataStructure);
+    ASSERT_NE(scene, nullptr);
+}
+
+
+TEST_F(utColladaImportExport, importCubeUTF16) {
+    Importer importer;
+
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/Collada/cube_UTF16LE.dae", aiProcess_ValidateDataStructure);
+    ASSERT_NE(scene, nullptr);
+}
+
+
+TEST_F(utColladaImportExport, importCubeUTF8) {
+    Importer importer;
+
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/Collada/cube_UTF8BOM.dae", aiProcess_ValidateDataStructure);
+    ASSERT_NE(scene, nullptr);
+}
+
+
+TEST_F(utColladaImportExport, importCube2UVs) {
+    Importer importer;
+
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/Collada/cube_with_2UVs.DAE", aiProcess_ValidateDataStructure);
+    ASSERT_NE(scene, nullptr);
+}
+
+
+TEST_F(utColladaImportExport, importCubeSpecialChars) {
+    Importer importer;
+
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/Collada/cube_xmlspecialchars.dae", aiProcess_ValidateDataStructure);
+    ASSERT_NE(scene, nullptr);
+}
+
+
+TEST_F(utColladaImportExport, importDuckTriangulate) {
+    Importer importer;
+
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/Collada/duck_triangulate.dae", aiProcess_ValidateDataStructure);
+    ASSERT_NE(scene, nullptr);
+}
+
+
+TEST_F(utColladaImportExport, importEarthCylindrical) {
+    Importer importer;
+
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/Collada/earthCylindrical.DAE", aiProcess_ValidateDataStructure);
+    ASSERT_NE(scene, nullptr);
+}
+
+
+TEST_F(utColladaImportExport, importKwxport) {
+    Importer importer;
+
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/Collada/kwxport_test_vcolors.dae", aiProcess_ValidateDataStructure);
+    ASSERT_NE(scene, nullptr);
+}
+
+
+#if 0
+// FIXME: disabled because it leaks memory
+
+
+TEST_F(utColladaImportExport, importAnimationLibrary) {
+    Importer importer;
+
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/Collada/library_animation_clips.dae", aiProcess_ValidateDataStructure);
+    ASSERT_NE(scene, nullptr);
+}
+
+
+#endif  // 0
+
+
+TEST_F(utColladaImportExport, importLights) {
+    Importer importer;
+
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/Collada/lights.dae", aiProcess_ValidateDataStructure);
+    ASSERT_NE(scene, nullptr);
+}
+
+
+TEST_F(utColladaImportExport, importRegr01) {
+    Importer importer;
+
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/Collada/regr01.dae", aiProcess_ValidateDataStructure);
+    ASSERT_NE(scene, nullptr);
+}
+
+
+TEST_F(utColladaImportExport, importSphere) {
+    Importer importer;
+
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/Collada/sphere.dae", aiProcess_ValidateDataStructure);
+    ASSERT_NE(scene, nullptr);
+}
+
+
+TEST_F(utColladaImportExport, importSphereTriangulate) {
+    Importer importer;
+
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/Collada/sphere_triangulate.dae", aiProcess_ValidateDataStructure);
+    ASSERT_NE(scene, nullptr);
+}
+
+
+TEST_F(utColladaImportExport, importTeapot) {
+    Importer importer;
+
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/Collada/teapot_instancenodes.DAE", aiProcess_ValidateDataStructure);
+    ASSERT_NE(scene, nullptr);
+}
+
+
 unsigned int GetMeshUseCount(const aiNode *rootNode) {
     unsigned int result = rootNode->mNumMeshes;
     for (unsigned int i = 0; i < rootNode->mNumChildren; ++i) {


### PR DESCRIPTION
Collada tests were unconditionally disabled by #6411. Revert that to re-enable them, add some more tests, clean up some code and fix a memory leak.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Expanded Collada import/export coverage for animations, cameras, geometry, encoding, UVs, lighting, special characters, and regression scenarios.
  - Collada test suites are now included consistently across build configurations.
  - Enabled animation-library import coverage as a standard smoke test.

- **Refactor**
  - Improved Collada animation ownership and processing to reduce unnecessary copying and simplify memory management without changing runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->