### PR TITLE
glTF: guard both exporters against a zero animation tick rate

### DIFF
--- a/code/AssetLib/glTF/glTFExporter.cpp
+++ b/code/AssetLib/glTF/glTFExporter.cpp
@@ -918,9 +918,12 @@ void glTFExporter::ExportMetadata()
 // Fall back to treating ticks as seconds, the same way the FBX exporter does.
 static float GetSafeTicksPerSecond(const aiAnimation* anim)
 {
-    // Classify after the narrowing cast so a double that underflows to 0.0f is caught too.
+    // Compare after the narrowing cast so a double that underflows to 0.0f is caught too.
+    // isfinite() first rejects NaN and the infinities; <= 0 then rejects both zeroes AND
+    // negatives, which are finite and non-zero and would otherwise turn positive source
+    // key times into negative glTF timestamps.
     const float ticksPerSecond = static_cast<float>(anim->mTicksPerSecond);
-    if (FP_ZERO == std::fpclassify(ticksPerSecond) || !std::isfinite(ticksPerSecond)) {
+    if (!std::isfinite(ticksPerSecond) || ticksPerSecond <= 0.0f) {
         return 1.0f;
     }
 

--- a/code/AssetLib/glTF/glTFExporter.cpp
+++ b/code/AssetLib/glTF/glTFExporter.cpp
@@ -59,6 +59,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <assimp/config.h>
 
 // Header files, standard library.
+#include <cmath>
 #include <memory>
 #include <limits>
 #include <inttypes.h>
@@ -910,6 +911,22 @@ void glTFExporter::ExportMetadata()
 	}
 }
 
