### PR TITLE
glTF2: cover animation interpolation with a regression test

### DIFF
--- a/test/models/glTF2/animation_interpolation_cubic.gltf
+++ b/test/models/glTF2/animation_interpolation_cubic.gltf
@@ -1,0 +1,77 @@
+{
+ "asset": {
+  "version": "2.0"
+ },
+ "scene": 0,
+ "scenes": [
+  {
+   "nodes": [
+    0
+   ]
+  }
+ ],
+ "nodes": [
+  {
+   "name": "Mover"
+  }
+ ],
+ "buffers": [
+  {
+   "byteLength": 80,
+   "uri": "data:application/octet-stream;base64,AAAAAAAAgD8AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAAAAAAAAAAA="
+  }
+ ],
+ "bufferViews": [
+  {
+   "buffer": 0,
+   "byteOffset": 0,
+   "byteLength": 8
+  },
+  {
+   "buffer": 0,
+   "byteOffset": 8,
+   "byteLength": 72
+  }
+ ],
+ "accessors": [
+  {
+   "bufferView": 0,
+   "componentType": 5126,
+   "count": 2,
+   "type": "SCALAR",
+   "min": [
+    0.0
+   ],
+   "max": [
+    1.0
+   ]
+  },
+  {
+   "bufferView": 1,
+   "componentType": 5126,
+   "count": 6,
+   "type": "VEC3"
+  }
+ ],
+ "animations": [
+  {
+   "name": "CUBICSPLINEAnim",
+   "samplers": [
+    {
+     "input": 0,
+     "output": 1,
+     "interpolation": "CUBICSPLINE"
+    }
+   ],
+   "channels": [
+    {
+     "sampler": 0,
+     "target": {
+      "node": 0,
+      "path": "translation"
+     }
+    }
+   ]
+  }
+ ]
+}

--- a/test/models/glTF2/animation_interpolation_linear.gltf
+++ b/test/models/glTF2/animation_interpolation_linear.gltf
@@ -1,0 +1,77 @@
+{
+ "asset": {
+  "version": "2.0"
+ },
+ "scene": 0,
+ "scenes": [
+  {
+   "nodes": [
+    0
+   ]
+  }
+ ],
+ "nodes": [
+  {
+   "name": "Mover"
+  }
+ ],
+ "buffers": [
+  {
+   "byteLength": 32,
+   "uri": "data:application/octet-stream;base64,AAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAA="
+  }
+ ],
+ "bufferViews": [
+  {
+   "buffer": 0,
+   "byteOffset": 0,
+   "byteLength": 8
+  },
+  {
+   "buffer": 0,
+   "byteOffset": 8,
+   "byteLength": 24
+  }
+ ],
+ "accessors": [
+  {
+   "bufferView": 0,
+   "componentType": 5126,
+   "count": 2,
+   "type": "SCALAR",
+   "min": [
+    0.0
+   ],
+   "max": [
+    1.0
+   ]
+  },
+  {
+   "bufferView": 1,
+   "componentType": 5126,
+   "count": 2,
+   "type": "VEC3"
+  }
+ ],
+ "animations": [
+  {
+   "name": "LINEARAnim",
+   "samplers": [
+    {
+     "input": 0,
+     "output": 1,
+     "interpolation": "LINEAR"
+    }
+   ],
+   "channels": [
+    {
+     "sampler": 0,
+     "target": {
+      "node": 0,
+      "path": "translation"
+     }
+    }
+   ]
+  }
+ ]
+}

--- a/test/models/glTF2/animation_interpolation_step.gltf
+++ b/test/models/glTF2/animation_interpolation_step.gltf
@@ -1,0 +1,77 @@
+{
+ "asset": {
+  "version": "2.0"
+ },
+ "scene": 0,
+ "scenes": [
+  {
+   "nodes": [
+    0
+   ]
+  }
+ ],
+ "nodes": [
+  {
+   "name": "Mover"
+  }
+ ],
+ "buffers": [
+  {
+   "byteLength": 32,
+   "uri": "data:application/octet-stream;base64,AAAAAAAAgD8AAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAA="
+  }
+ ],
+ "bufferViews": [
+  {
+   "buffer": 0,
+   "byteOffset": 0,
+   "byteLength": 8
+  },
+  {
+   "buffer": 0,
+   "byteOffset": 8,
+   "byteLength": 24
+  }
+ ],
+ "accessors": [
+  {
+   "bufferView": 0,
+   "componentType": 5126,
+   "count": 2,
+   "type": "SCALAR",
+   "min": [
+    0.0
+   ],
+   "max": [
+    1.0
+   ]
+  },
+  {
+   "bufferView": 1,
+   "componentType": 5126,
+   "count": 2,
+   "type": "VEC3"
+  }
+ ],
+ "animations": [
+  {
+   "name": "StepAnim",
+   "samplers": [
+    {
+     "input": 0,
+     "output": 1,
+     "interpolation": "STEP"
+    }
+   ],
+   "channels": [
+    {
+     "sampler": 0,
+     "target": {
+      "node": 0,
+      "path": "translation"
+     }
+    }
+   ]
+  }
+ ]
+}

