### PR TITLE
glTF2: set aiMesh::mMethod on meshes with morph targets

### DIFF
--- a/code/AssetLib/glTF2/glTF2Importer.cpp
+++ b/code/AssetLib/glTF2/glTF2Importer.cpp
@@ -646,6 +646,12 @@ void glTF2Importer::ImportMeshes(glTF2::Asset &r) {
 
             std::vector<Mesh::Primitive::Target> &targets = prim.targets;
             if (!targets.empty()) {
+                // Each target below is resolved to absolute positions: aiCreateAnimMesh
+                // copies the base mesh and the target's displacement is added on top.
+                // Blending those the way aiMorphingMethod_MORPH_NORMALIZED describes,
+                // base * (1 - sum(w)) + sum(w[i] * target[i]), reproduces glTF's
+                // base + sum(w[i] * displacement[i]) exactly.
+                aim->mMethod = aiMorphingMethod_MORPH_NORMALIZED;
                 aim->mNumAnimMeshes = (unsigned int)targets.size();
                 aim->mAnimMeshes = new aiAnimMesh *[aim->mNumAnimMeshes];
                 std::fill(aim->mAnimMeshes, aim->mAnimMeshes + aim->mNumAnimMeshes, nullptr);

--- a/test/unit/utglTF2ImportExport.cpp
+++ b/test/unit/utglTF2ImportExport.cpp
@@ -1151,3 +1151,30 @@ TEST_F(utglTF2ImportExport, importMalformedSparseAccessor) {
     std::string errorString = importer.GetErrorString();
     EXPECT_NE(errorString.find("Invalid sparse accessor: missing required 'values' object."), std::string::npos);
 }
+
+TEST_F(utglTF2ImportExport, importMorphingMethodIsSet) {
+    // Issue #5303: glTF morph meshes came back aiMorphingMethod_UNKNOWN because
+    // the importer never assigned mMethod.
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/glTF2/glTF-Sample-Models/AnimatedMorphCube-glTF/AnimatedMorphCube.gltf",
+            aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+    ASSERT_NE(0u, scene->mNumMeshes);
+
+    unsigned int meshesWithTargets = 0;
+    for (unsigned int i = 0; i < scene->mNumMeshes; ++i) {
+        const aiMesh *mesh = scene->mMeshes[i];
+        if (mesh->mNumAnimMeshes == 0) {
+            // A mesh without morph targets keeps the "not determined" value.
+            EXPECT_EQ(aiMorphingMethod_UNKNOWN, mesh->mMethod);
+            continue;
+        }
+        ++meshesWithTargets;
+        // The importer resolves each glTF target to absolute positions
+        // (aiCreateAnimMesh copies the base, then the target's delta is added),
+        // so the targets blend the way aiMorphingMethod_MORPH_NORMALIZED
+        // describes, not as relative offsets.
+        EXPECT_EQ(aiMorphingMethod_MORPH_NORMALIZED, mesh->mMethod);
+    }
+    EXPECT_GT(meshesWithTargets, 0u) << "fixture is expected to carry morph targets";
+}


### PR DESCRIPTION
Closes #5303.

## The problem

The glTF2 importer never assigns `aiMesh::mMethod`, so every mesh with morph targets comes back `aiMorphingMethod_UNKNOWN`. A caller receives a set of `aiAnimMesh` targets with no statement of how to combine them. Collada is currently the only importer that sets the field.

## Which value, and why it is not the obvious one

glTF phrases morph targets as displacements, so `aiMorphingMethod_MORPH_RELATIVE` looks like the answer. It is the wrong one here, because the field describes the data assimp hands back rather than the wording of the source format, and this importer does not hand back displacements.

`aiCreateAnimMesh` memcpy's the base mesh into each new `aiAnimMesh` (`code/Common/CreateAnimMesh.cpp`), and `ImportMeshes` then adds the target's delta on top of that copy:

```cpp
aiAnimMesh.mVertices[vertexId] += positionDiff[vertexId];
```

So each stored target is an absolute morphed position. `glTF2Exporter` is the mirror image and says so in its own comment — it subtracts the base again on the way out:

```cpp
// NOTE: in gltf it is the diff stored
pPositionDiff[vt] = pAnimMesh->mVertices[vt] - aim->mVertices[vt];
```

Absolute targets are what `aiMorphingMethod_MORPH_NORMALIZED` describes, and its blend reproduces glTF's exactly. Substituting `target[i] = base + delta[i]` into

```
base * (1 - sum(w)) + sum(w[i] * target[i])
```

gives `base + sum(w[i] * delta[i])`, which is the glTF formula. Tagging `MORPH_RELATIVE` would instead tell a caller to add the absolute targets onto the base a second time.

Nothing else changes: the assignment sits inside the existing `if (!targets.empty())`, so a mesh without morph targets still reports `UNKNOWN`.

## Testing

`importMorphingMethodIsSet` imports the `AnimatedMorphCube` fixture already in `test/models/`, asserts the method on every mesh that carries targets, and asserts meshes without targets keep `UNKNOWN`. It fails on master with `0 != 2` and passes with the change. No new assets.

```
$ bin/unit --gtest_filter="*glTF2*"
51 tests ... [  PASSED  ] 51 tests.

$ bin/unit
665 tests from 119 test suites ran. [  PASSED  ] 665 tests.
```

Built on Linux, gcc 13.3, `-DASSIMP_BUILD_TESTS=ON -DASSIMP_BUILD_ZLIB=ON`.

## One open question for you

`SimpleMorph`, `MorphPrimitivesTest`, `MorphStressTest` and `AnimatedMorphSphere` are also in `test/models/glTF2/` and would extend the same assertion cheaply. I kept the test to one fixture to stay small; say the word if you would rather it cover all of them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - glTF animation imports now support normalized 8-bit and 16-bit integer rotation and morph-weight data.
  - Morph-target meshes now use normalized morph blending semantics for improved compatibility.
  - Unsupported animation component formats are reported as import errors.

- **Tests**
  - Added coverage verifying normalized morphing methods for meshes with and without morph targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

Assisted-by: Claude (Anthropic)

Noting this per `AIToolPolicy.md`: the patch, the test and this description were drafted with an AI assistant. Flagging it late — it should have been on the PR from the start.
