### PR TITLE
glTF: refuse a float array with a non-numeric entry instead of reporting success

### DIFF
--- a/code/AssetLib/glTFCommon/glTFCommon.h
+++ b/code/AssetLib/glTFCommon/glTFCommon.h
@@ -302,9 +302,16 @@ template <unsigned int N>
 struct ReadHelper<float[N]> {
     static bool Read(Value &val, float (&out)[N]) {
         if (!val.IsArray() || val.Size() != N) return false;
+        // Check the whole array before writing any of it. An entry that is not
+        // a number used to be skipped while Read still reported success, so a
+        // Nullable<vec3> went isPresent over a value whose skipped component
+        // was never assigned. Refuse the array whole, the way a wrong size or a
+        // non-array already is refused, and leave out untouched either way.
         for (unsigned int i = 0; i < N; ++i) {
-            if (val[i].IsNumber())
-                out[i] = static_cast<float>(val[i].GetDouble());
+            if (!val[i].IsNumber()) return false;
+        }
+        for (unsigned int i = 0; i < N; ++i) {
+            out[i] = static_cast<float>(val[i].GetDouble());
         }
         return true;
     }

--- a/test/models/glTF2/malformed_node_scale.gltf
+++ b/test/models/glTF2/malformed_node_scale.gltf
@@ -1,0 +1,23 @@
+{
+  "asset": {
+    "version": "2.0"
+  },
+  "scene": 0,
+  "scenes": [
+    {
+      "nodes": [
+        0
+      ]
+    }
+  ],
+  "nodes": [
+    {
+      "name": "BadScale",
+      "scale": [
+        2.0,
+        "not-a-number",
+        3.0
+      ]
+    }
+  ]
+}

--- a/test/unit/utglTF2ImportExport.cpp
+++ b/test/unit/utglTF2ImportExport.cpp
@@ -1151,3 +1151,28 @@ TEST_F(utglTF2ImportExport, importMalformedSparseAccessor) {
     std::string errorString = importer.GetErrorString();
     EXPECT_NE(errorString.find("Invalid sparse accessor: missing required 'values' object."), std::string::npos);
 }
+
+TEST_F(utglTF2ImportExport, importMalformedNodeScaleIsRejected) {
+    // Issue #6190: ReadHelper<float[N]> skipped array entries that are not
+    // numbers but still returned true, so Nullable<vec3>::isPresent went true
+    // over a value whose skipped component was never written. Nullable leaves
+    // its value default-uninitialised, so the node took a scale with one
+    // indeterminate component.
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/glTF2/malformed_node_scale.gltf", 0);
+    ASSERT_NE(nullptr, scene);
+
+    const aiNode *bad = scene->mRootNode->FindNode("BadScale");
+    ASSERT_NE(nullptr, bad);
+
+    // A partially readable "scale" is not a scale. It has to be refused whole,
+    // the way a wrong-sized or non-array value already is, leaving the node at
+    // its default transform rather than at 2 on x and 3 on z with the y
+    // component never assigned.
+    aiVector3D scaling, position;
+    aiQuaternion rotation;
+    bad->mTransformation.Decompose(scaling, rotation, position);
+    EXPECT_FLOAT_EQ(1.0f, scaling.x);
+    EXPECT_FLOAT_EQ(1.0f, scaling.y);
+    EXPECT_FLOAT_EQ(1.0f, scaling.z);
+}


### PR DESCRIPTION
Closes #6190.

## The problem

`ReadHelper<float[N]>::Read` skipped array entries that are not numbers, then returned `true` anyway:

```cpp
if (!val.IsArray() || val.Size() != N) return false;
for (unsigned int i = 0; i < N; ++i) {
    if (val[i].IsNumber())
        out[i] = static_cast<float>(val[i].GetDouble());
}
return true;
```

Its two sibling error paths — a non-array, and an array of the wrong size — both return `false`. Only this case reported a successful read of a value it had not finished reading, which is what @jankrassnigg pointed out in the issue.

## Why it is reachable

`Nullable` stores its value with no initialiser (`T value;`), and takes `isPresent` straight from the reader's return:

```cpp
template <class T>
struct ReadHelper<Nullable<T>> {
    static bool Read(Value &val, Nullable<T> &out) {
        return out.isPresent = ReadHelper<T>::Read(val, out.value);
    }
};
```

`Node` holds `Nullable<vec3> translation`, `Nullable<vec4> rotation` and `Nullable<vec3> scale`. So a node carrying

```json
"scale": [2.0, "not-a-number", 3.0]
```

came out with `isPresent == true` over a value whose middle component was never assigned, and `glTF2Importer` then fed all three components through `CopyValue` into the node transform.

## The change

The array is validated in full before any of it is written. A malformed array is refused whole, the same way a wrong size already is, and the caller's array is left untouched rather than half-updated. That second part matters for the direct, non-`Nullable` reads — the node `"matrix"` path goes through `ReadValue` and `ReadMember(obj, "translation", ...)` ignores its result — where a partial write would otherwise persist.

Valid files are unaffected: an all-numeric array takes the same path and produces the same values.

## Testing

The test needs a file that is malformed in this specific way and no shipped asset is, so it adds a three-line `malformed_node_scale.gltf` alongside the existing `malformed_sparse.gltf`. It asserts the node keeps its default transform. On master it fails deterministically — the scale comes back `3` on z — so the assertion does not depend on whatever the unassigned component happens to contain.

```
$ bin/unit --gtest_filter="*glTF*"
55 tests from 2 test suites ran. [  PASSED  ] 55 tests.

$ bin/unit
665 tests from 119 test suites ran. [  PASSED  ] 665 tests.
```

Built on Linux, gcc 13.3, `-DASSIMP_BUILD_TESTS=ON -DASSIMP_BUILD_ZLIB=ON`.

## Note

This is independent of #6829, which I opened earlier today against `glTF2Importer.cpp`. The two touch different files and can be reviewed in either order.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Malformed numeric arrays are now rejected as a whole when they contain invalid entries.
  - Invalid node scale data no longer partially updates transforms; affected nodes retain their default scale instead of applying incomplete values.
  - Import handling is now more consistent and predictable when scale arrays contain non-numeric values.

- **Tests**
  - Added coverage to verify correct handling of malformed node scale data during import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

Assisted-by: Claude (Anthropic)

Noting this per `AIToolPolicy.md`: the patch, the test and this description were drafted with an AI assistant. Flagging it late — it should have been on the PR from the start.