--- a/test/unit/utglTF2ImportExport.cpp
+++ b/test/unit/utglTF2ImportExport.cpp
@@ -1151,3 +1151,40 @@ TEST_F(utglTF2ImportExport, importMalformedSparseAccessor) {
     std::string errorString = importer.GetErrorString();
     EXPECT_NE(errorString.find("Invalid sparse accessor: missing required 'values' object."), std::string::npos);
 }
+
+TEST_F(utglTF2ImportExport, importAnimationInterpolationIsPreserved) {
+    // The sampler's interpolation mode reaches the keys (da281b7f added the
+    // field, #6543 taught glTF2 to fill it). Nothing covered it, so a
+    // regression here would have been silent: every mode still imports, and
+    // aiAnimInterpolation_Linear is also the default a key is constructed with.
+    struct Expectation {
+        const char *file;
+        aiAnimInterpolation interpolation;
+        unsigned int numPositionKeys;
+    };
+    // CUBICSPLINE stores in-tangent, value and out-tangent per keyframe, so two
+    // keyframes arrive as six keys.
+    const Expectation expectations[] = {
+        { "/glTF2/animation_interpolation_step.gltf", aiAnimInterpolation_Step, 2 },
+        { "/glTF2/animation_interpolation_linear.gltf", aiAnimInterpolation_Linear, 2 },
+        { "/glTF2/animation_interpolation_cubic.gltf", aiAnimInterpolation_Cubic_Spline, 6 },
+    };
+
+    for (const Expectation &expected : expectations) {
+        Assimp::Importer importer;
+        const aiScene *scene = importer.ReadFile(std::string(ASSIMP_TEST_MODELS_DIR) + expected.file, 0);
+        ASSERT_NE(nullptr, scene) << expected.file << ": " << importer.GetErrorString();
+        ASSERT_EQ(1u, scene->mNumAnimations) << expected.file;
+
+        const aiAnimation *animation = scene->mAnimations[0];
+        ASSERT_EQ(1u, animation->mNumChannels) << expected.file;
+
+        const aiNodeAnim *channel = animation->mChannels[0];
+        EXPECT_STREQ("Mover", channel->mNodeName.C_Str()) << expected.file;
+        ASSERT_EQ(expected.numPositionKeys, channel->mNumPositionKeys) << expected.file;
+        for (unsigned int i = 0; i < channel->mNumPositionKeys; ++i) {
+            EXPECT_EQ(expected.interpolation, channel->mPositionKeys[i].mInterpolation)
+                    << expected.file << " key " << i;
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #5668, which I think can be closed — the feature it asks for is already on master. What is missing is coverage.

`da281b7f` introduced `aiAnimInterpolation` on `aiVectorKey` and `aiQuatKey`, and #6543 taught the glTF2 importer to fill it from the sampler. `grep -rn mInterpolation test/unit/` finds nothing, so that mapping has never been guarded.

The gap is easy to miss because a regression here is silent. Every sampler mode keeps importing, and `aiAnimInterpolation_Linear` is also the value a key is constructed with, so a broken mapping still yields a scene that loads and animates — just always linearly. Nothing throws and no count changes.

## What is in here

Three fixtures, one per sampler mode, each a single node with one translation channel and an inline base64 buffer, so no external asset is pulled in. The CUBICSPLINE file also pins the key count at six, since that mode stores an in-tangent and an out-tangent alongside each keyframe value and those arrive as keys of their own.

No source changes.

## Verification

I checked that the test catches the regression it names rather than only passing today. Pointing `MapInterpolation`'s `STEP` and `CUBICSPLINE` cases at `aiAnimInterpolation_Linear`:

```
expected: aiAnimInterpolation_Step (0)          actual: 1   animation_interpolation_step.gltf
expected: aiAnimInterpolation_Cubic_Spline (3)  actual: 1   animation_interpolation_cubic.gltf
```

Restoring the mapping turns it green again.

```
$ bin/unit --gtest_filter="*importAnimationInterpolationIsPreserved*"
[  PASSED  ] 1 test.

$ bin/unit
665 tests from 119 test suites ran. [  PASSED  ] 665 tests.
```

Built on Linux, gcc 13.3, `-DASSIMP_BUILD_TESTS=ON -DASSIMP_BUILD_ZLIB=ON`.

Independent of #6829 and #6830; this one touches only `test/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for glTF2 animation imports.
  * Verified that STEP, LINEAR, and CUBICSPLINE interpolation modes are preserved, along with the expected animation structure and position-key data.
  * This helps ensure imported animations retain their intended motion behavior across supported interpolation types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

Assisted-by: Claude (Anthropic)

Noting this per `AIToolPolicy.md`: the patch, the test and this description were drafted with an AI assistant. Flagging it late — it should have been on the PR from the start.