+// Keyframe times are stored in ticks and glTF wants seconds, so the exporters divide
+// by the tick rate. Formats that carry no tick rate leave aiAnimation::mTicksPerSecond
+// at its default 0 (3DS and Irr never set it, X leaves it 0 when the file has no
+// AnimTicksPerSecond object), which turned every exported timestamp into inf or NaN.
+// Fall back to treating ticks as seconds, the same way the FBX exporter does.
+static float GetSafeTicksPerSecond(const aiAnimation* anim)
+{
+    // Classify after the narrowing cast so a double that underflows to 0.0f is caught too.
+    const float ticksPerSecond = static_cast<float>(anim->mTicksPerSecond);
+    if (FP_ZERO == std::fpclassify(ticksPerSecond) || !std::isfinite(ticksPerSecond)) {
+        return 1.0f;
+    }
+
+    return ticksPerSecond;
+}
+
 inline void ExtractAnimationData(Asset& mAsset, std::string& animId, Ref<Animation>& animRef, Ref<Buffer>& buffer, const aiNodeAnim* nodeChannel, float ticksPerSecond)
 {
     // Loop over the data and check to see if it exactly matches an existing buffer.
@@ -1020,7 +1037,7 @@ void glTFExporter::ExportAnimations()
             Ref<Animation> animRef = mAsset->animations.Create(name);
 
             /******************* Parameters ********************/
-            ExtractAnimationData(*mAsset, name, animRef, bufferRef, nodeChannel, static_cast<float>(anim->mTicksPerSecond));
+            ExtractAnimationData(*mAsset, name, animRef, bufferRef, nodeChannel, GetSafeTicksPerSecond(anim));
 
             for (unsigned int j = 0; j < 3; ++j) {
                 std::string channelType;

--- a/code/AssetLib/glTF2/glTF2Exporter.cpp
+++ b/code/AssetLib/glTF2/glTF2Exporter.cpp
@@ -1632,6 +1632,21 @@ void glTF2Exporter::ExportMetadata() {
     }
 }
 
+// Keyframe times are stored in ticks and glTF wants seconds, so the exporters divide
+// by the tick rate. Formats that carry no tick rate leave aiAnimation::mTicksPerSecond
+// at its default 0 (3DS and Irr never set it, X leaves it 0 when the file has no
+// AnimTicksPerSecond object), which turned every exported timestamp into inf or NaN.
+// Fall back to treating ticks as seconds, the same way the FBX exporter does.
+static float GetSafeTicksPerSecond(const aiAnimation *anim) {
+    // Classify after the narrowing cast so a double that underflows to 0.0f is caught too.
+    const float ticksPerSecond = static_cast<float>(anim->mTicksPerSecond);
+    if (FP_ZERO == std::fpclassify(ticksPerSecond) || !std::isfinite(ticksPerSecond)) {
+        return 1.0f;
+    }
+
+    return ticksPerSecond;
+}
+
 inline Ref<Accessor> GetSamplerInputRef(Asset &asset, std::string &animId, Ref<Buffer> &buffer, std::vector<ai_real> &times) {
     return ExportData(asset, animId, buffer, (unsigned int)times.size(), &times[0], AttribType::SCALAR, AttribType::SCALAR, ComponentType_FLOAT);
 }
@@ -1708,7 +1723,7 @@ void glTF2Exporter::ExportAnimations() {
 
     for (unsigned int i = 0; i < mScene->mNumAnimations; ++i) {
         const aiAnimation *anim = mScene->mAnimations[i];
-        const float ticksPerSecond = static_cast<float>(anim->mTicksPerSecond);
+        const float ticksPerSecond = GetSafeTicksPerSecond(anim);
 
         std::string nameAnim = "anim";
         if (anim->mName.length > 0) {

--- a/code/AssetLib/glTF2/glTF2Exporter.cpp
+++ b/code/AssetLib/glTF2/glTF2Exporter.cpp
@@ -1638,9 +1638,12 @@ void glTF2Exporter::ExportMetadata() {
 // AnimTicksPerSecond object), which turned every exported timestamp into inf or NaN.
 // Fall back to treating ticks as seconds, the same way the FBX exporter does.
 static float GetSafeTicksPerSecond(const aiAnimation *anim) {
-    // Classify after the narrowing cast so a double that underflows to 0.0f is caught too.
+    // Compare after the narrowing cast so a double that underflows to 0.0f is caught too.
+    // isfinite() first rejects NaN and the infinities; <= 0 then rejects both zeroes AND
+    // negatives, which are finite and non-zero and would otherwise turn positive source
+    // key times into negative glTF timestamps.
     const float ticksPerSecond = static_cast<float>(anim->mTicksPerSecond);
-    if (FP_ZERO == std::fpclassify(ticksPerSecond) || !std::isfinite(ticksPerSecond)) {
+    if (!std::isfinite(ticksPerSecond) || ticksPerSecond <= 0.0f) {
         return 1.0f;
     }
 

--- a/test/unit/utglTF2ImportExport.cpp
+++ b/test/unit/utglTF2ImportExport.cpp
@@ -56,6 +56,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <rapidjson/schema.h>
 
 #include <array>
+#include <cmath>
 #include <fstream>
 #include <sstream>
 
@@ -794,6 +795,44 @@ TEST_F(utglTF2ImportExport, export_bad_accessor_bounds) {
     EXPECT_EQ(aiReturn_SUCCESS, exporter.Export(scene, "glb2", ASSIMP_TEST_MODELS_DIR "/glTF2/BoxWithInfinites-glTF-Binary/BoxWithInfinites_out.glb"));
     EXPECT_EQ(aiReturn_SUCCESS, exporter.Export(scene, "gltf2", ASSIMP_TEST_MODELS_DIR "/glTF2/BoxWithInfinites-glTF-Binary/BoxWithInfinites_out.gltf"));
 }
+
+#ifndef ASSIMP_BUILD_NO_3DS_IMPORTER
+TEST_F(utglTF2ImportExport, export_animation_without_tick_rate) {
+    // 3DS carries no tick rate, so aiAnimation::mTicksPerSecond stays at its default 0.
+    // The exporter divides keyframe times by it to convert ticks to seconds, which used
+    // to write inf/NaN timestamps and leave the accessor bounds at their sentinel values.
+    Assimp::Importer importer;
+    const aiScene *scene = importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/3DS/RotatingCube.3DS", aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, scene);
+    ASSERT_EQ(1u, scene->mNumAnimations);
+    ASSERT_EQ(0.0, scene->mAnimations[0]->mTicksPerSecond);
+
+    const char *outPath = ASSIMP_TEST_MODELS_DIR "/3DS/RotatingCube_out.gltf";
+    Assimp::Exporter exporter;
+    ASSERT_EQ(aiReturn_SUCCESS, exporter.Export(scene, "gltf2", outPath));
+
+    Assimp::Importer reimporter;
+    const aiScene *exported = reimporter.ReadFile(outPath, aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, exported);
+    ASSERT_NE(0u, exported->mNumAnimations);
+
+    for (unsigned int animIndex = 0; animIndex < exported->mNumAnimations; ++animIndex) {
+        const aiAnimation *anim = exported->mAnimations[animIndex];
+        for (unsigned int channelIndex = 0; channelIndex < anim->mNumChannels; ++channelIndex) {
+            const aiNodeAnim *channel = anim->mChannels[channelIndex];
+            for (unsigned int i = 0; i < channel->mNumPositionKeys; ++i) {
+                EXPECT_TRUE(std::isfinite(channel->mPositionKeys[i].mTime));
+            }
+            for (unsigned int i = 0; i < channel->mNumRotationKeys; ++i) {
+                EXPECT_TRUE(std::isfinite(channel->mRotationKeys[i].mTime));
+            }
+            for (unsigned int i = 0; i < channel->mNumScalingKeys; ++i) {
+                EXPECT_TRUE(std::isfinite(channel->mScalingKeys[i].mTime));
+            }
+        }
+    }
+}
+#endif // ASSIMP_BUILD_NO_3DS_IMPORTER
 
 TEST_F(utglTF2ImportExport, export_normalized_normals) {
     Assimp::Importer importer;

--- a/test/unit/utglTF2ImportExport.cpp
+++ b/test/unit/utglTF2ImportExport.cpp
@@ -57,6 +57,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <array>
 #include <cmath>
+#include <memory>
 #include <fstream>
 #include <sstream>
 
@@ -797,6 +798,30 @@ TEST_F(utglTF2ImportExport, export_bad_accessor_bounds) {
 }
 
 #ifndef ASSIMP_BUILD_NO_3DS_IMPORTER
+// Every exported key time must be finite AND non-negative. Source ticks are
+// non-negative, so a negative timestamp means the tick rate was applied with the
+// wrong sign rather than rejected.
+static void ExpectSaneKeyTimes(const aiScene *exported) {
+    for (unsigned int animIndex = 0; animIndex < exported->mNumAnimations; ++animIndex) {
+        const aiAnimation *anim = exported->mAnimations[animIndex];
+        for (unsigned int channelIndex = 0; channelIndex < anim->mNumChannels; ++channelIndex) {
+            const aiNodeAnim *channel = anim->mChannels[channelIndex];
+            for (unsigned int i = 0; i < channel->mNumPositionKeys; ++i) {
+                EXPECT_TRUE(std::isfinite(channel->mPositionKeys[i].mTime));
+                EXPECT_GE(channel->mPositionKeys[i].mTime, 0.0);
+            }
+            for (unsigned int i = 0; i < channel->mNumRotationKeys; ++i) {
+                EXPECT_TRUE(std::isfinite(channel->mRotationKeys[i].mTime));
+                EXPECT_GE(channel->mRotationKeys[i].mTime, 0.0);
+            }
+            for (unsigned int i = 0; i < channel->mNumScalingKeys; ++i) {
+                EXPECT_TRUE(std::isfinite(channel->mScalingKeys[i].mTime));
+                EXPECT_GE(channel->mScalingKeys[i].mTime, 0.0);
+            }
+        }
+    }
+}
+
 TEST_F(utglTF2ImportExport, export_animation_without_tick_rate) {
     // 3DS carries no tick rate, so aiAnimation::mTicksPerSecond stays at its default 0.
     // The exporter divides keyframe times by it to convert ticks to seconds, which used
@@ -816,21 +841,33 @@ TEST_F(utglTF2ImportExport, export_animation_without_tick_rate) {
     ASSERT_NE(nullptr, exported);
     ASSERT_NE(0u, exported->mNumAnimations);
 
-    for (unsigned int animIndex = 0; animIndex < exported->mNumAnimations; ++animIndex) {
-        const aiAnimation *anim = exported->mAnimations[animIndex];
-        for (unsigned int channelIndex = 0; channelIndex < anim->mNumChannels; ++channelIndex) {
-            const aiNodeAnim *channel = anim->mChannels[channelIndex];
-            for (unsigned int i = 0; i < channel->mNumPositionKeys; ++i) {
-                EXPECT_TRUE(std::isfinite(channel->mPositionKeys[i].mTime));
-            }
-            for (unsigned int i = 0; i < channel->mNumRotationKeys; ++i) {
-                EXPECT_TRUE(std::isfinite(channel->mRotationKeys[i].mTime));
-            }
-            for (unsigned int i = 0; i < channel->mNumScalingKeys; ++i) {
-                EXPECT_TRUE(std::isfinite(channel->mScalingKeys[i].mTime));
-            }
-        }
-    }
+    ExpectSaneKeyTimes(exported);
+}
+
+TEST_F(utglTF2ImportExport, export_animation_with_negative_tick_rate) {
+    // A negative tick rate is finite and non-zero, so it slipped past a guard that
+    // only rejected zero and the non-finite values -- and turned positive source key
+    // times into negative glTF timestamps.
+    Assimp::Importer importer;
+    ASSERT_NE(nullptr, importer.ReadFile(ASSIMP_TEST_MODELS_DIR "/3DS/RotatingCube.3DS",
+                                         aiProcess_ValidateDataStructure));
+    // GetOrphanedScene() hands over a mutable scene the caller owns, which is the only
+    // way to set a tick rate no importer in the tree produces.
+    std::unique_ptr<aiScene> scene(importer.GetOrphanedScene());
+    ASSERT_NE(nullptr, scene);
+    ASSERT_EQ(1u, scene->mNumAnimations);
+    scene->mAnimations[0]->mTicksPerSecond = -30.0;
+
+    const char *outPath = ASSIMP_TEST_MODELS_DIR "/3DS/RotatingCube_negative_out.gltf";
+    Assimp::Exporter exporter;
+    ASSERT_EQ(aiReturn_SUCCESS, exporter.Export(scene.get(), "gltf2", outPath));
+
+    Assimp::Importer reimporter;
+    const aiScene *exported = reimporter.ReadFile(outPath, aiProcess_ValidateDataStructure);
+    ASSERT_NE(nullptr, exported);
+    ASSERT_NE(0u, exported->mNumAnimations);
+
+    ExpectSaneKeyTimes(exported);
 }
 #endif // ASSIMP_BUILD_NO_3DS_IMPORTER
 


### PR DESCRIPTION
Closes #6466

## The bug

Keyframe times are stored in ticks and glTF stores them in seconds, so both
glTF exporters divide by `aiAnimation::mTicksPerSecond` — with nothing checking
that the tick rate is usable first.

`aiAnimation` default-constructs `mTicksPerSecond` to `0.`
(`include/assimp/anim.h`), and several importers never overwrite it. 3DS
(`3DSConverter.cpp`) and Irr create animations without touching it, and the X
importer passes through `XFile::Scene::mAnimTicksPerSecond`, itself 0 when the
file carries no `AnimTicksPerSecond` object. So the divide is reachable from
three shipped importers rather than being theoretical.

Reproduced with a model already in the tree, no new asset needed:

```
$ assimp export test/models/3DS/RotatingCube.3DS rot.gltf -fgltf2
```

| animation sampler input | before | after |
|---|---|---|
| count | 182 | 182 |
| `min` | `1.797...e+308` | `[0.0]` |
| `max` | `-1.797...e+308` | `[181.0]` |
| non-finite timestamps | **182** (1 NaN, 181 inf) | 0 |

The `min`/`max` degradation is a second spec violation the issue does not
mention: every comparison against NaN is false, so the bounds never update and
stay at their ±DBL_MAX sentinels — and glTF requires `min`/`max` on animation
sampler input accessors. On platforms that trap FP exceptions this raises
SIGFPE instead of writing garbage.

## The fix

Fall back to treating ticks as seconds, which is what the FBX exporter already
does in `to_ktime()` — so this follows a shape already accepted in-tree rather
than introducing one. One `static float GetSafeTicksPerSecond(const aiAnimation*)`
per exporter file, called from `ExportAnimations` (glTF2) and from the
`ExtractAnimationData` call site (glTF1), so all four division sites are covered
by two call sites.

The guard is `isfinite()` followed by `<= 0`, which rejects NaN, both
infinities, both zeroes and every negative in one expression. Two details worth
defending in review:

- The comparison happens **after** the narrowing cast to `float`, so a double
  that underflows to `0.0f` is caught too.
- `static` rather than `inline` because both files land in `namespace Assimp`
  and would otherwise share one ODR name.

## Test

`utglTF2ImportExport.export_animation_without_tick_rate` imports the 3DS model,
exports glTF2, reads the result back and asserts every position, rotation and
scaling key time is finite. Guarded with `#ifndef ASSIMP_BUILD_NO_3DS_IMPORTER`
(precedent: `ut3DSImportExport.cpp`) since it is the only cross-format input in
that file.

A second test, `export_animation_with_negative_tick_rate`, covers the negative
case CodeRabbit found in review: it claims the same scene with
`GetOrphanedScene()` so the rate is writable, sets it to `-30.0` and re-exports.
Both share an `ExpectSaneKeyTimes()` helper that requires each key time to be
finite **and** non-negative, since no source tick is negative.

Verified red/green for each:

| test | without its fix | with |
|---|---|---|
| `export_animation_without_tick_rate` | fails on `std::isfinite(...mTime)` | passes |
| `export_animation_with_negative_tick_rate` | **181 failed assertions** | passes |

Full suite on this branch is **699/699** against current `master` (`17ec36b24`).

## Notes for whoever merges it

This touches `test/unit/utglTF2ImportExport.cpp`, which #6831 also touches, so
whichever lands second will want a trivial rebase — the overlap is the include
block and the added test, not the same test.

It is also a fourth open PR from me while #6829, #6830 and #6831 are still
waiting. Per `AIToolPolicy.md`'s golden rule that a contribution should be worth
more than the review time it costs, treat this one as the lowest priority of the
four if that helps — the crash it fixes has been latent for a while and is not
urgent.

Assisted-by: Claude (Anthropic)

Noting this per `AIToolPolicy.md`: the patch, the test and this description were
drafted with an AI assistant. The trailer is also on the commit. #6466 is
labelled `Bug` / `Export` / `Sanitizer` / `glTF-Common`, not `good first issue`,
so the policy's prohibition on that label does not apply here — checked before
starting.

---

## Review round 1 (CodeRabbit)

Applied in `e7e405703`. A finite negative `mTicksPerSecond` passed both original
guards, and the consequence is worse than a sign flip: source ticks ascend, so
dividing by a negative rate makes the exported timestamps **descend**, which
assimp's own `ValidateDataStructureProcess` rejects —

```
Validation warning: aiNodeAnim::mRotationKeys[1].mTime (-33.33334) is smaller
than aiAnimation::mRotationKeys[0] (which is -0.00000)
```

— so it breaks the monotonicity animation consumers rely on. The replacement
guard is both simpler and stricter than what it replaces.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed animation exports where missing, zero, negative, or otherwise invalid tick-rate values could produce `NaN`, infinite, or negative keyframe timestamps.
  - Animation timing now defaults safely to a valid rate when source data does not provide a usable tick rate.
  - Improved reliability when exporting animated 3DS content to glTF and glTF2.
  - Preserved supported animation interpolation modes when importing glTF files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->